### PR TITLE
Issue 38963: Incorrect precursor count and plots in small molecule QC folder

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -856,7 +856,8 @@ public class TargetedMSController extends SpringActionController
         properties.put("fileCount", new SqlSelector(TargetedMSSchema.getSchema(), sql).getObject(Integer.class));
 
         // # precursors tracked, count of distinct precursors. Include peptides and small molecules
-        sql = new SQLFragment("SELECT DISTINCT COALESCE(p.ModifiedSequence, mp.CustomIonName) AS SeriesLabel, gp.Charge");
+        sql = new SQLFragment("SELECT DISTINCT COALESCE(p.ModifiedSequence, ");
+        sql.append(" concat(mp.CustomIonName, mp.IonFormula,mp.massMonoisotopic, mp.massAverage, gp.mz)) AS SeriesLabel, gp.Charge");
         sql.append(" FROM ").append(TargetedMSManager.getTableInfoGeneralPrecursor(), "gp");
         sql.append(" JOIN ").append(TargetedMSManager.getTableInfoGeneralMolecule(), "gm").append(" ON gp.GeneralMoleculeId = gm.Id");
         sql.append(" JOIN ").append(TargetedMSManager.getTableInfoPeptideGroup(), "pg").append(" ON gm.PeptideGroupId = pg.Id");

--- a/src/org/labkey/targetedms/outliers/OutlierGenerator.java
+++ b/src/org/labkey/targetedms/outliers/OutlierGenerator.java
@@ -67,10 +67,10 @@ public class OutlierGenerator
         sql.append("\nCOALESCE(X.SeriesLabel, COALESCE(pci.PrecursorId.ModifiedSequence,");
         sql.append("\n           ((CASE WHEN pci.MoleculePrecursorId.CustomIonName IS NULL THEN '' ELSE (pci.MoleculePrecursorId.CustomIonName || ', ') END)");
         sql.append("\n            || (CASE WHEN pci.MoleculePrecursorId.IonFormula IS NULL THEN '' ELSE (pci.MoleculePrecursorId.IonFormula || ', ') END)");
-        sql.append("\n            || ('[' || CAST (ROUND(pci.MoleculePrecursorId.massMonoisotopic, 4) AS NUMERIC) || '/'");
-        sql.append("\n            || CAST (ROUND(pci.MoleculePrecursorId.massAverage, 4) AS NUMERIC) || '] ')");
+        sql.append("\n            || ('[' || CAST (ROUND(pci.MoleculePrecursorId.massMonoisotopic, 4) AS VARCHAR) || '/'");
+        sql.append("\n            || CAST (ROUND(pci.MoleculePrecursorId.massAverage, 4) AS VARCHAR) || '] ')");
         sql.append("\n            ))");
-        sql.append("\n    || CAST (ROUND(COALESCE (pci.PrecursorId.Mz, pci.MoleculePrecursorId.Mz), 4) AS NUMERIC)");
+        sql.append("\n    || CAST (ROUND(COALESCE (pci.PrecursorId.Mz, pci.MoleculePrecursorId.Mz), 4) AS VARCHAR)");
         sql.append("\n    || (CASE WHEN COALESCE(pci.PrecursorId.Charge, pci.MoleculePrecursorId.Charge) > 0 THEN ' +' ELSE ' ' END)");
         sql.append("\n    || CAST(COALESCE(pci.PrecursorId.Charge, pci.MoleculePrecursorId.Charge) AS VARCHAR)) AS SeriesLabel,");
 

--- a/src/org/labkey/targetedms/outliers/OutlierGenerator.java
+++ b/src/org/labkey/targetedms/outliers/OutlierGenerator.java
@@ -63,7 +63,17 @@ public class OutlierGenerator
         sql.append("SELECT X.MetricSeriesIndex, X.MetricId, X.SampleFileId, ");
 
         sql.append("\nCOALESCE(pci.PrecursorId.Id, pci.MoleculePrecursorId.Id) AS PrecursorId,");
-        sql.append("\nCOALESCE(X.SeriesLabel, COALESCE(pci.PrecursorId.ModifiedSequence, pci.MoleculePrecursorId.CustomIonName, pci.MoleculePrecursorId.IonFormula) || (CASE WHEN COALESCE(pci.PrecursorId.Charge, pci.MoleculePrecursorId.Charge) > 0 THEN ' +' ELSE ' ' END) || CAST(COALESCE(pci.PrecursorId.Charge, pci.MoleculePrecursorId.Charge) AS VARCHAR)) AS SeriesLabel,");
+
+        sql.append("\nCOALESCE(X.SeriesLabel, COALESCE(pci.PrecursorId.ModifiedSequence,");
+        sql.append("\n           ((CASE WHEN pci.MoleculePrecursorId.CustomIonName IS NULL THEN '' ELSE (pci.MoleculePrecursorId.CustomIonName || ', ') END)");
+        sql.append("\n            || (CASE WHEN pci.MoleculePrecursorId.IonFormula IS NULL THEN '' ELSE (pci.MoleculePrecursorId.IonFormula || ', ') END)");
+        sql.append("\n            || ('[' || CAST (ROUND(pci.MoleculePrecursorId.massMonoisotopic, 4) AS NUMERIC) || '/'");
+        sql.append("\n            || CAST (ROUND(pci.MoleculePrecursorId.massAverage, 4) AS NUMERIC) || '] ')");
+        sql.append("\n            ))");
+        sql.append("\n    || CAST (ROUND(COALESCE (pci.PrecursorId.Mz, pci.MoleculePrecursorId.Mz), 4) AS NUMERIC)");
+        sql.append("\n    || (CASE WHEN COALESCE(pci.PrecursorId.Charge, pci.MoleculePrecursorId.Charge) > 0 THEN ' +' ELSE ' ' END)");
+        sql.append("\n    || CAST(COALESCE(pci.PrecursorId.Charge, pci.MoleculePrecursorId.Charge) AS VARCHAR)) AS SeriesLabel,");
+
         sql.append("\nCASE WHEN pci.PrecursorId.Id IS NOT NULL THEN 'Peptide' WHEN pci.MoleculePrecursorId.Id IS NOT NULL THEN 'Fragment' ELSE 'Other' END AS DataType,");
         sql.append("\nCOALESCE(pci.PrecursorId.Mz, pci.MoleculePrecursorId.Mz) AS MZ,");
 


### PR DESCRIPTION
#### Rationale
Small molecule precusors should be counted in a way that includes MassMonoisotopic, MassAverage and m/z.

#### Changes
This is a partial fix. It corrects the Java-side precursor identification. It doesn't address the Levey-Jennings plots, but that will happen when they are migrated to use the Java implementation.