### PR TITLE
Clean up dependencies for mspipeline module

### DIFF
--- a/api-src/org/labkey/api/targetedms/TargetedMSService.java
+++ b/api-src/org/labkey/api/targetedms/TargetedMSService.java
@@ -19,11 +19,15 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.TableCustomizer;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.ExperimentRunType;
+import org.labkey.api.exp.XarFormatException;
+import org.labkey.api.pipeline.PipelineValidationException;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.services.ServiceRegistry;
 import org.labkey.api.targetedms.model.SampleFileInfo;
+import org.labkey.api.view.ViewBackgroundInfo;
 
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
@@ -84,4 +88,6 @@ public interface TargetedMSService
     void addModificationSearchResultCustomizer(TableCustomizer columnInfo);
     List<TableCustomizer> getModificationSearchResultCustomizers();
 
+    /** @return rowId for pipeline job that will perform the import asynchronously */
+    Integer importSkylineDocument(ViewBackgroundInfo info, Path skylinePath) throws XarFormatException, PipelineValidationException;
 }

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -29,6 +29,7 @@ import org.jfree.chart.plot.PlotOrientation;
 import org.labkey.api.action.*;
 import org.labkey.api.analytics.AnalyticsService;
 import org.labkey.api.pipeline.PipelineJob;
+import org.labkey.api.pipeline.PipelineValidationException;
 import org.labkey.api.query.QueryDefinition;
 import org.labkey.api.security.permissions.ApplicationAdminPermission;
 import org.labkey.api.targetedms.TargetedMSService;
@@ -2849,9 +2850,9 @@ public class TargetedMSController extends SpringActionController
                 ViewBackgroundInfo info = getViewBackgroundInfo();
                 try
                 {
-                    TargetedMSManager.addRunToQueue(info, path, form.getPipeRoot(getContainer()));
+                    TargetedMSManager.addRunToQueue(info, path);
                 }
-                catch (IOException e)
+                catch (PipelineValidationException e)
                 {
                     errors.reject(ERROR_MSG, e.getMessage());
                     return false;
@@ -2885,14 +2886,14 @@ public class TargetedMSController extends SpringActionController
                 ViewBackgroundInfo info = getViewBackgroundInfo();
                 try
                 {
-                    Integer jobId = TargetedMSManager.addRunToQueue(info, path, form.getPipeRoot(getContainer()));
+                    Integer jobId = TargetedMSManager.addRunToQueue(info, path);
                     Map<String, Object> detailsMap = new HashMap<>(4);
                     detailsMap.put("Path", form.getPath());
                     detailsMap.put("File", FileUtil.getFileName(path));
                     detailsMap.put("RowId", jobId);
                     jobDetailsList.add(detailsMap);
                 }
-                catch (IOException e)
+                catch (PipelineValidationException e)
                 {
                     throw new ApiUsageException(e);
                 }

--- a/src/org/labkey/targetedms/TargetedMSServiceImpl.java
+++ b/src/org/labkey/targetedms/TargetedMSServiceImpl.java
@@ -19,6 +19,8 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.TableCustomizer;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.ExperimentRunType;
+import org.labkey.api.exp.XarFormatException;
+import org.labkey.api.pipeline.PipelineValidationException;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.targetedms.IModification;
@@ -28,9 +30,11 @@ import org.labkey.api.targetedms.SkylineAnnotation;
 import org.labkey.api.targetedms.TargetedMSFolderTypeListener;
 import org.labkey.api.targetedms.TargetedMSService;
 import org.labkey.api.targetedms.model.SampleFileInfo;
+import org.labkey.api.view.ViewBackgroundInfo;
 import org.labkey.targetedms.query.ModificationManager;
 import org.labkey.targetedms.query.ReplicateManager;
 
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -208,5 +212,11 @@ public class TargetedMSServiceImpl implements TargetedMSService
     public List<TableCustomizer> getModificationSearchResultCustomizers()
     {
         return Collections.unmodifiableList(_modificationSearchCustomizers);
+    }
+
+    @Override
+    public Integer importSkylineDocument(ViewBackgroundInfo info, Path skylinePath) throws XarFormatException, PipelineValidationException
+    {
+        return TargetedMSManager.addRunToQueue(info, skylinePath);
     }
 }


### PR DESCRIPTION
#### Rationale
mspipeline directly depended on the implementation for other modules, which is not really supported. Delete unused class that depended on Cloud module implementation, and expose TargetedMS dependency on the service