### PR TITLE
Fix intermittent TargetedMSQCGuideSetTest failure crawler/folder delete race condition

### DIFF
--- a/src/org/labkey/targetedms/outliers/OutlierGenerator.java
+++ b/src/org/labkey/targetedms/outliers/OutlierGenerator.java
@@ -67,7 +67,7 @@ public class OutlierGenerator
         sql.append("\nCASE WHEN pci.PrecursorId.Id IS NOT NULL THEN 'Peptide' WHEN pci.MoleculePrecursorId.Id IS NOT NULL THEN 'Fragment' ELSE 'Other' END AS DataType,");
         sql.append("\nCOALESCE(pci.PrecursorId.Mz, pci.MoleculePrecursorId.Mz) AS MZ,");
 
-        sql.append("\nX.PrecursorChromInfoId, sf.AcquiredTime, X.MetricValue, gs.RowId AS GuideSetId,");
+        sql.append("\nX.PrecursorChromInfoId, sf.AcquiredTime, X.MetricValue, COALESCE(gs.RowId, 0) AS GuideSetId,");
         sql.append("\nCASE WHEN (exclusion.ReplicateId IS NOT NULL) THEN TRUE ELSE FALSE END AS IgnoreInQC,");
         sql.append("\nCASE WHEN (sf.AcquiredTime >= gs.TrainingStart AND sf.AcquiredTime <= gs.TrainingEnd) THEN TRUE ELSE FALSE END AS InGuideSetTrainingRange");
         sql.append("\nFROM (");


### PR DESCRIPTION
Crawler requests overlap with folder deletion, resulting in null GuideSetIds from still-running query

Example failure on TeamCity:

https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_ModuleSuites_TargettedMSSqlserve/1011664

Failure stack trace:

ava.lang.IllegalStateException: Failed to copy property 'guideSetId' on class org.labkey.targetedms.model.RawMetricDataSet
	at org.labkey.api.data.BeanObjectFactory.handleArrayList(BeanObjectFactory.java:293)
	at org.labkey.api.data.BaseSelector$ArrayListResultSetHandler.handle(BaseSelector.java:157)
	at org.labkey.api.data.BaseSelector$ArrayListResultSetHandler.handle(BaseSelector.java:123)
	at org.labkey.api.data.SqlExecutingSelector$ExecutingResultSetFactory.handleResultSet(SqlExecutingSelector.java:454)
	at org.labkey.api.data.BaseSelector.getArrayList(BaseSelector.java:108)
	at org.labkey.api.data.BaseSelector.getArrayList(BaseSelector.java:103)
	at org.labkey.targetedms.outliers.OutlierGenerator.getRawMetricDataSets(OutlierGenerator.java:113)
	at org.labkey.targetedms.TargetedMSController$GetQCMetricOutliersAction.execute(TargetedMSController.java:1034)
	at org.labkey.targetedms.TargetedMSController$GetQCMetricOutliersAction.execute(TargetedMSController.java:1014)
	at org.labkey.api.action.BaseApiAction.handlePost(BaseApiAction.java:210)
	at org.labkey.api.action.ReadOnlyApiAction.handleGet(ReadOnlyApiAction.java:34)
	at org.labkey.api.action.BaseApiAction.handleRequest(BaseApiAction.java:122)