### PR TITLE
Issue 39238: IOException when chromatogram library archive file not available

### DIFF
--- a/src/org/labkey/targetedms/view/archivedRevisionsDownload.jsp
+++ b/src/org/labkey/targetedms/view/archivedRevisionsDownload.jsp
@@ -50,7 +50,7 @@
         ActionURL u = new ActionURL(TargetedMSController.DownloadChromLibraryAction.class, c);
         u.addParameter("revision", i);
         Path archiveFile = ChromatogramLibraryUtils.getChromLibFile(c, i);
-        if (!Files.isDirectory(archiveFile)) {
+        if (Files.exists(archiveFile) && !Files.isDirectory(archiveFile)) {
 %>
     <tr>
         <td><%= i %></td>


### PR DESCRIPTION
Broken by earlier refactor to use Path - !isDirectory is not the same as isFile when the Path doesn't exist