### PR TITLE
Issue 41819: Skipping TransitionChromInfo import for large documents breaks precursor plotting

### DIFF
--- a/resources/schemas/dbscripts/postgresql/targetedms-20.016-20.017.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-20.016-20.017.sql
@@ -1,0 +1,1 @@
+ALTER TABLE targetedms.PrecursorChromInfo ADD COLUMN TransitionChromatogramIndices BYTEA;

--- a/resources/schemas/dbscripts/sqlserver/targetedms-20.016-20.017.sql
+++ b/resources/schemas/dbscripts/sqlserver/targetedms-20.016-20.017.sql
@@ -1,1 +1,1 @@
-ALTER TABLE targetedms.PrecursorChromInfo ADD COLUMN TransitionChromatogramIndices IMAGE;
+ALTER TABLE targetedms.PrecursorChromInfo ADD TransitionChromatogramIndices IMAGE;

--- a/resources/schemas/dbscripts/sqlserver/targetedms-20.016-20.017.sql
+++ b/resources/schemas/dbscripts/sqlserver/targetedms-20.016-20.017.sql
@@ -1,0 +1,1 @@
+ALTER TABLE targetedms.PrecursorChromInfo ADD COLUMN TransitionChromatogramIndices IMAGE;

--- a/resources/schemas/targetedms.xml
+++ b/resources/schemas/targetedms.xml
@@ -556,6 +556,7 @@
                 <formatString>##0.####%</formatString>
                 <description>(sum area of precursors for this peptide in the same sample) / (total area of all precursors for the same grouping in the sample)</description>
             </column>
+            <column columnName="TransitionChromatogramIndices"/>
         </columns>
     </table>
     <table tableDbType="TABLE" tableName="GeneralTransition">

--- a/src/org/labkey/targetedms/SkylineDocImporter.java
+++ b/src/org/labkey/targetedms/SkylineDocImporter.java
@@ -382,10 +382,10 @@ public class SkylineDocImporter
                 TargetedMSManager.deleteGeneralTransitionDependent(getTableInfoTransitionChromInfo(), "TransitionId", whereClause);
 
                 // Since we don't have the TransitionChromInfos to use for the indices, copy them from the temp table
-                // into PrecursorChromInfo
+                // into PrecursorChromInfo (but filter to only touch the rows where we have matches in the temp table)
                 int updated = new SqlExecutor(TargetedMSSchema.getSchema()).execute("UPDATE " + getTableInfoPrecursorChromInfo() + " " +
                             "SET TransitionChromatogramIndices = (SELECT Indices FROM " + precursorChromInfoIndicesTempTableName +
-                        " WHERE Id = PrecursorChromInfoId)");
+                        " WHERE Id = PrecursorChromInfoId) WHERE Id IN (SELECT PrecursorChromInfoId FROM " + precursorChromInfoIndicesTempTableName + ")");
                 _log.info("Updated " + updated + " PrecursorChromInfos with transition chromatogram index information");
             }
 

--- a/src/org/labkey/targetedms/SkylineDocImporter.java
+++ b/src/org/labkey/targetedms/SkylineDocImporter.java
@@ -62,12 +62,12 @@ import org.labkey.targetedms.parser.*;
 import org.labkey.targetedms.parser.list.ListData;
 import org.labkey.targetedms.parser.skyaudit.AuditLogException;
 import org.labkey.targetedms.query.ConflictResultsManager;
-import org.labkey.targetedms.query.PeptideManager;
 import org.labkey.targetedms.query.ReplicateManager;
 import org.labkey.targetedms.query.RepresentativeStateManager;
 import org.labkey.targetedms.query.SkylineListManager;
 
 import javax.xml.stream.XMLStreamException;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -97,6 +97,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.locks.ReentrantLock;
 
