### PR TITLE
Issue 41317: conditionalize sql upgrade script to support older pg versions

### DIFF
--- a/resources/schemas/dbscripts/postgresql/targetedms-20.015-20.016.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-20.015-20.016.sql
@@ -66,51 +66,93 @@ BEGIN
        )
     THEN
         EXECUTE
-        'ALTER SEQUENCE targetedms.runs_id_seq as bigint;
-        ALTER SEQUENCE targetedms.predictor_id_seq as bigint;
-        ALTER SEQUENCE targetedms.peptide_id_seq as bigint;
-        ALTER SEQUENCE targetedms.instrument_id_seq as bigint;
-        ALTER SEQUENCE targetedms.replicate_id_seq as bigint;
-        ALTER SEQUENCE targetedms.samplefile_id_seq as bigint;
-        ALTER SEQUENCE targetedms.peptidegroup_id_seq as bigint;
-        ALTER SEQUENCE targetedms.isotopelabel_id_seq as bigint;
-        ALTER SEQUENCE targetedms.precursorchrominfo_id_seq as bigint;
-        ALTER SEQUENCE targetedms.transitionchrominfo_id_seq as bigint;
-        ALTER SEQUENCE targetedms.structuralmodification_id_seq as bigint;
-        ALTER SEQUENCE targetedms.structuralmodloss_id_seq as bigint;
-        ALTER SEQUENCE targetedms.isotopemodification_id_seq as bigint;
-        ALTER SEQUENCE targetedms.peptidestructuralmodification_id_seq as bigint;
-        ALTER SEQUENCE targetedms.peptideisotopemodification_id_seq as bigint;
-        ALTER SEQUENCE targetedms.transitionarearatio_id_seq as bigint;
-        ALTER SEQUENCE targetedms.precursorarearatio_id_seq as bigint;
-        ALTER SEQUENCE targetedms.peptidearearatio_id_seq as bigint;
-        ALTER SEQUENCE targetedms.spectrumlibrary_id_seq as bigint;
-        ALTER SEQUENCE targetedms.transitionoptimization_id_seq as bigint;
-        ALTER SEQUENCE targetedms.transitionloss_id_seq as bigint;
-        ALTER SEQUENCE targetedms.peptidegroupannotation_id_seq as bigint;
-        ALTER SEQUENCE targetedms.precursorannotation_id_seq as bigint;
-        ALTER SEQUENCE targetedms.precursorchrominfoannotation_id_seq as bigint;
-        ALTER SEQUENCE targetedms.transitionannotation_id_seq as bigint;
-        ALTER SEQUENCE targetedms.transitionchrominfoannotation_id_seq as bigint;
-        ALTER SEQUENCE targetedms.replicateannotation_id_seq as bigint;
-        ALTER SEQUENCE targetedms.annotationsettings_id_seq as bigint;
-        ALTER SEQUENCE targetedms.isolationscheme_id_seq as bigint;
-        ALTER SEQUENCE targetedms.isolationwindow_id_seq as bigint;
-        ALTER SEQUENCE targetedms.drifttimepredictionsettings_id_seq as bigint;
-        ALTER SEQUENCE targetedms.measureddrifttime_id_seq as bigint;
-        ALTER SEQUENCE targetedms.groupcomparisonsettings_id_seq as bigint;
-        ALTER SEQUENCE targetedms.quantificationsettings_id_seq as bigint;
-        ALTER SEQUENCE targetedms.listdefinition_id_seq as bigint;
-        ALTER SEQUENCE targetedms.listcolumndefinition_id_seq as bigint;
-        ALTER SEQUENCE targetedms.listitem_id_seq as bigint;
-        ALTER SEQUENCE targetedms.listitemvalue_id_seq as bigint;
-        ALTER SEQUENCE targetedms.samplefilechrominfo_id_seq as bigint;
-        ALTER SEQUENCE targetedms.nistlibinfo_id_seq as bigint;
-        ALTER SEQUENCE targetedms.spectrastlibinfo_id_seq as bigint;
-        ALTER SEQUENCE targetedms.chromatogramlibinfo_id_seq as bigint;
-        ALTER SEQUENCE targetedms.hunterlibinfo_id_seq as bigint;';
+        'ALTER SEQUENCE targetedms.runs_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.predictor_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.peptide_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.instrument_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.replicate_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.samplefile_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.peptidegroup_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.isotopelabel_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.precursorchrominfo_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.transitionchrominfo_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.structuralmodification_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.structuralmodloss_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.isotopemodification_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.peptidestructuralmodification_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.peptideisotopemodification_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.transitionarearatio_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.precursorarearatio_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.peptidearearatio_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.spectrumlibrary_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.transitionoptimization_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.transitionloss_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.peptidegroupannotation_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.precursorannotation_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.precursorchrominfoannotation_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.transitionannotation_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.transitionchrominfoannotation_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.replicateannotation_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.annotationsettings_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.isolationscheme_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.isolationwindow_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.drifttimepredictionsettings_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.measureddrifttime_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.groupcomparisonsettings_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.quantificationsettings_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.listdefinition_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.listcolumndefinition_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.listitem_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.listitemvalue_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.samplefilechrominfo_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.nistlibinfo_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.spectrastlibinfo_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.chromatogramlibinfo_id_seq as bigint;';
+        EXECUTE
+        'ALTER SEQUENCE targetedms.hunterlibinfo_id_seq as bigint;';
     END IF;
