### PR TITLE
Test updates due to update to GetQueryDetailsAction

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSSchema.java
+++ b/src/org/labkey/targetedms/TargetedMSSchema.java
@@ -83,6 +83,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -1439,7 +1440,7 @@ public class TargetedMSSchema extends UserSchema
     @Override
     public Set<String> getTableNames()
     {
-        CaseInsensitiveHashSet hs = new CaseInsensitiveHashSet();
+        HashSet hs = new HashSet();
         hs.add(TABLE_TARGETED_MS_RUNS);
         hs.add(TABLE_ENZYME);
         hs.add(TABLE_RUN_ENZYME);

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCGuideSetTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCGuideSetTest.java
@@ -323,7 +323,7 @@ public class TargetedMSQCGuideSetTest extends TargetedMSTest
         setupSubfolder(getProjectName(), folderName, FolderType.QC);
         importData(SProCoP_FILE_ANNOTATED);
         goToSchemaBrowser();
-        selectQuery("targetedms", "replicate");
+        selectQuery("targetedms", "replicate", "Replicate");
         //confirm table columns are present and of correct type representing replicate annotations:
         GetQueryDetailsCommand queryDetailsCommand = new GetQueryDetailsCommand("targetedms", "replicate");
         GetQueryDetailsResponse queryDetailsResponse = queryDetailsCommand.execute(createDefaultConnection(true),getProjectName() + "/" + folderName);

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -804,7 +804,7 @@ public class TargetedMSQCTest extends TargetedMSTest
         verifyQcSummary(1, 3, 2);
 
         //confirm 3 exclusions
-        DataRegionTable drt = getSchemaBrowserDataView("targetedms", "qcmetricexclusion");
+        DataRegionTable drt = getSchemaBrowserDataView("targetedms", "QCMetricExclusion");
         assertEquals("Wrong count", 3,drt.getDataRowCount());
         assertEquals("Wrong metric", " ", drt.getRowDataAsText(0,"MetricId").get(0));
         assertEquals("Wrong metric", " ", drt.getRowDataAsText(1,"MetricId").get(0));

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -559,7 +559,7 @@ public class TargetedMSQCTest extends TargetedMSTest
         assertEquals("Wrong precursors", precursors, qcPlotsWebPart.getPlotTitles());
 
         // Filter the grid to a single peptide
-        DataRegionTable drt =  getSchemaBrowserDataView("targetedms", "generalmoleculechrominfo");
+        DataRegionTable drt =  getSchemaBrowserDataView("targetedms", "GeneralMoleculeChromInfo");
 
         drt.setFilter("PeptideId", "Equals", "AGGSSEPVTGLADK");
 
@@ -585,7 +585,7 @@ public class TargetedMSQCTest extends TargetedMSTest
         verifyRow(drt, 3, QCREPLICATE_4, QC_2_FILE);
 
         goToSchemaBrowser();
-        selectQuery("targetedms", "replicateannotation", "ReplicateAnnotation");
+        selectQuery("targetedms", "ReplicateAnnotation");
         waitAndClickAndWait(Locator.linkWithText("view data"));
 
         // Ensure samples from QC-1 that exist in QC-2 have been overwritten
@@ -604,7 +604,7 @@ public class TargetedMSQCTest extends TargetedMSTest
 
         // Ensure QC-2 samples have been overwritten by QC-4
         goToSchemaBrowser();
-        selectQuery("targetedms", "precursorchrominfo", "PrecursorChromInfo");
+        selectQuery("targetedms", "PrecursorChromInfo");
         waitAndClickAndWait(Locator.linkWithText("view data"));
         assertTextPresent("42.2525");
         assertTextNotPresent("42.4541");
@@ -814,7 +814,7 @@ public class TargetedMSQCTest extends TargetedMSTest
         verifyQcSummary(1, 3, 2);
 
         //confirm 3 exclusions
-        DataRegionTable drt = getSchemaBrowserDataView("targetedms", "qcmetricexclusion", "QCMetricExclusion");
+        DataRegionTable drt = getSchemaBrowserDataView("targetedms", "QCMetricExclusion");
         assertEquals("Wrong count", 3,drt.getDataRowCount());
         assertEquals("Wrong metric", " ", drt.getRowDataAsText(0,"MetricId").get(0));
         assertEquals("Wrong metric", " ", drt.getRowDataAsText(1,"MetricId").get(0));
@@ -824,7 +824,7 @@ public class TargetedMSQCTest extends TargetedMSTest
         clickFolder(subFolderName);
         verifyQcSummary(1, 3, 2);
 
-        drt = getSchemaBrowserDataView("targetedms", "qcmetricexclusion", "QCMetricExclusion");
+        drt = getSchemaBrowserDataView("targetedms", "QCMetricExclusion");
         assertEquals("Wrong count", 3,drt.getDataRowCount());
         assertEquals("Wrong metric", " ", drt.getRowDataAsText(0,"MetricId").get(0));
         assertEquals("Wrong metric", " ", drt.getRowDataAsText(1,"MetricId").get(0));

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -585,7 +585,7 @@ public class TargetedMSQCTest extends TargetedMSTest
         verifyRow(drt, 3, QCREPLICATE_4, QC_2_FILE);
 
         goToSchemaBrowser();
-        selectQuery("targetedms", "replicateannotation");
+        selectQuery("targetedms", "replicateannotation", "ReplicateAnnotation");
         waitAndClickAndWait(Locator.linkWithText("view data"));
 
         // Ensure samples from QC-1 that exist in QC-2 have been overwritten
@@ -604,7 +604,7 @@ public class TargetedMSQCTest extends TargetedMSTest
 
         // Ensure QC-2 samples have been overwritten by QC-4
         goToSchemaBrowser();
-        selectQuery("targetedms", "precursorchrominfo");
+        selectQuery("targetedms", "precursorchrominfo", "PrecursorChromInfo");
         waitAndClickAndWait(Locator.linkWithText("view data"));
         assertTextPresent("42.2525");
         assertTextNotPresent("42.4541");
@@ -619,6 +619,12 @@ public class TargetedMSQCTest extends TargetedMSTest
     {
         goToSchemaBrowser();
         return viewQueryData(schemaName, queryName);
+    }
+
+    private DataRegionTable getSchemaBrowserDataView(String schemaName, String queryName, String publicName)
+    {
+        goToSchemaBrowser();
+        return viewQueryData(schemaName, queryName, null, publicName);
     }
 
     private void verifyCombinedLegend()
@@ -804,7 +810,7 @@ public class TargetedMSQCTest extends TargetedMSTest
         verifyQcSummary(1, 3, 2);
 
         //confirm 3 exclusions
-        DataRegionTable drt = getSchemaBrowserDataView("targetedms", "QCMetricExclusion");
+        DataRegionTable drt = getSchemaBrowserDataView("targetedms", "qcmetricexclusion", "QCMetricExclusion");
         assertEquals("Wrong count", 3,drt.getDataRowCount());
         assertEquals("Wrong metric", " ", drt.getRowDataAsText(0,"MetricId").get(0));
         assertEquals("Wrong metric", " ", drt.getRowDataAsText(1,"MetricId").get(0));
@@ -814,7 +820,7 @@ public class TargetedMSQCTest extends TargetedMSTest
         clickFolder(subFolderName);
         verifyQcSummary(1, 3, 2);
 
-        drt = getSchemaBrowserDataView("targetedms", "qcmetricexclusion");
+        drt = getSchemaBrowserDataView("targetedms", "qcmetricexclusion", "QCMetricExclusion");
         assertEquals("Wrong count", 3,drt.getDataRowCount());
         assertEquals("Wrong metric", " ", drt.getRowDataAsText(0,"MetricId").get(0));
         assertEquals("Wrong metric", " ", drt.getRowDataAsText(1,"MetricId").get(0));

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -791,6 +791,10 @@ public class TargetedMSQCTest extends TargetedMSTest
         //Check for clickable PDF and PNG export icons for Combined plot
         verifyDownloadablePlotIcons(1);
 
+        Locator bubbleClose = Locator.byClass("hopscotch-bubble-close");
+        if (isElementVisible(bubbleClose))
+            click(bubbleClose);
+
         //deselect "Show All Peptides in Single Plot"
         qcPlotsWebPart.setShowAllPeptidesInSinglePlot(false, currentPagePlotCount);
 


### PR DESCRIPTION
#### Rationale
GetQueryDetailsAction was updated to return the public name instead of the name that was passed in.  That public name is displayed in the details section of the schema browser.  These test updates account for that change.

#### Related Pull Requests
https://github.com/LabKey/platform/pull/1379

#### Changes
- Various test updates to look for public name to verify details have loaded
