### PR TITLE
Issue 37646: NoSuchFileException from org.labkey.targetedms.chromlibContainerChromatogramLibraryWriter.writeLibrary()

### DIFF
--- a/src/org/labkey/targetedms/chromlib/ChromatogramLibraryUtils.java
+++ b/src/org/labkey/targetedms/chromlib/ChromatogramLibraryUtils.java
@@ -95,7 +95,12 @@ public class ChromatogramLibraryUtils
      * Uses the container's RowId instead of name to handle renames gracefully */
     public static Path getChromLibFile(Container container, int revision) throws IOException
     {
-        Path chromLibDir = getChromLibDir(container, false);
+        return getChromLibFile(container, revision, false);
+    }
+
+    public static Path getChromLibFile(Container container, int revision, boolean createLibdir) throws IOException
+    {
+        Path chromLibDir = getChromLibDir(container, createLibdir);
         return chromLibDir.resolve(Constants.CHROM_LIB_FILE_NAME+"_"+container.getRowId()+"_rev"+revision+"."+Constants.CHROM_LIB_FILE_EXT);
     }
 

--- a/src/org/labkey/targetedms/chromlib/ContainerChromatogramLibraryWriter.java
+++ b/src/org/labkey/targetedms/chromlib/ContainerChromatogramLibraryWriter.java
@@ -23,7 +23,6 @@ import org.labkey.api.pipeline.LocalDirectory;
 import org.labkey.api.protein.ProteinService;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.security.User;
-import org.labkey.api.services.ServiceRegistry;
 import org.labkey.api.util.FileUtil;
 import org.labkey.targetedms.TargetedMSManager;
 import org.labkey.targetedms.TargetedMSRun;
@@ -135,7 +134,9 @@ public class ContainerChromatogramLibraryWriter
             close();
         }
 
-        Path finalChromLibFile = ChromatogramLibraryUtils.getChromLibFile(_container, libraryRevision);
+        Path finalChromLibFile = ChromatogramLibraryUtils.getChromLibFile(_container, libraryRevision,
+                true /*Create the lib directory if it does not already exist */);
+
         // Rename the temp file
         if(Files.exists(finalChromLibFile))
         {


### PR DESCRIPTION
Create a targetedMSLib folder under @files if it does not exist when the temp .clib file is moved to the final location. 