-END;
+END
 $$ LANGUAGE plpgsql;
 
 SELECT targetedms.handleSequences();

--- a/resources/schemas/dbscripts/postgresql/targetedms-20.015-20.016.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-20.015-20.016.sql
@@ -57,46 +57,61 @@ ALTER TABLE targetedms.TransitionOptimization ALTER COLUMN Id TYPE bigint;
 
 --------------------------------------------------------------------------------------------------
 ------------------- Update sequences to bigint --------------------------------------------------
-ALTER SEQUENCE targetedms.runs_id_seq as bigint;
-ALTER SEQUENCE targetedms.predictor_id_seq as bigint;
-ALTER SEQUENCE targetedms.peptide_id_seq as bigint;
-ALTER SEQUENCE targetedms.instrument_id_seq as bigint;
-ALTER SEQUENCE targetedms.replicate_id_seq as bigint;
-ALTER SEQUENCE targetedms.samplefile_id_seq as bigint;
-ALTER SEQUENCE targetedms.peptidegroup_id_seq as bigint;
-ALTER SEQUENCE targetedms.isotopelabel_id_seq as bigint;
-ALTER SEQUENCE targetedms.precursorchrominfo_id_seq as bigint;
-ALTER SEQUENCE targetedms.transitionchrominfo_id_seq as bigint;
-ALTER SEQUENCE targetedms.structuralmodification_id_seq as bigint;
-ALTER SEQUENCE targetedms.structuralmodloss_id_seq as bigint;
-ALTER SEQUENCE targetedms.isotopemodification_id_seq as bigint;
-ALTER SEQUENCE targetedms.peptidestructuralmodification_id_seq as bigint;
-ALTER SEQUENCE targetedms.peptideisotopemodification_id_seq as bigint;
-ALTER SEQUENCE targetedms.transitionarearatio_id_seq as bigint;
-ALTER SEQUENCE targetedms.precursorarearatio_id_seq as bigint;
-ALTER SEQUENCE targetedms.peptidearearatio_id_seq as bigint;
-ALTER SEQUENCE targetedms.spectrumlibrary_id_seq as bigint;
-ALTER SEQUENCE targetedms.transitionoptimization_id_seq as bigint;
-ALTER SEQUENCE targetedms.transitionloss_id_seq as bigint;
-ALTER SEQUENCE targetedms.peptidegroupannotation_id_seq as bigint;
-ALTER SEQUENCE targetedms.precursorannotation_id_seq as bigint;
-ALTER SEQUENCE targetedms.precursorchrominfoannotation_id_seq as bigint;
-ALTER SEQUENCE targetedms.transitionannotation_id_seq as bigint;
-ALTER SEQUENCE targetedms.transitionchrominfoannotation_id_seq as bigint;
-ALTER SEQUENCE targetedms.replicateannotation_id_seq as bigint;
-ALTER SEQUENCE targetedms.annotationsettings_id_seq as bigint;
-ALTER SEQUENCE targetedms.isolationscheme_id_seq as bigint;
-ALTER SEQUENCE targetedms.isolationwindow_id_seq as bigint;
-ALTER SEQUENCE targetedms.drifttimepredictionsettings_id_seq as bigint;
-ALTER SEQUENCE targetedms.measureddrifttime_id_seq as bigint;
-ALTER SEQUENCE targetedms.groupcomparisonsettings_id_seq as bigint;
-ALTER SEQUENCE targetedms.quantificationsettings_id_seq as bigint;
-ALTER SEQUENCE targetedms.listdefinition_id_seq as bigint;
-ALTER SEQUENCE targetedms.listcolumndefinition_id_seq as bigint;
-ALTER SEQUENCE targetedms.listitem_id_seq as bigint;
-ALTER SEQUENCE targetedms.listitemvalue_id_seq as bigint;
-ALTER SEQUENCE targetedms.samplefilechrominfo_id_seq as bigint;
-ALTER SEQUENCE targetedms.nistlibinfo_id_seq as bigint;
-ALTER SEQUENCE targetedms.spectrastlibinfo_id_seq as bigint;
-ALTER SEQUENCE targetedms.chromatogramlibinfo_id_seq as bigint;
-ALTER SEQUENCE targetedms.hunterlibinfo_id_seq as bigint;
+-- Issue 41317 : Alter sequence support in pg versions >= 10
+CREATE FUNCTION targetedms.handleSequences() RETURNS VOID AS $$
+DECLARE
+BEGIN
+    IF (
+        SELECT CAST(current_setting('server_version_num') as INT) >= 100000
+       )
+    THEN
+        ALTER SEQUENCE targetedms.runs_id_seq as bigint;
+        ALTER SEQUENCE targetedms.predictor_id_seq as bigint;
+        ALTER SEQUENCE targetedms.peptide_id_seq as bigint;
+        ALTER SEQUENCE targetedms.instrument_id_seq as bigint;
+        ALTER SEQUENCE targetedms.replicate_id_seq as bigint;
+        ALTER SEQUENCE targetedms.samplefile_id_seq as bigint;
+        ALTER SEQUENCE targetedms.peptidegroup_id_seq as bigint;
+        ALTER SEQUENCE targetedms.isotopelabel_id_seq as bigint;
+        ALTER SEQUENCE targetedms.precursorchrominfo_id_seq as bigint;
+        ALTER SEQUENCE targetedms.transitionchrominfo_id_seq as bigint;
+        ALTER SEQUENCE targetedms.structuralmodification_id_seq as bigint;
+        ALTER SEQUENCE targetedms.structuralmodloss_id_seq as bigint;
+        ALTER SEQUENCE targetedms.isotopemodification_id_seq as bigint;
+        ALTER SEQUENCE targetedms.peptidestructuralmodification_id_seq as bigint;
+        ALTER SEQUENCE targetedms.peptideisotopemodification_id_seq as bigint;
+        ALTER SEQUENCE targetedms.transitionarearatio_id_seq as bigint;
+        ALTER SEQUENCE targetedms.precursorarearatio_id_seq as bigint;
+        ALTER SEQUENCE targetedms.peptidearearatio_id_seq as bigint;
+        ALTER SEQUENCE targetedms.spectrumlibrary_id_seq as bigint;
+        ALTER SEQUENCE targetedms.transitionoptimization_id_seq as bigint;
+        ALTER SEQUENCE targetedms.transitionloss_id_seq as bigint;
+        ALTER SEQUENCE targetedms.peptidegroupannotation_id_seq as bigint;
+        ALTER SEQUENCE targetedms.precursorannotation_id_seq as bigint;
+        ALTER SEQUENCE targetedms.precursorchrominfoannotation_id_seq as bigint;
+        ALTER SEQUENCE targetedms.transitionannotation_id_seq as bigint;
+        ALTER SEQUENCE targetedms.transitionchrominfoannotation_id_seq as bigint;
+        ALTER SEQUENCE targetedms.replicateannotation_id_seq as bigint;
+        ALTER SEQUENCE targetedms.annotationsettings_id_seq as bigint;
+        ALTER SEQUENCE targetedms.isolationscheme_id_seq as bigint;
+        ALTER SEQUENCE targetedms.isolationwindow_id_seq as bigint;
+        ALTER SEQUENCE targetedms.drifttimepredictionsettings_id_seq as bigint;
+        ALTER SEQUENCE targetedms.measureddrifttime_id_seq as bigint;
+        ALTER SEQUENCE targetedms.groupcomparisonsettings_id_seq as bigint;
+        ALTER SEQUENCE targetedms.quantificationsettings_id_seq as bigint;
+        ALTER SEQUENCE targetedms.listdefinition_id_seq as bigint;
+        ALTER SEQUENCE targetedms.listcolumndefinition_id_seq as bigint;
+        ALTER SEQUENCE targetedms.listitem_id_seq as bigint;
+        ALTER SEQUENCE targetedms.listitemvalue_id_seq as bigint;
+        ALTER SEQUENCE targetedms.samplefilechrominfo_id_seq as bigint;
+        ALTER SEQUENCE targetedms.nistlibinfo_id_seq as bigint;
+        ALTER SEQUENCE targetedms.spectrastlibinfo_id_seq as bigint;
+        ALTER SEQUENCE targetedms.chromatogramlibinfo_id_seq as bigint;
+        ALTER SEQUENCE targetedms.hunterlibinfo_id_seq as bigint;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT targetedms.handleSequences();
+
+DROP FUNCTION targetedms.handleSequences;

