### PR TITLE
Issue 40456: Make it harder for users to ignore conflicts in chromatogram library folders

### DIFF
--- a/src/org/labkey/targetedms/SkylineDocImporter.java
+++ b/src/org/labkey/targetedms/SkylineDocImporter.java
@@ -50,6 +50,7 @@ import org.labkey.api.security.User;
 import org.labkey.api.targetedms.TargetedMSService;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.NetworkDrive;
+import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.writer.ZipUtil;
 import org.labkey.targetedms.SkylinePort.Irt.IRegressionFunction;
 import org.labkey.targetedms.SkylinePort.Irt.IrtRegressionCalculator;
@@ -59,6 +60,7 @@ import org.labkey.targetedms.calculations.quantification.RegressionFit;
 import org.labkey.targetedms.parser.*;
 import org.labkey.targetedms.parser.list.ListData;
 import org.labkey.targetedms.parser.skyaudit.AuditLogException;
+import org.labkey.targetedms.query.ConflictResultsManager;
 import org.labkey.targetedms.query.ReplicateManager;
 import org.labkey.targetedms.query.RepresentativeStateManager;
 import org.labkey.targetedms.query.SkylineListManager;
@@ -208,6 +210,20 @@ public class SkylineDocImporter
         TargetedMSService.FolderType folderType = TargetedMSManager.getFolderType(_container);
         _isProteinLibraryDoc = folderType == TargetedMSService.FolderType.LibraryProtein;
         _isPeptideLibraryDoc = folderType == TargetedMSService.FolderType.Library;
+
+        if(_isProteinLibraryDoc || _isPeptideLibraryDoc)
+        {
+            var conflictCount = ConflictResultsManager.getConflictCount(_user, _container);
+            if(conflictCount != 0)
+            {
+                var conflictTarget = _isProteinLibraryDoc ? "protein" : "peptide";
+                throw new PipelineJobException("The library folder has conflicts." +
+                        " The last document imported in to the folder had " + StringUtilsLabKey.pluralize(conflictCount, conflictTarget)
+                        + " that were already included in the library, resulting in conflicts." +
+                        " Please resolve the conflicts by choosing the version of each " + conflictTarget + " that should be included in the library." +
+                        " New Skyline documents can be added to the folder after the conflicts have been resolved.");
+            }
+        }
 
         _progressMonitor = new ProgressMonitor(job, folderType, _log);
 

--- a/src/org/labkey/targetedms/SkylineDocImporter.java
+++ b/src/org/labkey/targetedms/SkylineDocImporter.java
@@ -214,7 +214,7 @@ public class SkylineDocImporter
         if(_isProteinLibraryDoc || _isPeptideLibraryDoc)
         {
             var conflictCount = ConflictResultsManager.getConflictCount(_user, _container);
-            if(conflictCount != 0)
+            if(conflictCount > 0)
             {
                 var conflictTarget = _isProteinLibraryDoc ? "protein" : "peptide";
                 throw new PipelineJobException("The library folder has conflicts." +

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -5972,7 +5972,7 @@ public class TargetedMSController extends SpringActionController
             }
             catch (IOException | SQLException e)
             {
-                LOG.error("Error reading from chromatogram library file for revision " + libRevision, e);
+                LOG.error("Error reading from chromatogram library file for revision " + libRevision + " in container " + container.getPath(), e);
                 return null;
             }
         }

--- a/src/org/labkey/targetedms/chromlib/ChromatogramLibraryUtils.java
+++ b/src/org/labkey/targetedms/chromlib/ChromatogramLibraryUtils.java
@@ -24,13 +24,22 @@ import org.labkey.api.security.User;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.view.NotFoundException;
+import org.labkey.targetedms.TargetedMSController;
 import org.labkey.targetedms.TargetedMSManager;
+import org.labkey.targetedms.TargetedMSRun;
+import org.labkey.targetedms.query.ConflictResultsManager;
+import org.sqlite.SQLiteConfig;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -42,7 +51,7 @@ import java.util.Map;
 public class ChromatogramLibraryUtils
 {
     private static final String propMapKey = "chromLibRevision";
-    private static final int NO_LIB_REVISION = -1;
+    public static final int NO_LIB_REVISION = -1;
 
     public static boolean isRevisionCurrent(Container container, User user, String schemaVersion, int revisionNumber)
     {
@@ -60,6 +69,33 @@ public class ChromatogramLibraryUtils
         {
             return Integer.parseInt(propMap.get(propMapKey));
         }
+    }
+
+    public static int getLastStableLibRevision(Container container, User user) throws IOException
+    {
+        int currentRevision = getCurrentRevision(container, user);
+        // Get the oldest run that has conflicts
+        TargetedMSRun run = ConflictResultsManager.getOldestRunWithConflicts(container);
+        if(run == null)
+        {
+            // No conflicts.  Return the current revision
+            return currentRevision;
+        }
+        else
+        {
+            // Return the library version that was created just before the oldest run with conflicts.
+            // This should be the last revision that was built with no conflicts.
+            for(int i = currentRevision - 1; i > 0; i--)
+            {
+                Path clibFile = getChromLibFile(container, i);
+                if (Files.exists(clibFile) && !Files.isDirectory(clibFile)
+                        && run.getCreated().after(new Date(Files.getLastModifiedTime(clibFile).toMillis())))
+                {
+                    return i;
+                }
+            }
+        }
+        return NO_LIB_REVISION;
     }
 
     public static int incrementLibraryRevision(Container container, User user, LocalDirectory localDirectory)
@@ -160,5 +196,37 @@ public class ChromatogramLibraryUtils
         {
            throw new RuntimeException("There was an error writing a TargetedMS Library archive file.", exception);
         }
+    }
+
+    public static TargetedMSController.ChromLibAnalyteCounts getLibraryAnalyteCounts(Container container, int libRevision) throws IOException, SQLException
+    {
+        Path archiveFile = ChromatogramLibraryUtils.getChromLibFile(container, libRevision);
+        if(!Files.exists(archiveFile))
+        {
+            return null;
+        }
+
+        SQLiteConfig config = new SQLiteConfig();
+        config.setReadOnly(true);
+        try (Connection conn = DriverManager.getConnection("jdbc:sqlite:/" + archiveFile.toAbsolutePath().toString(), config.toProperties()))
+        {
+            TargetedMSController.ChromLibAnalyteCounts analyteCountsInLib = new TargetedMSController.ChromLibAnalyteCounts();
+            analyteCountsInLib.setPeptideGroupCount(getCountsIn("Protein", conn));
+            analyteCountsInLib.setPeptideCount(getCountsIn("Peptide", conn));
+            analyteCountsInLib.setTransitionCount(getCountsIn("Transition", conn));
+            return analyteCountsInLib;
+        }
+    }
+
+    private static int getCountsIn(String tableName, Connection conn) throws SQLException
+    {
+        try (Statement stmt = conn.createStatement(); ResultSet rs = stmt.executeQuery("SELECT COUNT(*) from " + tableName))
+        {
+            if (rs.next())
+            {
+                return rs.getInt(1);
+            }
+        }
+        return 0;
     }
 }

