### PR TITLE
Fix a bunch of TargetedMS tests. TargetedMSTable wasn't actually immu…

### DIFF
--- a/src/org/labkey/targetedms/query/TargetedMSForeignKey.java
+++ b/src/org/labkey/targetedms/query/TargetedMSForeignKey.java
@@ -38,8 +38,9 @@ public class TargetedMSForeignKey extends LookupForeignKey
     @Override
     public TableInfo getLookupTableInfo()
     {
-        TableInfo table = _schema.getTable(_tableName);
-        ((TargetedMSTable)table).setNeedsContainerWhereClause(false);
-        return table;
+        // Avoid applying a container filter on lookups. The import process should be only creating FKs to data
+        // in the same container. Thus, we can rely on the outer query doing the proper filtering and avoid
+        // what can be expensive multi-table joins to get to a table that has the Container column we need
+        return _schema.getTable(_tableName, ContainerFilter.EVERYTHING);
     }
 }

--- a/src/org/labkey/targetedms/query/TargetedMSTable.java
+++ b/src/org/labkey/targetedms/query/TargetedMSTable.java
@@ -89,11 +89,6 @@ public class TargetedMSTable extends FilteredTable<TargetedMSSchema>
         // Don't apply the container filter normally, let us apply it in our wrapper around the normally generated SQL
     }
 
-    public void setNeedsContainerWhereClause(boolean needsContainerWhereClause)
-    {
-        _needsContainerWhereClause = needsContainerWhereClause;
-    }
-
     @Override
     @NotNull
     public SQLFragment getFromSQL(String alias)
@@ -102,7 +97,7 @@ public class TargetedMSTable extends FilteredTable<TargetedMSSchema>
         sql.append(super.getFromSQL("X"));
         sql.append(" ");
 
-        if (_needsContainerWhereClause || _containerTableFilter != null)
+        if (getContainerFilter() != ContainerFilter.EVERYTHING || _containerTableFilter != null)
         {
             sql.append(_joinType != null ? _joinType.getSQL() : "");
 


### PR DESCRIPTION
…table, which made it quite unsafe to cache. Now it is, and we can use a ContainerFilter (already handled via the caching code) to control the lookup behavior to get the same optimized query generated.