### PR TITLE
Fix SkylineAuditLogManager and SkylineAuditLogParser failures

### DIFF
--- a/src/org/labkey/targetedms/parser/skyaudit/UnitTestUtil.java
+++ b/src/org/labkey/targetedms/parser/skyaudit/UnitTestUtil.java
@@ -120,7 +120,9 @@ public class UnitTestUtil
     {
         File workingDir = new File(System.getProperty(SkylineAuditLogParser.TestCase.SYS_PROPERTY_CWD) + "/temp");
         if(!workingDir.exists())
-            throw new FileExistsException("Cannot get a working dir for testing");
+            workingDir.mkdir();
+        if (!workingDir.exists())
+            throw new FileExistsException("Cannot get a working dir for testing: " + workingDir.getPath());
         File zipDir = new File(workingDir, SkylineFileUtils.getBaseName(pZip.getName()));
 
         if (zipDir.exists())


### PR DESCRIPTION
Create the directory if it doesn't exist

https://teamcity.labkey.org/viewLog.html?buildId=822946&buildTypeId=bt402#testNameId4567756945780607794