### PR TITLE
Issue 40831: Overflowing integer values on PK for targetedms.TransitionChromInfo

### DIFF
--- a/src/org/labkey/targetedms/SkylineDocImporter.java
+++ b/src/org/labkey/targetedms/SkylineDocImporter.java
@@ -1708,7 +1708,7 @@ public class SkylineDocImporter
     {
         for (TransitionChromInfo transChromInfo : transitionChromInfos)
         {
-            SampleFile sampleFile = skylineIdSampleFileIdMap.get(SampleFileKey.getKey(transChromInfo));
+            SampleFile sampleFile = skylineIdSampleFileIdMap.get(SampleFileKey.getKey(transChromInfo.getReplicateName(), transChromInfo.getSkylineSampleFileId()));
             if (sampleFile == null)
             {
                 throw new PanoramaBadDataException("Database ID not found for Skyline samplefile id " + transChromInfo.getSkylineSampleFileId() + " in replicate " + transChromInfo.getReplicateName());
@@ -1815,10 +1815,20 @@ public class SkylineDocImporter
         }
     }
 
+    /** Remove this overloaded version when all tables have migrated to 8-byte ID columns */
     private void insertAnnotation(PreparedStatement stmt, AbstractAnnotation annotation, int entityId) throws SQLException
     {
         int index = 1;
         stmt.setInt(index++, entityId);
+        stmt.setString(index++, annotation.getName());
+        stmt.setString(index++, annotation.getValue());
+        stmt.execute();
+    }
+
+    private void insertAnnotation(PreparedStatement stmt, AbstractAnnotation annotation, long entityId) throws SQLException
+    {
+        int index = 1;
+        stmt.setLong(index++, entityId);
         stmt.setString(index++, annotation.getName());
         stmt.setString(index++, annotation.getValue());
         stmt.execute();
@@ -1886,7 +1896,11 @@ public class SkylineDocImporter
             setInteger(_transitionChromInfoStmt, index++, transChromInfo.getRankByLevel());
             setBoolean(_transitionChromInfoStmt, index, transChromInfo.getForcedIntegration());
 
-            insertAndUpdateId(transChromInfo, _transitionChromInfoStmt);
+            try (ResultSet rs = TargetedMSManager.getSqlDialect().executeWithResults(_transitionChromInfoStmt))
+            {
+                rs.next();
+                transChromInfo.setId(rs.getLong(1));
+            }
         }
         catch (SQLException e)
         {
@@ -2124,12 +2138,17 @@ public class SkylineDocImporter
 
         public static SampleFileKey getKey(ChromInfo chromInfo)
         {
-            return new SampleFileKey(chromInfo.getReplicateName(), chromInfo.getSkylineSampleFileId());
+            return getKey(chromInfo.getReplicateName(), chromInfo.getSkylineSampleFileId());
         }
 
         public static SampleFileKey getKey(Replicate replicate, SampleFile sampleFile)
         {
-            return new SampleFileKey(replicate.getName(), sampleFile.getSkylineId());
+            return getKey(replicate.getName(), sampleFile.getSkylineId());
+        }
+
+        public static SampleFileKey getKey(String replicateName, String sampleFileName)
+        {
+            return new SampleFileKey(replicateName, sampleFileName);
         }
 
         @Override

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -1263,7 +1263,7 @@ public class TargetedMSController extends SpringActionController
         @Override
         public ModelAndView getView(ChromatogramForm form, BindException errors)
         {
-            int precursorId = form.getId();
+            long precursorId = form.getId();
             Precursor precursor = PrecursorManager.getPrecursor(getContainer(), precursorId, getUser());
             if (precursor == null)
             {
@@ -1359,7 +1359,7 @@ public class TargetedMSController extends SpringActionController
         @Override
         public ModelAndView getView(ChromatogramForm form, BindException errors)
         {
-            int precursorId = form.getId();
+            long precursorId = form.getId();
             MoleculePrecursor precursor = MoleculePrecursorManager.getPrecursor(getContainer(), precursorId, getUser());
             if (precursor == null)
             {
@@ -1441,7 +1441,7 @@ public class TargetedMSController extends SpringActionController
         @Override
         public ModelAndView getView(ChromatogramForm form, BindException errors)
         {
-            int peptideId = form.getId();
+            long peptideId = form.getId();
             Peptide peptide = PeptideManager.getPeptide(getContainer(), peptideId);
             if (peptide == null)
             {
@@ -1758,7 +1758,7 @@ public class TargetedMSController extends SpringActionController
 
     public static class ChromatogramForm extends AbstractChartForm
     {
-        private int _id;
+        private long _id;
         private boolean _syncY = false;
         private boolean _syncX = false;
         private boolean _splitGraph = false;
@@ -1772,12 +1772,12 @@ public class TargetedMSController extends SpringActionController
             setDefaultChartWidth(400);
         }
 
-        public int getId()
+        public long getId()
         {
             return _id;
         }
 
-        public void setId(int id)
+        public void setId(long id)
         {
             _id = id;
         }
@@ -1921,7 +1921,7 @@ public class TargetedMSController extends SpringActionController
         @Override
         public ModelAndView getView(ChromatogramForm form, BindException errors)
         {
-            int peptideId = form.getId();  // peptide Id
+            long peptideId = form.getId();  // peptide Id
 
             Peptide peptide = PeptideManager.getPeptide(getContainer(), peptideId);
             if(peptide == null)
@@ -2021,7 +2021,7 @@ public class TargetedMSController extends SpringActionController
         @Override
         public ModelAndView getView(ChromatogramForm form, BindException errors)
         {
-            int moleculeId = form.getId();
+            long moleculeId = form.getId();
 
             Molecule molecule = MoleculeManager.getMolecule(getContainer(), moleculeId);
             if (molecule == null)
@@ -4081,12 +4081,12 @@ public class TargetedMSController extends SpringActionController
         private List<ReplicateAnnotation> _replicateAnnotationValueList;
 
         // fields for proteomics
-        private int _peptideId;
-        private int _precursorId;
+        private long _peptideId;
+        private long _precursorId;
         private List<Peptide> _peptideList;
 
         // fields for small molecule
-        private int _moleculeId;
+        private long _moleculeId;
         private int _moleculePrecursorId;
         private List<Molecule> _moleculeList;
 
@@ -4130,32 +4130,32 @@ public class TargetedMSController extends SpringActionController
             _peptideGroupId = peptideGroupId;
         }
 
-        public int getPeptideId()
+        public long getPeptideId()
         {
             return _peptideId;
         }
 
-        public void setPeptideId(int peptideId)
+        public void setPeptideId(long peptideId)
         {
             _peptideId = peptideId;
         }
 
-        public int getPrecursorId()
+        public long getPrecursorId()
         {
             return _precursorId;
         }
 
-        public void setPrecursorId(int precursorId)
+        public void setPrecursorId(long precursorId)
         {
             _precursorId = precursorId;
         }
 
-        public int getMoleculeId()
+        public long getMoleculeId()
         {
             return _moleculeId;
         }
 
-        public void setMoleculeId(int moleculeId)
+        public void setMoleculeId(long moleculeId)
         {
             _moleculeId = moleculeId;
         }

--- a/src/org/labkey/targetedms/TargetedMSManager.java
+++ b/src/org/labkey/targetedms/TargetedMSManager.java
@@ -1161,7 +1161,7 @@ public class TargetedMSManager
         purgeDeletedRuns();
     }
 
-    public static TargetedMSRun getRunForPrecursor(int precursorId)
+    public static TargetedMSRun getRunForPrecursor(long precursorId)
     {
         String sql = "SELECT run.* FROM "+
                      getTableInfoRuns()+" AS run, "+
@@ -1183,7 +1183,7 @@ public class TargetedMSManager
         return run;
     }
 
-    public static TargetedMSRun getRunForGeneralMolecule(int id)
+    public static TargetedMSRun getRunForGeneralMolecule(long id)
     {
         String sql = "SELECT run.* FROM "+
                      getTableInfoRuns()+" AS run, "+
@@ -2145,7 +2145,7 @@ public class TargetedMSManager
         return null;
     }
 
-    public static int getMaxTransitionCount(int moleculeId)
+    public static int getMaxTransitionCount(long moleculeId)
     {
         SQLFragment maxTransitionSQL = new SQLFragment("select MAX(c) FROM\n" +
                 "(\n" +
@@ -2166,7 +2166,7 @@ public class TargetedMSManager
         return maxCount != null ? maxCount.intValue() : 0;
     }
 
-    public static int getMaxTransitionCountForPrecursor(int precursorId)
+    public static int getMaxTransitionCountForPrecursor(long precursorId)
     {
         SQLFragment maxTransitionSQL = new SQLFragment("select MAX(c) FROM\n" +
                 "(\n" +

--- a/src/org/labkey/targetedms/parser/PeakAreaRatioCalculator.java
+++ b/src/org/labkey/targetedms/parser/PeakAreaRatioCalculator.java
@@ -282,7 +282,7 @@ public class PeakAreaRatioCalculator
         }
     }
 
-    // Calculator for transition area ratios for a single transtion from one precursor
+    // Calculator for transition area ratios for a single transition from one precursor
     // in one sample file.
     private class TransitionAreaRatioCalculator extends AreaRatioCalculator<TransitionChromInfo, TransitionAreaRatio>
     {
@@ -309,7 +309,7 @@ public class PeakAreaRatioCalculator
         }
     }
 
-    private abstract class AreaRatioCalculator <T extends ChromInfo, R extends AreaRatio>
+    private abstract class AreaRatioCalculator <T, R extends AreaRatio>
     {
         private Map<Integer, T> _labelIdChromInfoMap;
 

--- a/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
+++ b/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
@@ -1539,7 +1539,7 @@ public class SkylineDocumentParser implements AutoCloseable
     {
         GeneralMoleculeChromInfo chromInfo = new GeneralMoleculeChromInfo();
         chromInfo.setReplicateName(XmlUtil.readRequiredAttribute(reader, "replicate", PEPTIDE_RESULT));
-        setSkylineSampleFileId(reader, chromInfo);
+        chromInfo.setSkylineSampleFileId(getSkylineSampleFileId(reader, chromInfo.getReplicateName()));
         chromInfo.setRetentionTime(XmlUtil.readDoubleAttribute(reader, "retention_time"));
         chromInfo.setPeakCountRatio(XmlUtil.readDoubleAttribute(reader, "peak_count_ratio"));
         chromInfo.setExcludeFromCalibration(XmlUtil.readBooleanAttribute(reader, "exclude_from_calibration", false));
@@ -1547,18 +1547,18 @@ public class SkylineDocumentParser implements AutoCloseable
         return chromInfo;
     }
 
-    private void setSkylineSampleFileId(XMLStreamReader reader, ChromInfo chromInfo)
+    private String getSkylineSampleFileId(XMLStreamReader reader, String replicateName)
     {
         String skylineSampleFileId = XmlUtil.readAttribute(reader, "file");
         if(skylineSampleFileId == null)
         {
-            skylineSampleFileId = _replicateSampleFileIdMap.get(chromInfo.getReplicateName());
+            skylineSampleFileId = _replicateSampleFileIdMap.get(replicateName);
             if(skylineSampleFileId == null)
             {
-                throw new IllegalStateException("Could not find Skyline-given sample file Id for chrom info in replicate "+chromInfo.getReplicateName());
+                throw new IllegalStateException("Could not find Skyline-given sample file Id for chrom info in replicate " + replicateName);
             }
         }
-        chromInfo.setSkylineSampleFileId(skylineSampleFileId);
+        return skylineSampleFileId;
     }
 
     private MoleculePrecursor readMoleculePrecursor(XMLStreamReader reader, Molecule molecule) throws XMLStreamException, IOException
@@ -1994,7 +1994,7 @@ public class SkylineDocumentParser implements AutoCloseable
         chromInfo.setAnnotations(annotations);
 
         chromInfo.setReplicateName(XmlUtil.readRequiredAttribute(reader, "replicate", PRECURSOR_PEAK));
-        setSkylineSampleFileId(reader, chromInfo);
+        chromInfo.setSkylineSampleFileId(getSkylineSampleFileId(reader, chromInfo.getReplicateName()));
         chromInfo.setOptimizationStep(XmlUtil.readIntegerAttribute(reader, "step"));
         chromInfo.setBestRetentionTime(XmlUtil.readDoubleAttribute(reader, "retention_time"));
         chromInfo.setMinStartTime(XmlUtil.readDoubleAttribute(reader, "start_time"));
@@ -2368,7 +2368,7 @@ public class SkylineDocumentParser implements AutoCloseable
         chromInfo.setAnnotations(annotations);
 
         chromInfo.setReplicateName(XmlUtil.readRequiredAttribute(reader, "replicate", TRANSITION_PEAK));
-        setSkylineSampleFileId(reader, chromInfo);
+        chromInfo.setSkylineSampleFileId(getSkylineSampleFileId(reader, chromInfo.getReplicateName()));
         chromInfo.setOptimizationStep(XmlUtil.readIntegerAttribute(reader, "step"));
         chromInfo.setRetentionTime(XmlUtil.readDoubleAttribute(reader, "retention_time"));
         chromInfo.setStartTime(XmlUtil.readDoubleAttribute(reader, "start_time"));

--- a/src/org/labkey/targetedms/parser/TransitionAreaRatio.java
+++ b/src/org/labkey/targetedms/parser/TransitionAreaRatio.java
@@ -22,25 +22,25 @@ package org.labkey.targetedms.parser;
  */
 public class TransitionAreaRatio extends AreaRatio
 {
-    private int _transitionChromInfoId;
-    private int _transitionChromInfoStdId;
+    private long _transitionChromInfoId;
+    private long _transitionChromInfoStdId;
 
-    public int getTransitionChromInfoId()
+    public long getTransitionChromInfoId()
     {
         return _transitionChromInfoId;
     }
 
-    public void setTransitionChromInfoId(int transitionChromInfoId)
+    public void setTransitionChromInfoId(long transitionChromInfoId)
     {
         _transitionChromInfoId = transitionChromInfoId;
     }
 
-    public int getTransitionChromInfoStdId()
+    public long getTransitionChromInfoStdId()
     {
         return _transitionChromInfoStdId;
     }
 
-    public void setTransitionChromInfoStdId(int transitionChromInfoStdId)
+    public void setTransitionChromInfoStdId(long transitionChromInfoStdId)
     {
         _transitionChromInfoStdId = transitionChromInfoStdId;
     }

--- a/src/org/labkey/targetedms/parser/TransitionChromInfo.java
+++ b/src/org/labkey/targetedms/parser/TransitionChromInfo.java
@@ -15,12 +15,16 @@
 
 package org.labkey.targetedms.parser;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
 /**
  * User: vsharma
  * Date: 4/16/12
  * Time: 3:04 PM
  */
-public class TransitionChromInfo extends ChromInfo<TransitionChromInfoAnnotation>
+public class TransitionChromInfo //extends ChromInfo<TransitionChromInfoAnnotation>
 {
     private int _transitionId;
     private int _precursorChromInfoId;
@@ -52,6 +56,80 @@ public class TransitionChromInfo extends ChromInfo<TransitionChromInfoAnnotation
     private Integer Rank;
     private Integer RankByLevel;
     private Boolean ForcedIntegration;
+
+    /** HACK TO UPDATE TO LONG FOR ID COLUMN - ISSUE 40831 */
+    private String _replicateName;
+    private String _skylineSampleFileId;
+    private int _sampleFileId;
+    private List<TransitionChromInfoAnnotation> _annotations = Collections.emptyList();
+    private long _id;
+
+    public String getSkylineSampleFileId()
+    {
+        return _skylineSampleFileId;
+    }
+
+    public void setSkylineSampleFileId(String skylineSampleFileId)
+    {
+        _skylineSampleFileId = skylineSampleFileId;
+    }
+
+    public String getReplicateName()
+    {
+        return _replicateName;
+    }
+
+    public void setReplicateName(String replicateName)
+    {
+        _replicateName = replicateName;
+    }
+
+    public int getSampleFileId()
+    {
+        return _sampleFileId;
+    }
+
+    public void setSampleFileId(int sampleFileId)
+    {
+        _sampleFileId = sampleFileId;
+    }
+
+
+    public long getId()
+    {
+        return _id;
+    }
+    public void setId(long id)
+    {
+        _id = id;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TransitionChromInfo that = (TransitionChromInfo) o;
+        return _id == that._id;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(_id, getClass());
+    }
+
+    public List<TransitionChromInfoAnnotation> getAnnotations()
+    {
+        return _annotations;
+    }
+
+    public void setAnnotations(List<TransitionChromInfoAnnotation> annotations)
+    {
+        _annotations = Collections.unmodifiableList(annotations);
+    }
+    /** END HACK TO UPDATE TO LONG FOR ID COLUMN */
+
 
 
     public int getTransitionId()

--- a/src/org/labkey/targetedms/parser/TransitionChromInfoAnnotation.java
+++ b/src/org/labkey/targetedms/parser/TransitionChromInfoAnnotation.java
@@ -21,14 +21,14 @@ package org.labkey.targetedms.parser;
  */
 public class TransitionChromInfoAnnotation extends AbstractAnnotation
 {
-    private int _transitionChromInfoId;
+    private long _transitionChromInfoId;
 
-    public int getTransitionChromInfoId()
+    public long getTransitionChromInfoId()
     {
         return _transitionChromInfoId;
     }
 
-    public void setTransitionChromInfoId(int transitionChromInfoId)
+    public void setTransitionChromInfoId(long transitionChromInfoId)
     {
         _transitionChromInfoId = transitionChromInfoId;
     }

--- a/src/org/labkey/targetedms/query/MoleculeManager.java
+++ b/src/org/labkey/targetedms/query/MoleculeManager.java
@@ -27,7 +27,7 @@ public class MoleculeManager
 {
     private MoleculeManager() {}
 
-    public static Molecule getMolecule(Container c, int id)
+    public static Molecule getMolecule(Container c, long id)
     {
         SQLFragment sql = new SQLFragment("SELECT mol.*, gm.* FROM ");
         sql.append(TargetedMSManager.getTableInfoMolecule(), "mol");

--- a/src/org/labkey/targetedms/query/MoleculePrecursorManager.java
+++ b/src/org/labkey/targetedms/query/MoleculePrecursorManager.java
@@ -38,7 +38,7 @@ public class MoleculePrecursorManager
 {
     private MoleculePrecursorManager() {}
 
-    public static MoleculePrecursor getPrecursor(Container c, int id, User user)
+    public static MoleculePrecursor getPrecursor(Container c, long id, User user)
     {
         TargetedMSSchema schema = new TargetedMSSchema(user, c);
 

--- a/src/org/labkey/targetedms/query/PeptideChromatogramsTableInfo.java
+++ b/src/org/labkey/targetedms/query/PeptideChromatogramsTableInfo.java
@@ -28,7 +28,7 @@ import org.labkey.targetedms.TargetedMSSchema;
  */
 public class PeptideChromatogramsTableInfo extends FilteredTable<TargetedMSSchema>
 {
-    private int _peptideId;
+    private long _peptideId;
 
     public PeptideChromatogramsTableInfo(TargetedMSSchema schema)
     {
@@ -45,7 +45,7 @@ public class PeptideChromatogramsTableInfo extends FilteredTable<TargetedMSSchem
                                          ChromatogramDisplayColumnFactory.TYPE.GENERAL_MOLECULE));
     }
 
-    public void setPeptideId(int peptideId)
+    public void setPeptideId(long peptideId)
     {
         _peptideId = peptideId;
     }

--- a/src/org/labkey/targetedms/query/PeptideManager.java
+++ b/src/org/labkey/targetedms/query/PeptideManager.java
@@ -45,7 +45,7 @@ public class PeptideManager
 
     private PeptideManager() {}
 
-    public static Peptide getPeptide(Container c, int id)
+    public static Peptide getPeptide(Container c, long id)
     {
         SQLFragment sql = new SQLFragment("SELECT pep.*, gm.* FROM ");
         sql.append(TargetedMSManager.getTableInfoPeptide(), "pep");
@@ -64,7 +64,7 @@ public class PeptideManager
         return new SqlSelector(TargetedMSManager.getSchema(), sql).getObject(Peptide.class);
     }
 
-    public static GeneralMoleculeChromInfo getGeneralMoleculeChromInfo(Container c, int id)
+    public static GeneralMoleculeChromInfo getGeneralMoleculeChromInfo(Container c, long id)
     {
         SQLFragment sql = new SQLFragment("SELECT gmci.* FROM ");
         sql.append(TargetedMSManager.getTableInfoGeneralMoleculeChromInfo(), "gmci");

--- a/src/org/labkey/targetedms/query/PrecursorChromatogramsTableInfo.java
+++ b/src/org/labkey/targetedms/query/PrecursorChromatogramsTableInfo.java
@@ -28,7 +28,7 @@ import org.labkey.targetedms.TargetedMSSchema;
  */
 public class PrecursorChromatogramsTableInfo extends FilteredTable<TargetedMSSchema>
 {
-    private int _precursorId;
+    private long _precursorId;
 
     public PrecursorChromatogramsTableInfo(TargetedMSSchema schema)
     {
@@ -52,7 +52,7 @@ public class PrecursorChromatogramsTableInfo extends FilteredTable<TargetedMSSch
         peptideCol.setDisplayColumnFactory(colFactory);
     }
 
-    public void setPrecursorId(int precursorId)
+    public void setPrecursorId(long precursorId)
     {
         _precursorId = precursorId;
     }

--- a/src/org/labkey/targetedms/query/PrecursorManager.java
+++ b/src/org/labkey/targetedms/query/PrecursorManager.java
@@ -66,7 +66,7 @@ public class PrecursorManager
 
     private PrecursorManager() {}
 
-    public static Precursor getPrecursor(Container c, int id, User user)
+    public static Precursor getPrecursor(Container c, long id, User user)
     {
         TargetedMSSchema schema = new TargetedMSSchema(user, c);
 
@@ -87,7 +87,7 @@ public class PrecursorManager
         return new SqlSelector(TargetedMSManager.getSchema(), sql).getObject(Precursor.class);
     }
 
-    public static PrecursorChromInfo getPrecursorChromInfo(Container c, int id)
+    public static PrecursorChromInfo getPrecursorChromInfo(Container c, long id)
     {
         SQLFragment sql = new SQLFragment("SELECT pci.* FROM ");
         sql.append(TargetedMSManager.getTableInfoPrecursorChromInfo(), "pci");
@@ -769,7 +769,7 @@ public class PrecursorManager
         }
     }
 
-    public static boolean canBeSplitView(int peptideId)
+    public static boolean canBeSplitView(long peptideId)
     {
         SQLFragment sql = new SQLFragment("SELECT DISTINCT gt.fragmenttype FROM ");
         sql.append(TargetedMSManager.getTableInfoGeneralTransition(), "gt");
@@ -790,7 +790,7 @@ public class PrecursorManager
         return false;
     }
 
-    public static boolean hasOptimizationPeaks(int peptideId)
+    public static boolean hasOptimizationPeaks(long peptideId)
     {
         SQLFragment sql = new SQLFragment("SELECT pci.Id FROM ");
         sql.append(TargetedMSManager.getTableInfoGeneralMolecule(), "gm");

--- a/src/org/labkey/targetedms/query/TransitionManager.java
+++ b/src/org/labkey/targetedms/query/TransitionManager.java
@@ -51,7 +51,7 @@ public class TransitionManager
     }
 
     @Nullable
-    public static TransitionChromInfo getTransitionChromInfo(Container c, int id)
+    public static TransitionChromInfo getTransitionChromInfo(Container c, long id)
     {
         SQLFragment sql = new SQLFragment("SELECT tci.* FROM ");
         sql.append(TargetedMSManager.getTableInfoTransitionChromInfo(), "tci");

--- a/src/org/labkey/targetedms/view/summaryChartsView.jsp
+++ b/src/org/labkey/targetedms/view/summaryChartsView.jsp
@@ -47,13 +47,13 @@
 
     // for proteomics summary charts
     List<Peptide> peptideList = bean.getPeptideList();
-    int peptideId = bean.getPeptideId(); // Used when displaying peak areas for a single peptide in multiple replicates
+    long peptideId = bean.getPeptideId(); // Used when displaying peak areas for a single peptide in multiple replicates
                                          // or grouped by replicate annotation.
-    int precursorId = bean.getPrecursorId(); // Used when displaying peak areas for a single precursor
+    long precursorId = bean.getPrecursorId(); // Used when displaying peak areas for a single precursor
 
     // for small molecule summary charts
     List<Molecule> moleculeList = bean.getMoleculeList();
-    int moleculeId = bean.getMoleculeId();
+    long moleculeId = bean.getMoleculeId();
     int moleculePrecursorId = bean.getMoleculePrecursorId();
 
     if ((peptideList != null && !peptideList.isEmpty()) || peptideId != 0 || precursorId != 0)


### PR DESCRIPTION
#### Rationale
PanoramaWeb.org has overflowed the integer (4-byte) values for the targetedms.TransitionChromInfo table's Id column.

#### Changes
Both the Java code and the DB tables are using 4-byte ints and will need to switch to long/bigint. While we should widen all or many of the PKs in the targetedms schema, this is the only table that's close (targetedms.precursorchominfo is at ~330 million, well short of 2 billion). Thus, we can just handle the code update in 20.3 and run SQL against the one affected server to unblock, and do 20.11 work to make all of the tables support the wider column.