### PR TITLE
Issue 40488: SQLException when trying to delete a Skyline document in…

### DIFF
--- a/src/org/labkey/targetedms/query/PrecursorManager.java
+++ b/src/org/labkey/targetedms/query/PrecursorManager.java
@@ -472,7 +472,7 @@ public class PrecursorManager
         sql.append(" AND");
         sql.append(" prec.ModifiedSequence = ?");
         sql.add(prec.getModifiedSequence());
-        sql.append(" ORDER BY gp.Modified DESC ");
+        sql.append(" ORDER BY run.Modified DESC ");
 
         Precursor[] deprecatedPrecursors = new SqlSelector(TargetedMSManager.getSchema(), sql).getArray(Precursor.class);
         if (deprecatedPrecursors.length == 0)


### PR DESCRIPTION
#### Rationale
Peptide Chromatogram Library folders rely on the timestamp in the GeneralPrecursor.Modified column to revert back to a previous state of the library when a document is deleted from the folder.  This column was deleted in targetems-19.31-19.32.sql because I thought it was not needed. The column will be added back and populated with the value in targetedms.runs.Modified column (see Issue 40487).  In the mean time we will temporarily update the query to use runs.Modified instead so that we don't get a SQLException.  Runs.Modified should be a good substitute for the missing column. 

