### PR TITLE
Don't talk about peptides if we have small molecule data

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -27,6 +27,7 @@ import org.jetbrains.annotations.Nullable;
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.ChartUtilities;
 import org.jfree.chart.JFreeChart;
+import org.jfree.chart.axis.NumberAxis;
 import org.jfree.chart.plot.PlotOrientation;
 import org.jfree.chart.title.TextTitle;
 import org.jfree.data.category.DefaultCategoryDataset;
@@ -5807,6 +5808,8 @@ public class TargetedMSController extends SpringActionController
                     false,                     // tooltips?
                     false                     // URLs?
             );
+            // Don't show fractional values on the y-axis
+            chart.getCategoryPlot().getRangeAxis().setStandardTickUnits(NumberAxis.createIntegerTickUnits());
             chart.setBackgroundPaint(new Color(1,1,1,1));
 
             response.setContentType("image/png");

--- a/src/org/labkey/targetedms/view/conflictSummary.jsp
+++ b/src/org/labkey/targetedms/view/conflictSummary.jsp
@@ -25,6 +25,7 @@
 <%
 
     long conflictCount = ConflictResultsManager.getConflictCount(getUser(), getContainer());
+    boolean hasMolecules = TargetedMSManager.containerHasSmallMolecules(getContainer());
     TargetedMSService.FolderType folderType = TargetedMSManager.getFolderType(getContainer());
     ActionURL conflictViewUrl = (folderType == TargetedMSService.FolderType.LibraryProtein) ?
                                            new ActionURL(TargetedMSController.ShowProteinConflictUiAction.class, getContainer()) :
@@ -42,7 +43,7 @@
     <%}%>
     <%if(folderType == TargetedMSService.FolderType.Library){%>
         <div style="color:red; font-weight:bold;">
-            There are conflicting peptides in this folder.
+            There are conflicting <%= h(hasMolecules ? "molecules" : "peptides") %> in this folder.
             <a style="color:red; text-decoration:underline;" href="<%= h(conflictViewUrl) %>">Resolve conflicts.</a>
         </div>
     <%}%>


### PR DESCRIPTION
#### Rationale
We added support for small molecule chromatogram libraries, and shouldn't talk about "peptides" if we don't have any

#### Changes
* Use "molecules" unless we only have "peptides"