### PR TITLE
Issue 41900: Sample file chromatograms plot images are too big

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -262,8 +262,10 @@ import static org.labkey.api.targetedms.TargetedMSService.FolderType;
 import static org.labkey.api.targetedms.TargetedMSService.MODULE_NAME;
 import static org.labkey.api.targetedms.TargetedMSService.RAW_FILES_DIR;
 import static org.labkey.api.targetedms.TargetedMSService.RAW_FILES_TAB;
+import static org.labkey.api.util.DOM.Attribute.height;
 import static org.labkey.api.util.DOM.Attribute.method;
 import static org.labkey.api.util.DOM.Attribute.src;
+import static org.labkey.api.util.DOM.Attribute.width;
 import static org.labkey.api.util.DOM.DIV;
 import static org.labkey.api.util.DOM.TD;
 import static org.labkey.api.util.DOM.TR;
@@ -4043,7 +4045,8 @@ public class TargetedMSController extends SpringActionController
             {
                 ActionURL chromURL = new ActionURL(SampleFileChromatogramChartAction.class, getContainer());
                 chromURL.addParameter("id", sampleFileChromInfo.getId());
-                HtmlView chromView = new HtmlView(DOM.IMG(at(src, chromURL.toString())));
+                SampleFileChromInfoForm imgForm = new SampleFileChromInfoForm();
+                HtmlView chromView = new HtmlView(DOM.IMG(at(src, chromURL.toString(), height, imgForm.getChartHeight(), width, imgForm.getChartWidth())));
                 chromView.setFrame(WebPartView.FrameType.PORTAL);
                 chromView.setTitle(sampleFileChromInfo.getTextId());
                 result.addView(chromView);

--- a/src/org/labkey/targetedms/chart/ChromatogramChartMaker.java
+++ b/src/org/labkey/targetedms/chart/ChromatogramChartMaker.java
@@ -123,7 +123,7 @@ class ChromatogramChartMaker
 
         // Limit labels to one decimal place on the x-axis (retention time).
         NumberAxis xAxis = (NumberAxis)chart.getXYPlot().getDomainAxis();
-        xAxis.setNumberFormatOverride(new DecimalFormat("0.0"));
+        xAxis.setNumberFormatOverride(new DecimalFormat("#,##0.0"));
 
         // Display scaled values in the y-axis tick labels.  The scaling factor is displayed in the axis label.
         NumberAxis yAxis = (NumberAxis)chart.getXYPlot().getRangeAxis();
@@ -131,7 +131,7 @@ class ChromatogramChartMaker
             @Override
             public StringBuffer format(double number, StringBuffer toAppendTo, FieldPosition pos)
             {
-                String pattern = (yAxis.getUpperBound() - yAxis.getLowerBound()) / chromatogramDataset.getIntensityScale() > 100 ? "0" : "0.0";
+                String pattern = (yAxis.getUpperBound() - yAxis.getLowerBound()) / chromatogramDataset.getIntensityScale() > 100 ? "#,##0" : "#,##0.0";
                 // Display the scaled value in the tick label.
                 return toAppendTo.append(new DecimalFormat(pattern).format(number / chromatogramDataset.getIntensityScale()));
             }

--- a/src/org/labkey/targetedms/chart/ComparisonChartMaker.java
+++ b/src/org/labkey/targetedms/chart/ComparisonChartMaker.java
@@ -322,7 +322,7 @@ public class ComparisonChartMaker
         xAxis.setMaximumCategoryLabelWidthRatio(0.3f);
         xAxis.setCategoryLabelPositions(CategoryLabelPositions.UP_90);
         NumberAxis yAxis = (NumberAxis)plot.getRangeAxis();
-        yAxis.setNumberFormatOverride(new DecimalFormat(yAxis.getUpperBound() - yAxis.getLowerBound() > 100 ? "0" : "0.0"));
+        yAxis.setNumberFormatOverride(new DecimalFormat(yAxis.getUpperBound() - yAxis.getLowerBound() > 100 ? "#,##0" : "#,##0.0"));
         xAxis.setLabelFont(yAxis.getLabelFont());
         xAxis.setTickLabelFont(yAxis.getTickLabelFont());
         plot.setDomainAxis(xAxis);


### PR DESCRIPTION
#### Rationale
As part of the work for 41819, I switched the Panorama plots to generate higher resolution images. That means that we need to explicitly set the height and width of the plots in the HTML that we generate so that they scale appropriately. This is a good practice anyway, but without it the plots render 2x their desired size.

#### Related Pull Requests
* https://github.com/LabKey/targetedms/pull/285

#### Changes
* Set size for plot images
* Show comma separators for axis values > 1000