### PR TITLE
Ensure that small molecules that don't have a custom ion name still get a series label for QC plotting

### DIFF
--- a/resources/queries/targetedms/QCMetric_fwb.sql
+++ b/resources/queries/targetedms/QCMetric_fwb.sql
@@ -17,7 +17,7 @@ SELECT
   COALESCE(PrecursorId.Id, MoleculePrecursorId.Id) AS PrecursorId,
   Id AS PrecursorChromInfoId,
   SampleFileId AS SampleFileId,
-  COALESCE(PrecursorId.ModifiedSequence, MoleculePrecursorId.CustomIonName) || (CASE WHEN COALESCE(PrecursorId.Charge, MoleculePrecursorId.Charge) > 0 THEN ' +' ELSE ' ' END) || CAST(COALESCE(PrecursorId.Charge, MoleculePrecursorId.Charge) AS VARCHAR) AS SeriesLabel,
+  COALESCE(PrecursorId.ModifiedSequence, MoleculePrecursorId.CustomIonName, MoleculePrecursorId.IonFormula) || (CASE WHEN COALESCE(PrecursorId.Charge, MoleculePrecursorId.Charge) > 0 THEN ' +' ELSE ' ' END) || CAST(COALESCE(PrecursorId.Charge, MoleculePrecursorId.Charge) AS VARCHAR) AS SeriesLabel,
   CASE WHEN PrecursorId.Id IS NOT NULL THEN 'Peptide' ELSE 'Fragment' END AS DataType,
   MaxFWB AS MetricValue,
   COALESCE(PrecursorId.Mz, MoleculePrecursorId.Mz) AS mz

--- a/resources/queries/targetedms/QCMetric_fwhm.sql
+++ b/resources/queries/targetedms/QCMetric_fwhm.sql
@@ -17,7 +17,7 @@ SELECT
   COALESCE(PrecursorId.Id, MoleculePrecursorId.Id) AS PrecursorId,
   Id AS PrecursorChromInfoId,
   SampleFileId AS SampleFileId,
-  COALESCE(PrecursorId.ModifiedSequence, MoleculePrecursorId.CustomIonName) || (CASE WHEN COALESCE(PrecursorId.Charge, MoleculePrecursorId.Charge) > 0 THEN ' +' ELSE ' ' END) || CAST(COALESCE(PrecursorId.Charge, MoleculePrecursorId.Charge) AS VARCHAR) AS SeriesLabel,
+  COALESCE(PrecursorId.ModifiedSequence, MoleculePrecursorId.CustomIonName, MoleculePrecursorId.IonFormula) || (CASE WHEN COALESCE(PrecursorId.Charge, MoleculePrecursorId.Charge) > 0 THEN ' +' ELSE ' ' END) || CAST(COALESCE(PrecursorId.Charge, MoleculePrecursorId.Charge) AS VARCHAR) AS SeriesLabel,
   CASE WHEN PrecursorId.Id IS NOT NULL THEN 'Peptide' ELSE 'Fragment' END AS DataType,
   MaxFWHM AS MetricValue,
   COALESCE(PrecursorId.Mz, MoleculePrecursorId.Mz) AS mz

--- a/resources/queries/targetedms/QCMetric_lhRatio.sql
+++ b/resources/queries/targetedms/QCMetric_lhRatio.sql
@@ -17,7 +17,7 @@ SELECT
   COALESCE(PrecursorChromInfoId.PrecursorId.Id, PrecursorChromInfoId.MoleculePrecursorId.Id) AS PrecursorId,
   PrecursorChromInfoId.Id AS PrecursorChromInfoId,
   PrecursorChromInfoId.SampleFileId AS SampleFileId,
-  COALESCE(PrecursorChromInfoId.PrecursorId.ModifiedSequence, PrecursorChromInfoId.MoleculePrecursorId.CustomIonName) || (CASE WHEN COALESCE(PrecursorChromInfoId.PrecursorId.Charge, PrecursorChromInfoId.MoleculePrecursorId.Charge) > 0 THEN ' +' ELSE ' ' END) || CAST(COALESCE(PrecursorChromInfoId.PrecursorId.Charge, PrecursorChromInfoId.MoleculePrecursorId.Charge) AS VARCHAR) AS SeriesLabel,
+  COALESCE(PrecursorChromInfoId.PrecursorId.ModifiedSequence, PrecursorChromInfoId.MoleculePrecursorId.CustomIonName, PrecursorChromInfoId.MoleculePrecursorId.IonFormula) || (CASE WHEN COALESCE(PrecursorChromInfoId.PrecursorId.Charge, PrecursorChromInfoId.MoleculePrecursorId.Charge) > 0 THEN ' +' ELSE ' ' END) || CAST(COALESCE(PrecursorChromInfoId.PrecursorId.Charge, PrecursorChromInfoId.MoleculePrecursorId.Charge) AS VARCHAR) AS SeriesLabel,
   CASE WHEN PrecursorChromInfoId.PrecursorId.Id IS NOT NULL THEN 'Peptide' ELSE 'Fragment' END AS DataType,
   AreaRatio AS MetricValue,
   COALESCE(PrecursorChromInfoId.PrecursorId.Mz, PrecursorChromInfoId.MoleculePrecursorId.Mz) AS mz