--- a/src/org/labkey/targetedms/query/ConflictResultsManager.java
+++ b/src/org/labkey/targetedms/query/ConflictResultsManager.java
@@ -489,7 +489,7 @@ public class ConflictResultsManager
     private static Integer getOldestConflictRunId(Container container)
     {
         SQLFragment sqlFragment = new SQLFragment();
-        sqlFragment.append(" SELECT r.id FROM ");
+        sqlFragment.append("SELECT r.id FROM ");
         sqlFragment.append(TargetedMSManager.getTableInfoGeneralPrecursor(), "p");
         sqlFragment.append(" INNER JOIN ");
         sqlFragment.append(TargetedMSManager.getTableInfoGeneralMolecule(), "gm");

--- a/src/org/labkey/targetedms/query/ConflictResultsManager.java
+++ b/src/org/labkey/targetedms/query/ConflictResultsManager.java
@@ -19,7 +19,6 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
-import org.labkey.api.data.SqlExecutingSelector;
 import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
@@ -481,11 +480,6 @@ public class ConflictResultsManager
        return conflictCount;
     }
 
-    public static boolean hasConflicts(User user, Container container)
-    {
-        return getConflictCount(user, container) != 0;
-    }
-
     public static TargetedMSRun getOldestRunWithConflicts(Container container)
     {
         Integer runId = getOldestConflictRunId(container);
@@ -517,19 +511,5 @@ public class ConflictResultsManager
 
         DbSchema schema = TargetedMSManager.getSchema();
         return new SqlSelector(schema, schema.getSqlDialect().limitRows(sqlFragment, 1)).getObject(Integer.class);
-    }
-
-    public static TargetedMSRun getLastStableLibraryRun(Container container)
-    {
-        Integer runId = getOldestConflictRunId(container);
-
-        SQLFragment sql = new SQLFragment("SELECT MAX(id) FROM ").append(TargetedMSManager.getTableInfoRuns(), "r");
-        if(runId != null)
-        {
-            sql.append(" WHERE id < ?").add(runId);
-        }
-        Integer lastStableLibRunId = new SqlSelector(TargetedMSManager.getSchema(), sql).getObject(Integer.class);
-
-        return lastStableLibRunId != null ? TargetedMSManager.getRun(lastStableLibRunId) : null;
     }
 }

--- a/src/org/labkey/targetedms/query/RepresentativeStateManager.java
+++ b/src/org/labkey/targetedms/query/RepresentativeStateManager.java
@@ -86,9 +86,10 @@ public class RepresentativeStateManager
             TargetedMsRepresentativeStateAuditProvider.addAuditEntry(container, user,
                     "Updated representative state. Number of conflicts " + conflictCount);
 
+            Table.update(user, TargetedMSManager.getTableInfoRuns(), run, run.getId());
+
             transaction.commit();
         }
-        Table.update(user, TargetedMSManager.getTableInfoRuns(), run, run.getId());
     }
 
     private static void revertProteinRepresentativeState(User user, Container container, TargetedMSRun run)

--- a/src/org/labkey/targetedms/view/chromatogramLibraryDownload.jsp
+++ b/src/org/labkey/targetedms/view/chromatogramLibraryDownload.jsp
@@ -28,51 +28,99 @@
 <%@ page import="java.nio.file.Files" %>
 <%@ page import="java.nio.file.Path" %>
 <%@ page import="java.text.DecimalFormat" %>
+<%@ page import="org.labkey.api.security.permissions.InsertPermission" %>
+<%@ page import="org.labkey.api.util.StringUtilsLabKey" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
     Container c = getContainer();
     User user = getUser();
     TargetedMSService.FolderType folderType = TargetedMSManager.getFolderType(c);
 
