### PR TITLE
Issue 41789: Refinements to PeptideId report

### DIFF
--- a/resources/queries/targetedms/PeptideIds.query.xml
+++ b/resources/queries/targetedms/PeptideIds.query.xml
@@ -9,6 +9,9 @@
                     <column columnName="Sequence">
                         <displayColumnFactory>
                             <className>org.labkey.targetedms.query.ModifiedSequenceDisplayColumn$PeptideDisplayColumnFactory</className>
+                            <properties>
+                                <property name="showNextAndPrevious">true</property>
+                            </properties>
                         </displayColumnFactory>
                     </column>
                     <column columnName="MinObservedPeptideMass">

--- a/resources/queries/targetedms/PeptideIds.sql
+++ b/resources/queries/targetedms/PeptideIds.sql
@@ -4,11 +4,21 @@ SELECT
    MIN((PrecursorId.mz - 1.00727647) * PrecursorId.Charge * (1 + (pci.AverageMassErrorPPM / 1000000 ))) AS MinObservedPeptideMass,
    MAX((PrecursorId.mz - 1.00727647) * PrecursorId.Charge * (1 + (pci.AverageMassErrorPPM / 1000000 ))) AS MaxObservedPeptideMass,
    PrecursorId.NeutralMass AS ExpectedPeptideMass,
-   SUBSTRING(PrecursorId.PeptideId.PeptideGroupId.Label, 6, 1) || (PrecursorId.PeptideId.StartIndex + 1) || '-' || (PrecursorId.PeptideId.EndIndex) AS PeptideIdentity,
+   -- Concatenate the empty string so that the protein DisplayColumn doesn't get propagated too
+   PrecursorId.PeptideId.PeptideGroupId.Label || '' AS Chain,
+   (PrecursorId.PeptideId.StartIndex + 1) || '-' || (PrecursorId.PeptideId.EndIndex) AS PeptideLocation,
    PrecursorId.PeptideId.Sequence,
+   PrecursorId.PeptideId.NextAA @hidden,
+   PrecursorId.PeptideId.PreviousAA @hidden,
    PrecursorId.ModifiedSequence AS PeptideModifiedSequence @hidden,
    PrecursorId.PeptideId AS Id @hidden,
-   (SELECT GROUP_CONCAT(StructuralModId.Name) FROM targetedms.PeptideStructuralModification psm WHERE psm.PeptideId = pci.PrecursorId.PeptideId) AS Modification
+   -- Show the modifications and their locations
+   (SELECT GROUP_CONCAT((StructuralModId.Name ||
+                         ' @ ' ||
+                         SUBSTRING(PrecursorId.PeptideId.Sequence, IndexAA + 1, 1) ||
+                         CAST(IndexAA + PrecursorId.PeptideId.StartIndex AS VARCHAR)),
+       (', ' || CHR(10)))
+   FROM targetedms.PeptideStructuralModification psm WHERE psm.PeptideId = pci.PrecursorId.PeptideId) AS Modification
 FROM
      targetedms.precursorchrominfo pci
 GROUP BY
@@ -18,5 +28,7 @@ GROUP BY
    PrecursorId.PeptideId.PeptideGroupId,
    PrecursorId.PeptideId.PeptideGroupId.Label,
    PrecursorId.PeptideId.Sequence,
+   PrecursorId.PeptideId.NextAA,
+   PrecursorId.PeptideId.PreviousAA,
    PrecursorId.PeptideId.StartIndex,
    PrecursorId.PeptideId.EndIndex


### PR DESCRIPTION
#### Rationale
As customers have used this report, they've generated a few requested tweaks.

#### Changes
* Show the protein chain and the peptide location as two separate columns instead of combining into a single column.
* Include the next and previous amino acids in the sequence column.
* Show the location of modifications on the protein/peptide sequence in addition to just the modification name.