### PR TITLE
Fix targetedms build.

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSFolderType.java
+++ b/src/org/labkey/targetedms/TargetedMSFolderType.java
@@ -126,7 +126,8 @@ public class TargetedMSFolderType extends MultiPortalFolderType
             if (Portal.getParts(container, RAW_FILES_TAB).size() == 0)
             {
                 ActionURL url = new ActionURL(TargetedMSController.AddRawDataTabAction.class, container);
-                NavTree addRawData = new NavTree("Add Raw Data Tab", url).usePost();
+                NavTree addRawData = new NavTree("Add Raw Data Tab", "javascript:{}");
+                addRawData.setScript(PageFlowUtil.postOnClickJavaScript(url));
                 adminNavTree.addChild(addRawData);
             }
         }


### PR DESCRIPTION
Merged too soon... NavTree.usePost() is still on the CSRF FB, so revert to previous code.