-    long peptideGroupCount = TargetedMSController.getNumRepresentativeProteins(user, c);
-    long peptideCount = TargetedMSController.getNumRepresentativePeptides(c);
-    long transitionCount = TargetedMSController.getNumRankedTransitions(c);
-    DecimalFormat format = new DecimalFormat("#,###");
-    int currentRevision = ChromatogramLibraryUtils.getCurrentRevision(c, user);
-    Path archiveFile = ChromatogramLibraryUtils.getChromLibFile(c, currentRevision);
-
     long conflictCount = ConflictResultsManager.getConflictCount(user, c);
+    boolean hasConflicts = conflictCount != 0;
+    int currentRevision = ChromatogramLibraryUtils.getCurrentRevision(c, user);
+    int libRevision = hasConflicts ? ChromatogramLibraryUtils.getLastStableLibRevision(c, user) : currentRevision;
+
+    TargetedMSController.ChromLibAnalyteCounts chromLibAnalyteCounts = TargetedMSController.getChromLibAnalyteCounts(user, c, libRevision);
+    long peptideGroupCount = chromLibAnalyteCounts != null ? chromLibAnalyteCounts.getPeptideGroupCount() : 0;
+    long peptideCount = chromLibAnalyteCounts != null ? chromLibAnalyteCounts.getPeptideCount() : 0;
+    long transitionCount = chromLibAnalyteCounts != null ? chromLibAnalyteCounts.getTransitionCount() : 0;
+
+    DecimalFormat format = new DecimalFormat("#,###");
+
+    Path archiveFile = ChromatogramLibraryUtils.getChromLibFile(c, libRevision);
+
     ActionURL conflictViewUrl = (folderType == TargetedMSService.FolderType.LibraryProtein) ?
                                            new ActionURL(TargetedMSController.ShowProteinConflictUiAction.class, c) :
                                            new ActionURL(TargetedMSController.ShowPrecursorConflictUiAction.class, c);
+
+    boolean readOnlyUser = !getContainer().hasPermission(getUser(), InsertPermission.class);
+
+    String conflictMessage = "";
+    String analyteType = folderType == TargetedMSService.FolderType.LibraryProtein ? "protein" : "peptide";
+    boolean libFileExists = Files.exists(archiveFile);
+    if(hasConflicts)
+    {
+        String stableLibFileText = libFileExists ? "The download link below is for the last stable version of the library."
+                : "The last stable version of the library could not be found on the server"; // In case the file has been deleted from the server.
+        conflictMessage = readOnlyUser ? "The chromatogram library in this folder is in a conflicted state and is awaiting action from a folder administrator to resolve the conflicts. " +
+                stableLibFileText
+                : "The last Skyline document imported in this folder had " + StringUtilsLabKey.pluralize(conflictCount, analyteType) + " that were already a part of the library.  " +
+                "Please click the link below to resolve conflicts and choose the version of each " + analyteType + " that should be included in the library. " +
+                "The library cannot be extended until the conflicts are resolved. " + stableLibFileText;
+    }
 %>
 
 <div class="labkey-download">
+
+<% if(hasConflicts) { %>
+    <div style="color:red; margin-top:10px;"><%= h(conflictMessage) %></div>
+    <% if(!readOnlyUser) { %>
+      <div style="color:red; font-weight:bold;">
+      The library folder has <%= h(StringUtilsLabKey.pluralize(conflictCount, "conflicting " + analyteType)) %>.&nbsp;
+      <a style="color:red; text-decoration:underline;" href="<%= h(conflictViewUrl) %>">Resolve conflicts </a>
+      </div>
+    <% } %>
+<% } %>
+
 <%