--- a/resources/schemas/dbscripts/postgresql/targetedms-20.015-20.016.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-20.015-20.016.sql
@@ -65,7 +65,8 @@ BEGIN
         SELECT CAST(current_setting('server_version_num') as INT) >= 100000
        )
     THEN
-        ALTER SEQUENCE targetedms.runs_id_seq as bigint;
+        EXECUTE
+        'ALTER SEQUENCE targetedms.runs_id_seq as bigint;
         ALTER SEQUENCE targetedms.predictor_id_seq as bigint;
         ALTER SEQUENCE targetedms.peptide_id_seq as bigint;
         ALTER SEQUENCE targetedms.instrument_id_seq as bigint;
@@ -107,7 +108,7 @@ BEGIN
         ALTER SEQUENCE targetedms.nistlibinfo_id_seq as bigint;
         ALTER SEQUENCE targetedms.spectrastlibinfo_id_seq as bigint;
         ALTER SEQUENCE targetedms.chromatogramlibinfo_id_seq as bigint;
-        ALTER SEQUENCE targetedms.hunterlibinfo_id_seq as bigint;
+        ALTER SEQUENCE targetedms.hunterlibinfo_id_seq as bigint;';
     END IF;
 END;
 $$ LANGUAGE plpgsql;


### PR DESCRIPTION
#### Rationale
Recent changes to id columns in targetedms schema from ints to bigints involve an sql upgrade script containing syntax that is not supported in older versions (supported by LabKey Server) of postgres. This work adds a condition to run new syntax based on the version.

Not supported syntax in versions <= 10 : 
ALTER SEQUENCE targetedms.runs_id_seq as bigint;
