### PR TITLE
Switch to DisplayColumn.getFormattedHtml() and use HtmlString

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -123,6 +123,7 @@ import org.labkey.api.util.DOM;
 import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.HelpTopic;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.StringUtilsLabKey;
@@ -1741,7 +1742,7 @@ public class TargetedMSController extends SpringActionController
             _precursor = precursor;
         }
 
-        public String getModifiedPeptideHtml()
+        public HtmlString getModifiedPeptideHtml()
         {
             return new ModifiedPeptideHtmlMaker().getPrecursorHtml(getPrecursor(), getRun().getId(), _targetedMSSchema);
         }

--- a/src/org/labkey/targetedms/TargetedMSSchema.java
+++ b/src/org/labkey/targetedms/TargetedMSSchema.java
@@ -60,6 +60,7 @@ import org.labkey.api.query.UserIdQueryForeignKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.util.ContainerContext;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.StringExpression;
 import org.labkey.api.util.UnexpectedException;
@@ -743,9 +744,9 @@ public class TargetedMSSchema extends UserSchema
                                 return getValue(ctx);
                             }
                             @Override
-                            public @NotNull String getFormattedValue(RenderContext ctx)
+                            public @NotNull HtmlString getFormattedHtml(RenderContext ctx)
                             {
-                                return PageFlowUtil.filter(getValue(ctx));
+                                return HtmlString.of(getValue(ctx));
                             }
                             @Override
                             public boolean isFilterable()
@@ -1582,9 +1583,9 @@ public class TargetedMSSchema extends UserSchema
 
         @NotNull
         @Override
-        public String getFormattedValue(RenderContext ctx)
+        public HtmlString getFormattedHtml(RenderContext ctx)
         {
-            return PageFlowUtil.filter(getValue(ctx));
+            return HtmlString.of(getValue(ctx));
         }
 
         @Override

--- a/src/org/labkey/targetedms/query/AnnotatedTargetedMSTable.java
+++ b/src/org/labkey/targetedms/query/AnnotatedTargetedMSTable.java
@@ -32,6 +32,8 @@ import org.labkey.api.gwt.client.FacetingBehaviorType;
 import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.LookupForeignKey;
+import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.targetedms.TargetedMSManager;
 import org.labkey.targetedms.TargetedMSSchema;
@@ -359,19 +361,19 @@ public class AnnotatedTargetedMSTable extends TargetedMSTable
 
         /** The HTML encoded annotation name/value pairs */
         @Override @NotNull
-        public String getFormattedValue(RenderContext ctx)
+        public HtmlString getFormattedHtml(RenderContext ctx)
         {
-            StringBuilder sb = new StringBuilder();
-            String separator = "";
+            HtmlStringBuilder sb = HtmlStringBuilder.of();
+            HtmlString separator = HtmlString.EMPTY_STRING;
             for (String annotation : getAnnotations(ctx))
             {
                 sb.append(separator);
-                separator = "<br/>";
-                sb.append("<nobr>");
-                sb.append(PageFlowUtil.filter(annotation));
-                sb.append("</nobr>");
+                separator = HtmlString.BR;
+                sb.append(HtmlString.unsafe("<nobr>"));
+                sb.append(annotation);
+                sb.append(HtmlString.unsafe("</nobr>"));
             }
-            return sb.toString();
+            return sb.getHtmlString();
         }
     }
 

--- a/src/org/labkey/targetedms/query/IconColumn.java
+++ b/src/org/labkey/targetedms/query/IconColumn.java
@@ -21,6 +21,8 @@ import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.DataColumn;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.query.FieldKey;
+import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.targetedms.view.IconFactory;
 
@@ -50,31 +52,36 @@ public abstract class IconColumn extends DataColumn
 
     abstract String getLinkTitle();
 
-    abstract String getCellDataHtml(RenderContext ctx);
+    abstract HtmlString getCellDataHtml(RenderContext ctx);
 
     boolean removeLinkDefaultColor()
     {
         return true;
     }
 
-    private String getIconHtml(String iconPath)
+    private HtmlString getIconHtml(String iconPath)
     {
         if(StringUtils.isBlank(iconPath))
         {
-            return "";
+            return HtmlString.EMPTY_STRING;
         }
 
         StringBuilder imgHtml = new StringBuilder("<img src=\"");
         imgHtml.append(PageFlowUtil.filter(iconPath)).append("\"").append(" title=\"" + PageFlowUtil.filter(getLinkTitle()) +"\"").append(" width=\"16\" height=\"16\" style=\"margin-right: 5px;\"/>");
-        return imgHtml.toString();
+        return HtmlString.unsafe(imgHtml.toString());
     }
 
     @Override