-        if (peptideCount > 0 || peptideGroupCount > 0)
+        if (ChromatogramLibraryUtils.NO_LIB_REVISION != currentRevision)
         {
 %>
+
 <div class="banner">
 <table>
 <tr>
-    <! -- graph # of proteins and peptides in the library -->
+    <% if(!hasConflicts) { %>
+    <! -- graph # of proteins and peptides in the library.
+          Display the graph only if there are no conflicts in the folder
+    -->
 <td><img src="<%= h(new ActionURL(TargetedMSController.GraphLibraryStatisticsAction.class, c)) %>"></td>
+    <% } %>
 <td style="vert-align: top; text-align: center; padding-left: 2em">
 <h3><%= h(c.getName())%> Library</h3>
+
+<% if(libFileExists) { %>
 <p>
-    <%= button("Download").href(new ActionURL(TargetedMSController.DownloadChromLibraryAction.class, c))%>
+    <%= button("Download").href(new ActionURL(TargetedMSController.DownloadChromLibraryAction.class, c).addParameter("revision", libRevision))%>
 </p>
-        <%= h(ChromatogramLibraryUtils.getDownloadFileName(c, currentRevision)) %>
-    <%= h(Files.exists(archiveFile) ? "(" + FileUtils.byteCountToDisplaySize(Files.size(archiveFile)) + ")" : "") %>
+        <%= h(ChromatogramLibraryUtils.getDownloadFileName(c, libRevision)) %>
+    <%= h("(" + FileUtils.byteCountToDisplaySize(Files.size(archiveFile)) + ")") %>
     <br/>
-    Revision <%=currentRevision%><br/>
+    Revision <%=libRevision%><br/>
     <br/>
+<% } else { %>
+    <p>Library file <%= h(ChromatogramLibraryUtils.getDownloadFileName(c, libRevision)) %> does not exist on the server.</p>
+<% } %>
 <%= link("Archived Revisions", new ActionURL(TargetedMSController.ArchivedRevisionsAction.class, c))%>
 </tr>
 </table>
 </div>
+
+<% if(chromLibAnalyteCounts != null) { %>
 <table width="100%">
 <tr>
+
 <td width="80%">
     <h3>Library Statistics:</h3>
     <p class="banner">
@@ -81,17 +129,6 @@
             {
 %>
         The library contains <%= h(format.format(peptideCount))%> peptides with <%= h(format.format(transitionCount))%> ranked transitions.
-
-<%
-                if(conflictCount > 0) {
-%>
-                    <div style="color:red; font-weight:bold; margin-top:10px">
-                        There are <%=conflictCount%> conflicting peptides in this folder.
-                        <a style="color:red; text-decoration:underline;" href="<%= h(conflictViewUrl) %>">Resolve conflicts</a>
-                    </div>
-<%
-                }
-%>
 <%
             }
             else if (folderType == TargetedMSService.FolderType.LibraryProtein)
@@ -99,30 +136,22 @@
 %>
         The library contains <%= h(format.format(peptideGroupCount))%> proteins with <%= h(format.format(peptideCount)) %> ranked peptides.<br>
         The <%=h(format.format(peptideCount))%> ranked peptides contain <%= h(format.format(transitionCount))%> ranked transitions.
-
-<%
-                if(conflictCount > 0) {
-%>
-                    <div style="color:red; font-weight:bold; margin-top:10px">
-                        There are <%=conflictCount%> conflicting proteins in this folder.
-                        <a style="color:red; text-decoration:underline;" href="<%= h(conflictViewUrl) %>">Resolve conflicts</a>
-                    </div>
-<%
-                }
-%>
 <%
             }
 %>
 </td><td valign="top" width="20%" nowrap>
 </td>
+
 </tr>
 </table>
+<% } %>
+
 <%
         }
         else
         {
 %>
-  This library does not currently contain any data. Import a file in the Data Pipeline to proceed.
+  This library does not currently contain any data. Import a Skyline document to proceed.
 <%
         }
 %>

--- a/src/org/labkey/targetedms/view/chromatogramLibraryDownload.jsp
+++ b/src/org/labkey/targetedms/view/chromatogramLibraryDownload.jsp
@@ -54,7 +54,7 @@
                                            new ActionURL(TargetedMSController.ShowProteinConflictUiAction.class, c) :
                                            new ActionURL(TargetedMSController.ShowPrecursorConflictUiAction.class, c);
 
-    boolean readOnlyUser = !getContainer().hasPermission(getUser(), InsertPermission.class);
+    boolean readOnlyUser = !getContainer().hasPermission(getUser(), InsertPermission.class); // Importing a document and resolving conflicts require Insert permissions.
 
     String conflictMessage = "";
     String analyteType = folderType == TargetedMSService.FolderType.LibraryProtein ? "protein" : "peptide";
@@ -62,10 +62,10 @@
     if(hasConflicts)
     {
         String stableLibFileText = libFileExists ? "The download link below is for the last stable version of the library."
-                : "The last stable version of the library could not be found on the server"; // In case the file has been deleted from the server.
+                : "The last stable version of the library could not be found on the server."; // In case the file has been deleted from the server.
         conflictMessage = readOnlyUser ? "The chromatogram library in this folder is in a conflicted state and is awaiting action from a folder administrator to resolve the conflicts. " +
                 stableLibFileText
-                : "The last Skyline document imported in this folder had " + StringUtilsLabKey.pluralize(conflictCount, analyteType) + " that were already a part of the library.  " +
+                : "The last Skyline document imported in this folder had " + StringUtilsLabKey.pluralize(conflictCount, analyteType) + " that were already a part of the library. " +
                 "Please click the link below to resolve conflicts and choose the version of each " + analyteType + " that should be included in the library. " +
                 "The library cannot be extended until the conflicts are resolved. " + stableLibFileText;
     }
@@ -76,9 +76,8 @@
 <% if(hasConflicts) { %>
     <div style="color:red; margin-top:10px;"><%= h(conflictMessage) %></div>
     <% if(!readOnlyUser) { %>
-      <div style="color:red; font-weight:bold;">
-      The library folder has <%= h(StringUtilsLabKey.pluralize(conflictCount, "conflicting " + analyteType)) %>.&nbsp;
-      <a style="color:red; text-decoration:underline;" href="<%= h(conflictViewUrl) %>">Resolve conflicts </a>
+      <div style="color:red; font-weight:bold;font-style:italic;margin-top:5px; margin-bottom:5px;">
+      <a style="color:red; text-decoration:underline;" href="<%= h(conflictViewUrl) %>">RESOLVE CONFLICTS</a>
       </div>
     <% } %>
 <% } %>
@@ -109,7 +108,7 @@
     <br/>
     Revision <%=libRevision%><br/>
     <br/>
-<% } else { %>
+<% } else if(libRevision != ChromatogramLibraryUtils.NO_LIB_REVISION) { %>
     <p>Library file <%= h(ChromatogramLibraryUtils.getDownloadFileName(c, libRevision)) %> does not exist on the server.</p>
 <% } %>
 <%= link("Archived Revisions", new ActionURL(TargetedMSController.ArchivedRevisionsAction.class, c))%>

