### PR TITLE
Use consistent versions for Commons Collections 4 and Google Protocol Buffers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import org.labkey.gradle.util.BuildUtils;
 
 dependencies
 {
-   external 'com.google.protobuf:protobuf-java:3.12.2'
+   external "com.google.protobuf:protobuf-java:${googleProtocolBufVersion}"
    external "org.xerial:sqlite-jdbc:3.7.2"
    external "org.apache.commons:commons-math3:${commonsMath3Version}"
    external "org.jfree:jcommon:1.0.17"


### PR DESCRIPTION
#### Rationale
We don't want conflicting versions of libraries across modules.

https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_VerifyDependencies/1145949?

#### Related Pull Requests
* https://github.com/LabKey/DiscvrLabKeyModules/pull/65
* https://github.com/LabKey/server/pull/2

#### Changes
* Consolidate on Commons Collections 4.2 and Google Protocol Buffers 3.12.2