### PR TITLE
Issue 40229: targetedms lookups target DB schema TableInfo

### DIFF
--- a/src/org/labkey/targetedms/SkylineAuditLogManager.java
+++ b/src/org/labkey/targetedms/SkylineAuditLogManager.java
@@ -231,6 +231,11 @@ public class SkylineAuditLogManager
                 }
             }
 
+            if (!expander.areAllMessagesExpanded())
+            {
+                _logger.warn("At least one audit log expansion token failed to expand. This is expected for old Skyline documents, but not for newer ones");
+            }
+
             if (hashValidationFailures > 0)
             {
                 _securityMgr.reportErrorForIntegrityLevel(

--- a/src/org/labkey/targetedms/SkylineAuditLogManager.java
+++ b/src/org/labkey/targetedms/SkylineAuditLogManager.java
@@ -192,6 +192,7 @@ public class SkylineAuditLogManager
             //since entries in the log file are in reverse chronological order we have to
             //read them in the list and then reverse it before the tree processing
             List<AuditLogEntry> entries = new ArrayList<>();
+            int hashValidationFailures = 0;
             //while next entry is not null
             while (pContext._parser.hasNextEntry())
             {
@@ -202,9 +203,13 @@ public class SkylineAuditLogManager
                     //throw or log the results based on the integrity level setting
                     if (!ent.verifyHash())
                     {
-                        _securityMgr.reportErrorForIntegrityLevel(
-                                String.format("Hash value verification failed for the log entry timestamped with %s", ent.getOffsetCreateTimestamp().toString()),
-                                SkylineAuditLogSecurityManager.INTEGRITY_LEVEL.ANY);
+                        if (hashValidationFailures == 0)
+                        {
+                            _securityMgr.reportErrorForIntegrityLevel(
+                                    String.format("Hash value verification failed for the log entry timestamped with %s. This is expected for older Skyline documents with audit logs that do not contain hashes. Suppressing warning for remainder of file", ent.getOffsetCreateTimestamp().toString()),
+                                    SkylineAuditLogSecurityManager.INTEGRITY_LEVEL.ANY);
+                        }
+                        hashValidationFailures++;
                     }
                     ent.setDocumentGUID(pContext._documentGUID);
                     entries.add(ent);
@@ -224,6 +229,19 @@ public class SkylineAuditLogManager
                             "Error when parsing audit log file.",
                             SkylineAuditLogSecurityManager.INTEGRITY_LEVEL.ANY, e);
                 }
+            }
+
+            if (hashValidationFailures > 0)
+            {
+                _securityMgr.reportErrorForIntegrityLevel(
+                        "Hash value verification failed for " + hashValidationFailures + " of " + entries.size() + " total entries",
+                        SkylineAuditLogSecurityManager.INTEGRITY_LEVEL.ANY);
+            }
+
+            // Issue 39455 - bail out if there were no audit log entries
+            if (entries.isEmpty())
+            {
+                return 0;
             }
 
             if(pContext._runId != null)       //set the document version id on the chronologically last log entry.