--- a/src/org/labkey/targetedms/view/chromatogramLibraryDownload.jsp
+++ b/src/org/labkey/targetedms/view/chromatogramLibraryDownload.jsp
@@ -42,9 +42,9 @@
     int libRevision = hasConflicts ? ChromatogramLibraryUtils.getLastStableLibRevision(c, user) : currentRevision;
 
     TargetedMSController.ChromLibAnalyteCounts chromLibAnalyteCounts = TargetedMSController.getChromLibAnalyteCounts(user, c, libRevision);
-    long peptideGroupCount = chromLibAnalyteCounts != null ? chromLibAnalyteCounts.getPeptideGroupCount() : 0;
-    long peptideCount = chromLibAnalyteCounts != null ? chromLibAnalyteCounts.getPeptideCount() : 0;
-    long transitionCount = chromLibAnalyteCounts != null ? chromLibAnalyteCounts.getTransitionCount() : 0;
+    long peptideGroupCount = chromLibAnalyteCounts.getPeptideGroupCount();
+    long peptideCount = chromLibAnalyteCounts.getPeptideCount();
+    long transitionCount = chromLibAnalyteCounts.getTransitionCount();
 
     DecimalFormat format = new DecimalFormat("#,###");
 
@@ -116,7 +116,7 @@
 </table>
 </div>
 
