### PR TITLE
Prevent calculating fold changes on decoy peptides.

### DIFF
--- a/src/org/labkey/targetedms/calculations/RunQuantifier.java
+++ b/src/org/labkey/targetedms/calculations/RunQuantifier.java
@@ -38,6 +38,7 @@ import org.labkey.targetedms.parser.FoldChange;
 import org.labkey.targetedms.parser.GeneralMolecule;
 import org.labkey.targetedms.parser.GeneralMoleculeChromInfo;
 import org.labkey.targetedms.parser.GroupComparisonSettings;
+import org.labkey.targetedms.parser.Peptide;
 import org.labkey.targetedms.parser.PeptideGroup;
 import org.labkey.targetedms.parser.PeptideSettings;
 import org.labkey.targetedms.parser.QuantificationSettings;
@@ -270,6 +271,7 @@ public class RunQuantifier
         {
             Collection<GeneralMoleculeResultDataSet> resultDataSets = generalMolecules.stream()
                     .filter(peptide-> null == peptide.getStandardType())
+                    .filter(peptide-> !(peptide instanceof Peptide && Boolean.TRUE.equals(((Peptide) peptide).getDecoy())))
                     .map(peptide -> new GeneralMoleculeResultDataSet(_user, _container, _replicateDataSet, peptide))
                     .collect(Collectors.toList());
             foldChanges.addAll(calculateFoldChanges(settings, resultDataSets));


### PR DESCRIPTION
There is a Skyline document that takes a really long time to import into Panorama.
This was happening because Panorama is trying to calculate protein-level fold changes, and there is one "protein" that has thousands of decoy peptides in it.
Part of the fold change calculation is order N-squared in the total number of transitions under the protein, so this was taking a really long time.

This change makes it so that we do not include decoy peptides when doing protein-level fold change calculations. This will fix the symptom we are seeing where this document took a long time to import.

Longer term, I should also fix it so that we don't have that order-n-squared problem, so that it won't be slow even if a real protein has lots of transitions.

Vagisha has suggested that we merge this into release19.2-SNAPSHOT?