--- a/src/org/labkey/targetedms/TargetedMSSchema.java
+++ b/src/org/labkey/targetedms/TargetedMSSchema.java
@@ -235,17 +235,27 @@ public class TargetedMSSchema extends UserSchema
 
     private static SQLFragment getJoinToRunsTable(String tableAlias)
     {
+        return getJoinToRunsTable(tableAlias, "RunId");
+    }
+
+    private static SQLFragment getJoinToRunsTable(String tableAlias, String columnName)
+    {
         tableAlias = tableAlias == null ? "" : tableAlias + ".";
         return makeInnerJoin(TargetedMSManager.getTableInfoRuns(),
-                TargetedMSTable.CONTAINER_COL_TABLE_ALIAS, tableAlias + "RunId");
+                TargetedMSTable.CONTAINER_COL_TABLE_ALIAS, tableAlias + columnName);
     }
 
     private static SQLFragment makeInnerJoin(TableInfo table, String alias, String colRight)
     {
+        return makeInnerJoin(table, alias, colRight, "id");
+    }
+
+    private static SQLFragment makeInnerJoin(TableInfo table, String alias, String colRight, String colLeft)
+    {
         SQLFragment sql = new SQLFragment("INNER JOIN ");
         sql.append(table, alias);
         sql.append(" ON ( ");
-        sql.append(alias).append(".id");
+        sql.append(alias).append(".").append(colLeft);
         sql.append(" = ");
         sql.append(colRight);
         sql.append(" ) ");
@@ -394,6 +404,37 @@ public class TargetedMSSchema extends UserSchema
             public FieldKey getContainerFieldKey()
             {
                 return FieldKey.fromParts("RunId", "Container");
+            }
+        },
+        RunVersionFK
+        {
+            @Override
+            public SQLFragment getSQL()
+            {
+                SQLFragment sql = new SQLFragment();
+                sql.append(getJoinToRunsTable(null, "VersionId"));
+                return sql;
+            }
+            @Override
+            public FieldKey getContainerFieldKey()
+            {
+                return FieldKey.fromParts("VersionId", "Container");
+            }
+        },
+        EntryVersionFK
+        {
+            @Override
+            public SQLFragment getSQL()
+            {
+                SQLFragment sql = new SQLFragment();
+                sql.append(makeInnerJoin(TargetedMSManager.getTableInfoSkylineAuditLogEntry(), "e", "X.EntryId", "EntryId"));
+                sql.append(getJoinToRunsTable("e", "VersionId"));
+                return sql;
+            }
+            @Override
+            public FieldKey getContainerFieldKey()
+            {
+                return FieldKey.fromParts("EntryId", "VersionId", "Container");
             }
         },
         PeptideGroupFK
@@ -611,7 +652,7 @@ public class TargetedMSSchema extends UserSchema
             @Override
             public TableInfo getLookupTableInfo()
             {
-                FilteredTable result = new FilteredTable<>(TargetedMSManager.getTableInfoRuns(), TargetedMSSchema.this, cf);
+                FilteredTable<TargetedMSSchema> result = new FilteredTable<>(TargetedMSManager.getTableInfoRuns(), TargetedMSSchema.this, cf);
                 result.addWrapColumn(result.getRealTable().getColumn("Id"));
                 result.addWrapColumn(result.getRealTable().getColumn("Description"));
                 result.addWrapColumn(result.getRealTable().getColumn("Created"));
@@ -685,7 +726,7 @@ public class TargetedMSSchema extends UserSchema
                 return result;
             }
 
-            private void addVersionsColumn(FilteredTable result)
+            private void addVersionsColumn(FilteredTable<?> result)
             {
                 var versionsCol = result.addWrapColumn("Versions", result.getRealTable().getColumn("ExperimentRunLSID"));
                 versionsCol.setTextAlign("right");
@@ -767,7 +808,7 @@ public class TargetedMSSchema extends UserSchema
             @Override
             public @Nullable TableInfo getLookupTableInfo()
             {
-                return TargetedMSManager.getTableInfoRuns();
+                return getTable(TABLE_RUNS, cf);
             }
         });
         result.addColumn(replacedByCol);
