### PR TITLE
Fix TargetedMSQCSummaryTest.testShowAutoQC and TargetedMSQCTest.testQ…

### DIFF
--- a/test/src/org/labkey/test/components/targetedms/QCSummaryWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/QCSummaryWebPart.java
@@ -120,6 +120,7 @@ public final class QCSummaryWebPart extends BodyWebPart<QCSummaryWebPart.Element
         static final Locator recentSampleFilesLoading = Locator.tagWithClass("div", "sample-file-details-loading");
         static final Locator recentSampleFile = Locator.css("div.sample-file-item");
         static final Locator recentSampleFileOutliers = Locator.css("div.sample-file-item-outliers");
+        static final Locator recentSampleFileAcquired = Locator.css("div.sample-file-item-acquired");
     }
 
     public class QcSummaryTile extends Component
@@ -131,6 +132,7 @@ public final class QCSummaryWebPart extends BodyWebPart<QCSummaryWebPart.Element
         private final WebElement autoQCIcon = Locator.css("div.auto-qc-ping span").findWhenNeeded(this);
         private List<WebElement> _recentSampleFiles;
         private List<WebElement> _recentSampleFileOutliers;
+        private List<WebElement> _recentSampleFileAcquired;
 
         private String _folderName;
         private Integer _fileCount;
@@ -220,10 +222,29 @@ public final class QCSummaryWebPart extends BodyWebPart<QCSummaryWebPart.Element
             return _recentSampleFileOutliers;
         }
 
-        public boolean hasRecentSampleFileWithOulierTxt(String acquiredDate, String outlierStr)
+        public List<WebElement> getRecentSampleFileAcquired()
+        {
+            if (_recentSampleFileAcquired == null)
+            {
+                _recentSampleFileAcquired = new ArrayList<>();
+                _recentSampleFileAcquired.addAll(Locators.recentSampleFileAcquired.findElements(this));
+            }
+            return _recentSampleFileAcquired;
+        }
+
+        public String getRecentSampleFileWithOutliers(String acquiredDate)
         {
             acquiredDate = acquiredDate.substring(0, acquiredDate.lastIndexOf(":")); // Sample file listing doesn't include seconds
-            return Locators.recentSampleFile.withText(" " + acquiredDate + " - " + outlierStr).findElements(this).size() == 1;
+            List<WebElement> acquiredElements = getRecentSampleFileAcquired();
+            List<WebElement> outliersElements = getRecentSampleFileOutliers();
+            for (int i = 0; i < acquiredElements.size(); i++)
+            {
+                if (acquiredElements.get(i).getText().contains(acquiredDate))
+                {
+                    return outliersElements.get(i).getText();
+                }
+            }
+            return null;
         }
     }
 }

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCSummaryTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCSummaryTest.java
@@ -230,12 +230,12 @@ public class TargetedMSQCSummaryTest extends TargetedMSTest
         setAutoQCPingTimeOut(QCPING_TIMEOUT);
 
         waitForElements(Locator.tagWithClass("div", "sample-file-item"), 6);
-        tempStringList01.put("Q_Exactive_08_23_2013_JGB_58", "0");
-        tempStringList01.put("Q_Exactive_08_23_2013_JGB_51", "0");
-        tempStringList01.put("Q_Exactive_08_23_2013_JGB_37", "0");
+        tempStringList01.put("Q_Exactive_08_23_2013_JGB_58", "27");
+        tempStringList01.put("Q_Exactive_08_23_2013_JGB_51", "26");
+        tempStringList01.put("Q_Exactive_08_23_2013_JGB_37", "29");
         tempStringList02.add(Arrays.asList("Q_Exactive_08_23_2013_JGB_58", "Acquired Date/Time: 2013-08-27 14:45"));
         tempStringList02.add(Arrays.asList("Q_Exactive_08_23_2013_JGB_51", "Acquired Date/Time: 2013-08-27 03:19"));
-        tempStringList02.add(Arrays.asList("No outliers"));
+        tempStringList02.add(Arrays.asList("Q_Exactive_08_23_2013_JGB_37", "Acquired Date/Time: 2013-08-26 04:27"));
         validateSampleFile(0, tempStringList01, tempStringList02);
 
         validateAutoQCStatus(MAIN_SUMMARY, Arrays.asList("qc-none", "fa-circle-o"), "Has never been pinged");

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -799,19 +799,19 @@ public class TargetedMSQCTest extends TargetedMSTest
         changePointExclusionState(acquiredDateStr, QCPlotsWebPart.QCPlotExclusionState.Include, 2);
 
         // verify initial QC summary outlier info
