### PR TITLE
Issue 41741: Per-row DB queries when rendering chromatogram plots

### DIFF
--- a/src/org/labkey/targetedms/query/GeneralMoleculePrecursorChromatogramsTableInfo.java
+++ b/src/org/labkey/targetedms/query/GeneralMoleculePrecursorChromatogramsTableInfo.java
@@ -73,7 +73,7 @@ public class GeneralMoleculePrecursorChromatogramsTableInfo extends FilteredTabl
 
         pepChromCol.setDisplayColumnFactory(new ChromatogramDisplayColumnFactory(
                                                         schema.getContainer(),
-                                                        ChromatogramDisplayColumnFactory.TYPE.GENERAL_MOLECULE,
+                                                        ChromatogramDisplayColumnFactory.Type.GeneralMoleculePeer,
                                                         form.getChartWidth(),
                                                         form.getChartHeight(),
                                                         form.isSyncY(),
@@ -89,7 +89,7 @@ public class GeneralMoleculePrecursorChromatogramsTableInfo extends FilteredTabl
         {
             ((BaseColumnInfo)colInfo).setDisplayColumnFactory(new ChromatogramDisplayColumnFactory(
                                                         schema.getContainer(),
-                                                        ChromatogramDisplayColumnFactory.TYPE.PRECURSOR,
+                                                        ChromatogramDisplayColumnFactory.Type.PrecursorPeer,
                                                         form.getChartWidth(),
                                                         form.getChartHeight(),
                                                         form.isSyncY(),

--- a/src/org/labkey/targetedms/query/PeptideChromatogramsTableInfo.java
+++ b/src/org/labkey/targetedms/query/PeptideChromatogramsTableInfo.java
@@ -42,7 +42,7 @@ public class PeptideChromatogramsTableInfo extends FilteredTable<TargetedMSSchem
         var chartCol = getMutableColumn("Id");
         chartCol.setLabel("");
         chartCol.setDisplayColumnFactory(new ChromatogramDisplayColumnFactory(getContainer(),
-                                         ChromatogramDisplayColumnFactory.TYPE.GENERAL_MOLECULE));
+                                         ChromatogramDisplayColumnFactory.Type.GeneralMoleculeSampleLookup));
     }
 
     public void setPeptideId(long peptideId)

--- a/src/org/labkey/targetedms/query/PrecursorChromatogramsTableInfo.java
+++ b/src/org/labkey/targetedms/query/PrecursorChromatogramsTableInfo.java
@@ -48,7 +48,7 @@ public class PrecursorChromatogramsTableInfo extends FilteredTable<TargetedMSSch
         peptideCol.setLabel("");
 
         ChromatogramDisplayColumnFactory colFactory = new ChromatogramDisplayColumnFactory(getContainer(),
-                ChromatogramDisplayColumnFactory.TYPE.PRECURSOR, chartWidth, chartHeight);
+                ChromatogramDisplayColumnFactory.Type.PrecursorSampleLookup, chartWidth, chartHeight);
         peptideCol.setDisplayColumnFactory(colFactory);
     }
 

--- a/src/org/labkey/targetedms/query/ReplicateManager.java
+++ b/src/org/labkey/targetedms/query/ReplicateManager.java
@@ -102,32 +102,6 @@ public class ReplicateManager
         return new SqlSelector(TargetedMSManager.getSchema(), sqlFragment).getObject(ReplicateAnnotation.class);
     }
 
-    public static SampleFile getSampleFileForPrecursorChromInfo(long precursorChromInfoId)
-    {
-        String sql = "SELECT sf.* FROM "+
-                     TargetedMSManager.getTableInfoSampleFile()+" AS sf, "+
-                     TargetedMSManager.getTableInfoPrecursorChromInfo()+" AS pci "+
-                     "WHERE sf.Id=pci.SampleFileId "+
-                     "AND pci.Id=?";
-        SQLFragment sf = new SQLFragment(sql);
-        sf.add(precursorChromInfoId);
-
-        return new SqlSelector(TargetedMSManager.getSchema(), sf).getObject(SampleFile.class);
-    }
-
-    public static SampleFile getSampleFileForGeneralMoleculeChromInfo(long generalMoleculeChromInfoId)
-    {
-        String sql = "SELECT sf.* FROM "+
-                     TargetedMSManager.getTableInfoSampleFile()+" AS sf, "+
-                     TargetedMSManager.getTableInfoGeneralMoleculeChromInfo()+" AS gmci "+
-                     "WHERE sf.Id=gmci.SampleFileId "+
-                     "AND gmci.Id=?";
-        SQLFragment sf = new SQLFragment(sql);
-        sf.add(generalMoleculeChromInfoId);
-
-        return new SqlSelector(TargetedMSManager.getSchema(), sf).getObject(SampleFile.class);
-    }
-
     public static List<SampleFile> getSampleFilesForRun(long runId)
     {
         String sql = "SELECT sf.* FROM "+


### PR DESCRIPTION
#### Rationale
It's bad for a single thread to be using multiple DB connections, as it can lead to deadlocks on the connection pool

#### Changes
* Fetch the sample name as part of the primary query so that we don't need to do a per-plot query