### PR TITLE
Issue 37919: Include only those modifications in ProteomeXchange XML that are actually used in the Skyline document  

### DIFF
--- a/src/org/labkey/targetedms/proteomexchange/ExperimentModificationGetter.java
+++ b/src/org/labkey/targetedms/proteomexchange/ExperimentModificationGetter.java
@@ -51,26 +51,26 @@ public class ExperimentModificationGetter
 
         for(TargetedMSRun run: runs)
         {
-            List<PeptideSettings.RunStructuralModification> smods = ModificationManager.getStructuralModificationsForRun(run.getId());
-            for(PeptideSettings.RunStructuralModification mod: smods)
+            List<PeptideSettings.StructuralModification> smods = ModificationManager.getStructuralModificationsUsedInRun(run.getId());
+            for(PeptideSettings.StructuralModification mod: smods)
             {
-                PxModification pxMod = strModMap.get(mod.getStructuralModId());
+                PxModification pxMod = strModMap.get(mod.getId());
                 if(pxMod == null)
                 {
                     pxMod = getStructuralUnimodMod(mod, uMods);
-                    strModMap.put(mod.getStructuralModId(), pxMod);
+                    strModMap.put(mod.getId(), pxMod);
                 }
                 pxMod.addSkylineDoc(run.getFileName());
             }
 
-            List<PeptideSettings.RunIsotopeModification> iMods = ModificationManager.getIsotopeModificationsForRun(run.getId());
-            for(PeptideSettings.RunIsotopeModification mod: iMods)
+            List<PeptideSettings.IsotopeModification> iMods = ModificationManager.getIsotopeModificationsUsedInRun(run.getId());
+            for(PeptideSettings.IsotopeModification mod: iMods)
             {
-                PxModification pxMod = isoModMap.get(mod.getIsotopeModId());
+                PxModification pxMod = isoModMap.get(mod.getId());
                 if(pxMod == null)
                 {
                     pxMod = getIsotopicUnimodMod(mod, uMods, expAnnot.getContainer());
-                    isoModMap.put(mod.getIsotopeModId(), pxMod);
+                    isoModMap.put(mod.getId(), pxMod);
                 }
                 pxMod.addSkylineDoc(run.getFileName());
             }

--- a/src/org/labkey/targetedms/query/ModificationManager.java
+++ b/src/org/labkey/targetedms/query/ModificationManager.java
@@ -127,6 +127,14 @@ public class ModificationManager
         return isotopeModIndexMassDiff;
     }
 
+    /**
+     * Returns a list of isotopic modifications for a run (Skyline document).  This includes all the isotopic modifications
+     * that were checked in the Peptide Settings > Modifications tab in Skyline.  The modifications are under
+     * <peptide_settings> -> <peptide_modification> -> <heavy_modifications> element in the .sky file.  They are stored
+     * in the targetedms.RunIsotopeModification table.
+     * @param runId
+     * @return List of isotopic modifications
+     */
     public static List<PeptideSettings.RunIsotopeModification> getIsotopeModificationsForRun(int runId)
     {
         SQLFragment sql = new SQLFragment();
@@ -142,6 +150,14 @@ public class ModificationManager
         return new SqlSelector(TargetedMSManager.getSchema(), sql).getArrayList(PeptideSettings.RunIsotopeModification.class);
     }
 
+    /**
+     * Returns a list of structural modifications for a run (Skyline document).  This includes all the structural modifications
+     * that were checked in the Peptide Settings > Modifications tab in Skyline.  The modifications are under
+     * <peptide_settings> -> <peptide_modification> -> <static_modifications> element in the .sky file.  They are stored
+     * in the targetedms.RunStructuralModification table.
+     * @param runId
+     * @return List of structural modifications
+     */
     public static List<PeptideSettings.RunStructuralModification> getStructuralModificationsForRun(int runId)
     {
         SQLFragment sql = new SQLFragment();
@@ -157,6 +173,11 @@ public class ModificationManager
         return new SqlSelector(TargetedMSManager.getSchema(), sql).getArrayList(PeptideSettings.RunStructuralModification.class);
     }
 
+    /**
+     * Returns a list of isotopic modifications found in at least one peptide in the run (Skyline document).
+     * @param runId
+     * @return List of isotopic modifications
+     */
     public static List<PeptideSettings.IsotopeModification> getIsotopeModificationsUsedInRun(int runId)
     {
         return getModificationsUsedInRun(runId, TargetedMSManager.getTableInfoPeptideIsotopeModification(),
@@ -164,6 +185,11 @@ public class ModificationManager
                 PeptideSettings.IsotopeModification.class);
     }
 
+    /**
+     * Returns a list of structural modifications found in at least one peptide in the run (Skyline document).
+     * @param runId
+     * @return List of structural modifications
+     */
     public static List<PeptideSettings.StructuralModification> getStructuralModificationsUsedInRun(int runId)
     {
         return getModificationsUsedInRun(runId, TargetedMSManager.getTableInfoPeptideStructuralModification(),


### PR DESCRIPTION
<peptide_modification> under <peptide_settings> in a .sky file includes all the modifications that the user checked in the Peptide Settings > Modifications tab. This can include more modifications than are actually used in the document, i.e. there is a peptide in the document with that modification. When validating a ProteomeXchange submission only include those modifications that were found in at least one peptide in the document. 
