### PR TITLE
Issue 40469: java.util.zip.DataFormatException if chromatogram size i…

### DIFF
--- a/src/org/labkey/targetedms/parser/SkylineBinaryParser.java
+++ b/src/org/labkey/targetedms/parser/SkylineBinaryParser.java
@@ -300,7 +300,23 @@ public class SkylineBinaryParser
             // For older data that got saved in the database without a value for uncompressedSize
             uncompressedSize = (Integer.SIZE / 8) * numPoints * (numTransitions + 1);
         }
-        return uncompress(bytes, uncompressedSize);
+        try
+        {
+            return uncompress(bytes, uncompressedSize);
+        }
+        catch (DataFormatException e)
+        {
+            // Issue 40469 - we may have -1 from a legacy import, but not have compressed data. If so, the attempt
+            // to uncompress will blow up and we can just return the original bytes
+            if (uncompressedSize.intValue() == -1)
+            {
+                return bytes;
+            }
+            else
+            {
+                throw e;
+            }
+        }
     }
 
     public static byte[] uncompress(byte[] bytes, Integer uncompressedSize) throws DataFormatException


### PR DESCRIPTION
…s unknown and bytes are not compressed

#### Rationale
It's possible for the targetedms.precursorchrominfo table to have chromatograms where we don't know the uncompressed size, but the byte array hasn't been compressed. It appears that even within a single Skyline document, we can have a mix of compressed and uncompressed chromatograms.

