### PR TITLE
Issue 40227: SQLException when importing a Skyline document with a chromatogram library

### DIFF
--- a/src/org/labkey/targetedms/SkylineDocImporter.java
+++ b/src/org/labkey/targetedms/SkylineDocImporter.java
@@ -660,6 +660,8 @@ public class SkylineDocImporter
                         break;
                     case "nist":
                     case "spectrast":
+                    default: // Set a librarySourceId even if there is no match.
+                             // The librarySourceId is meaningless now and will be dropped in the next schema update (Issue 40227).
                         library.setLibrarySourceId(librarySourceTypes.get("NIST"));
                         break;
                 }


### PR DESCRIPTION
Temporary fix for 20.3.  Real fix will be in develop: https://github.com/LabKey/targetedms/pull/164