### PR TITLE
Improve incremental rendering layout for QC Summary web part

### DIFF
--- a/src/org/labkey/targetedms/view/qcSummary.jsp
+++ b/src/org/labkey/targetedms/view/qcSummary.jsp
@@ -38,7 +38,7 @@
     Integer sampleLimit = (Integer)HttpView.currentModel();
 %>
 
-<div id=<%=q(qcSummaryId)%>></div>
+<div style="min-height: 160px;" id=<%=q(qcSummaryId)%> ></div>
 
 <script type="text/javascript">
     Ext4.onReady(function()

--- a/test/src/org/labkey/test/components/targetedms/QCSummaryWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/QCSummaryWebPart.java
@@ -127,7 +127,7 @@ public final class QCSummaryWebPart extends BodyWebPart<QCSummaryWebPart.Element
     {
         private final WebElement _el;
 
-        private final Locator emptyText = Locator.tagWithClass("div", "item-text").withText("No sample files imported");
+        private final Locator emptyText = Locator.tagWithClass("div", "qc-summary-text").withText("No sample files imported");
         private final WebElement folderLink = Locator.css("div.folder-name a").findWhenNeeded(this);
         private final WebElement autoQCIcon = Locator.css("div.auto-qc-ping span").findWhenNeeded(this);
         private List<WebElement> _recentSampleFiles;

--- a/webapp/TargetedMS/css/QCSummary.css
+++ b/webapp/TargetedMS/css/QCSummary.css
@@ -47,8 +47,13 @@
 }
 
 .sample-file-details {
-    padding-top: 5px;
     cursor: pointer;
+    min-height: 9em;
+}
+
+.qc-summary-text {
+    padding-top: 5px;
+    padding-bottom: 5px;
 }
 
 .sample-file-field-label {

--- a/webapp/TargetedMS/js/QCSummaryPanel.js
+++ b/webapp/TargetedMS/js/QCSummaryPanel.js
@@ -129,16 +129,16 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
                     '</div>',
                 '</tpl>',
                 '<tpl if="docCount == 0 && isParent !== true">',
-                    '<div class="item-text">No sample files imported</div>',
+                    '<div class="qc-summary-text">No sample files imported</div>',
                     '<div class="auto-qc-ping" id="{autoQcCalloutId}">AutoQC <span class="{autoQCPing:this.getAutoQCPingClass}"></span></div>',
                 '<tpl elseif="docCount == 0 && parentOnly">',
-                    '<div class="item-text">No data found.</div>',
+                    '<div class="qc-summary-text">No data found.</div>',
                 '<tpl elseif="docCount &gt; 0">',
-                    '<div class="item-text">',
+                    '<div class="qc-summary-text">',
                         '<a href="{path:this.getSampleFileLink}">{fileCount} sample file{fileCount:this.pluralize}</a> ' +
                             'tracking {precursorCount} precursor{precursorCount:this.pluralize} with {metricCount} metric{metricCount:this.pluralize}',
                     '</div>',
-                    '<div class="item-text sample-file-details sample-file-details-loading" id="qc-summary-samplefiles-{id}">...</div>',
+                    '<div class="item-text sample-file-details sample-file-details-loading" id="qc-summary-samplefiles-{id}">Loading...</div>',
                     '<div class="auto-qc-ping" id="{autoQcCalloutId}">AutoQC <span class="{autoQCPing:this.getAutoQCPingClass}"></span></div>',
                 '</tpl>',
             '</tpl>',
@@ -283,7 +283,7 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
             });
             html += '</table>';
             if (container.fileCount > sampleFiles.length) {
-                html += '<div class="item-text">Showing only the most recently imported samples. <a href="' + LABKEY.ActionURL.buildURL('targetedms', 'qcSummaryHistory.view', container.path) + '">View all</a></div>';
+                html += '<div class="qc-summary-text">Showing only the most recently imported samples. <a href="' + LABKEY.ActionURL.buildURL('targetedms', 'qcSummaryHistory.view', container.path) + '">View all</a></div>';
             }
             var sampleFilesDiv = Ext4.get('qc-summary-samplefiles-' + container.id);
             sampleFilesDiv.update(html);


### PR DESCRIPTION
#### Rationale
The QC summary web part is resizing at least twice during a standard render as it gets API responses. That's a lot of flashing for the user, and it's causing test failures too as the content shifts while the test is interacting with it

#### Changes
Reserve the expected amount of space for the web part when it has no child folders, and when it does, reserve enough space for them as soon as we know how many there will be. When there's < 3 samples loaded in a folder (uncommon) we'll reserve a little extra room more than we'll need, but it won't be needed elsewhere with so little data, so no problem.