+import static org.labkey.targetedms.TargetedMSManager.getTableInfoPrecursorChromInfo;
 import static org.labkey.targetedms.TargetedMSManager.getTableInfoTransitionChromInfo;
 
 /**
@@ -151,11 +152,10 @@ public class SkylineDocImporter
     private transient PreparedStatement _precursorAnnotationStmt;
     private transient PreparedStatement _transitionChromInfoStmt;
     private transient PreparedStatement _precursorChromInfoStmt;
+    private transient PreparedStatement _precursorChromInfoIndicesStmt;
     private File _auditLogFile;
 
-    private boolean _importTransitionChromInfos = true;
-
-    private Set<String> _missingLibraries = new HashSet<>();
+    private final Set<String> _missingLibraries = new HashSet<>();
 
     @JsonCreator
     private SkylineDocImporter(@JsonProperty("_expData") ExpData expData, @JsonProperty("_context") XarContext context,
@@ -273,7 +273,8 @@ public class SkylineDocImporter
     {
         // TODO - Consider if this is too big to fit in a single transaction. If so, need to blow away all existing
         // data for this run before restarting the import in the case of a retry
-        if (!TargetedMSManager.getSchema().getScope().isTransactionActive())
+        DbScope.Transaction transaction = TargetedMSManager.getSchema().getScope().getCurrentTransaction();
+        if (transaction == null)
         {
             throw new IllegalStateException("Callers should start their own transaction");
         }
@@ -283,8 +284,18 @@ public class SkylineDocImporter
 
         TargetedMSService.FolderType folderType = TargetedMSManager.getFolderType(run.getContainer());
 
+        final String suffix = StringUtilsLabKey.getPaddedUniquifier(9);
+        final String precursorChromInfoIndicesTempTableName = TargetedMSManager.getSqlDialect().getTempTablePrefix() +  "PrecursorChromInfoIndices" + suffix;
+
         try (SkylineDocumentParser parser = new SkylineDocumentParser(f, _log, run.getContainer(), _progressMonitor.getParserProgressTracker()))
         {
+            new SqlExecutor(TargetedMSSchema.getSchema()).execute("CREATE " +
+                    TargetedMSManager.getSqlDialect().getTempTableKeyword() + " TABLE " + precursorChromInfoIndicesTempTableName + " ( " +
+                    "\tPrecursorChromInfoId BIGINT NOT NULL PRIMARY KEY,\n" +
+                    "\tIndices " + TargetedMSManager.getSqlDialect().getBinaryDataType() +
+                    ")");
+            _precursorChromInfoIndicesStmt = ensureStatement(null,"INSERT INTO " + precursorChromInfoIndicesTempTableName + "(PrecursorChromInfoId, Indices) VALUES (?, ?)", false);
+
             run.setFormatVersion(parser.getFormatVersion());
             run.setSoftwareVersion(parser.getSoftwareVersion());
 
@@ -357,7 +368,7 @@ public class SkylineDocImporter
                 }
             }
 
-            if (parser.getTransitionChromInfoCount() > SkylineDocumentParser.MAX_TRANSITION_CHROM_INFOS)
+            if (!parser.shouldSaveTransitionChromInfos())
             {
                 _log.info("None of the " + parser.getTransitionChromInfoCount() + " TransitionChromInfos in the file were imported because they exceed the limit of " + SkylineDocumentParser.MAX_TRANSITION_CHROM_INFOS);
                 SQLFragment whereClause = new SQLFragment("WHERE r.Id = ?", _runId);
@@ -367,7 +378,14 @@ public class SkylineDocImporter
                 TargetedMSManager.deleteTransitionChromInfoDependent(TargetedMSManager.getTableInfoTransitionChromInfoAnnotation(), whereClause);
                 TargetedMSManager.deleteTransitionChromInfoDependent(TargetedMSManager.getTableInfoTransitionAreaRatio(), whereClause);
                 TargetedMSManager.deleteGeneralTransitionDependent(getTableInfoTransitionChromInfo(), "TransitionId", whereClause);
+
+                int updated = new SqlExecutor(TargetedMSSchema.getSchema()).execute("UPDATE " + getTableInfoPrecursorChromInfo() + " " +
+                            "SET TransitionChromatogramIndices = (SELECT Indices FROM " + precursorChromInfoIndicesTempTableName +
+                        " WHERE Id = PrecursorChromInfoId)");
+                _log.info("Updated " + updated + " PrecursorChromInfos with transition chromatogram index information");
             }
+
+            new SqlExecutor(TargetedMSSchema.getSchema()).execute("DROP TABLE " + precursorChromInfoIndicesTempTableName);
 
             // Done parsing document
             _progressMonitor.getParserProgressTracker().complete("Done parsing Skyline document.");
@@ -460,6 +478,8 @@ public class SkylineDocImporter
         }
         finally
         {
+            if (_precursorChromInfoIndicesStmt != null) { try { _precursorChromInfoIndicesStmt.close(); } catch (SQLException ignored) {} }
+            _precursorChromInfoIndicesStmt = null;
             if (_transitionChromInfoAnnotationStmt != null) { try { _transitionChromInfoAnnotationStmt.close(); } catch (SQLException ignored) {} }
             _transitionChromInfoAnnotationStmt = null;
             if (_transitionAnnotationStmt != null) { try { _transitionAnnotationStmt.close(); } catch (SQLException ignored) {} }
@@ -614,10 +634,7 @@ public class SkylineDocImporter
 
         public void addSampleToDelete(String currentSamplePath, SampleFile oldSampleFile)
         {
-            if(oldSamplesToDelete.get(currentSamplePath) == null)
-            {
-                oldSamplesToDelete.put(currentSamplePath, new HashSet<>());
-            }
+            oldSamplesToDelete.computeIfAbsent(currentSamplePath, k -> new HashSet<>());
             oldSamplesToDelete.get(currentSamplePath).add(oldSampleFile);
         }
     }
@@ -1213,7 +1230,7 @@ public class SkylineDocImporter
             }
 
             insertPeptideOrSmallMolecule(optimizationInfo, skylineIdSampleFileIdMap, modInfo,
-                    libraryNameIdMap, pepGroup, generalMolecule, transitionSettings);
+                    libraryNameIdMap, pepGroup, generalMolecule, transitionSettings, parser);
         }
         if(peptideCount > 0)
         {
@@ -1269,7 +1286,8 @@ public class SkylineDocImporter
                                               Map<String, Long> libraryNameIdMap,
                                               PeptideGroup pepGroup,
                                               GeneralMolecule generalMolecule,
-                                              TransitionSettings transitionSettings)
+                                              TransitionSettings transitionSettings,
+                                              SkylineDocumentParser parser)
     {
         Peptide peptide = null;
 
@@ -1303,7 +1321,7 @@ public class SkylineDocImporter
 
             for (MoleculePrecursor moleculePrecursor : molecule.getMoleculePrecursorsList())
             {
-                insertMoleculePrecursor(molecule, moleculePrecursor, skylineIdSampleFileIdMap, modInfo, sampleFileIdGeneralMolChromInfoIdMap);
+                insertMoleculePrecursor(molecule, moleculePrecursor, skylineIdSampleFileIdMap, modInfo, sampleFileIdGeneralMolChromInfoIdMap, parser);
             }
         }
 
@@ -1337,7 +1355,7 @@ public class SkylineDocImporter
                         libraryNameIdMap,
                         peptide,
                         sampleFileIdGeneralMolChromInfoIdMap,
-                        precursor);
+                        precursor, parser);
             }
 
             // 4. Calculate and insert peak area ratios
@@ -1415,9 +1433,9 @@ public class SkylineDocImporter
     private void insertMoleculePrecursor(Molecule molecule, MoleculePrecursor moleculePrecursor,
                                          Map<SampleFileKey, SampleFile> skylineIdSampleFileIdMap,
                                          ModificationInfo modInfo,
-                                         Map<Long, Long> sampleFileIdGeneralMolChromInfoIdMap)
+                                         Map<Long, Long> sampleFileIdGeneralMolChromInfoIdMap, SkylineDocumentParser parser)
     {
-        GeneralPrecursor gp = insertGeneralPrecursor(modInfo, molecule, moleculePrecursor);
+        GeneralPrecursor<?> gp = insertGeneralPrecursor(modInfo, molecule, moleculePrecursor);
 
         moleculePrecursor.setIsotopeLabelId(gp.getIsotopeLabelId());
         moleculePrecursor.setId(gp.getId());
@@ -1432,11 +1450,11 @@ public class SkylineDocImporter
 
         for(MoleculeTransition moleculeTransition: moleculePrecursor.getTransitionsList())
         {
-            insertMoleculeTransition(moleculePrecursor, moleculeTransition, skylineIdSampleFileIdMap, sampleFilePrecursorChromInfoIdMap);
+            insertMoleculeTransition(moleculePrecursor, moleculeTransition, skylineIdSampleFileIdMap, sampleFilePrecursorChromInfoIdMap, parser);
         }
     }
 
-    private void insertPrecursorAnnotation(List<PrecursorAnnotation> precursorAnnotations, GeneralPrecursor gp, long id)
+    private void insertPrecursorAnnotation(List<PrecursorAnnotation> precursorAnnotations, GeneralPrecursor<?> gp, long id)
     {
         for (PrecursorAnnotation annotation : precursorAnnotations)
         {
@@ -1448,7 +1466,8 @@ public class SkylineDocImporter
 
     private void insertMoleculeTransition(MoleculePrecursor moleculePrecursor, MoleculeTransition moleculeTransition,
                                           Map<SampleFileKey, SampleFile> skylineIdSampleFileIdMap,
-                                          Map<SampleFileOptStepKey, Long> sampleFilePrecursorChromInfoIdMap)
+                                          Map<SampleFileOptStepKey, Long> sampleFilePrecursorChromInfoIdMap,
+                                          SkylineDocumentParser parser)
     {
         GeneralTransition gt = new GeneralTransition();
         gt.setGeneralPrecursorId(moleculePrecursor.getId());
@@ -1474,7 +1493,7 @@ public class SkylineDocImporter
         //small molecule transition annotations
         insertTransitionAnnotation(moleculeTransition.getAnnotations(), moleculeTransition.getId()); //adding small molecule transition annotation in TransitionAnnotation table. We might need to change this if we decide to have a separate MoleculeTransitionAnnotation table in the future.
 
-        insertTransitionChromInfos(gt.getId(), moleculeTransition.getChromInfoList(), skylineIdSampleFileIdMap, sampleFilePrecursorChromInfoIdMap);
+        insertTransitionChromInfos(gt.getId(), moleculeTransition.getChromInfoList(), skylineIdSampleFileIdMap, sampleFilePrecursorChromInfoIdMap, parser);
     }
 
     private void insertTransitionAnnotation(List<TransitionAnnotation> annotations, long id)
@@ -1492,7 +1511,8 @@ public class SkylineDocImporter
                                  Map<String, Long> libraryNameIdMap,
                                  Peptide peptide,
                                  Map<Long, Long> sampleFileIdGeneralMolChromInfoIdMap,
-                                 Precursor precursor)
+                                 Precursor precursor,
+                                 SkylineDocumentParser parser)
     {
         if(_isPeptideLibraryDoc)
         {
@@ -1508,7 +1528,7 @@ public class SkylineDocImporter
             }
         }
 
-        GeneralPrecursor gp = insertGeneralPrecursor(modInfo, peptide, precursor);
+        GeneralPrecursor<?> gp = insertGeneralPrecursor(modInfo, peptide, precursor);
 
         precursor.setIsotopeLabelId(gp.getIsotopeLabelId());
         precursor.setId(gp.getId());
@@ -1528,11 +1548,11 @@ public class SkylineDocImporter
         // 4. transition
         for(Transition transition: precursor.getTransitionsList())
         {
-            insertTransition(optimizationInfo, skylineIdSampleFileIdMap, modInfo, precursor, sampleFilePrecursorChromInfoIdMap, transition);
+            insertTransition(optimizationInfo, skylineIdSampleFileIdMap, modInfo, precursor, sampleFilePrecursorChromInfoIdMap, transition, parser);
         }
     }
 
-    private void insertLibInfo(Precursor.LibraryInfo libraryInfo, Precursor precursor, GeneralPrecursor gp, Map<String, Long> libraryNameIdMap, TableInfo tableInfo)
+    private void insertLibInfo(Precursor.LibraryInfo libraryInfo, Precursor precursor, GeneralPrecursor<?> gp, Map<String, Long> libraryNameIdMap, TableInfo tableInfo)
     {
         if(libraryInfo != null)
         {
@@ -1558,10 +1578,10 @@ public class SkylineDocImporter
         }
     }
 
-    private GeneralPrecursor insertGeneralPrecursor(ModificationInfo modInfo, GeneralMolecule peptide, GeneralPrecursor precursor)
+    private GeneralPrecursor<?> insertGeneralPrecursor(ModificationInfo modInfo, GeneralMolecule peptide, GeneralPrecursor<?> precursor)
     {
         //setting values for GeneralPrecursor here seems odd - is there a better way?
-        GeneralPrecursor gp = new GeneralPrecursor();
+        GeneralPrecursor<?> gp = new GeneralPrecursor<>();
         gp.setGeneralMoleculeId(peptide.getId());
         gp.setMz(precursor.getMz());
         gp.setCharge(precursor.getCharge());
@@ -1585,7 +1605,7 @@ public class SkylineDocImporter
                                   ModificationInfo modInfo,
                                   Precursor precursor,
                                   Map<SampleFileOptStepKey, Long> sampleFilePrecursorChromInfoIdMap,
-                                  Transition transition)
+                                  Transition transition, SkylineDocumentParser parser)
     {
         GeneralTransition gt = new GeneralTransition();
         gt.setGeneralPrecursorId(precursor.getId());
@@ -1632,7 +1652,7 @@ public class SkylineDocImporter
         }
 
         // transition results
-        insertTransitionChromInfos(gt.getId(), transition.getChromInfoList(), skylineIdSampleFileIdMap, sampleFilePrecursorChromInfoIdMap);
+        insertTransitionChromInfos(gt.getId(), transition.getChromInfoList(), skylineIdSampleFileIdMap, sampleFilePrecursorChromInfoIdMap, parser);
 
         // transition neutral losses
         for (TransitionLoss loss : transition.getNeutralLosses())
@@ -1757,9 +1777,10 @@ public class SkylineDocImporter
 
     private void insertTransitionChromInfos(long gtId, List<TransitionChromInfo> transitionChromInfos,
                                             Map<SampleFileKey, SampleFile> skylineIdSampleFileIdMap,
-                                            Map<SampleFileOptStepKey, Long> sampleFilePrecursorChromInfoIdMap)
+                                            Map<SampleFileOptStepKey, Long> sampleFilePrecursorChromInfoIdMap,
+                                            SkylineDocumentParser parser)
     {
-        if (!_importTransitionChromInfos)
+        if (!parser.shouldSaveTransitionChromInfos())
         {
             return;
         }
@@ -1887,20 +1908,27 @@ public class SkylineDocImporter
      * tradeoff between having more custom code and the perf hit from Table.insert() having to prep a statement for
      * every row
      */
