### PR TITLE
TargetedMS: increase length of peptidegroup.gene column

### DIFF
--- a/resources/schemas/dbscripts/postgresql/targetedms-19.17-19.18.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-19.17-19.18.sql
@@ -1,0 +1,2 @@
+-- Increase the length of the Gene column. The gene field can contain all possible gene names that a protein product is associated with. This can get really long.
+ALTER TABLE targetedms.PeptideGroup ALTER COLUMN gene TYPE VARCHAR(2000);

--- a/resources/schemas/dbscripts/sqlserver/targetedms-19.17-19.18.sql
+++ b/resources/schemas/dbscripts/sqlserver/targetedms-19.17-19.18.sql
@@ -1,0 +1,2 @@
+-- Increase the length of the Gene column. The gene field can contain all possible gene names that a protein product is associated with. This can get really long.
+ALTER TABLE targetedms.PeptideGroup ALTER COLUMN gene NVARCHAR(2000);

--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -212,7 +212,7 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
     @Override
     public double getVersion()
     {
-        return 19.17;
+        return 19.18;
     }
 
     @Override


### PR DESCRIPTION
Gene field in some fasta files (e.g. from Flybase) contain all possible gene names that a protein products is associated with. This can get rather long. I am increasing it to 2000 as we discussed over email in March.