--- a/resources/queries/targetedms/QCMetric_massAccuracy.sql
+++ b/resources/queries/targetedms/QCMetric_massAccuracy.sql
@@ -17,7 +17,7 @@ SELECT
   COALESCE(PrecursorId.Id, MoleculePrecursorId.Id) AS PrecursorId,
   Id AS PrecursorChromInfoId,
   SampleFileId AS SampleFileId,
-  COALESCE(PrecursorId.ModifiedSequence, MoleculePrecursorId.CustomIonName) || (CASE WHEN COALESCE(PrecursorId.Charge, MoleculePrecursorId.Charge) > 0 THEN ' +' ELSE ' ' END) || CAST(COALESCE(PrecursorId.Charge, MoleculePrecursorId.Charge) AS VARCHAR) AS SeriesLabel,
+  COALESCE(PrecursorId.ModifiedSequence, MoleculePrecursorId.CustomIonName, MoleculePrecursorId.IonFormula) || (CASE WHEN COALESCE(PrecursorId.Charge, MoleculePrecursorId.Charge) > 0 THEN ' +' ELSE ' ' END) || CAST(COALESCE(PrecursorId.Charge, MoleculePrecursorId.Charge) AS VARCHAR) AS SeriesLabel,
   CASE WHEN PrecursorId.Id IS NOT NULL THEN 'Peptide' ELSE 'Fragment' END AS DataType,
   AverageMassErrorPPM AS MetricValue,
   COALESCE(PrecursorId.Mz, MoleculePrecursorId.Mz) AS mz

--- a/resources/queries/targetedms/QCMetric_peakArea.sql
+++ b/resources/queries/targetedms/QCMetric_peakArea.sql
@@ -17,7 +17,7 @@ SELECT
   COALESCE(PrecursorId.Id, MoleculePrecursorId.Id) AS PrecursorId,
   Id AS PrecursorChromInfoId,
   SampleFileId AS SampleFileId,
-  COALESCE(PrecursorId.ModifiedSequence, MoleculePrecursorId.CustomIonName) || (CASE WHEN COALESCE(PrecursorId.Charge, MoleculePrecursorId.Charge) > 0 THEN ' +' ELSE ' ' END) || CAST(COALESCE(PrecursorId.Charge, MoleculePrecursorId.Charge) AS VARCHAR) AS SeriesLabel,
+  COALESCE(PrecursorId.ModifiedSequence, MoleculePrecursorId.CustomIonName, MoleculePrecursorId.IonFormula) || (CASE WHEN COALESCE(PrecursorId.Charge, MoleculePrecursorId.Charge) > 0 THEN ' +' ELSE ' ' END) || CAST(COALESCE(PrecursorId.Charge, MoleculePrecursorId.Charge) AS VARCHAR) AS SeriesLabel,
 --   COALESCE(PrecursorId.ModifiedSequence, MoleculePrecursorId.CustomIonName) AS SeriesLabel,
   CASE WHEN PrecursorId.Id IS NOT NULL THEN 'Peptide' ELSE 'Fragment' END AS DataType,
   TotalArea AS MetricValue,

--- a/resources/queries/targetedms/QCMetric_precursorArea.sql
+++ b/resources/queries/targetedms/QCMetric_precursorArea.sql
@@ -17,7 +17,7 @@ SELECT
   COALESCE(PrecursorId.Id, MoleculePrecursorId.Id) AS PrecursorId,
   Id AS PrecursorChromInfoId,
   SampleFileId AS SampleFileId,
-  COALESCE(PrecursorId.ModifiedSequence, MoleculePrecursorId.CustomIonName) || (CASE WHEN COALESCE(PrecursorId.Charge, MoleculePrecursorId.Charge) > 0 THEN ' +' ELSE ' ' END) || CAST(COALESCE(PrecursorId.Charge, MoleculePrecursorId.Charge) AS VARCHAR) AS SeriesLabel,
+  COALESCE(PrecursorId.ModifiedSequence, MoleculePrecursorId.CustomIonName, MoleculePrecursorId.IonFormula) || (CASE WHEN COALESCE(PrecursorId.Charge, MoleculePrecursorId.Charge) > 0 THEN ' +' ELSE ' ' END) || CAST(COALESCE(PrecursorId.Charge, MoleculePrecursorId.Charge) AS VARCHAR) AS SeriesLabel,
   CASE WHEN PrecursorId.Id IS NOT NULL THEN 'Peptide' ELSE 'Fragment' END AS DataType,
   TotalPrecursorArea AS MetricValue,
   COALESCE(PrecursorId.Mz, MoleculePrecursorId.Mz) AS mz