-    private PreparedStatement ensureStatement(PreparedStatement stmt, String sql, boolean reselect) throws SQLException
+    private PreparedStatement ensureStatement(PreparedStatement stmt, String sql, boolean reselect)
     {
         if (stmt == null)
         {
-            assert TargetedMSManager.getSchema().getScope().isTransactionActive();
-            Connection c = TargetedMSManager.getSchema().getScope().getConnection();
-            if (reselect)
+            try
             {
-                SQLFragment reselectSQL = new SQLFragment(sql);
-                // All we really need is a ColumnInfo of the right name and type, so choose one of the TableInfos to supply it
-                TargetedMSManager.getSchema().getSqlDialect().addReselect(reselectSQL, getTableInfoTransitionChromInfo().getColumn("Id"), null);
-                sql = reselectSQL.getSQL();
+                assert TargetedMSManager.getSchema().getScope().isTransactionActive();
+                Connection c = TargetedMSManager.getSchema().getScope().getConnection();
+                if (reselect)
+                {
+                    SQLFragment reselectSQL = new SQLFragment(sql);
+                    // All we really need is a ColumnInfo of the right name and type, so choose one of the TableInfos to supply it
+                    TargetedMSManager.getSchema().getSqlDialect().addReselect(reselectSQL, getTableInfoTransitionChromInfo().getColumn("Id"), null);
+                    sql = reselectSQL.getSQL();
+                }
+                stmt = c.prepareStatement(sql);
             }
-            stmt = c.prepareStatement(sql);
+            catch (SQLException e)
+            {
+                throw new RuntimeSQLException(e);
+            }
         }
         return stmt;
     }
