### PR TITLE
Get chromatogram data from skyd file if not found in db when writing chromatogram library

### DIFF
--- a/src/org/labkey/targetedms/SkylineDocImporter.java
+++ b/src/org/labkey/targetedms/SkylineDocImporter.java
@@ -352,6 +352,9 @@ public class SkylineDocImporter
 
             if (run.isRepresentative())
             {
+                // Persist the run so that the skydDataId is available when writing the updated chromatogram library.
+                // skydDataId is required to get to the skyd file for reading chromatograms when they are not saved in the db.
+                Table.update(_user, TargetedMSManager.getTableInfoRuns(), run, run.getId());
                 RepresentativeStateManager.setRepresentativeState(_user, _container, _localDirectory, run, run.getRepresentativeDataState());
             }
 

--- a/src/org/labkey/targetedms/parser/PrecursorChromInfo.java
+++ b/src/org/labkey/targetedms/parser/PrecursorChromInfo.java
@@ -445,9 +445,9 @@ public class PrecursorChromInfo extends ChromInfo<PrecursorChromInfoAnnotation>
 
             ChromatogramBinaryFormat binaryFormat = ChromatogramBinaryFormat.values()[getChromatogramFormat()];
 
-            Object[] compressedBytesAndStatus = getCompressedBytesAndStatus(run, loadFromSkyd);
-            byte[] compressedBytes = (byte[]) compressedBytesAndStatus[0];
-            Chromatogram.SourceStatus status = (Chromatogram.SourceStatus) compressedBytesAndStatus[1];
+            CompressedBytesAndStatus compressedBytesAndStatus = getCompressedBytesAndStatus(run, loadFromSkyd);
+            byte[] compressedBytes = compressedBytesAndStatus.getCompressedBytes();
+            Chromatogram.SourceStatus status = compressedBytesAndStatus.getStatus();
 
             if (compressedBytes == null)
             {
@@ -463,7 +463,7 @@ public class PrecursorChromInfo extends ChromInfo<PrecursorChromInfoAnnotation>
         }
     }
 
-    private Object[] getCompressedBytesAndStatus(TargetedMSRun run, boolean loadFromSkyd)
+    private CompressedBytesAndStatus getCompressedBytesAndStatus(TargetedMSRun run, boolean loadFromSkyd)
     {
         byte[] databaseBytes = getChromatogram();
         byte[] compressedBytes = databaseBytes;
@@ -517,14 +517,36 @@ public class PrecursorChromInfo extends ChromInfo<PrecursorChromInfoAnnotation>
         {
             status = Chromatogram.SourceStatus.dbOnly;
         }
-        return new Object[]{compressedBytes, status};
+        return new CompressedBytesAndStatus(compressedBytes, status);
+    }
+
+    private class CompressedBytesAndStatus
+    {
+        private final byte[] _compressedBytes;
+        private final Chromatogram.SourceStatus _status;
+
+        private CompressedBytesAndStatus(byte[] compressedBytes, Chromatogram.SourceStatus status)
+        {
+            _compressedBytes = compressedBytes;
+            _status = status;
+        }
+
+        public byte[] getCompressedBytes()
+        {
+            return _compressedBytes;
+        }
+
+        public Chromatogram.SourceStatus getStatus()
+        {
+            return _status;
+        }
     }
 
     @Nullable
     public byte[] getChromatogramBytes(TargetedMSRun run)
     {
         boolean loadFromSkyd = Boolean.parseBoolean(TargetedMSModule.PREFER_SKYD_FILE_CHROMATOGRAMS_PROPERTY.getEffectiveValue(_container));
-        Object[] compressedBytesAndStatus = getCompressedBytesAndStatus(run, loadFromSkyd);
-        return (byte[])compressedBytesAndStatus[0];
+        CompressedBytesAndStatus compressedBytesAndStatus = getCompressedBytesAndStatus(run, loadFromSkyd);
+        return compressedBytesAndStatus.getCompressedBytes();
     }
 }


### PR DESCRIPTION
If chromatograms for a precursor are not saved in the database, due to "Skip chromatogram import into database" property being enabled, values in the "Chromatogram" column of the "Precursor" table in a chromatogram library are null. Chromatogram data should be read from the skyd file in this case.