### PR TITLE
Issue 41610: Simplify ContainerJoinType.PrecursorChromInfoFK

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSSchema.java
+++ b/src/org/labkey/targetedms/TargetedMSSchema.java
@@ -344,16 +344,13 @@ public class TargetedMSSchema extends UserSchema
             public SQLFragment getSQL()
             {
                 SQLFragment sql = new SQLFragment();
-                sql.append(makeInnerJoin(TargetedMSManager.getTableInfoPrecursorChromInfo(), "pci", "PrecursorChromInfoId"));
-                sql.append(makeInnerJoin(TargetedMSManager.getTableInfoSampleFile(), "sfile", "pci.SampleFileId"));
-                sql.append(makeInnerJoin(TargetedMSManager.getTableInfoReplicate(), "rep", "sfile.ReplicateId"));
-                sql.append(getJoinToRunsTable("rep"));
+                sql.append(makeInnerJoin(TargetedMSManager.getTableInfoPrecursorChromInfo(), TargetedMSTable.CONTAINER_COL_TABLE_ALIAS, "PrecursorChromInfoId"));
                 return sql;
             }
             @Override
             public FieldKey getContainerFieldKey()
             {
-                return FieldKey.fromParts("PrecursorChromInfoId", "SampleFileId", "ReplicateId", "RunId", "Container");
+                return FieldKey.fromParts("PrecursorChromInfoId", "Container");
             }
         },
         PrecursorFK


### PR DESCRIPTION
#### Rationale
ContainerJoinType.PrecursorChromInfoFK does not need joins to the targetedms.runs table for container filtering since the PrecursorChromInfo table has a "Container" column.

