### PR TITLE
Issue 40377: Support alternative to RowId value as URL parameter

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -3674,7 +3674,19 @@ public class TargetedMSController extends SpringActionController
     public static class RunDetailsForm extends QueryViewAction.QueryExportForm
     {
         private int _id = 0;
+        private String _fileName;
         private String _view;
+        private boolean _attemptedLookupByName;
+
+        public String getFileName()
+        {
+            return _fileName;
+        }
+
+        public void setFileName(String fileName)
+        {
+            _fileName = fileName;
+        }
 
         public void setId(int id)
         {
@@ -3683,11 +3695,21 @@ public class TargetedMSController extends SpringActionController
 
         public int getId()
         {
+            if (_id == 0 && _fileName != null && !_attemptedLookupByName)
+            {
+                // Support an alternative to the RowId-style parameter to look up by document name. See issue 40377
+                _attemptedLookupByName = true;
+                TargetedMSRun run = TargetedMSManager.getRunByFileName(_fileName, getContainer());
+                if (run != null)
+                {
+                    _id = run.getId();
+                }
+            }
             return _id;
         }
 
         public boolean hasRunId() {
-            return _id > 0;
+            return getId() > 0;
         }
 
         public String getView()

--- a/src/org/labkey/targetedms/TargetedMSManager.java
+++ b/src/org/labkey/targetedms/TargetedMSManager.java
@@ -859,11 +859,17 @@ public class TargetedMSManager
                 container.getId(), SkylineDocImporter.STATUS_SUCCESS, Boolean.FALSE);
     }
 
+    @Nullable
     public static TargetedMSRun getRunByFileName(String fileName, Container container)
     {
         SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("Container"), container.getId());
         filter.addCondition(FieldKey.fromParts("FileName"), fileName);
-        return new TableSelector(TargetedMSManager.getTableInfoRuns(), filter, null).getObject(TargetedMSRun.class);
+        List<TargetedMSRun> matches = new TableSelector(TargetedMSManager.getTableInfoRuns(), filter, null).getArrayList(TargetedMSRun.class);
+        if (matches.size() == 1)
+        {
+            return matches.get(0);
+        }
+        return null;
     }
 
     public static boolean isRunConflicted(TargetedMSRun run)


### PR DESCRIPTION
#### Rationale
PanoramaPublic is a public repository for Skyline/Panorama data. Users upload data to a private folder, and there's a workflow to review, approve, and copy it to a public location.

https://panoramaweb.org/project/Panorama%20Public/begin.view?

Users sometimes create wikis that reference specific files they've imported. Those URLs current expect the Id column from the imported file, which is a RowId. That means that their link will break when it's copied to the public folder, since the data is reimported and will have a different RowId in its new home.

We can support an alternative URL parameter that lets the user specify the file name instead. If it's ambiguous, because the user uploaded the same file to different subdirectories under the file root (this should be exceedingly rare, as typically they're all in the file root itself), we'll simply treat it as if they didn't specify an ID at all.