### PR TITLE
Issue 40545: NPE in org.labkey.targetedms.calculations.GeneralMoleculeResultDataSet.getTotalArea()

### DIFF
--- a/src/org/labkey/targetedms/calculations/GeneralMoleculeResultDataSet.java
+++ b/src/org/labkey/targetedms/calculations/GeneralMoleculeResultDataSet.java
@@ -91,7 +91,8 @@ public class GeneralMoleculeResultDataSet
         {
             for (ChromInfoRecord chromInfoRecord : records)
             {
-                if (chromInfoRecord.getTransitionChromInfo().getSampleFileId() != sampleFileId)
+                TransitionChromInfo tci = chromInfoRecord.getTransitionChromInfo();
+                if (tci.getSampleFileId() != sampleFileId)
                 {
                     continue;
                 }
@@ -99,7 +100,10 @@ public class GeneralMoleculeResultDataSet
                 {
                     continue;
                 }
-                total += chromInfoRecord.getTransitionChromInfo().getArea();
+                if (tci.getArea() != null)
+                {
+                    total += tci.getArea();
+                }
             }
         }
         return total;


### PR DESCRIPTION
#### Rationale
Area is a Double, so it can be null.

#### Changes
Check for null before trying to add it to the running tally