### PR TITLE
Add MAM folder type and only show some report links in it

### DIFF
--- a/api-src/org/labkey/api/targetedms/TargetedMSService.java
+++ b/api-src/org/labkey/api/targetedms/TargetedMSService.java
@@ -50,7 +50,7 @@ public interface TargetedMSService
 
     enum FolderType
     {
-        Experiment, Library, LibraryProtein, QC, Undefined
+        Experiment, ExperimentMAM, Library, LibraryProtein, QC, Undefined
     }
 
     String MODULE_NAME = "TargetedMS";

--- a/src/org/labkey/targetedms/view/folderSetup.jsp
+++ b/src/org/labkey/targetedms/view/folderSetup.jsp
@@ -55,6 +55,11 @@ tr.spaceUnder > td
                     - A collection of published Skyline documents for various experimental designs
                 </td>
             </tr>
+            <tr class="spaceUnder">
+                <td>
+                    <input type="radio" name="folderType" id="multiAttributeMethod" value="<%= h(TargetedMSService.FolderType.Experiment.toString()) %>"> <b>Multi-attribute method (MAM)</b> - An experimental data folder variant with additional reporting for multi-attribute method analyses
+                </td>
+            </tr>
             <tr>
                 <td>
                     <input type="radio" name="folderType" id="chromatogramLibrary" value="<%= h(TargetedMSService.FolderType.Library.toString()) %>"> <b>Chromatogram library</b> - Curated precursor and product ion expression data for use in designing and validating future experiments
@@ -67,7 +72,7 @@ tr.spaceUnder > td
             </tr>
             <tr>
                 <td>
-                    <input type="radio" name="folderType" id="QC" value="<%= h(TargetedMSService.FolderType.QC.toString()) %>"> <b>QC</b> - Quality control metrics of reagents and instruments
+                    <input type="radio" name="folderType" id="QC" value="<%= h(TargetedMSService.FolderType.QC.toString()) %>"> <b>Quality control</b> - System suitability monitoring of reagents and instruments
                 </td>
             </tr>
             <tr>

--- a/src/org/labkey/targetedms/view/runSummaryView.jsp
+++ b/src/org/labkey/targetedms/view/runSummaryView.jsp
@@ -29,6 +29,7 @@
 <%@ page import="org.labkey.targetedms.TargetedMSManager" %>
 <%@ page import="org.labkey.targetedms.TargetedMSSchema" %>
 <%@ page import="org.labkey.api.util.StringUtilsLabKey" %>
+<%@ page import="org.labkey.api.targetedms.TargetedMSService" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 
 <%
@@ -96,7 +97,7 @@
         if (run.getCalibrationCurveCount() > 0) { %>, <a href="<%= h(calibrationCurveListAction.getLocalURIString()) %>"><%= h(StringUtilsLabKey.pluralize(run.getCalibrationCurveCount(), "calibration curve"))%></a><% }
         if (run.getListCount() > 0) { %>, <a href="<%= h(listAction.getLocalURIString()) %>"><%= h(StringUtilsLabKey.pluralize(run.getListCount(), "list"))%></a><% } %>
         <% if (run.getSoftwareVersion() != null) { %>&nbsp;-&nbsp; <%= h(run.getSoftwareVersion()) %> <% } %>
-        <% if (run.getPeptideCount() > 0) { %>
+        <% if (TargetedMSService.get().getFolderType(run.getContainer()) == TargetedMSService.FolderType.ExperimentMAM && run.getPeptideCount() > 0) { %>
             &nbsp;-&nbsp;
             <a href="<%= h(ptmReportAction.getLocalURIString()) %>">PTM Report</a>,
             <a href="<%= h(peptideMapAction.getLocalURIString()) %>">Peptide Map</a>


### PR DESCRIPTION
#### Rationale
As we add more reporting for Multi-Attribute Method use cases, we don't want to clutter the UI for other users. Also, by pulling this out as a new folder type, it helps to clearly advertise that we're optimizing for MAM.

#### Changes
New folder type for MAM usage
PTM and peptide map reports only show up in MAM folders