### PR TITLE
Issue 40803: targetedms-20.007-20.008.sql uses syntax unsupported in PG 9.5

### DIFF
--- a/resources/schemas/dbscripts/postgresql/targetedms-20.007-20.008.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-20.007-20.008.sql
@@ -1,4 +1,4 @@
-ALTER TABLE targetedms.transition add column IF NOT EXISTS complexFragmentIon TEXT;
+ALTER TABLE targetedms.transition add column complexFragmentIon TEXT;
 
 
 


### PR DESCRIPTION
#### Rationale
We claim to support Postgres 9.5. Let's do it!

#### Changes
Remove unnecessary syntax when creating column