-<% if(chromLibAnalyteCounts != null) { %>
+<% if(chromLibAnalyteCounts.exists()) { %>
 <table width="100%">
 <tr>
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSLibraryIrtTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSLibraryIrtTest.java
@@ -18,8 +18,11 @@ package org.labkey.test.tests.targetedms;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.Locator;
 import org.labkey.test.categories.DailyB;
 import org.labkey.test.categories.MS2;
+import org.labkey.test.util.LogMethod;
+import org.openqa.selenium.WebElement;
 
 import static org.junit.Assert.assertEquals;
 
@@ -45,7 +48,7 @@ public class TargetedMSLibraryIrtTest extends TargetedMSIrtTest
     private static final String CALCULATED_FROM_SHARED_MSG = "Successfully calculated iRT regression line from 705 shared peptides";
     private static final String CALCULATED_FROM_FULL_STANDARD_LIST = "Calculated iRT regression line from full standard list";
 
-    private int goodImport = 0;
+    private int libRevision = 0;
 
     @Test
     public void testSteps()
@@ -56,22 +59,28 @@ public class TargetedMSLibraryIrtTest extends TargetedMSIrtTest
         // 1. Quick sanity check
         assertEquals("Imported iRT Peptide count is incorrect.", PEPTIDE_COUNT, getRowCount());
         assertEquals("Imported iRT value is incorrect for peptide " + UPDATE_PEPTIDE, ORIGINAL_VALUE, getIrtValue(UPDATE_PEPTIDE), DELTA);
-        goodImport++;
+        libRevision++;
 
         // 2. Correlation throwing out one standard.
         importData(SKY_FILE_ONE_BAD_STANDARD, 2);
         checkLogMessage(IGNORE_ONE_STANDARD_MSG);
-        goodImport++;
+        libRevision++;
 
         // 2.a. Verify standard peptides were excluded from new insert/update
         assertEquals("More than one row for standard peptide " + STANDARD_PEPTIDE, 1, getRowsForPeptide(STANDARD_PEPTIDE).size());
         assertEquals("Import count should only be 1 for standard peptide " + STANDARD_PEPTIDE, 1, getImportCount(STANDARD_PEPTIDE));
 
+        // Resolve conflicts otherwise the next import will fail
+        resolveConflicts();
+
         // 3. Correlation on shared peptides / scale values
         importData(SKY_FILE_DOUBLE_TIMES_NO_STANDARDS, 3);
         checkLogMessage(CALCULATED_FROM_SHARED_MSG);
         assertEquals("Normalized, weighted value is incorrect for peptide  " + UPDATE_PEPTIDE, ORIGINAL_VALUE, getIrtValue(UPDATE_PEPTIDE), DELTA);
-        goodImport++;
+        libRevision++;
+
+        // Resolve conflicts otherwise the next import will fail
+        resolveConflicts();
 
         // 4. Correlation on all standards / weighted average / new library peptide test. Import another copy which has been modified with a different value for one of the peptides (sign flipped so average should be 0),
         // and has a new peptide added to it.
@@ -81,14 +90,34 @@ public class TargetedMSLibraryIrtTest extends TargetedMSIrtTest
         assertEquals("Import count is incorrect for peptide " + UPDATE_PEPTIDE, 4, getImportCount(UPDATE_PEPTIDE));
         assertEquals("Import count is incorrect for peptide " + OMITTED_PEPTIDE, 3, getImportCount(OMITTED_PEPTIDE));
         assertEquals("Import count is incorrect for peptide " + NEW_PEPTIDE, 1, getImportCount(NEW_PEPTIDE));
-        goodImport++;
+        libRevision++;
+
+        // Resolve conflicts otherwise the next import will fail
+        resolveConflicts();
 
         // 5. Shared peptide correlation test. Import another copy which doesn't match the same set of standards as the first import.
         // Allowed, as of Issue 32924: Port Skyline changes to allowable iRT discrepancy during import
         importData(SKY_FILE_BAD_STANDARDS, 5);
         checkLogMessage(CALCULATED_FROM_FULL_STANDARD_LIST);
-        goodImport++;
+        libRevision++;
 
-        downloadLibraryExport(goodImport);
+        // Resolve conflicts so that the revision number matches up in the download link and expected revision in downloadLibraryExport() below
+        resolveConflicts();
+
+        downloadLibraryExport(libRevision);
+    }
+
+    @LogMethod
+    private void resolveConflicts()
+    {
+        log("Resolving conflicts");
+        goToDashboard();
+        var resolveConflictsLink = Locator.linkWithText("RESOLVE CONFLICTS");
+        assertElementPresent(resolveConflictsLink);
+        clickAndWait(resolveConflictsLink);
+        WebElement selectAllOldTargets = Locator.id("selectAllOld").findElement(this.getDriver());
+        selectAllOldTargets.click();
+        clickButton("Apply Changes");
+        libRevision++;
     }
 }

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSLibraryIrtTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSLibraryIrtTest.java
@@ -112,11 +112,11 @@ public class TargetedMSLibraryIrtTest extends TargetedMSIrtTest
     {
         log("Resolving conflicts");
         goToDashboard();
-        var resolveConflictsLink = Locator.linkWithText("RESOLVE CONFLICTS");
+
+        var resolveConflictsLink = Locator.tagWithClass("div", "labkey-download").descendant(Locator.linkWithText("RESOLVE CONFLICTS"));
         assertElementPresent(resolveConflictsLink);
         clickAndWait(resolveConflictsLink);
-        WebElement selectAllOldTargets = Locator.id("selectAllOld").findElement(this.getDriver());
-        selectAllOldTargets.click();
+        click(Locator.tagWithId("span", "selectAllOld"));
         clickButton("Apply Changes");
         libRevision++;
     }

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSLibraryTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSLibraryTest.java
@@ -213,9 +213,15 @@ public class TargetedMSLibraryTest extends TargetedMSTest
     private void verifyAndResolveConflicts()
     {
         log("Verifying that expected conflicts exist");
-        assertElementPresent(Locator.xpath("//div[contains(text(), \"The library folder has 4 conflicting proteins.\") and contains(@style, \"color:red; font-weight:bold\")]"));
-        var resolveConflictsLink = Locator.linkWithText("Resolve conflicts");
+        String[] conflictText = new String[] {"The last Skyline document imported in this folder had 4 proteins that were already a part of the library",
+                "Please click the link below to resolve conflicts and choose the version of each protein that should be included in the library",
+                "The library cannot be extended until the conflicts are resolved. The download link below is for the last stable version of the library"};
+        assertTextPresent(conflictText);
+        var resolveConflictsLink = Locator.linkWithText("RESOLVE CONFLICTS");
         assertElementPresent(resolveConflictsLink);
+
+        verifyConflictsAsReadOnlyUser();
+
         clickAndWait(resolveConflictsLink);
         assertTextPresent(
                 "Conflicting Proteins in Document",
@@ -244,6 +250,15 @@ public class TargetedMSLibraryTest extends TargetedMSTest
         }
 
         clickButton("Apply Changes");
+    }
+
+    private void verifyConflictsAsReadOnlyUser()
+    {
+        impersonateRole("Reader");
+        String conflictText = "The chromatogram library in this folder is in a conflicted state and is awaiting action from a folder administrator to resolve the conflicts. " +
+                "The download link below is for the last stable version of the library.";
+        assertTextPresent(conflictText);
+        stopImpersonating(false);
     }
 
     @LogMethod

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSLibraryTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSLibraryTest.java
@@ -175,7 +175,7 @@ public class TargetedMSLibraryTest extends TargetedMSTest
         {
             // The library stats graph is not displayed if the folder has conflicts.
             assertElementNotPresent(Locator.xpath("//img[contains(@src, 'graphLibraryStatistics.view')]"));
-            assertTextPresent("The library cannot be extended until the conflicts are resolved. The download link below is for the last stable version of the library");
+            assertTextPresent("The library cannot be extended until the conflicts are resolved", "The download link below is for the last stable version of the library");
         }
         assertTextPresent(
                 proteinCount + " proteins", peptideCount + " ranked peptides",
@@ -255,8 +255,8 @@ public class TargetedMSLibraryTest extends TargetedMSTest
     private void verifyConflictsAsReadOnlyUser()
     {
         impersonateRole("Reader");
-        String conflictText = "The chromatogram library in this folder is in a conflicted state and is awaiting action from a folder administrator to resolve the conflicts. " +
-                "The download link below is for the last stable version of the library.";
+        String[] conflictText = new String[] {"The chromatogram library in this folder is in a conflicted state and is awaiting action from a folder administrator to resolve the conflicts",
+                "The download link below is for the last stable version of the library."};
         assertTextPresent(conflictText);
         stopImpersonating(false);
     }

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSLibraryTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSLibraryTest.java
@@ -217,7 +217,8 @@ public class TargetedMSLibraryTest extends TargetedMSTest
                 "Please click the link below to resolve conflicts and choose the version of each protein that should be included in the library",
                 "The library cannot be extended until the conflicts are resolved. The download link below is for the last stable version of the library"};
         assertTextPresent(conflictText);
-        var resolveConflictsLink = Locator.linkWithText("RESOLVE CONFLICTS");
+
+        var resolveConflictsLink = Locator.tagWithClass("div", "labkey-download").descendant(Locator.linkWithText("RESOLVE CONFLICTS"));
         assertElementPresent(resolveConflictsLink);
 
         verifyConflictsAsReadOnlyUser();

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSLibraryTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSLibraryTest.java
@@ -23,6 +23,7 @@ import org.labkey.test.categories.DailyB;
 import org.labkey.test.categories.MS2;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