-        verifyQCSummarySampleFileOutliers(sampleFileAcquiredDates[0], "no outliers");
+        verifyQCSummarySampleFileOutliers(sampleFileAcquiredDates[0], "0");
         verifyQCSummarySampleFileOutliers(sampleFileAcquiredDates[1], "not included in QC");
-        verifyQCSummarySampleFileOutliers(sampleFileAcquiredDates[2], "no outliers");
+        verifyQCSummarySampleFileOutliers(sampleFileAcquiredDates[2], "0");
 
         // create a guide set and verify updated QC Summary outliers info
         qcPlotsWebPart.createGuideSet(new GuideSet(sampleFileAcquiredDates[0], sampleFileAcquiredDates[1], null, 2), null);
-        verifyQCSummarySampleFileOutliers(sampleFileAcquiredDates[2], "10/16 (Levey-Jennings), 10/16 (Moving Range) outliers");
+        verifyQCSummarySampleFileOutliers(sampleFileAcquiredDates[2], "20");
 
         // change data point to only be excluded for a single metric and verify outliers changed
         changePointExclusionState(getAcquiredDateDisplayStr(sampleFileAcquiredDates[1]), QCPlotsWebPart.QCPlotExclusionState.ExcludeMetric, 2);
-        verifyQCSummarySampleFileOutliers(sampleFileAcquiredDates[2], "2/16 (Levey-Jennings), 3/16 (Moving Range) outliers");
+        verifyQCSummarySampleFileOutliers(sampleFileAcquiredDates[2], "5");
         changePointExclusionState(getAcquiredDateDisplayStr(sampleFileAcquiredDates[2]), QCPlotsWebPart.QCPlotExclusionState.ExcludeMetric, 2);
-        verifyQCSummarySampleFileOutliers(sampleFileAcquiredDates[2], "1/14 (Moving Range) outliers");
+        verifyQCSummarySampleFileOutliers(sampleFileAcquiredDates[2], "1");
     }
 
     private void verifyQCSummarySampleFileOutliers(String acquiredDate, String outlierInfo)
@@ -819,8 +819,8 @@ public class TargetedMSQCTest extends TargetedMSTest
         PanoramaDashboard qcDashboard = new PanoramaDashboard(this);
         qcDashboard.getQcSummaryWebPart().waitForRecentSampleFiles(3);
         QCSummaryWebPart.QcSummaryTile qcSummaryTile = qcDashboard.getQcSummaryWebPart().getQcSummaryTiles().get(0);
-        assertTrue("Unexpected outlier information for QC summary sample file, expected: "
-                + acquiredDate + " - " + outlierInfo, qcSummaryTile.hasRecentSampleFileWithOulierTxt(acquiredDate, outlierInfo));
+        assertEquals("Unexpected outlier information for QC summary sample file for "
+                + acquiredDate, outlierInfo, qcSummaryTile.getRecentSampleFileWithOutliers(acquiredDate));
     }
 
     private String getAcquiredDateDisplayStr(String acquiredDate)

--- a/webapp/TargetedMS/js/QCSummaryPanel.js
+++ b/webapp/TargetedMS/js/QCSummaryPanel.js
@@ -272,7 +272,7 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
 
                 var iconCls = !sampleFile.IgnoreForAllMetric ? (!sampleFile.hasOutliers ? 'fa-file-o qc-correct' : 'fa-file qc-error') : 'fa-file-o qc-none';
                 html += '<tr id="' + sampleFile.calloutId + '"><td><div class="sample-file-item">'
-                        + '<span class="fa ' + iconCls + '"></span> ' + Ext4.util.Format.htmlEncode(sampleFile.SampleFile) + '</div></td><td>' + Ext4.util.Format.date(Ext4.Date.parse(sampleFile.AcquiredTime, LABKEY.Utils.getDateTimeFormatWithMS()), LABKEY.extDefaultDateTimeFormat || 'Y-m-d H:i:s') + '</td>';
+                        + '<span class="fa ' + iconCls + '"></span> ' + Ext4.util.Format.htmlEncode(sampleFile.SampleFile) + '</div></td><td><div class="sample-file-item-acquired">' + Ext4.util.Format.date(Ext4.Date.parse(sampleFile.AcquiredTime, LABKEY.Utils.getDateTimeFormatWithMS()), LABKEY.extDefaultDateTimeFormat || 'Y-m-d H:i:s') + '</div></td>';
 
                 var totalOutliers = sampleFile.NonConformers + sampleFile.mR + sampleFile.CUSUMm + sampleFile.CUSUMv;
                 html += '<td style="text-align: right"><div class="sample-file-item-outliers">';


### PR DESCRIPTION
…CPlotExclusions

Update test based on new QC summary layout (missed a couple of test cases with original refactor) and there's a default guide set now to generate outliers even if user hasn't explicitly created one