@@ -899,7 +940,7 @@ public class TargetedMSSchema extends UserSchema
         }
         if (TABLE_REPRESENTATIVE_DATA_STATE.equalsIgnoreCase(name))
         {
-            EnumTableInfo tableInfo = new EnumTableInfo<>(
+            EnumTableInfo<RepresentativeDataState> tableInfo = new EnumTableInfo<>(
                     RepresentativeDataState.class,
                     this,
                     RepresentativeDataState::getLabel,
@@ -1264,18 +1305,6 @@ public class TargetedMSSchema extends UserSchema
             return result;
         }
 
-        if (getTableNames().contains(name))
-        {
-            FilteredTable<TargetedMSSchema> result = new FilteredTable<>(getSchema().getTable(name), this, cf);
-            result.wrapAllColumns(true);
-            if (name.equalsIgnoreCase(TABLE_RUNS))
-            {
-                result.getMutableColumn("DataId").setFk(QueryForeignKey.from(_expSchema, cf).to(ExpSchema.TableType.Data.name(), null, null));
-                result.getMutableColumn("SkydDataId").setFk(QueryForeignKey.from(_expSchema, cf).to(ExpSchema.TableType.Data.name(), null, null));
-            }
-            return result;
-        }
-
         // Issue 35966 - Show a custom set of columns by default for a run-scoped replicate view
         if (name.toLowerCase().startsWith(SAMPLE_FILE_RUN_PREFIX))
         {
@@ -1302,6 +1331,29 @@ public class TargetedMSSchema extends UserSchema
             return new TargetedMSTable(getSchema().getTable(name), this, cf, ContainerJoinType.PrecursorFK);
         }
 
+        if (TABLE_SKYLINE_AUDITLOG_ENTRY.equalsIgnoreCase(name))
+        {
+            return new TargetedMSTable(getSchema().getTable(name), this, cf, ContainerJoinType.RunVersionFK);
+        }
+
+        if (TABLE_SKYLINE_AUDITLOG_MESSAGE.equalsIgnoreCase(name))
+        {
+            return new TargetedMSTable(getSchema().getTable(name), this, cf, ContainerJoinType.EntryVersionFK);
+        }
+
+        if (getTableNames().contains(name))
+        {
+            FilteredTable<TargetedMSSchema> result = new FilteredTable<>(getSchema().getTable(name), this, cf);
+            result.wrapAllColumns(true);
+            if (name.equalsIgnoreCase(TABLE_RUNS))
+            {
+                result.getMutableColumn("DataId").setFk(QueryForeignKey.from(_expSchema, cf).to(ExpSchema.TableType.Data.name(), null, null));
+                result.getMutableColumn("Owner").setFk(new UserIdQueryForeignKey(this, true));
+                result.getMutableColumn("SkydDataId").setFk(QueryForeignKey.from(_expSchema, cf).to(ExpSchema.TableType.Data.name(), null, null));
+            }
+            TargetedMSTable.fixupLookups(result);
+            return result;
+        }
 
         return null;
     }

--- a/src/org/labkey/targetedms/TargetedMSSchema.java
+++ b/src/org/labkey/targetedms/TargetedMSSchema.java
@@ -1331,15 +1331,16 @@ public class TargetedMSSchema extends UserSchema
             return new TargetedMSTable(getSchema().getTable(name), this, cf, ContainerJoinType.PrecursorFK);
         }
 
-        if (TABLE_SKYLINE_AUDITLOG_ENTRY.equalsIgnoreCase(name))
-        {
-            return new TargetedMSTable(getSchema().getTable(name), this, cf, ContainerJoinType.RunVersionFK);
-        }
-
-        if (TABLE_SKYLINE_AUDITLOG_MESSAGE.equalsIgnoreCase(name))
-        {
-            return new TargetedMSTable(getSchema().getTable(name), this, cf, ContainerJoinType.EntryVersionFK);
-        }
+        // TODO - partial fix for 40235
+//        if (TABLE_SKYLINE_AUDITLOG_ENTRY.equalsIgnoreCase(name))
+//        {
+//            return new TargetedMSTable(getSchema().getTable(name), this, cf, ContainerJoinType.RunVersionFK);
+//        }
+//
+//        if (TABLE_SKYLINE_AUDITLOG_MESSAGE.equalsIgnoreCase(name))
+//        {
+//            return new TargetedMSTable(getSchema().getTable(name), this, cf, ContainerJoinType.EntryVersionFK);
+//        }
 
         if (getTableNames().contains(name))
         {

--- a/src/org/labkey/targetedms/parser/skyaudit/AuditLogMessageExpander.java
+++ b/src/org/labkey/targetedms/parser/skyaudit/AuditLogMessageExpander.java
@@ -183,9 +183,9 @@ public class AuditLogMessageExpander
                 );
                 hasMatches = true;
             }
