### PR TITLE
Update jars.txt to match new protobuf-java version

### DIFF
--- a/resources/credits/jars.txt
+++ b/resources/credits/jars.txt
@@ -1,4 +1,4 @@
 {table}
 Filename|Component|Version|Source|License|LabKey Dev|Purpose
-protobuf-java-3.2.0.jar|Protocol Buffers|3.2.0|{link:Github Google|https://github.com/google/protobuf/releases}|{link:Custom|https://github.com/google/protobuf/blob/master/LICENSE}|nicksh|Binary data parsing
+protobuf-java-3.12.2.jar|Protocol Buffers|3.12.2|{link:Github Google|https://github.com/google/protobuf/releases}|{link:Custom|https://github.com/google/protobuf/blob/master/LICENSE}|nicksh|Binary data parsing
 {table}


### PR DESCRIPTION
#### Rationale
We updated this library in the recent support for cross-linked peptides, but failed to update our reference to it in credits.txt

#### Related Pull Requests
https://github.com/LabKey/targetedms/pull/204