@@ -1956,16 +1984,6 @@ public class SkylineDocImporter
         }
     }
 
-    /** Assumes the statement is an INSERT with a reselect of the new sequence value */
-    private void insertAndUpdateId(SkylineEntity entity, PreparedStatement stmt) throws SQLException
-    {
-        try (ResultSet rs = TargetedMSManager.getSqlDialect().executeWithResults(stmt))
-        {
-            rs.next();
-            entity.setId(rs.getInt(1));
-        }
-    }
-
     private void insertPrecursorChromInfo(PrecursorChromInfo preChromInfo)
     {
         try
@@ -2011,12 +2029,20 @@ public class SkylineDocImporter
             setDouble(_precursorChromInfoStmt, index++, preChromInfo.getIonMobilityMs1());
             setDouble(_precursorChromInfoStmt, index++, preChromInfo.getIonMobilityFragment());
             setDouble(_precursorChromInfoStmt, index++, preChromInfo.getIonMobilityWindow());
-            _precursorChromInfoStmt.setString(index, preChromInfo.getIonMobilityType());
+            _precursorChromInfoStmt.setString(index++, preChromInfo.getIonMobilityType());
 
             try (ResultSet rs = TargetedMSManager.getSqlDialect().executeWithResults(_precursorChromInfoStmt))
             {
                 rs.next();
                 preChromInfo.setId(rs.getLong(1));
+            }
+
+            byte[] indices = preChromInfo.getTransitionChromatogramIndices();
+            if (indices != null)
+            {
+                _precursorChromInfoIndicesStmt.setLong(1, preChromInfo.getId());
+                _precursorChromInfoIndicesStmt.setBinaryStream(2, new ByteArrayInputStream(indices), indices.length);
+                _precursorChromInfoIndicesStmt.execute();
             }
         }
         catch (SQLException e)
