### PR TITLE
Issue 40731: Perf issues when bot hits targetedms-showPeptideMap.view

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -3506,6 +3506,9 @@ public class TargetedMSController extends SpringActionController
                     return tempDef;
                 }
             };
+            // Issue 40731- prevent expensive cross-folder queries when the results will always be scoped to the current
+            // run anyway
+            settings.setContainerFilterName(null);
             settings.setBaseFilter(new SimpleFilter(FieldKey.fromParts("PeptideGroupId", "RunId"), form.getId()));
             TargetedMSSchema schema = new TargetedMSSchema(getUser(), getContainer());
             return schema.createView(getViewContext(), settings, errors);

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -3524,6 +3524,9 @@ public class TargetedMSController extends SpringActionController
         protected QueryView createQueryView(RunDetailsForm form, BindException errors, boolean forExport, String dataRegion)
         {
             QuerySettings settings = new QuerySettings(getViewContext(), _dataRegionName, "PeptideIds");
+            // Issue 40731- prevent expensive cross-folder queries when the results will always be scoped to the current
+            // run anyway
+            settings.setContainerFilterName(null);
             settings.setBaseFilter(new SimpleFilter(FieldKey.fromParts("PeptideGroupId", "RunId"), form.getId()));
             TargetedMSSchema schema = new TargetedMSSchema(getUser(), getContainer());
             return schema.createView(getViewContext(), settings, errors);


### PR DESCRIPTION
with ContainerFilter = AllFolders

#### Rationale
This is a report backed by a custom query, and the action is always filtering it to show a specific run's data. Thus, the folder filter isn't meaningful, but it's causing the query to be incredibly expensive to run

#### Changes
Throw out any folder filter from the URL, so we get the same results in a much better query plan