### PR TITLE
Issue 38094 - add ionMatchTolerance in librarySettings table and read the value from transitionSettings.transitionLibraries

### DIFF
--- a/resources/schemas/dbscripts/postgresql/targetedms-20.004-20.005.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-20.004-20.005.sql
@@ -1,0 +1,1 @@
+ALTER TABLE targetedms.LibrarySettings ADD COLUMN ionMatchTolerance DOUBLE PRECISION;

--- a/resources/schemas/dbscripts/sqlserver/targetedms-20.004-20.005.sql
+++ b/resources/schemas/dbscripts/sqlserver/targetedms-20.004-20.005.sql
@@ -1,0 +1,1 @@
+ALTER TABLE targetedms.LibrarySettings ADD ionMatchTolerance DOUBLE PRECISION;

--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -202,7 +202,7 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
     @Override
     public Double getSchemaVersion()
     {
-        return 20.004;
+        return 20.005;
     }
 
     @Override

--- a/src/org/labkey/targetedms/parser/PeptideSettingsParser.java
+++ b/src/org/labkey/targetedms/parser/PeptideSettingsParser.java
@@ -371,7 +371,6 @@ class PeptideSettingsParser
         settings.setPick(XmlUtil.readRequiredAttribute(reader, PICK, PEPTIDE_LIBRARIES));
         settings.setRankType(XmlUtil.readAttribute(reader, RANK_TYPE, null));
         settings.setPeptideCount(XmlUtil.readIntegerAttribute(reader, PEPTIDE_COUNT));
-        settings.setIonMatchTolerance(XmlUtil.readDoubleAttribute(reader, "ion_match_tolerance"));
 
         List<PeptideSettings.SpectrumLibrary> libraryList = new ArrayList<>();
         settings.setLibraries(libraryList);

--- a/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
+++ b/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
@@ -650,6 +650,10 @@ public class SkylineDocumentParser implements AutoCloseable
             {
                 break;
             }
+            if (XmlUtil.isStartElement(reader, evtType, TRANSITION_LIBRARIES))
+            {
+                _peptideSettings.getLibrarySettings().setIonMatchTolerance(XmlUtil.readDoubleAttribute(reader, "ion_match_tolerance"));
+            }
 
             if (XmlUtil.isStartElement(reader, evtType, TRANSITION_PREDICTION))
             {


### PR DESCRIPTION
#### Rationale
This work reads the ionMatchTolerance from TransitionSettings.TransitionLibraries instead of <peptide_settings><peptide_libraries> 

#### Changes
* new column in LibrarySettings table