@@ -2606,7 +2632,7 @@ public class SkylineDocImporter
         return new OptimizationInfo(insertCEOptmizations, insertDPOptmizations, cePredictor, dpPredictor);
     }
 
-    private class OptimizationInfo
+    private static class OptimizationInfo
     {
         private final boolean _insertCEOptmizations;
         private final boolean _insertDPOptmizations;
@@ -2625,19 +2651,19 @@ public class SkylineDocImporter
     private void adjustProgressParts(ProgressMonitor progress, DataSettings dataSettings, QuantificationSettings quantificationSettings)
     {
         RegressionFit regressionFit = getRegressionFit(quantificationSettings);
-        boolean hasCalCurves = regressionFit != RegressionFit.NONE ? true : false;
+        boolean hasCalCurves = regressionFit != RegressionFit.NONE;
 
         progress.updateProgressParts(dataSettings.getGroupComparisons().size() > 0, hasCalCurves);
     }
 
-    private class ProgressMonitor implements IProgressMonitor
+    private static class ProgressMonitor implements IProgressMonitor
     {
         private final ProgressPart _parserPart;     // Document parsing
         private final ProgressPart _qcCleanupPart;  // QC cleanup - remove redundant samples from older runs
         private final ProgressPart _foldChangePart; // Fold change calculations for group comparisons
         private final ProgressPart _calCurvesPart;  // Calibration curve calculations
 
-        private List<IProgressStatus> _progressParts;
+        private final List<IProgressStatus> _progressParts;
         private final PipelineJob _job;
         private int _lastProgressPerc = 0;
 
@@ -2655,7 +2681,7 @@ public class SkylineDocImporter
             _parserPart = new ProgressPart(isQc ? 60 : 80, this);
             _qcCleanupPart = new ProgressPart(isQc ? 30 : 0, this);
             _foldChangePart = new ProgressPart(isQc ? 4 : 9, this);
-            _calCurvesPart =  new ProgressPart(isQc ? 4 : 9, this);
+            _calCurvesPart = new ProgressPart(isQc ? 4 : 9, this);
 
             _progressParts = Arrays.asList(_parserPart, _qcCleanupPart, _foldChangePart, _calCurvesPart);
         }
@@ -2752,11 +2778,11 @@ public class SkylineDocImporter
         }
 
 
