### PR TITLE
Avoid SQL Server deadlock exception during end of TargetedMSQCGuideSetTest

### DIFF
--- a/src/org/labkey/targetedms/query/SampleFileTable.java
+++ b/src/org/labkey/targetedms/query/SampleFileTable.java
@@ -87,7 +87,9 @@ public class SampleFileTable extends TargetedMSTable
         ActionURL url = new ActionURL(TargetedMSController.ShowSampleFileAction.class, getContainer());
         Map<String, String> urlParams = new HashMap<>();
         urlParams.put("id", "Id");
-        setDetailsURL(new DetailsURL(url, urlParams));
+        DetailsURL detailsURL = new DetailsURL(url, urlParams);
+        setDetailsURL(detailsURL);
+        getMutableColumn("ReplicateId").setURL(detailsURL);
     }
 
     @Override
@@ -97,7 +99,7 @@ public class SampleFileTable extends TargetedMSTable
         {
             // Always include these columns
             List<FieldKey> defaultCols = new ArrayList<>(Arrays.asList(
-                    FieldKey.fromParts("ReplicateId", "Name"),
+                    FieldKey.fromParts("ReplicateId"),
                     FieldKey.fromParts("FilePath"),
                     FieldKey.fromParts("AcquiredTime")));
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCGuideSetTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCGuideSetTest.java
@@ -40,6 +40,7 @@ import org.labkey.test.components.targetedms.ParetoPlotsWebPart;
 import org.labkey.test.components.targetedms.QCPlotsWebPart;
 import org.labkey.test.pages.targetedms.PanoramaDashboard;
 import org.labkey.test.pages.targetedms.ParetoPlotPage;
+import org.labkey.test.util.APIContainerHelper;
 import org.labkey.test.util.DataRegionTable;
 
 import java.io.IOException;
@@ -66,13 +67,13 @@ public class TargetedMSQCGuideSetTest extends TargetedMSTest
             "VLVLDTDYK",
             "VYVEELKPTPEGDLEILLQK"};
 
-    private static GuideSet gs1 = new GuideSet("2013/08/01", "2013/08/01 00:00:01", "first guide set, entirely before initial data with no data points in range");
-    private static GuideSet gs2 = new GuideSet("2013/08/02", "2013/08/11", "second guide set, starts before initial data start date with only one data point in range");
-    private static GuideSet gs3 = new GuideSet("2013/08/14 22:48:37", "2013/08/16 20:26:28", "third guide set, ten data points in range", 10);
-    private static GuideSet gs4 = new GuideSet("2013/08/21 07:56:12", "2013/08/21 13:15:01", "fourth guide set, four data points in range", 4);
-    private static GuideSet gs5 = new GuideSet("2013/08/27 03:00", "2013/08/31 00:00", "fifth guide set, extends beyond last initial data point with two data points in range");
+    private static final GuideSet gs1 = new GuideSet("2013/08/01", "2013/08/01 00:00:01", "first guide set, entirely before initial data with no data points in range");
+    private static final GuideSet gs2 = new GuideSet("2013/08/02", "2013/08/11", "second guide set, starts before initial data start date with only one data point in range");
+    private static final GuideSet gs3 = new GuideSet("2013/08/14 22:48:37", "2013/08/16 20:26:28", "third guide set, ten data points in range", 10);
+    private static final GuideSet gs4 = new GuideSet("2013/08/21 07:56:12", "2013/08/21 13:15:01", "fourth guide set, four data points in range", 4);
+    private static final GuideSet gs5 = new GuideSet("2013/08/27 03:00", "2013/08/31 00:00", "fifth guide set, extends beyond last initial data point with two data points in range");
 
-    private static GuideSet gsSmallMolecule = new GuideSet("2014/07/15 12:40", "2014/07/15 13:40", "Guide set for small molecules");
+    private static final GuideSet gsSmallMolecule = new GuideSet("2014/07/15 12:40", "2014/07/15 13:40", "Guide set for small molecules");
 
 
     @Override
@@ -105,18 +106,9 @@ public class TargetedMSQCGuideSetTest extends TargetedMSTest
     @Override
     protected void doCleanup(boolean afterTest) throws TestTimeoutException
     {
-        // Wait for active requests to finish processing into an attempt to avoid a SQL Server deadlock exception between
-        // the request and the delete
-        beginAt("/admin-memTracker.view");
-        int waits = 0;
-        while(waits < 20 && isRequestThreadActive())
-        {
-            waits++;
-            try { Thread.sleep(1000); } catch (InterruptedException ignored) {}
-            refresh();
-        }
-
-        _containerHelper.deleteProject(getProjectName(), afterTest);
+        // Use the API-based approach for deletion so that we don't trigger AJAX requests navigating to the delete page
+        // that may run in the background and cause SQL Server deadlock exceptions
+        new APIContainerHelper(this).deleteProject(getProjectName(), afterTest);
     }
 
     @Test
@@ -337,7 +329,7 @@ public class TargetedMSQCGuideSetTest extends TargetedMSTest
         selectQuery("targetedms", "Replicate");
         //confirm table columns are present and of correct type representing replicate annotations:
         GetQueryDetailsCommand queryDetailsCommand = new GetQueryDetailsCommand("targetedms", "Replicate");
-        GetQueryDetailsResponse queryDetailsResponse = queryDetailsCommand.execute(createDefaultConnection(true),getProjectName() + "/" + folderName);
+        GetQueryDetailsResponse queryDetailsResponse = queryDetailsCommand.execute(createDefaultConnection(),getProjectName() + "/" + folderName);
         List<GetQueryDetailsResponse.Column> columns = queryDetailsResponse.getColumns();
 
         int groupingIndex = 11;
@@ -405,7 +397,7 @@ public class TargetedMSQCGuideSetTest extends TargetedMSTest
             else
                 cmd.addFilter("SeriesLabel", null, Filter.Operator.ISBLANK);
 
-            SelectRowsResponse response = cmd.execute(createDefaultConnection(false), getCurrentContainerPath());
+            SelectRowsResponse response = cmd.execute(createDefaultConnection(), getCurrentContainerPath());
 
             Rowset rowset = response.getRowset();
             assertEquals("Unexpected number of filtered rows", 1, rowset.getSize());

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCGuideSetTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCGuideSetTest.java
@@ -105,6 +105,17 @@ public class TargetedMSQCGuideSetTest extends TargetedMSTest
     @Override
     protected void doCleanup(boolean afterTest) throws TestTimeoutException
     {
+        // Wait for active requests to finish processing into an attempt to avoid a SQL Server deadlock exception between
+        // the request and the delete
+        beginAt("/admin-memTracker.view");
+        int waits = 0;
+        while(waits < 20 && isRequestThreadActive())
+        {
+            waits++;
+            try { Thread.sleep(1000); } catch (InterruptedException ignored) {}
+            refresh();
+        }
+
         _containerHelper.deleteProject(getProjectName(), afterTest);
     }
 


### PR DESCRIPTION
#### Rationale
We're hitting periodic failures in TargetedMSQCGuideSetTest on SQL Server. The test is going to the folder deletion UI via the project's main portal page, and not waiting for all of the AJAX requests to complete. One API call is taking a few seconds, and before it's done we're already starting deleting the project. That causes a SQL Server deadlock exception.

#### Changes
* Use API-based deletion