-    public @NotNull String getFormattedValue(RenderContext ctx)
+    public @NotNull HtmlString getFormattedHtml(RenderContext ctx)
     {
-        String iconHtml = getIconHtml(getIconPath());
-        String cellDataHtml = getCellDataHtml(ctx);
-        return "<nobr>" + iconHtml + (cellDataHtml == null ? "" : cellDataHtml) + "</nobr>";
+        HtmlString iconHtml = getIconHtml(getIconPath());
+        HtmlString cellDataHtml = getCellDataHtml(ctx);
+        return
+                HtmlStringBuilder.of(HtmlString.unsafe("<nobr>")).
+                        append(iconHtml).
+                        append(cellDataHtml == null ? HtmlString.EMPTY_STRING : cellDataHtml).
+                        append(HtmlString.unsafe("</nobr>")).
+                        getHtmlString();
     }
 
     @Override
@@ -108,9 +115,9 @@ public abstract class IconColumn extends DataColumn
         }
 
         @Override
-        String getCellDataHtml(RenderContext ctx)
+        HtmlString getCellDataHtml(RenderContext ctx)
         {
-            return PageFlowUtil.filter(ctx.get(getColumnInfo().getFieldKey(), String.class));
+            return HtmlString.of(ctx.get(getColumnInfo().getFieldKey(), String.class));
         }
 
         @Override

--- a/src/org/labkey/targetedms/query/ModifiedSequenceDisplayColumn.java
+++ b/src/org/labkey/targetedms/query/ModifiedSequenceDisplayColumn.java
@@ -21,6 +21,7 @@ import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.DisplayColumnFactory;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.query.FieldKey;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.targetedms.view.IconFactory;
 import org.labkey.targetedms.view.ModifiedPeptideHtmlMaker;
@@ -41,7 +42,7 @@ public abstract class ModifiedSequenceDisplayColumn extends IconColumn
 {
     private final ModifiedPeptideHtmlMaker _htmlMaker;
     String _iconPath;
-    String _cellData;
+    HtmlString _cellData;
 
     public static final String PEPTIDE_COLUMN_NAME = "ModifiedPeptideDisplayColumn";
     public static final String PRECURSOR_COLUMN_NAME = "ModifiedPrecursorDisplayColumn";
@@ -74,7 +75,7 @@ public abstract class ModifiedSequenceDisplayColumn extends IconColumn
     }
 
     @Override
-    String getCellDataHtml(RenderContext ctx)
+    HtmlString getCellDataHtml(RenderContext ctx)
     {
         return _cellData;
     }
