### PR TITLE
Issue 38800: Fix parsing of attributes in SkylineDocumentParser.readGeneralTransition()

### DIFF
--- a/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
+++ b/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
@@ -2221,12 +2221,6 @@ public class SkylineDocumentParser implements AutoCloseable
         if(explicitDeclusteringPotential != null)
             transition.setExplicitDeclusteringPotential(Double.valueOf(explicitDeclusteringPotential));
 
-        String explicitDriftTimeMsec = reader.getAttributeValue(null, "explicit_ion_mobility_high_energy_offset");
-        if (explicitDriftTimeMsec == null)
-            explicitDriftTimeMsec = reader.getAttributeValue(null, "explicit_drift_time_msec");
-        if(explicitDriftTimeMsec != null)
-            transition.setExplicitDriftTimeMSec(Double.valueOf(explicitDriftTimeMsec));
-
         String explicitDriftTimeHighEnergyOffsetMsec = reader.getAttributeValue(null, "explicit_ion_mobility_high_energy_offset");
         if (explicitDriftTimeHighEnergyOffsetMsec == null)
             explicitDriftTimeHighEnergyOffsetMsec = reader.getAttributeValue(null, "explicit_drift_time_high_energy_offset_msec");

--- a/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
+++ b/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
@@ -2200,11 +2200,16 @@ public class SkylineDocumentParser implements AutoCloseable
         if(explicitCollisionEnergy != null)
             transition.setExplicitCollisionEnergy(Double.valueOf(explicitCollisionEnergy));
 
-        String sLens = reader.getAttributeValue(null, "s_lens");
+        String sLens = reader.getAttributeValue(null, "explicit_s_lens");
+        if (sLens == null)
+            // Fall back on older attribute name
+            sLens = reader.getAttributeValue(null, "s_lens");
         if(sLens != null)
             transition.setsLens(Double.valueOf(sLens));
 
-        String coneVoltage = reader.getAttributeValue(null, "cone_voltage");
+        String coneVoltage = reader.getAttributeValue(null, "explicit_cone_voltage");
+        if (coneVoltage == null)
+            coneVoltage = reader.getAttributeValue(null, "cone_voltage");
         if(coneVoltage != null)
             transition.setConeVoltage(Double.valueOf(coneVoltage));
 

--- a/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
+++ b/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
@@ -2202,27 +2202,27 @@ public class SkylineDocumentParser implements AutoCloseable
 
         String sLens = reader.getAttributeValue(null, "s_lens");
         if(sLens != null)
-            transition.setExplicitCollisionEnergy(Double.valueOf(sLens));
+            transition.setsLens(Double.valueOf(sLens));
 
         String coneVoltage = reader.getAttributeValue(null, "cone_voltage");
         if(coneVoltage != null)
-            transition.setExplicitCollisionEnergy(Double.valueOf(coneVoltage));
+            transition.setConeVoltage(Double.valueOf(coneVoltage));
 
         String explicitCompensationVoltage = reader.getAttributeValue(null, "explicit_compensation_voltage");
         if(explicitCompensationVoltage != null)
-            transition.setExplicitCollisionEnergy(Double.valueOf(explicitCompensationVoltage));
+            transition.setExplicitCompensationVoltage(Double.valueOf(explicitCompensationVoltage));
 
         String explicitDeclusteringPotential = reader.getAttributeValue(null, "explicit_declustering_potential");
         if(explicitDeclusteringPotential != null)
-            transition.setExplicitCollisionEnergy(Double.valueOf(explicitDeclusteringPotential));
+            transition.setExplicitDeclusteringPotential(Double.valueOf(explicitDeclusteringPotential));
 
         String explicitDriftTimeMsec = reader.getAttributeValue(null, "explicit_drift_time_msec");
         if(explicitDriftTimeMsec != null)
-            transition.setExplicitCollisionEnergy(Double.valueOf(explicitDriftTimeMsec));
+            transition.setExplicitDriftTimeMSec(Double.valueOf(explicitDriftTimeMsec));
 
         String explicitDriftTimeHighEnergyOffsetMsec = reader.getAttributeValue(null, "explicit_drift_time_high_energy_offset_msec");
         if(explicitDriftTimeHighEnergyOffsetMsec != null)
-            transition.setExplicitCollisionEnergy(Double.valueOf(explicitDriftTimeHighEnergyOffsetMsec));
+            transition.setExplicitDriftTimeHighEnergyOffsetMSec(Double.valueOf(explicitDriftTimeHighEnergyOffsetMsec));
 
         _transitionCount++;
     }

--- a/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
+++ b/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
@@ -2221,11 +2221,15 @@ public class SkylineDocumentParser implements AutoCloseable
         if(explicitDeclusteringPotential != null)
             transition.setExplicitDeclusteringPotential(Double.valueOf(explicitDeclusteringPotential));
 
-        String explicitDriftTimeMsec = reader.getAttributeValue(null, "explicit_drift_time_msec");
+        String explicitDriftTimeMsec = reader.getAttributeValue(null, "explicit_ion_mobility_high_energy_offset");
+        if (explicitDriftTimeMsec == null)
+            explicitDriftTimeMsec = reader.getAttributeValue(null, "explicit_drift_time_msec");
         if(explicitDriftTimeMsec != null)
             transition.setExplicitDriftTimeMSec(Double.valueOf(explicitDriftTimeMsec));
 
-        String explicitDriftTimeHighEnergyOffsetMsec = reader.getAttributeValue(null, "explicit_drift_time_high_energy_offset_msec");
+        String explicitDriftTimeHighEnergyOffsetMsec = reader.getAttributeValue(null, "explicit_ion_mobility_high_energy_offset");
+        if (explicitDriftTimeHighEnergyOffsetMsec == null)
+            explicitDriftTimeHighEnergyOffsetMsec = reader.getAttributeValue(null, "explicit_drift_time_high_energy_offset_msec");
         if(explicitDriftTimeHighEnergyOffsetMsec != null)
             transition.setExplicitDriftTimeHighEnergyOffsetMSec(Double.valueOf(explicitDriftTimeHighEnergyOffsetMsec));
 


### PR DESCRIPTION
Take 2, hopefully with the right diff now.