--- a/resources/queries/targetedms/QCMetric_retentionTime.sql
+++ b/resources/queries/targetedms/QCMetric_retentionTime.sql
@@ -17,7 +17,7 @@ SELECT
   COALESCE(PrecursorId.Id, MoleculePrecursorId.Id) AS PrecursorId,
   Id AS PrecursorChromInfoId,
   SampleFileId AS SampleFileId,
-  COALESCE(PrecursorId.ModifiedSequence, MoleculePrecursorId.CustomIonName) || (CASE WHEN COALESCE(PrecursorId.Charge, MoleculePrecursorId.Charge) > 0 THEN ' +' ELSE ' ' END) || CAST(COALESCE(PrecursorId.Charge, MoleculePrecursorId.Charge) AS VARCHAR) AS SeriesLabel,
+  COALESCE(PrecursorId.ModifiedSequence, MoleculePrecursorId.CustomIonName, MoleculePrecursorId.IonFormula) || (CASE WHEN COALESCE(PrecursorId.Charge, MoleculePrecursorId.Charge) > 0 THEN ' +' ELSE ' ' END) || CAST(COALESCE(PrecursorId.Charge, MoleculePrecursorId.Charge) AS VARCHAR) AS SeriesLabel,
   CASE WHEN PrecursorId.Id IS NOT NULL THEN 'Peptide' ELSE 'Fragment' END AS DataType,
   BestRetentionTime AS MetricValue,
   COALESCE(PrecursorId.Mz, MoleculePrecursorId.Mz) AS mz

--- a/resources/queries/targetedms/QCMetric_transitionArea.sql
+++ b/resources/queries/targetedms/QCMetric_transitionArea.sql
@@ -17,7 +17,7 @@ SELECT
   COALESCE(PrecursorId.Id, MoleculePrecursorId.Id) AS PrecursorId,
   Id AS PrecursorChromInfoId,
   SampleFileId AS SampleFileId,
-  COALESCE(PrecursorId.ModifiedSequence, MoleculePrecursorId.CustomIonName) || (CASE WHEN COALESCE(PrecursorId.Charge, MoleculePrecursorId.Charge) > 0 THEN ' +' ELSE ' ' END) || CAST(COALESCE(PrecursorId.Charge, MoleculePrecursorId.Charge) AS VARCHAR) AS SeriesLabel,
+  COALESCE(PrecursorId.ModifiedSequence, MoleculePrecursorId.CustomIonName, MoleculePrecursorId.IonFormula) || (CASE WHEN COALESCE(PrecursorId.Charge, MoleculePrecursorId.Charge) > 0 THEN ' +' ELSE ' ' END) || CAST(COALESCE(PrecursorId.Charge, MoleculePrecursorId.Charge) AS VARCHAR) AS SeriesLabel,
   CASE WHEN PrecursorId.Id IS NOT NULL THEN 'Peptide' ELSE 'Fragment' END AS DataType,
   TotalNonPrecursorArea AS MetricValue,
   COALESCE(PrecursorId.Mz, MoleculePrecursorId.Mz) AS mz

--- a/resources/queries/targetedms/QCMetric_transitionPrecursorRatio.sql
+++ b/resources/queries/targetedms/QCMetric_transitionPrecursorRatio.sql
@@ -17,7 +17,7 @@ SELECT
   COALESCE(PrecursorId.Id, MoleculePrecursorId.Id) AS PrecursorId,
   Id AS PrecursorChromInfoId,
   SampleFileId AS SampleFileId,
-  COALESCE(PrecursorId.ModifiedSequence, MoleculePrecursorId.CustomIonName) || (CASE WHEN COALESCE(PrecursorId.Charge, MoleculePrecursorId.Charge) > 0 THEN ' +' ELSE ' ' END) || CAST(COALESCE(PrecursorId.Charge, MoleculePrecursorId.Charge) AS VARCHAR) AS SeriesLabel,
+  COALESCE(PrecursorId.ModifiedSequence, MoleculePrecursorId.CustomIonName, MoleculePrecursorId.IonFormula) || (CASE WHEN COALESCE(PrecursorId.Charge, MoleculePrecursorId.Charge) > 0 THEN ' +' ELSE ' ' END) || CAST(COALESCE(PrecursorId.Charge, MoleculePrecursorId.Charge) AS VARCHAR) AS SeriesLabel,
   CASE WHEN PrecursorId.Id IS NOT NULL THEN 'Peptide' ELSE 'Fragment' END AS DataType,
   TransitionPrecursorRatio AS MetricValue,
   COALESCE(PrecursorId.Mz, MoleculePrecursorId.Mz) AS mz


### PR DESCRIPTION
Found this bug, which resulted in an NPE in the QC metric Java code, when working with a document that had small molecule data and ions without a custom name