@@ -161,7 +162,7 @@ public abstract class ModifiedSequenceDisplayColumn extends IconColumn
 
             if(peptideId == null || sequence == null || runId == null)
             {
-                _cellData = PageFlowUtil.filter(peptideModifiedSequence);
+                _cellData = HtmlString.of(peptideModifiedSequence);
             }
             else
             {
@@ -216,7 +217,7 @@ public abstract class ModifiedSequenceDisplayColumn extends IconColumn
 
             if(precursorId == null || peptideId == null || isotopeLabelId == null || precursorModifiedSequence == null || sequence == null || runId == null)
             {
-                _cellData = PageFlowUtil.filter(precursorModifiedSequence);
+                _cellData = HtmlString.of(precursorModifiedSequence);
             }
             else
             {

--- a/src/org/labkey/targetedms/view/AnnotationUIDisplayColumn.java
+++ b/src/org/labkey/targetedms/view/AnnotationUIDisplayColumn.java
@@ -20,6 +20,7 @@ import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.DataColumn;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.query.FieldKey;
+import org.labkey.api.util.HtmlString;
 
 import java.util.Set;
 
@@ -59,14 +60,13 @@ public class AnnotationUIDisplayColumn extends DataColumn
     }
 
     @Override @NotNull
-    public String getFormattedValue(RenderContext ctx)
+    public HtmlString getFormattedHtml(RenderContext ctx)
     {
-        String result = h(getValue(ctx));
-        result = result.replaceAll("\\n", "<br />");
-        return result;
+        return HtmlString.of(getValue(ctx).toString(), true);
     }
 
     @Override
+    @NotNull
     public Object getValue(RenderContext ctx)
     {
         String note = (String)ctx.get(_noteFieldKey);

--- a/src/org/labkey/targetedms/view/ModifiedPeptideHtmlMaker.java
+++ b/src/org/labkey/targetedms/view/ModifiedPeptideHtmlMaker.java
@@ -17,6 +17,7 @@ package org.labkey.targetedms.view;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.targetedms.TargetedMSSchema;
 import org.labkey.targetedms.chart.ChartColors;
@@ -56,28 +57,28 @@ public class ModifiedPeptideHtmlMaker
         _firstIsotopeLabelIdInDocMap = new HashMap<>();
     }
 
-    public String getPrecursorHtml(Precursor precursor, Long runId, TargetedMSSchema schema)
+    public HtmlString getPrecursorHtml(Precursor precursor, Long runId, TargetedMSSchema schema)
     {
         Peptide peptide = PeptideManager.getPeptide(schema.getContainer(), precursor.getGeneralMoleculeId());
         return getPrecursorHtml(peptide, precursor, runId);
     }
 
-    public String getPrecursorHtml(Peptide peptide, Precursor precursor, Long runId)
+    public HtmlString getPrecursorHtml(Peptide peptide, Precursor precursor, Long runId)
     {
         return getPrecursorHtml(peptide.getId(), precursor.getIsotopeLabelId(), peptide.getSequence(), precursor.getModifiedSequence(), runId);
     }
 
-    public String getPrecursorHtml(long peptideId, long isotopeLabelId, String peptideSequence, String precursorModifiedSequence, Long runId)
+    public HtmlString getPrecursorHtml(long peptideId, long isotopeLabelId, String peptideSequence, String precursorModifiedSequence, Long runId)
     {
         return getHtml(peptideId, isotopeLabelId, peptideSequence, precursorModifiedSequence, runId, null, null);
     }
 
-    public String getPeptideHtml(Peptide peptide, Long runId)
+    public HtmlString getPeptideHtml(Peptide peptide, Long runId)
     {
         return getPeptideHtml(peptide.getId(), peptide.getSequence(), peptide.getPeptideModifiedSequence(), runId, null, null);
     }
 
-    public String getPeptideHtml(long peptideId, String sequence, String peptideModifiedSequence, Long runId, @Nullable String previousAA, @Nullable String nextAA)
+    public HtmlString getPeptideHtml(long peptideId, String sequence, String peptideModifiedSequence, Long runId, @Nullable String previousAA, @Nullable String nextAA)
     {
         String altSequence = peptideModifiedSequence;
         if(StringUtils.isBlank(altSequence))
@@ -88,7 +89,7 @@ public class ModifiedPeptideHtmlMaker
         return getHtml(peptideId, null, sequence, altSequence, runId, previousAA, nextAA);
     }
 
-    private String getHtml(long peptideId,  @Nullable Long isotopeLabelId, String sequence, String altSequence, Long runId, @Nullable String previousAA, @Nullable String nextAA)
+    private HtmlString getHtml(long peptideId,  @Nullable Long isotopeLabelId, String sequence, String altSequence, Long runId, @Nullable String previousAA, @Nullable String nextAA)
     {
         Long firstIsotopeLabelIdInDoc = null;
         if(runId != null)
@@ -171,7 +172,7 @@ public class ModifiedPeptideHtmlMaker
         {
             result.append("<div style='color:red;'>" + PageFlowUtil.filter(error.toString()) + "</div>");
         }
-        return result.toString();
+        return HtmlString.unsafe(result.toString());
     }
 
     public String toHex(int rgb)

--- a/src/org/labkey/targetedms/view/peptideSummaryView.jsp
+++ b/src/org/labkey/targetedms/view/peptideSummaryView.jsp
@@ -58,7 +58,7 @@
     </tr>
     <tr>
         <td class="labkey-form-label">Sequence</td>
-        <td><%=text(new ModifiedPeptideHtmlMaker().getPeptideHtml(bean.getPeptide(), bean.getRun().getId()))%></td>
+        <td><%=new ModifiedPeptideHtmlMaker().getPeptideHtml(bean.getPeptide(), bean.getRun().getId())%></td>
     </tr>
     <tr>
         <td class="labkey-form-label">NeutralMass</td>

--- a/src/org/labkey/targetedms/view/precursorChromatogramsView.jsp
+++ b/src/org/labkey/targetedms/view/precursorChromatogramsView.jsp
@@ -41,7 +41,7 @@
     </tr>
     <tr>
         <td class="labkey-form-label">Precursor</td>
-        <td><%= text(bean.getModifiedPeptideHtml())%></td>
+        <td><%= bean.getModifiedPeptideHtml() %></td>
     </tr>
 
     <%


### PR DESCRIPTION
#### Rationale
Switch to using HtmlString when rendering a grid or details value to ensure proper encoding. Fix up many problematic subclasses.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1602

#### Changes
* Remove deprecated getFormattedValue(), consolidate on getFormattedHtml()
* Use HtmlString to signal this is specifically for HTML