### PR TITLE
Reorder download options to prioritize SKYP files

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -5078,15 +5078,17 @@ public class TargetedMSController extends SpringActionController
 
         final ActionURL fullDownloadUrl = new ActionURL(TargetedMSController.DownloadDocumentAction.class, run.getContainer()).replaceParameter("id", Long.toString(run.getId()));
 
-        NavTree fullDownloadNavTree = new NavTree("Full Skyline file", fullDownloadUrl);
-        fullDownloadNavTree.setScript(onClickScript);
-        navTree.addChild(fullDownloadNavTree);
-
         ActionURL pointerDownloadUrl = fullDownloadUrl.clone().replaceParameter("view", "skyp");
 
         NavTree pointerDownloadNavTree = new NavTree("SkyP file (link only, 1KB)", pointerDownloadUrl);
         pointerDownloadNavTree.setScript(onClickScript);
         navTree.addChild(pointerDownloadNavTree);
+
+        navTree.addSeparator();
+
+        NavTree fullDownloadNavTree = new NavTree("Full Skyline file", fullDownloadUrl);
+        fullDownloadNavTree.setScript(onClickScript);
+        navTree.addChild(fullDownloadNavTree);
 
         ActionURL runURL = new ActionURL(ShowPrecursorListAction.class, run.getContainer()).addParameter("fileName", run.getFileName());
         if (AppProps.getInstance().getUseContainerRelativeURL())

--- a/src/org/labkey/targetedms/TargetedMSSchema.java
+++ b/src/org/labkey/targetedms/TargetedMSSchema.java
@@ -61,7 +61,6 @@ import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.util.ContainerContext;
 import org.labkey.api.util.HtmlString;
-import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.StringExpression;
 import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.view.ActionURL;
@@ -1335,7 +1334,9 @@ public class TargetedMSSchema extends UserSchema
         if (TABLE_KEYWORD_CATEGORIES.equalsIgnoreCase(name) ||
                 TABLE_KEYWORDS.equalsIgnoreCase(name))
         {
-            return new TargetedMSTable(getSchema().getTable(name), this, cf, null);
+            FilteredTable<TargetedMSSchema> result = new FilteredTable<>(getSchema().getTable(name), this);
+            result.wrapAllColumns(true);
+            return result;
         }
 
         if (getTableNames().contains(name))


### PR DESCRIPTION
#### Rationale
.skyp files are quicker to download and easier to open in Skyline than the full .sky.zip files. So let's promote their use

#### Changes
* Reorder menu options to put SKYP first, with separator from the less frequently used options