### PR TITLE
Issue 41317: targetedms-20.015-20.016.sql uses syntax unsupported in Postgres 9.5/6

### DIFF
--- a/resources/schemas/dbscripts/postgresql/targetedms-20.015-20.016.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-20.015-20.016.sql
@@ -157,4 +157,4 @@ $$ LANGUAGE plpgsql;
 
 SELECT targetedms.handleSequences();
 
-DROP FUNCTION targetedms.handleSequences;
+DROP FUNCTION targetedms.handleSequences();


### PR DESCRIPTION
#### Related Pull Requests
* https://github.com/LabKey/targetedms/pull/246

