### PR TITLE
Issue 37921: Use exp.data to check for completeness of raw data instead of checking for existence of files

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -59,6 +59,7 @@ import org.labkey.targetedms.chart.ReplicateLabelMinimizer;
 import org.labkey.targetedms.parser.skyaudit.SkylineAuditLogParser;
 import org.labkey.targetedms.pipeline.CopyExperimentPipelineProvider;
 import org.labkey.targetedms.pipeline.TargetedMSPipelineProvider;
+import org.labkey.targetedms.proteomexchange.SubmissionDataValidator;
 import org.labkey.targetedms.query.JournalManager;
 import org.labkey.targetedms.search.ModificationSearchWebPart;
 import org.labkey.targetedms.search.ProteinSearchWebPart;
@@ -520,6 +521,7 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
         set.add(ComparisonCategory.TestCase.class);
         set.add(ReplicateLabelMinimizer.TestCase.class);
         set.add(SkylineAuditLogParser.TestCase.class);
+        set.add(SubmissionDataValidator.TestCase.class);
         return set;
 
     }

--- a/src/org/labkey/targetedms/proteomexchange/SubmissionDataStatus.java
+++ b/src/org/labkey/targetedms/proteomexchange/SubmissionDataStatus.java
@@ -89,7 +89,7 @@ public class SubmissionDataStatus
             Set<String> fileNames = new HashSet<>(pathsFromSameSkyDocs.size());
             for(String filePath: pathsFromSameSkyDocs)
             {
-                fileNames.add(SubmissionDataValidator.getSampleFileName(filePath));
+                fileNames.add(FilenameUtils.getName(filePath));
             }
             MissingRawData missing = new MissingRawData(skydocs, fileNames);
             missingData.add(missing);


### PR DESCRIPTION
Issue 37921: Use exp.data to check for completeness of raw data instead of checking for existence of files

Lookup exp.data to determine if all the raw data has been uploaded. 
Data for an experiment can be organized in sub-containers. This patch eliminates checking for the existence of raw files in the parent container if they are not found in the same container as the Skyline document. Raw data for Skyline documents in a sub-container has be be uploaded to the same container.