-        private class ProgressPart implements IProgressStatus
+        private static class ProgressPart implements IProgressStatus
         {
             private int _partPercent; // percent share of total progress
             private int _percDone;
-            private IProgressMonitor _progressMonitor;
+            private final IProgressMonitor _progressMonitor;
 
             public ProgressPart(int partPercent, IProgressMonitor progressMonitor)
             {

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -2751,7 +2751,7 @@ public class TargetedMSController extends SpringActionController
 
         private Integer _chartWidth = null;
         private Integer _chartHeight = null;
-        private int _dpi = SCREEN_RES;
+        private int _dpi = 144;
 
         public int getChartWidth()
         {
@@ -4184,16 +4184,20 @@ public class TargetedMSController extends SpringActionController
             summaryChartBean.setReplicateList(ReplicateManager.getReplicatesForRun(group.getRunId()));
             summaryChartBean.setReplicateAnnotationNameList(ReplicateManager.getReplicateAnnotationNamesForRun(group.getRunId()));
             summaryChartBean.setReplicateAnnotationValueList(ReplicateManager.getUniqueSortedAnnotationNameValue(group.getRunId()));
+            int count = 0;
             // Peptide summary charts
             if (peptideCount != null && peptideCount > 0)
             {
+                count += peptideCount.intValue();
                 summaryChartBean.setPeptideList(new ArrayList<>(PeptideManager.getPeptidesForGroup(group.getId(), new TargetedMSSchema(getUser(), getContainer()))));
             }
             // Molecule summary charts
             else if (moleculeCount != null && moleculeCount > 0)
             {
+                count += moleculeCount.intValue();
                 summaryChartBean.setMoleculeList(new ArrayList<>(MoleculeManager.getMoleculesForGroup(group.getId())));
             }
+            summaryChartBean.setInitialWidth(Math.max(600, 100 + count * 30));
             JspView<SummaryChartBean> summaryChartView = new JspView<>("/org/labkey/targetedms/view/summaryChartsView.jsp", summaryChartBean);
             summaryChartView.setTitle("Summary Charts");
             summaryChartView.enableExpandCollapse("SummaryChartsView", false);

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -3692,6 +3692,7 @@ public class TargetedMSController extends SpringActionController
             // run anyway
             settings.setContainerFilterName(null);
             settings.setBaseFilter(new SimpleFilter(FieldKey.fromParts("PeptideGroupId", "RunId"), form.getId()));
+            settings.setBaseSort(new Sort("Sequence"));
             TargetedMSSchema schema = new TargetedMSSchema(getUser(), getContainer());
             return schema.createView(getViewContext(), settings, errors);
         }

--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -215,7 +215,7 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
     @Override
     public Double getSchemaVersion()
     {
-        return 20.016;
+        return 20.017;
     }
 
     @Override

--- a/src/org/labkey/targetedms/chart/ChromatogramChartMaker.java
+++ b/src/org/labkey/targetedms/chart/ChromatogramChartMaker.java
@@ -131,8 +131,9 @@ class ChromatogramChartMaker
             @Override
             public StringBuffer format(double number, StringBuffer toAppendTo, FieldPosition pos)
             {
+                String pattern = (yAxis.getUpperBound() - yAxis.getLowerBound()) / chromatogramDataset.getIntensityScale() > 100 ? "0" : "0.0";
                 // Display the scaled value in the tick label.
-                return toAppendTo.append(new DecimalFormat("0.0").format(number / chromatogramDataset.getIntensityScale()));
+                return toAppendTo.append(new DecimalFormat(pattern).format(number / chromatogramDataset.getIntensityScale()));
             }
 
             @Override

--- a/src/org/labkey/targetedms/chart/ComparisonChartMaker.java
+++ b/src/org/labkey/targetedms/chart/ComparisonChartMaker.java
@@ -321,8 +321,8 @@ public class ComparisonChartMaker
         }
         xAxis.setMaximumCategoryLabelWidthRatio(0.3f);
         xAxis.setCategoryLabelPositions(CategoryLabelPositions.UP_90);
-        ValueAxis yAxis = plot.getRangeAxis();
-        ((NumberAxis)yAxis).setNumberFormatOverride(new DecimalFormat("0.0"));
+        NumberAxis yAxis = (NumberAxis)plot.getRangeAxis();
+        yAxis.setNumberFormatOverride(new DecimalFormat(yAxis.getUpperBound() - yAxis.getLowerBound() > 100 ? "0" : "0.0"));
         xAxis.setLabelFont(yAxis.getLabelFont());
         xAxis.setTickLabelFont(yAxis.getTickLabelFont());
         plot.setDomainAxis(xAxis);

--- a/src/org/labkey/targetedms/chart/LabelFactory.java
+++ b/src/org/labkey/targetedms/chart/LabelFactory.java
@@ -133,9 +133,14 @@ public class LabelFactory
     public static String moleculePrecursorLabel(long moleculePrecursorId, User user, Container container)
     {
         MoleculePrecursor moleculePrecursor = MoleculePrecursorManager.getPrecursor(container, moleculePrecursorId, user);
+        String primaryName = moleculePrecursor.getCustomIonName();
+        if (primaryName == null)
+        {
+            primaryName = moleculePrecursor.getIonFormula();
+        }
 
-        return moleculePrecursor.getCustomIonName() +
-                " - " + Formats.f4.format(moleculePrecursor.getMz()) +
+        return (primaryName == null ? "" : (primaryName + " - ")) +
+                Formats.f4.format(moleculePrecursor.getMz()) +
                 getChargeLabel(moleculePrecursor.getCharge());
     }
 
@@ -180,7 +185,7 @@ public class LabelFactory
 
         return generalMoleculeChromInfoChartTitle(pepChromInfo) +
                 '\n' +
-                molecule.getCustomIonName();
+                molecule.getName();
     }
 
     public static String precursorChromInfoChartTitle(PrecursorChromInfo pChromInfo)

--- a/src/org/labkey/targetedms/parser/PrecursorChromInfo.java
+++ b/src/org/labkey/targetedms/parser/PrecursorChromInfo.java
@@ -21,7 +21,6 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.util.UnexpectedException;
-import org.labkey.targetedms.TargetedMSController;
 import org.labkey.targetedms.TargetedMSModule;
 import org.labkey.targetedms.TargetedMSRun;
 
