### PR TITLE
Issue 38219: Mean and SD not being calculated or plotted correctly for some Panorama QC metrics

### DIFF
--- a/webapp/TargetedMS/js/BaseQCPlotPanel.js
+++ b/webapp/TargetedMS/js/BaseQCPlotPanel.js
@@ -240,7 +240,6 @@ Ext4.define('LABKEY.targetedms.BaseQCPlotPanel', {
                         MetricValues: []
                     };
                 }
-                row.MetricValue = Math.round(row.MetricValue * 10000) / 10000; // round to four decimals
 
                 plotDataMap[row['SeriesLabel']].Series[row['SeriesType']].MetricValues.push(row.MetricValue);
                 plotDataMap[row['SeriesLabel']].Series[row['SeriesType']].Rows.push(row);


### PR DESCRIPTION
Removing rounding off for the display data points