+import org.labkey.test.util.PipelineStatusTable;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
@@ -41,6 +42,7 @@ public class TargetedMSLibraryTest extends TargetedMSTest
 {
     private static final String SKY_FILE1 = "Stergachis-SupplementaryData_2_a.sky.zip";
     private static final String SKY_FILE2 = "Stergachis-SupplementaryData_2_b.sky.zip";
+    private static final String SKY_FILE3 = "MRMer_renamed_protein.zip";
 
     @Test
     public void testSteps()
@@ -49,9 +51,29 @@ public class TargetedMSLibraryTest extends TargetedMSTest
         importData(SKY_FILE1);
         verifyRevision1();
         importData(SKY_FILE2, 2);
+        testImportFailAfterConflict();
         verifyRevision2();
         verifyAndResolveConflicts();
         verifyRevision3();
+        testImportSucceedAfterConflictResolved();
+    }
+
+    private void testImportFailAfterConflict()
+    {
+        // Imports in a library folder with conflicts should fail
+        importData(SKY_FILE3, 3, true);
+        PipelineStatusTable statusTable = new PipelineStatusTable(getDriver());
+        var status = statusTable.clickStatusLink("Skyline document import - MRMer_renamed_protein.zip");
+        status.assertLogTextContains("The library folder has conflicts.", "New Skyline documents can be added to the folder after the conflicts have been resolved");
+
+        checkExpectedErrors(1); // Clear the error to keep the test from failing
+    }
+
+    private void testImportSucceedAfterConflictResolved()
+    {
+        // Delete the failed job first otherwise the test fails
+        deletePipelineJob("Skyline document import - MRMer_renamed_protein.zip", false);
+        importData(SKY_FILE3, 3);
     }
 
     @Override
@@ -109,7 +131,9 @@ public class TargetedMSLibraryTest extends TargetedMSTest
         log("Verifying expected protein/peptide counts in library revision 2 after uploading " + SKY_FILE2);
 
         // Download link, library statistics and revision in the ChromatogramLibraryDownloadWebpart
-        verifyChromatogramLibraryDownloadWebPart(10, 89, 582, 2);
+        // The folder has conflicts so the download link and the numbers should be for the last stable library built
+        // before conflicts, which is revision 1.
+        verifyChromatogramLibraryDownloadWebPart(7, 55, 343, 1, true);
 
         // Proteins in SKY_FILE1: "CTCF", "TAF11", "MAX", "QPrEST_CystC_HPRR5000001", "HPRR1440042", "DifferentProteinSameLabel",  "iRT-C18 Standard Peptides"
         // Proteins in SKY_FILE2: "TP53", "GATA3", "MAX", "HPRR350065", "HPRR1440042", "DifferentProteinSameLabel", "HPRR5000001", "iRT-C18 Standard Peptides"
