### PR TITLE
Issue 41960: Exclude non-quantitative transitions in precursor peak chromatograms

### DIFF
--- a/src/org/labkey/targetedms/chart/ChromatogramDataset.java
+++ b/src/org/labkey/targetedms/chart/ChromatogramDataset.java
@@ -527,7 +527,7 @@ public abstract class ChromatogramDataset
             // Each key in the map is the index for a transition peak (TransitionChromInfo) into the RT and intensity arrays
             // Value is the value in the "quantitative" column for the corresponding transition.
             // This value will be null if the transition is quantitative.
-            Map<Integer, Boolean> transitionChromIndexes = TransitionManager.getTransitionChromatogramIndexes(pChromInfo);
+            Map<Integer, Boolean> transitionChromIndexes = TransitionManager.getTransitionChromatogramIndexes(pChromInfo, _user, _container);
 
             // We will consider the precursor peak to be "quantitative" if any of its transition peaks are quantitative.
             // The value in the transitionChromIndexes map for a quantitative transition peak  will be null.

--- a/src/org/labkey/targetedms/query/TransitionManager.java
+++ b/src/org/labkey/targetedms/query/TransitionManager.java
@@ -162,14 +162,23 @@ public class TransitionManager
      * transition is quantitative.
      */
     @NotNull
-    public static Map<Integer, Boolean> getTransitionChromatogramIndexes(PrecursorChromInfo pci)
+    public static Map<Integer, Boolean> getTransitionChromatogramIndexes(PrecursorChromInfo pci, User user, Container container)
     {
         if (pci.getTransitionChromatogramIndicesList() != null)
         {
+            List<Transition> transitions = TransitionManager.getTransitionsForPrecursor(pci.getPrecursorId(), user, container);
+            if (transitions.size() != pci.getTransitionChromatogramIndicesList().size())
+            {
+                throw new IllegalStateException("Mismatch in transitions and indices lengths: " + transitions.size() + " vs " + pci.getTransitionChromatogramIndicesList().size());
+            }
+
             Map<Integer, Boolean> result = new LinkedHashMap<>();
+            int i = 0;
             for (Integer index : pci.getTransitionChromatogramIndicesList())
             {
-                result.put(index, true);
+                Transition transition = transitions.get(i); // Transition list is sorted by the 'Id' column so should be in the same order as the chromatogram indices list
+                result.put(index, transition.explicitQuantitative());
+                i++;
             }
             return result;
         }


### PR DESCRIPTION
#### Rationale
Intensities of non-quantitative transitions should be excluded when calculating intensities of points across a precursor peak chromatogram. This is not happening when TransitionChromInfos are not saved.
