### PR TITLE
Issue 40523: Offer convenient way to get stable, relative link to Skyline file

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSSchema.java
+++ b/src/org/labkey/targetedms/TargetedMSSchema.java
@@ -66,6 +66,7 @@ import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.PopupMenu;
 import org.labkey.api.view.ViewContext;
+import org.labkey.api.view.template.ClientDependency;
 import org.labkey.targetedms.parser.Chromatogram;
 import org.labkey.targetedms.parser.ChromatogramBinaryFormat;
 import org.labkey.targetedms.parser.ReplicateAnnotation;
@@ -630,6 +631,15 @@ public class TargetedMSSchema extends UserSchema
                     {
                         return new DataColumn(colInfo)
                         {
+
+                            @Override
+                            public @NotNull Set<ClientDependency> getClientDependencies()
+                            {
+                                Set<ClientDependency> result = super.getClientDependencies();
+                                result.add(TargetedMSController.getDownloadMenuClientDependency());
+                                return result;
+                            }
+
                             @Override
                             public void renderGridCellContents(RenderContext ctx, Writer out) throws IOException
                             {

--- a/src/org/labkey/targetedms/view/runSummaryView.jsp
+++ b/src/org/labkey/targetedms/view/runSummaryView.jsp
@@ -30,13 +30,25 @@
 <%@ page import="org.labkey.targetedms.TargetedMSSchema" %>
 <%@ page import="org.labkey.api.util.StringUtilsLabKey" %>
 <%@ page import="org.labkey.api.targetedms.TargetedMSService" %>
+<%@ page import="org.labkey.api.view.template.ClientDependencies" %>
+<%@ page import="org.labkey.api.view.PopupMenu" %>
+<%@ page import="org.labkey.api.view.template.ClientDependency" %>
+<%@ page import="org.labkey.api.util.Pair" %>
+<%@ page import="java.io.IOException" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
+
+<%!
+    @Override
+    public void addClientDependencies(ClientDependencies dependencies)
+    {
+        dependencies.add(TargetedMSController.getDownloadMenuClientDependency());
+    }
+%>
 
 <%
     JspView<TargetedMSController.RunDetailsBean> me = (JspView<TargetedMSController.RunDetailsBean>) HttpView.currentView();
     TargetedMSController.RunDetailsBean bean = me.getModelBean();
     TargetedMSRun run = bean.getRun();
-    Path skyDocFile = SkylineFileUtils.getSkylineFile(run.getExperimentRunLSID(), getContainer());
 
     ActionURL downloadAction = new ActionURL(TargetedMSController.DownloadDocumentAction.class, getContainer());
     downloadAction.addParameter("id", run.getId());

--- a/webapp/TargetedMS/js/clipboardHelper.js
+++ b/webapp/TargetedMS/js/clipboardHelper.js
@@ -1,0 +1,12 @@
+/** Copies a string argument to the clipboard, via a text area temporarily injected into the DOM */
+function copyStringToClipboard(s)
+{
+    var textarea = document.createElement('textarea');
+    textarea.setAttribute('type', 'hidden');
+    textarea.textContent = s;
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand('copy');
+    textarea.remove();
+    window.alert('Copied "' + s + '" to the clipboard.');
+}


### PR DESCRIPTION
#### Rationale
Panorama offers a workflow where a folder of data is copied from one project to a shared project (called Panorama Public), where it's read-only.

https://panoramaweb.org/project/Panorama%20Public/begin.view?

User often use wikis to describe the data they're posting, and sometimes want to have links to individual documents. There are a couple of problems at the moment:

1. The URL contains the RowId of the import, which will be different in the copied folder since the files are reimported.
2. It's not convenient to get a relative URL, which is important because the wiki will be copied into a new folder and we don't want to link back to the original container after the wiki is copied.

#### Related Pull Requests
https://github.com/LabKey/platform/pull/1231

#### Changes
1. Support a fileName parameter on the URL that is the file name of the Skyline document that was imported. This can be used in both the original and new location, and in practice will be unique to the file of interest. (This was already merged into 20.3).
2. Add new menu items to the download link that copy both the relative and absolute URLs to the clipboard that use the fileName parameter instead of id.
