### PR TITLE
Fix the version support number returned by GetMaxSupportedVersionsAction

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -2927,7 +2927,7 @@ public class TargetedMSController extends SpringActionController
         {
             ApiSimpleResponse response = new ApiSimpleResponse();
             response.put("SKY_version", SkylineDocumentParser.MAX_SUPPORTED_VERSION);
-            response.put("SKYD_version", SkylineBinaryParser.FORMAT_VERSION_CACHE);
+            response.put("SKYD_version", SkylineBinaryParser.FORMAT_VERSION_CACHE.ordinal());
             return response;
         }
     }


### PR DESCRIPTION
Here is the fix to make it so that Skyline queries the server about which skyd file format to save as.

There is a different problem in Skyline where trying to save as version 19.1 produces something invalid. This will be fixed in Skyline github project in pull request number 685.