@@ -29,11 +28,8 @@ import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.io.ObjectInputStream;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 /**
  * User: vsharma
@@ -51,7 +47,6 @@ public class PrecursorChromInfo extends AbstractChromInfo
     private Double _minStartTime;
     private Double _maxEndTime;
     private Double _totalArea;
-    private Double _totalAreaNormalized;
     private Double _totalBackground;
     private Double _maxFwhm;
     private Double _maxHeight;
@@ -148,16 +143,6 @@ public class PrecursorChromInfo extends AbstractChromInfo
     public void setTotalArea(Double totalArea)
     {
         _totalArea = totalArea;
-    }
-
-    public Double getTotalAreaNormalized()
-    {
-        return _totalAreaNormalized;
-    }
-
-    public void setTotalAreaNormalized(Double totalAreaNormalized)
-    {
-        _totalAreaNormalized = totalAreaNormalized;
     }
 
     public Double getTotalBackground()
@@ -438,6 +423,11 @@ public class PrecursorChromInfo extends AbstractChromInfo
         return _transitionChromatogramIndices;
     }
 
+    /**
+     * When we don't have the TransitionChromInfos in the DB, we store the indices into the transition chromatogram.
+     * It's not needed in SQL queries, so we pack it into a byte array. The first two bytes are a 16-bit integer
+     * representing the number of indices included, followed by two bytes for each 16-bit integer index.
+     */
     public byte[] getTransitionChromatogramIndices()
     {
         if (_transitionChromatogramIndices == null)
@@ -455,7 +445,7 @@ public class PrecursorChromInfo extends AbstractChromInfo
         }
         catch (IOException e)
         {
-            throw new UnexpectedException(e);
+            throw UnexpectedException.wrap(e);
         }
         return bOut.toByteArray();
     }
@@ -485,6 +475,7 @@ public class PrecursorChromInfo extends AbstractChromInfo
         }
     }
 
+    /** Fake up enough of a TransitionChromInfo to enable most of the transition chromatogram plotting */
     public TransitionChromInfo makeDummyTransitionChromInfo(int index)
     {
         TransitionChromInfo dummy = new TransitionChromInfo();

--- a/src/org/labkey/targetedms/parser/SkylineBinaryParser.java
+++ b/src/org/labkey/targetedms/parser/SkylineBinaryParser.java
@@ -119,7 +119,9 @@ public class SkylineBinaryParser
         parseFiles();
         parsePeaks();
         parseTransitions();
+        _log.debug("Starting to load chromatogram headers");
         parseChromatograms();
+        _log.debug("Done loading chromatogram headers");
     }
 
     public static class CachedFile

--- a/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
+++ b/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
@@ -175,14 +175,15 @@ public class SkylineDocumentParser implements AutoCloseable
     private int _transitionCount;
     private int _replicateCount;
     private int _listCount;
+
+    /** Tally the transition/replicate combinations so that we can avoid storing huge DIA-type runs in the DB */
     private int _transitionChromInfoCount;
 
     /**
      * To prevent giant DIA documents from overwhelming the DB, we skip importing TransitionChromInfos if the document
      * has more than 100,000
      */
-//    public static final int MAX_TRANSITION_CHROM_INFOS = 100_000;
-    public static final int MAX_TRANSITION_CHROM_INFOS = 10;
+    public static final int MAX_TRANSITION_CHROM_INFOS = 100_000;
 
     /** Null if we haven't found a SKYD to parse */
     @Nullable
@@ -232,6 +233,7 @@ public class SkylineDocumentParser implements AutoCloseable
         readDocumentVersion(_reader);
     }
 