-            else{
+            else
+            {
                 _allMessagesExpanded = false;
-                _logger.warn(String.format("Audit log expansion token %s cannot be expanded. Either invalid function index or unknown name.", match.group(0)));
                 resultBuilder.append(match.group(0));
             }
             lastPos = match.end();

--- a/src/org/labkey/targetedms/parser/skyaudit/SkylineAuditLogSecurityManager.java
+++ b/src/org/labkey/targetedms/parser/skyaudit/SkylineAuditLogSecurityManager.java
@@ -42,15 +42,12 @@ public class SkylineAuditLogSecurityManager
 
     private INTEGRITY_LEVEL _verificationLevel;
     private Container _container;
-    private User _user;
     private Logger _logger;
-    private Module _panorama;
 
-    public SkylineAuditLogSecurityManager(Container pContainer, User pUser) throws AuditLogException{
+    public SkylineAuditLogSecurityManager(Container pContainer, User pUser) throws AuditLogException
+    {
         _container = pContainer;
-        _user = pUser;
         _logger = Logger.getLogger(this.getClass());
-
 
         TargetedMSModule targetedMSModule = null;
         for (Module m : _container.getActiveModules())

--- a/src/org/labkey/targetedms/query/GuideSetTable.java
+++ b/src/org/labkey/targetedms/query/GuideSetTable.java
@@ -29,6 +29,7 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.FilteredTable;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.RowIdQueryUpdateService;
+import org.labkey.api.query.UserIdQueryForeignKey;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
@@ -49,7 +50,7 @@ public class GuideSetTable extends FilteredTable<TargetedMSSchema>
         super(TargetedMSManager.getTableInfoGuideSet(), schema);
 
         wrapAllColumns(true);
-        getMutableColumn("Container").setFk(new ContainerForeignKey(schema));
+        TargetedMSTable.fixupLookups(this);
 
         // add expr column to calculate the reference end date for a guide set, can be null if it is the last guide set
         ExprColumn referenceEndCol = new ExprColumn(this, FieldKey.fromParts("ReferenceEnd"), getReferenceEndSql(ExprColumn.STR_TABLE_ALIAS), JdbcType.TIMESTAMP);

--- a/src/org/labkey/targetedms/query/MoleculeTransitionsTableInfo.java
+++ b/src/org/labkey/targetedms/query/MoleculeTransitionsTableInfo.java
@@ -21,6 +21,7 @@ import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.WrappedColumn;
 import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.FieldKey;
+import org.labkey.api.query.QueryForeignKey;
 import org.labkey.targetedms.TargetedMSManager;
 import org.labkey.targetedms.TargetedMSSchema;
 import org.labkey.targetedms.view.AnnotationUIDisplayColumn;
@@ -46,6 +47,8 @@ public class MoleculeTransitionsTableInfo extends AbstractGeneralTransitionTable
         var precursorIdCol = wrapColumn("MoleculePrecursorId", getRealTable().getColumn(precursorCol.getFieldKey()));
         precursorIdCol.setFk(new TargetedMSForeignKey(getUserSchema(), TargetedMSSchema.TABLE_MOLECULE_PRECURSOR, cf));
         addColumn(precursorIdCol);
+
+        getMutableColumn("TransitionId").setFk(QueryForeignKey.from(getUserSchema(), cf).schema(getUserSchema()).table("transition"));
 
         SQLFragment sql = new SQLFragment(" COALESCE(" + ExprColumn.STR_TABLE_ALIAS + ".CustomIonName, " +
                 ExprColumn.STR_TABLE_ALIAS + ".IonFormula, "  +

--- a/src/org/labkey/targetedms/query/QCAnnotationTable.java
+++ b/src/org/labkey/targetedms/query/QCAnnotationTable.java
@@ -40,7 +40,7 @@ public class QCAnnotationTable extends FilteredTable<TargetedMSSchema>
         super(TargetedMSManager.getTableInfoQCAnnotation(), schema, cf);
 
         wrapAllColumns(true);
-        getMutableColumn("Container").setFk(new ContainerForeignKey(schema));
+        TargetedMSTable.fixupLookups(this);
         getMutableColumn("QCAnnotationTypeId").setFk(QueryForeignKey
                 .from(schema, ContainerFilter.Type.CurrentPlusProjectAndShared.create(schema))
                 .to(TargetedMSSchema.TABLE_QC_ANNOTATION_TYPE, "Id", "Name"));

--- a/src/org/labkey/targetedms/query/QCAnnotationTypeTable.java
+++ b/src/org/labkey/targetedms/query/QCAnnotationTypeTable.java
@@ -50,7 +50,7 @@ public class QCAnnotationTypeTable extends FilteredTable<TargetedMSSchema>
     {
         super(TargetedMSManager.getTableInfoQCAnnotationType(), schema, cf);
         wrapAllColumns(true);
-        getMutableColumn("Container").setFk(new ContainerForeignKey(schema));
+        TargetedMSTable.fixupLookups(this);
         getMutableColumn("Color").setDisplayColumnFactory(new DisplayColumnFactory()
         {
             @Override

--- a/src/org/labkey/targetedms/query/QCEnabledMetricsTable.java
+++ b/src/org/labkey/targetedms/query/QCEnabledMetricsTable.java
@@ -35,6 +35,7 @@ public class QCEnabledMetricsTable extends FilteredTable<TargetedMSSchema>
     public QCEnabledMetricsTable(TargetedMSSchema schema, ContainerFilter cf)
     {
         super(TargetedMSManager.getTableInfoQCEnabledMetrics(), schema, cf);
+        TargetedMSTable.fixupLookups(this);
         wrapAllColumns(true);
     }
 

--- a/src/org/labkey/targetedms/query/QCMetricConfigurationTable.java
+++ b/src/org/labkey/targetedms/query/QCMetricConfigurationTable.java
@@ -39,6 +39,7 @@ public class QCMetricConfigurationTable extends FilteredTable<TargetedMSSchema>
     {
         super(TargetedMSManager.getTableInfoQCMetricConfiguration(), schema, cf);
         wrapAllColumns(true);
+        TargetedMSTable.fixupLookups(this);
         setInsertURL(LINK_DISABLER);
         setDeleteURL(LINK_DISABLER);
         setUpdateURL(LINK_DISABLER);

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSAuditLogTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSAuditLogTest.java
@@ -31,7 +31,7 @@ public class TargetedMSAuditLogTest extends TargetedMSTest
     }
 
     private void doInit()
-    {
+    {showSkylineAuditLog
         setupFolder(FolderType.QC);
         _userHelper.createUser(USER);
         new ApiPermissionsHelper(this).setUserPermissions(USER, "Reader");

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSAuditLogTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSAuditLogTest.java
@@ -31,7 +31,7 @@ public class TargetedMSAuditLogTest extends TargetedMSTest
     }
 
     private void doInit()
-    {showSkylineAuditLog
+    {
         setupFolder(FolderType.QC);
         _userHelper.createUser(USER);
         new ApiPermissionsHelper(this).setUserPermissions(USER, "Reader");


### PR DESCRIPTION
#### Rationale
We want lookups in the tables that we expose through the schema browser to be targeting other tables as exposed in the schema browser, not the lower level SchemaTableInfos

This was also a chance to clean up some of the logging when importing Skyline's audit logs

#### Changes
Fixup a lot of lookup definitions to use their UserSchema variants, both for targetedms tables and things like core.Containers and core.Users

Issue 39521: Suppress SkylineAuditLogManager logging about audit log expansion token
Issue 39455: IndexOutOfBoundsException when importing Skyline document with zero audit log entries
Issue 40527: Suppress excessive logging from SkylineAuditLogSecurityManager on old Skyline doc imports