@@ -137,8 +161,22 @@ public class TargetedMSLibraryTest extends TargetedMSTest
 
     private void verifyChromatogramLibraryDownloadWebPart(int proteinCount, int peptideCount, int transitionCount, int revision)
     {
+        verifyChromatogramLibraryDownloadWebPart(proteinCount, peptideCount, transitionCount, revision, false);
+    }
+
+    private void verifyChromatogramLibraryDownloadWebPart(int proteinCount, int peptideCount, int transitionCount, int revision, boolean hasConflict)
+    {
         clickAndWait(Locator.linkContainingText("Panorama Dashboard"));
-        assertElementPresent(Locator.xpath("//img[contains(@src, 'graphLibraryStatistics.view')]"));
+        if(!hasConflict)
+        {
+            assertElementPresent(Locator.xpath("//img[contains(@src, 'graphLibraryStatistics.view')]"));
+        }
+        else
+        {
+            // The library stats graph is not displayed if the folder has conflicts.
+            assertElementNotPresent(Locator.xpath("//img[contains(@src, 'graphLibraryStatistics.view')]"));
+            assertTextPresent("The library cannot be extended until the conflicts are resolved. The download link below is for the last stable version of the library");
+        }
         assertTextPresent(
                 proteinCount + " proteins", peptideCount + " ranked peptides",
                 transitionCount + " ranked transitions");
@@ -175,9 +213,10 @@ public class TargetedMSLibraryTest extends TargetedMSTest
     private void verifyAndResolveConflicts()
     {
         log("Verifying that expected conflicts exist");
-        assertElementPresent(Locator.xpath("//div[contains(text(), \"There are 4 conflicting proteins in this folder.\") and contains(@style, \"color:red; font-weight:bold\")]"));
-        assertElementPresent(Locator.xpath("//tr[td[div[a[contains(@style,'color:red; text-decoration:underline;') and text()='Resolve conflicts']]]]"));
-        clickAndWait(Locator.linkContainingText("Resolve conflicts"));
+        assertElementPresent(Locator.xpath("//div[contains(text(), \"The library folder has 4 conflicting proteins.\") and contains(@style, \"color:red; font-weight:bold\")]"));
+        var resolveConflictsLink = Locator.linkWithText("Resolve conflicts");
+        assertElementPresent(resolveConflictsLink);
+        clickAndWait(resolveConflictsLink);
         assertTextPresent(
                 "Conflicting Proteins in Document",
                 "Current Library Proteins",

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSPeptideLibraryTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSPeptideLibraryTest.java
@@ -206,7 +206,7 @@ public class TargetedMSPeptideLibraryTest extends TargetedMSTest
                 "Please click the link below to resolve conflicts and choose the version of each peptide that should be included in the library",
                 "The library cannot be extended until the conflicts are resolved. The download link below is for the last stable version of the library"};
         assertTextPresent(conflictText);
-        var resolveConflictsLink = Locator.linkWithText("RESOLVE CONFLICTS");
+        var resolveConflictsLink = Locator.tagWithClass("div", "labkey-download").descendant(Locator.linkWithText("RESOLVE CONFLICTS"));
         assertElementPresent(resolveConflictsLink);
         clickAndWait(resolveConflictsLink);
         assertTextPresent(

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSPeptideLibraryTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSPeptideLibraryTest.java
@@ -52,31 +52,11 @@ public class TargetedMSPeptideLibraryTest extends TargetedMSTest
         importData(SKY_FILE1);
         verifyRevision1();
         importData(SKY_FILE2, 2);
-        testImportFailAfterConflict();
         verifyRevision2();
         verifyAndResolveConflicts();
         verifyRevision3();
         deleteSkyFile(SKY_FILE2);
         verifyRevision4();
-        testImportSucceedAfterConflictResolved();
-    }
-
-    private void testImportFailAfterConflict()
-    {
-        // Imports in a library folder with conflicts should fail
-        importData(SKY_FILE3, 3, true);
-        PipelineStatusTable statusTable = new PipelineStatusTable(getDriver());
-        var status = statusTable.clickStatusLink("Skyline document import - MRMer_renamed_protein.zip");
-        status.assertLogTextContains("The library folder has conflicts.", "New Skyline documents can be added to the folder after the conflicts have been resolved");
-
-        checkExpectedErrors(1); // Clear the error to keep the test from failing
-    }
-
-    private void testImportSucceedAfterConflictResolved()
-    {
-        // Delete the failed job first otherwise the test fails
-        deletePipelineJob("Skyline document import - MRMer_renamed_protein.zip", false);
-        importData(SKY_FILE3, 3);
     }
 
     @Override
@@ -222,8 +202,11 @@ public class TargetedMSPeptideLibraryTest extends TargetedMSTest
     private void verifyAndResolveConflicts()
     {
         log("Verifying that expected conflicts exist");
-        assertElementPresent(Locator.xpath("//div[contains(text(), \"The library folder has 10 conflicting peptides.\") and contains(@style, \"color:red; font-weight:bold\")]"));
-        var resolveConflictsLink = Locator.linkWithText("Resolve conflicts");
+        String[] conflictText = new String[] {"The last Skyline document imported in this folder had 10 peptides that were already a part of the library",
+                "Please click the link below to resolve conflicts and choose the version of each peptide that should be included in the library",
+                "The library cannot be extended until the conflicts are resolved. The download link below is for the last stable version of the library"};
+        assertTextPresent(conflictText);
+        var resolveConflictsLink = Locator.linkWithText("RESOLVE CONFLICTS");
         assertElementPresent(resolveConflictsLink);
         clickAndWait(resolveConflictsLink);
         assertTextPresent(

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSPeptideLibraryTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSPeptideLibraryTest.java
@@ -189,7 +189,7 @@ public class TargetedMSPeptideLibraryTest extends TargetedMSTest
         {
             // The library stats graph is not displayed if the folder has conflicts.
             assertElementNotPresent(Locator.xpath("//img[contains(@src, 'graphLibraryStatistics.view')]"));
-            assertTextPresent("The library cannot be extended until the conflicts are resolved. The download link below is for the last stable version of the library");
+            assertTextPresent("The library cannot be extended until the conflicts are resolved", "The download link below is for the last stable version of the library");
         }
         assertTextPresent(
                 peptideCount + " peptides",

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSTest.java
@@ -153,6 +153,12 @@ public abstract class TargetedMSTest extends BaseWebDriverTest
     @LogMethod
     protected void importData(@LoggedParam String file, int jobCount)
     {
+        importData(file, jobCount, false);
+    }
+
+    @LogMethod
+    protected void importData(@LoggedParam String file, int jobCount, boolean expectError)
+    {
         Locator.XPathLocator importButtonLoc = Locator.lkButton("Process and Import Data");
         WebElement importButton = importButtonLoc.findElementOrNull(getDriver());
         if (null == importButton)
@@ -166,7 +172,7 @@ public abstract class TargetedMSTest extends BaseWebDriverTest
             _fileBrowserHelper.uploadFile(TestFileUtils.getSampleData("TargetedMS/" + file));
         _fileBrowserHelper.importFile(fileName, "Import Skyline Results");
         waitForText("Skyline document import");
-        waitForPipelineJobsToComplete(jobCount, file, false);
+        waitForPipelineJobsToComplete(jobCount, file, expectError);
     }
 
     protected void verifyRunSummaryCountsSmallMol(int proteinCount, int peptideCount, int moleculeCount, int precursorCount, int transitionCount, int replicateCount, int calibrationCount, int listCount)


### PR DESCRIPTION
#### Rationale
It is too easy for users to ignore conflicts in library folders.  

#### Changes
- Document upload in a library folder fails if the folder has conflicts
- If there are conflicts in a folder show the download link for the last stable library revision 

