### PR TITLE
Fix another intermittent QC test failure during container deletion

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSManager.java
+++ b/src/org/labkey/targetedms/TargetedMSManager.java
@@ -2117,7 +2117,7 @@ public class TargetedMSManager
 
             return OutlierGenerator.get().getSampleFiles(rawMetricDataSets, stats, metricMap, container, sampleFileLimit);
         }
-        return null;
+        return Collections.emptyList();
     }
 
     public static int getMaxTransitionCount(int moleculeId)

--- a/src/org/labkey/targetedms/model/RawMetricDataSet.java
+++ b/src/org/labkey/targetedms/model/RawMetricDataSet.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.targetedms.model;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.targetedms.model.OutlierCounts;
 import org.labkey.api.visualization.Stats;
@@ -282,7 +283,7 @@ public class RawMetricDataSet
         return isCUSUMOutlier(cusumMN);
     }
 
-    public void increment(OutlierCounts counts, GuideSetStats stats)
+    public void increment(@NotNull OutlierCounts counts, @NotNull GuideSetStats stats)
     {
         counts.setTotalCount(counts.getTotalCount() + 1);
         if (isLeveyJenningsOutlier(stats))


### PR DESCRIPTION
#### Rationale
TargetedMSQCGuideSetTest is failing intermittently with a NPE triggered by the container deletion happening while the server's still processing requests from the crawler

#### Changes
Be tolerant of SampleFiles no longer existing even if they had QC data a second ago