### PR TITLE
Prevent calculating fold changes on decoy peptides.

### DIFF
--- a/src/org/labkey/targetedms/calculations/RunQuantifier.java
+++ b/src/org/labkey/targetedms/calculations/RunQuantifier.java
@@ -38,6 +38,7 @@ import org.labkey.targetedms.parser.FoldChange;
 import org.labkey.targetedms.parser.GeneralMolecule;
 import org.labkey.targetedms.parser.GeneralMoleculeChromInfo;
 import org.labkey.targetedms.parser.GroupComparisonSettings;
+import org.labkey.targetedms.parser.Peptide;
 import org.labkey.targetedms.parser.PeptideGroup;
 import org.labkey.targetedms.parser.PeptideSettings;
 import org.labkey.targetedms.parser.QuantificationSettings;
@@ -270,6 +271,7 @@ public class RunQuantifier
         {
             Collection<GeneralMoleculeResultDataSet> resultDataSets = generalMolecules.stream()
                     .filter(peptide-> null == peptide.getStandardType())
+                    .filter(peptide-> !(peptide instanceof Peptide && Boolean.TRUE.equals(((Peptide) peptide).getDecoy())))
                     .map(peptide -> new GeneralMoleculeResultDataSet(_user, _container, _replicateDataSet, peptide))
                     .collect(Collectors.toList());
             foldChanges.addAll(calculateFoldChanges(settings, resultDataSets));


### PR DESCRIPTION
Here's a different pull request where the same change has been cherry picked into the 19.2 snapshot branch.