### PR TITLE
Issue 35987: Update default guideset calculation

### DIFF
--- a/webapp/TargetedMS/js/BaseQCPlotPanel.js
+++ b/webapp/TargetedMS/js/BaseQCPlotPanel.js
@@ -52,7 +52,7 @@ Ext4.define('LABKEY.targetedms.BaseQCPlotPanel', {
                 + '\nSELECT NULL AS GuideSetId, MIN(SampleFileId.AcquiredTime) AS TrainingStart, MAX(SampleFileId.AcquiredTime) AS TrainingEnd,'
                 + '\nNULL AS ReferenceEnd, SeriesLabel, \'' + series + '\' AS SeriesType, COUNT(SampleFileId) AS NumRecords, AVG(MetricValue) AS Mean, STDDEV(MetricValue) AS StandardDev'
                 + '\nFROM '+ schema + '.' + table
-                + exclusion
+                + exclusion + '\nAND (SampleFileId.AcquiredTime < (coalesce((select MIN(TrainingStart) from guideset), now())))'
                 + '\nGROUP BY SeriesLabel';
     },
 


### PR DESCRIPTION
Default guideset calculations include values across entire plot if no guidesets are defined, otherwise only include values to the left of the first guideset from the left.