### PR TITLE
Issue 40270: Drop targetedms.MoleculePrecursor.MoleculePrecursorId 

### DIFF
--- a/resources/schemas/dbscripts/postgresql/targetedms-20.003-20.004.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-20.003-20.004.sql
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2020 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ALTER TABLE targetedms.moleculeprecursor DROP COLUMN moleculeprecursorid;

--- a/resources/schemas/dbscripts/sqlserver/targetedms-20.003-20.004.sql
+++ b/resources/schemas/dbscripts/sqlserver/targetedms-20.003-20.004.sql
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2020 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ALTER TABLE targetedms.moleculeprecursor DROP COLUMN moleculeprecursorid;

--- a/resources/schemas/targetedms.xml
+++ b/resources/schemas/targetedms.xml
@@ -419,7 +419,6 @@
             <column columnName="MassAverage">
                 <formatString>0.0000</formatString>
             </column>
-            <column columnName="MoleculePrecursorId"/>
         </columns>
     </table>
     <table tableDbType="TABLE" tableName="Precursor">

--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -202,7 +202,7 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
     @Override
     public Double getSchemaVersion()
     {
-        return 20.003;
+        return 20.004;
     }
 
     @Override

--- a/src/org/labkey/targetedms/parser/MoleculePrecursor.java
+++ b/src/org/labkey/targetedms/parser/MoleculePrecursor.java
@@ -28,7 +28,6 @@ public class MoleculePrecursor extends GeneralPrecursor<MoleculeTransition>
     private String _customIonName;
     private Double _massMonoisotopic;
     private Double _massAverage;
-    private String _moleculePrecursorId;
 
     public String getIonFormula()
     {
@@ -68,16 +67,6 @@ public class MoleculePrecursor extends GeneralPrecursor<MoleculeTransition>
     public void setMassAverage(Double massAverage)
     {
         _massAverage = massAverage;
-    }
-
-    public String getMoleculePrecursorId()
-    {
-        return _moleculePrecursorId;
-    }
-
-    public void setMoleculePrecursorId(String moleculePrecursorId)
-    {
-        _moleculePrecursorId = moleculePrecursorId;
     }
 
     @Override

--- a/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
+++ b/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
@@ -1600,7 +1600,6 @@ public class SkylineDocumentParser implements AutoCloseable
 
         moleculePrecursor.setMassMonoisotopic(readRequiredMass(reader, true, MASS_MONOISOTOPIC));
         moleculePrecursor.setMassAverage(readRequiredMass(reader, false, MASS_AVERAGE));
-        moleculePrecursor.setMoleculePrecursorId(XmlUtil.readAttribute(reader, ID));
 
         Double explicitIonMobility = XmlUtil.readDoubleAttribute(reader, "explicit_ion_mobility");
         // fall back to support older documents


### PR DESCRIPTION
#### Rationale
This column is redundant with targetedms.Molecule.MoleculeId, so we can drop it