+    /** @return if we've exceeded the maximum count of TransitionChromInfos that we want to store for a run */
     public boolean shouldSaveTransitionChromInfos()
     {
         return _transitionChromInfoCount < MAX_TRANSITION_CHROM_INFOS;

--- a/src/org/labkey/targetedms/parser/TransitionChromInfo.java
+++ b/src/org/labkey/targetedms/parser/TransitionChromInfo.java
@@ -15,16 +15,12 @@
 
 package org.labkey.targetedms.parser;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-
 /**
  * User: vsharma
  * Date: 4/16/12
  * Time: 3:04 PM
  */
-public class TransitionChromInfo //extends ChromInfo<TransitionChromInfoAnnotation>
+public class TransitionChromInfo extends ChromInfo<TransitionChromInfoAnnotation>
 {
     private long _transitionId;
     private long _precursorChromInfoId;
@@ -34,7 +30,6 @@ public class TransitionChromInfo //extends ChromInfo<TransitionChromInfoAnnotati
     private Double _endTime;
     private Double _height;
     private Double _area;
-    private Double _areaNormalized;
     private Double _background;
     private Double _massErrorPPM;
     private Double _fwhm;
@@ -56,81 +51,6 @@ public class TransitionChromInfo //extends ChromInfo<TransitionChromInfoAnnotati
     private Integer Rank;
     private Integer RankByLevel;
     private Boolean ForcedIntegration;
-
-    /** HACK TO UPDATE TO LONG FOR ID COLUMN - ISSUE 40831 */
-    private String _replicateName;
-    private String _skylineSampleFileId;
-    private long _sampleFileId;
-    private List<TransitionChromInfoAnnotation> _annotations = Collections.emptyList();
-    private long _id;
-
-    public String getSkylineSampleFileId()
-    {
-        return _skylineSampleFileId;
-    }
-
-    public void setSkylineSampleFileId(String skylineSampleFileId)
-    {
-        _skylineSampleFileId = skylineSampleFileId;
-    }
-
-    public String getReplicateName()
-    {
-        return _replicateName;
-    }
-
-    public void setReplicateName(String replicateName)
-    {
-        _replicateName = replicateName;
-    }
-
-    public long getSampleFileId()
-    {
-        return _sampleFileId;
-    }
-
-    public void setSampleFileId(long sampleFileId)
-    {
-        _sampleFileId = sampleFileId;
-    }
-
-
-    public long getId()
-    {
-        return _id;
-    }
-    public void setId(long id)
-    {
-        _id = id;
-    }
-
-    @Override
-    public boolean equals(Object o)
-    {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        TransitionChromInfo that = (TransitionChromInfo) o;
-        return _id == that._id;
-    }
-
-    @Override
-    public int hashCode()
-    {
-        return Objects.hash(_id, getClass());
-    }
-
-    public List<TransitionChromInfoAnnotation> getAnnotations()
-    {
-        return _annotations;
-    }
-
-    public void setAnnotations(List<TransitionChromInfoAnnotation> annotations)
-    {
-        _annotations = Collections.unmodifiableList(annotations);
-    }
-    /** END HACK TO UPDATE TO LONG FOR ID COLUMN */
-
-
 
     public long getTransitionId()
     {
@@ -200,16 +120,6 @@ public class TransitionChromInfo //extends ChromInfo<TransitionChromInfoAnnotati
     public void setArea(Double area)
     {
         _area = area;
-    }
-
-    public Double getAreaNormalized()
-    {
-        return _areaNormalized;
-    }
-
-    public void setAreaNormalized(Double areaNormalized)
-    {
-        _areaNormalized = areaNormalized;
     }
 
     public Double getBackground()

--- a/src/org/labkey/targetedms/query/MoleculeTransitionManager.java
+++ b/src/org/labkey/targetedms/query/MoleculeTransitionManager.java
@@ -18,6 +18,7 @@ package org.labkey.targetedms.query;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.SimpleFilter;
+import org.labkey.api.data.Sort;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.query.FieldKey;
@@ -26,6 +27,7 @@ import org.labkey.targetedms.TargetedMSSchema;
 import org.labkey.targetedms.parser.MoleculeTransition;
 
 import java.util.Collection;
+import java.util.List;
 
 public class MoleculeTransitionManager
 {
@@ -39,11 +41,11 @@ public class MoleculeTransitionManager
     }
 
     @NotNull
-    public static Collection<MoleculeTransition> getTransitionsForPrecursor(long precursorId, User user, Container container)
+    public static List<MoleculeTransition> getTransitionsForPrecursor(long precursorId, User user, Container container)
     {
         return new TableSelector(new MoleculeTransitionsTableInfo(new TargetedMSSchema(user, container), null, true),
                 MoleculeTransition.getColumns(),
-                new SimpleFilter(FieldKey.fromParts("GeneralPrecursorId"), precursorId), null)
-            .getCollection(MoleculeTransition.class);
+                new SimpleFilter(FieldKey.fromParts("GeneralPrecursorId"), precursorId), new Sort("TransitionId"))
+            .getArrayList(MoleculeTransition.class);
     }
 }

--- a/src/org/labkey/targetedms/view/summaryChartsView.jsp
+++ b/src/org/labkey/targetedms/view/summaryChartsView.jsp
@@ -377,12 +377,16 @@
     // peak areas graph
     var peakAreasImg = Ext4.create('Ext.Img', {
         src: <%=q(peakAreaUrl)%>,
-        renderTo: Ext4.get('peakAreasGraphImg')
+        renderTo: Ext4.get('peakAreasGraphImg'),
+        width: <%= bean.getInitialWidth() %>,
+        height: <%= bean.getInitialHeight()%>
     });
 
     var retentionTimesImg = Ext4.create('Ext.Img', {
         src: <%=q(retentionTimesUrl)%>,
-        renderTo: Ext4.get('retentionTimesGraphImg')
+        renderTo: Ext4.get('retentionTimesGraphImg'),
+        width: <%= bean.getInitialWidth() %>,
+        height: <%= bean.getInitialHeight()%>
     });
 
     // buttons
@@ -425,6 +429,10 @@
             // change the src of the image
             peakAreasImg.setSrc(pearAreaUrl);
             retentionTimesImg.setSrc(retentionTimesUrl);
+            peakAreasImg.setHeight(parseInt(chartHeightTb.getValue()));
+            peakAreasImg.setWidth(parseInt(chartWidthTb.getValue()));
+            retentionTimesImg.setHeight(parseInt(chartHeightTb.getValue()));
+            retentionTimesImg.setWidth(parseInt(chartWidthTb.getValue()));
         }
     });
 


### PR DESCRIPTION
#### Rationale
20.7 introduced a change where we skip creating rows in targetedms.TransitionChromInfo for documents that would be adding more than 100,000 entries. That had the unfortunate side effect of breaking chromatogram plots at both the precursor and transition levels

#### Changes
* Create a new column on targetedms.PrecursorChromInfo that holds the indices we need, and is only populated if we end up dropping the TransitionChromInfo data
* Populate new column via a temp table once we realize we've crossed the threshold
* Use new info to render chromatograms properly. Precursor chromatograms are full fidelity. Transition chromatograms are based on the precursor's start/end times, and lack the best retention time and mass error PPM unique to the transitions
* Switch to higher-resolution plots for chromatograms and sample comparison charts
* Don't show "null" in small molecule plots when we don't have a custom ion name