### PR TITLE
Avoid wrapping heavy/light label text values

### DIFF
--- a/resources/schemas/targetedms.xml
+++ b/resources/schemas/targetedms.xml
@@ -31,7 +31,6 @@
             </column>
             <column columnName="Name">
                 <columnTitle>Label</columnTitle>
-                <displayWidth>15</displayWidth>
             </column>
         </columns>
     </table>


### PR DESCRIPTION
Don't explicitly set the display width to 15 pixels, which is too narrow for pretty much any text values. This is the only column in Panorama that has a width set, and it's causing values like "heavy" to wrap.