### PR TITLE
Issue 41973: Populate additional information for rendering chromatograms

### DIFF
--- a/resources/schemas/dbscripts/postgresql/targetedms-20.017-20.018.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-20.017-20.018.sql
@@ -1,0 +1,1 @@
+ALTER TABLE targetedms.PrecursorChromInfo ADD COLUMN BestMassErrorPPM Real;

--- a/resources/schemas/dbscripts/sqlserver/targetedms-20.017-20.018.sql
+++ b/resources/schemas/dbscripts/sqlserver/targetedms-20.017-20.018.sql
@@ -1,0 +1,1 @@
+ALTER TABLE targetedms.PrecursorChromInfo ADD BestMassErrorPPM Real;

--- a/resources/schemas/targetedms.xml
+++ b/resources/schemas/targetedms.xml
@@ -530,6 +530,7 @@
             <column columnName="Note"/>
             <column columnName="MaxHeight"/>
             <column columnName="AverageMassErrorPPM"/>
+            <column columnName="BestMassErrorPPM"/>
             <column columnName="UncompressedSize">
                 <isHidden>true</isHidden>
             </column>

--- a/src/org/labkey/targetedms/SkylineDocImporter.java
+++ b/src/org/labkey/targetedms/SkylineDocImporter.java
@@ -1995,7 +1995,7 @@ public class SkylineDocImporter
         try
         {
             _precursorChromInfoStmt = ensureStatement(_precursorChromInfoStmt,
-                    "INSERT INTO targetedms.precursorchrominfo( precursorid, samplefileid, generalmoleculechrominfoid, bestretentiontime, minstarttime, maxendtime, totalarea, totalbackground, maxfwhm, peakcountratio, numtruncated, librarydotp, optimizationstep, note, chromatogram, numtransitions, numpoints, maxheight, isotopedotp, averagemasserrorppm, userset, uncompressedsize, identified, container, chromatogramformat, chromatogramoffset, chromatogramlength, qvalue, zscore, ccs, drifttimems1, drifttimefragment, drifttimewindow, ionmobilityms1, ionmobilityfragment, ionmobilitywindow, ionmobilitytype) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    "INSERT INTO targetedms.precursorchrominfo( precursorid, samplefileid, generalmoleculechrominfoid, bestretentiontime, minstarttime, maxendtime, totalarea, totalbackground, maxfwhm, peakcountratio, numtruncated, librarydotp, optimizationstep, note, chromatogram, numtransitions, numpoints, maxheight, isotopedotp, averagemasserrorppm, bestmasserrorppm, userset, uncompressedsize, identified, container, chromatogramformat, chromatogramoffset, chromatogramlength, qvalue, zscore, ccs, drifttimems1, drifttimefragment, drifttimewindow, ionmobilityms1, ionmobilityfragment, ionmobilitywindow, ionmobilitytype) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     true);
 
             int index = 1;
@@ -2019,6 +2019,7 @@ public class SkylineDocImporter
             setDouble(_precursorChromInfoStmt, index++, preChromInfo.getMaxHeight());
             setDouble(_precursorChromInfoStmt, index++, preChromInfo.getIsotopeDotP());
             setDouble(_precursorChromInfoStmt, index++, preChromInfo.getAverageMassErrorPPM());
+            setDouble(_precursorChromInfoStmt, index++, preChromInfo.getBestMassErrorPPM());
             _precursorChromInfoStmt.setString(index++, preChromInfo.getUserSet());
             setInteger(_precursorChromInfoStmt, index++, preChromInfo.getUncompressedSize());
             _precursorChromInfoStmt.setString(index++, preChromInfo.getIdentified());

--- a/src/org/labkey/targetedms/TargetedMSManager.java
+++ b/src/org/labkey/targetedms/TargetedMSManager.java
@@ -88,6 +88,7 @@ import org.labkey.targetedms.parser.Replicate;
 import org.labkey.targetedms.parser.RepresentativeDataState;
 import org.labkey.targetedms.parser.SampleFile;
 import org.labkey.targetedms.parser.SampleFileChromInfo;
+import org.labkey.targetedms.parser.TransitionSettings;
 import org.labkey.targetedms.parser.skyaudit.AuditLogException;
 import org.labkey.targetedms.pipeline.TargetedMSImportPipelineJob;
 import org.labkey.targetedms.query.GuideSetTable;
@@ -2411,5 +2412,19 @@ public class TargetedMSManager
         executor.execute("DROP TABLE " + precursorGroupingsTableName);
         executor.execute("DROP TABLE " + moleculeGroupingsTableName);
         executor.execute("DROP TABLE " + areasTableName);
+    }
+
+    /**
+     * Returns the Transition Full Scan setttings for the given run.  This may be null if the settings were not included
+     * in the Skyline document.
+     * @param runId
+     * @return
+     */
+    @Nullable
+    public static TransitionSettings.FullScanSettings getTransitionFullScanSettings(long runId)
+    {
+        return new TableSelector(TargetedMSManager.getTableInfoTransitionFullScanSettings(),
+                new SimpleFilter(FieldKey.fromParts("runId"), runId), null)
+                .getObject(TransitionSettings.FullScanSettings.class);
     }
 }

--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -217,7 +217,7 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
     @Override
     public Double getSchemaVersion()
     {
-        return 20.017;
+        return 20.018;
     }
 
     @Override

--- a/src/org/labkey/targetedms/chart/ChromatogramChartMaker.java
+++ b/src/org/labkey/targetedms/chart/ChromatogramChartMaker.java
@@ -121,7 +121,9 @@ class ChromatogramChartMaker
                 isMulitLineAnnotation = true;
         }
 
-        // Limit labels to one or two decimal place on the x-axis (retention time).
+        // Limit labels to one or two decimal place on the x-axis (retention time). Added second decimal place to
+        // avoid repeated tick labels when the displayed RT range is small.
+        // TODO: There is probably a better way to avoid repeated tick labels.
         NumberAxis xAxis = (NumberAxis)chart.getXYPlot().getDomainAxis();
         xAxis.setNumberFormatOverride(new DecimalFormat("#,##0.0#"));
 

--- a/src/org/labkey/targetedms/chart/ChromatogramChartMaker.java
+++ b/src/org/labkey/targetedms/chart/ChromatogramChartMaker.java
@@ -78,7 +78,7 @@ class ChromatogramChartMaker
 
     public JFreeChart make(final ChromatogramDataset chromatogramDataset)
     {
-        return make(chromatogramDataset, "Retention Time", "Intensity " + getIntensityScaleString(chromatogramDataset), true);
+        return make(chromatogramDataset, "Retention Time", "Intensity", true);
     }
 
     public JFreeChart make(final ChromatogramDataset chromatogramDataset, String xLabel, String yLabel, boolean legend)
@@ -121,12 +121,14 @@ class ChromatogramChartMaker
                 isMulitLineAnnotation = true;
         }
 
-        // Limit labels to one decimal place on the x-axis (retention time).
+        // Limit labels to one or two decimal place on the x-axis (retention time).
         NumberAxis xAxis = (NumberAxis)chart.getXYPlot().getDomainAxis();
-        xAxis.setNumberFormatOverride(new DecimalFormat("#,##0.0"));
+        xAxis.setNumberFormatOverride(new DecimalFormat("#,##0.0#"));
 
         // Display scaled values in the y-axis tick labels.  The scaling factor is displayed in the axis label.
         NumberAxis yAxis = (NumberAxis)chart.getXYPlot().getRangeAxis();
+        // Calculate the scaling factor AFTER the plot data has been populated
+        yAxis.setLabel(yLabel + " " + getIntensityScaleString(chromatogramDataset));
         yAxis.setNumberFormatOverride(new NumberFormat(){
             @Override
             public StringBuffer format(double number, StringBuffer toAppendTo, FieldPosition pos)

--- a/src/org/labkey/targetedms/chart/ChromatogramDataset.java
+++ b/src/org/labkey/targetedms/chart/ChromatogramDataset.java
@@ -944,6 +944,10 @@ public abstract class ChromatogramDataset
             {
                 // Use TransitionChromInfo.getHeight() to determine the most intense transition so that we are consistent with Skyline.
                 isMoreIntense = transitionChromInfo.getHeight() > _bestTransitionPeakHeight;
+                if(quantitative && isMoreIntense)
+                {
+                    _bestTransitionPeakHeight = transitionChromInfo.getHeight();
+                }
             }
             if(quantitative && isMoreIntense)
             {
@@ -954,8 +958,6 @@ public abstract class ChromatogramDataset
                 _bestTransitionRt = tciPeak.getPeakRt();
                 _bestTransitionSeriesIndex = seriesIndex;
                 _bestTransitionPpm = tciPeak.getMassErrorPpm();
-
-                _bestTransitionPeakHeight = transitionChromInfo.getHeight();
             }
         }
 

--- a/src/org/labkey/targetedms/chart/LabelFactory.java
+++ b/src/org/labkey/targetedms/chart/LabelFactory.java
@@ -38,6 +38,7 @@ import org.labkey.targetedms.query.PeptideManager;
 import org.labkey.targetedms.query.PrecursorManager;
 import org.labkey.targetedms.query.ReplicateManager;
 
+import java.text.DecimalFormat;
 import java.util.Map;
 
 /**
@@ -57,6 +58,8 @@ public class LabelFactory
                                                 "--",
                                                 "---"};
 
+    private static final DecimalFormat sign = new DecimalFormat("+0;-0");
+
     private LabelFactory() {}
 
     public static String transitionLabel(Transition transition)
@@ -68,7 +71,7 @@ public class LabelFactory
             Integer massIndex = transition.getMassIndex();
             if(massIndex != null && massIndex != 0)
             {
-                label.append("+").append(transition.getMassIndex());
+                label.append(sign.format(transition.getMassIndex()));
             }
         }
         else if(transition.isCustomIon())

--- a/src/org/labkey/targetedms/model/PrecursorChromInfoPlus.java
+++ b/src/org/labkey/targetedms/model/PrecursorChromInfoPlus.java
@@ -35,9 +35,7 @@ public class PrecursorChromInfoPlus extends PrecursorChromInfo implements Precur
 
     private int _isotopeLabelId;
 
-    private Double _minPeakRt;
-    private Double _maxPeakRt;
-    private boolean _quantitative;
+    private ChromatogramDataset.RtRange _peakBoundary;
 
     public String getGroupName()
     {
@@ -113,36 +111,32 @@ public class PrecursorChromInfoPlus extends PrecursorChromInfo implements Precur
 
     public double getMinPeakRt()
     {
-        if(_minPeakRt == null)
-        {
-            initPeakRtRange();
-        }
-        return _minPeakRt;
+        initPeakRtRange();
+        return _peakBoundary.getMinRt();
     }
 
     public double getMaxPeakRt()
     {
-        if(_maxPeakRt == null)
-        {
-            initPeakRtRange();
-        }
-        return _maxPeakRt;
+        initPeakRtRange();
+        return _peakBoundary.getMaxRt();
     }
 
     private void initPeakRtRange()
     {
-        ChromatogramDataset.RtRange peakRt = PrecursorManager.getPrecursorPeakRtRange(this);
-        _minPeakRt = peakRt.getMinRt();
-        _maxPeakRt = peakRt.getMaxRt();
+        if(_peakBoundary == null)
+        {
+            _peakBoundary = PrecursorManager.getPrecursorPeakRtRange(this);
+        }
     }
 
-    public boolean isQuantitative()
+    public boolean hasPeakBoundary()
     {
-        return _quantitative;
+        initPeakRtRange();
+        return !_peakBoundary.isEmpty();
     }
 
-    public void setQuantitative(boolean quantitative)
+    public boolean isRtInPeakBoundary(double rt)
     {
-        _quantitative = quantitative;
+        return hasPeakBoundary() &&  rt >= getMinPeakRt() && rt <= getMaxPeakRt();
     }
 }

--- a/src/org/labkey/targetedms/parser/GeneralTransition.java
+++ b/src/org/labkey/targetedms/parser/GeneralTransition.java
@@ -15,6 +15,8 @@
  */
 package org.labkey.targetedms.parser;
 
+import org.jetbrains.annotations.Nullable;
+
 import java.util.List;
 
 public class GeneralTransition extends AnnotatedEntity<TransitionAnnotation>
@@ -196,7 +198,7 @@ public class GeneralTransition extends AnnotatedEntity<TransitionAnnotation>
     }
 
     // Look at TransitionDocNode.IsQuantitative(SrmSettings settings) in the Skyline code
-    public boolean isQuantitative(TransitionSettings.FullScanSettings settings)
+    public boolean isQuantitative(@Nullable TransitionSettings.FullScanSettings settings)
     {
         if(!explicitQuantitative())
         {

--- a/src/org/labkey/targetedms/parser/PrecursorChromInfo.java
+++ b/src/org/labkey/targetedms/parser/PrecursorChromInfo.java
@@ -51,6 +51,7 @@ public class PrecursorChromInfo extends AbstractChromInfo
     private Double _maxFwhm;
     private Double _maxHeight;
     private Double _averageMassErrorPPM;
+    private Double _bestMassErrorPPM;
     private Double _peakCountRatio;
     private Integer _numTruncated;
     private String _identified;
@@ -183,6 +184,21 @@ public class PrecursorChromInfo extends AbstractChromInfo
     public void setAverageMassErrorPPM(Double averageMassErrorPPM)
     {
         _averageMassErrorPPM = averageMassErrorPPM;
+    }
+
+    public Double getBestMassErrorPPM()
+    {
+        return _bestMassErrorPPM;
+    }
+
+    public void setBestMassErrorPPM(Double bestMassErrorPPM)
+    {
+        _bestMassErrorPPM = bestMassErrorPPM;
+    }
+
+    public Double getBestOrAvgMassError()
+    {
+        return _bestMassErrorPPM != null ? _bestMassErrorPPM : _averageMassErrorPPM;
     }
 
     public Double getPeakCountRatio()
@@ -481,6 +497,8 @@ public class PrecursorChromInfo extends AbstractChromInfo
         TransitionChromInfo dummy = new TransitionChromInfo();
         dummy.setStartTime(getMinStartTime());
         dummy.setEndTime(getMaxEndTime());
+        dummy.setRetentionTime(getBestRetentionTime());
+        dummy.setMassErrorPPM(getBestMassErrorPPM());
         dummy.setChromatogramIndex(getTransitionChromatogramIndicesList().get(index));
         return dummy;
     }

--- a/src/org/labkey/targetedms/parser/PrecursorChromInfo.java
+++ b/src/org/labkey/targetedms/parser/PrecursorChromInfo.java
@@ -196,11 +196,6 @@ public class PrecursorChromInfo extends AbstractChromInfo
         _bestMassErrorPPM = bestMassErrorPPM;
     }
 
-    public Double getBestOrAvgMassError()
-    {
-        return _bestMassErrorPPM != null ? _bestMassErrorPPM : _averageMassErrorPPM;
-    }
-
     public Double getPeakCountRatio()
     {
         return _peakCountRatio;
@@ -497,7 +492,6 @@ public class PrecursorChromInfo extends AbstractChromInfo
         TransitionChromInfo dummy = new TransitionChromInfo();
         dummy.setStartTime(getMinStartTime());
         dummy.setEndTime(getMaxEndTime());
-        dummy.setRetentionTime(getBestRetentionTime());
         dummy.setMassErrorPPM(getBestMassErrorPPM());
         dummy.setChromatogramIndex(getTransitionChromatogramIndicesList().get(index));
         return dummy;

--- a/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
+++ b/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
@@ -1676,12 +1676,17 @@ public class SkylineDocumentParser implements AutoCloseable
 
         _precursorCount++;
 
-        updatePrecursorChromInfos(moleculePrecursor);
+        setBestMassErrorPpm(moleculePrecursor);
 
         return moleculePrecursor;
     }
 
-    private <T extends GeneralTransition> void updatePrecursorChromInfos(GeneralPrecursor<T> precursor)
+    // Issue 41973: Populate additional information for rendering chromatograms
+    // Set the BestMassErrorPpm for each PrecursorChromInfo of the given precursor. This is the mass error of the most intense
+    // transition peak in a replicate. Skyline does not give us this value but we need it to label the precursor peaks in
+    // chromatogram charts. We can query it from TransitionChromInfos but we are saving it with the PrecursorChromInfo
+    // because TransitionChromInfos do not get saved for large documents.
+    private void setBestMassErrorPpm(GeneralPrecursor<?> precursor)
     {
         TransitionSettings.FullScanSettings fullScanSettings = _transitionSettings == null ? null : _transitionSettings.getFullScanSettings();
 
@@ -1843,7 +1848,7 @@ public class SkylineDocumentParser implements AutoCloseable
 
         _precursorCount++;
 
-        updatePrecursorChromInfos(precursor);
+        setBestMassErrorPpm(precursor);
         return precursor;
     }
     private Transition transitionProtoToTransition(SkylineDocument.SkylineDocumentProto.Transition transitionProto) {

--- a/src/org/labkey/targetedms/query/MoleculePrecursorManager.java
+++ b/src/org/labkey/targetedms/query/MoleculePrecursorManager.java
@@ -29,7 +29,6 @@ import org.labkey.targetedms.TargetedMSSchema;
 import org.labkey.targetedms.model.PrecursorChromInfoLitePlus;
 import org.labkey.targetedms.model.PrecursorChromInfoPlus;
 import org.labkey.targetedms.parser.MoleculePrecursor;
-import org.labkey.targetedms.parser.Precursor;
 import org.labkey.targetedms.parser.RepresentativeDataState;
 
 import java.util.HashSet;
@@ -204,7 +203,6 @@ public class MoleculePrecursorManager
     {
         SQLFragment sql = new SQLFragment("SELECT ");
         sql.append("pci.* , pg.Label AS groupName, mol.customIonName, prec.Charge");
-        sql.append(", (SELECT ").append(PrecursorManager.getIsQuantitativeSql()).append(") AS quantitative ");
         sql.append(" FROM ");
         joinTablesForMoleculePrecursorChromInfo(sql, user, container);
         sql.append(" WHERE ");

--- a/src/org/labkey/targetedms/query/PrecursorManager.java
+++ b/src/org/labkey/targetedms/query/PrecursorManager.java
@@ -569,7 +569,7 @@ public class PrecursorManager
         return count != null && count.intValue() == ids.size() ;
     }
 
-    public static double getMaxPrecursorIntensity(long generalMoleculeId)
+    public static Double getMaxPrecursorIntensity(long generalMoleculeId)
     {
         SQLFragment sql = new SQLFragment("SELECT MAX(precHeight) FROM (");
         sql.append("SELECT SUM(tci.Height) AS precHeight FROM ");
@@ -791,7 +791,7 @@ public class PrecursorManager
             // Min peak start and max peak end times for a precursor chrom info can be null if none of the
             // transitions for the precursor are quantitative. We will try to get the min start and max end
             // retention times from the transition chrom infos instead.
-            return TransitionManager.getPrecursorPeakRtRange(pci.getId());
+            return TransitionManager.getTransitionPeakRtRange(pci.getId());
         }
     }
 

--- a/src/org/labkey/targetedms/query/PrecursorManager.java
+++ b/src/org/labkey/targetedms/query/PrecursorManager.java
@@ -576,8 +576,6 @@ public class PrecursorManager
      * Getting the actual max intensity would require summing up the intensities across the points of each peak. But this
      * method should give us a value that is at least as much as the max intensity since we are summing up the tallest
      * point of each transition.
-     * @param generalMoleculeId
-     * @return
      */
     public static Double getMaxPrecursorIntensityEstimate(long generalMoleculeId)
     {
@@ -606,8 +604,6 @@ public class PrecursorManager
      * MaxHeight of a PrecursorChromInfo is the height of the tallest transition peak for the precursor in a replicate.
      * This can be used for getting the height of the tallest transition peak for a peptide over all the replicates
      * when we are synchronizing the intensity axis for transition peak chromatograms.
-     * @param generalMoleculeId
-     * @return
      */
     public static Double getMaxPrecursorMaxHeight(long generalMoleculeId)
     {

--- a/src/org/labkey/targetedms/query/TransitionManager.java
+++ b/src/org/labkey/targetedms/query/TransitionManager.java
@@ -29,14 +29,18 @@ import org.labkey.targetedms.TargetedMSManager;
 import org.labkey.targetedms.TargetedMSSchema;
 import org.labkey.targetedms.chart.ChromatogramDataset;
 import org.labkey.targetedms.chart.ChromatogramDataset.RtRange;
+import org.labkey.targetedms.parser.GeneralTransition;
 import org.labkey.targetedms.parser.PrecursorChromInfo;
 import org.labkey.targetedms.parser.Transition;
 import org.labkey.targetedms.parser.TransitionChromInfo;
+import org.labkey.targetedms.parser.TransitionSettings;
 
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * User: vsharma
@@ -113,12 +117,7 @@ public class TransitionManager
                                  .getObject(TransitionChromInfo.class);
     }
 
-    public static double getMaxTransitionIntensity(long peptideId)
-    {
-        return getMaxTransitionIntensity(peptideId, Transition.Type.ALL);
-    }
-
-    public static double getMaxTransitionIntensity(long generalMoleculeId, Transition.Type fragmentType)
+    public static Double getMaxTransitionIntensity(long generalMoleculeId, Transition.Type fragmentType)
     {
         SQLFragment sql = new SQLFragment("SELECT MAX(tci.Height) FROM ");
         sql.append(TargetedMSManager.getTableInfoGeneralMoleculeChromInfo(), "gmci");
@@ -156,41 +155,94 @@ public class TransitionManager
 
     /**
      * @param pci a precursor peak from the PrecursorChromInfo table
-     * @return a map where the keys are the index for a transition peak (TransitionChromInfo) into the RT and intensity arrays
-     * for the precursor peak (stored in the "chromatogram" column of PrecursorChromInfo or read from the skyd file).
-     * Values are the value in the "quantitative" column for the corresponding transition. This value will be null if the
-     * transition is quantitative.
+     * @param fullScanSettings Transition full scan settings for the Skyline document
+     * @return a List of TransitionChromInfoAndQuantitative objects that encapsulate a TransitionChromInfo and
+     * a boolean value indicating if the transition is quantitative or not. Whether a transition is quantitative
+     * is determined by GeneralTransition.isQuantitative(@Nullable TransitionSettings.FullScanSettings settings)
      */
     @NotNull
-    public static Map<Integer, Boolean> getTransitionChromatogramIndexes(PrecursorChromInfo pci, User user, Container container)
+    public static List<TransitionChromInfoAndQuantitative> getTransitionChromInfoAndQuantitative(PrecursorChromInfo pci, TransitionSettings.FullScanSettings fullScanSettings)
     {
+        List<GeneralTransition> transitions = TransitionManager.getGeneralTransitionsForPrecursor(pci.getPrecursorId());
+        List<TransitionChromInfoAndQuantitative> result = new ArrayList<>();
+
         if (pci.getTransitionChromatogramIndicesList() != null)
         {
-            List<Transition> transitions = TransitionManager.getTransitionsForPrecursor(pci.getPrecursorId(), user, container);
-            if (transitions.size() != pci.getTransitionChromatogramIndicesList().size())
-            {
-                throw new IllegalStateException("Mismatch in transitions and indices lengths: " + transitions.size() + " vs " + pci.getTransitionChromatogramIndicesList().size());
-            }
+            List<Integer> chromatogramIndexList = pci.getTransitionChromatogramIndicesList();
 
-            Map<Integer, Boolean> result = new LinkedHashMap<>();
-            int i = 0;
-            for (Integer index : pci.getTransitionChromatogramIndicesList())
+            if (transitions.size() != chromatogramIndexList.size())
             {
-                Transition transition = transitions.get(i); // Transition list is sorted by the 'Id' column so should be in the same order as the chromatogram indices list
-                result.put(index, transition.explicitQuantitative());
+                throw new IllegalStateException("Mismatch in transitions and indices lengths: " + transitions.size() + " vs " + chromatogramIndexList.size());
+            }
+            int i = 0;
+            for (Integer index : chromatogramIndexList)
+            {
+                // Transition list is sorted by the 'Id' column so should be in the same order as the chromatogram indices list
+                GeneralTransition transition = transitions.get(i);
+                result.add(new TransitionChromInfoAndQuantitative(pci.makeDummyTransitionChromInfo(index), transition.isQuantitative(fullScanSettings)));
                 i++;
             }
-            return result;
+        }
+        else
+        {
+            Map<Long, GeneralTransition> transitionMap = transitions.stream().collect(Collectors.toMap(GeneralTransition::getId, Function.identity()));
+            List<TransitionChromInfo> tciList = getTransitionChromInfoList(pci.getId());
+            for(TransitionChromInfo tci: tciList)
+            {
+                GeneralTransition transition = transitionMap.get(tci.getTransitionId());
+                if(transition == null)
+                {
+                    throw new IllegalStateException("Cannot find transtion for TransitionChromInfo. TransitionId is: " + tci.getTransitionId());
+                }
+                result.add(new TransitionChromInfoAndQuantitative(tci, transition.isQuantitative(fullScanSettings)));
+            }
         }
 
-        SQLFragment sql = new SQLFragment("SELECT tci.ChromatogramIndex, gt.Quantitative FROM ")
-                .append(TargetedMSManager.getTableInfoTransitionChromInfo(), "tci")
-                .append(" INNER JOIN ")
-                .append(TargetedMSManager.getTableInfoGeneralTransition(), "gt")
-                .append(" ON gt.id = tci.transitionId ")
-                .append(" WHERE tci.PrecursorChromInfoId = ? ORDER BY gt.Id").add(pci.getId());
+        return result;
+    }
 
-        return new SqlSelector(TargetedMSManager.getSchema(), sql).fillValueMap(new LinkedHashMap<>());
+    public static class TransitionChromInfoAndQuantitative
+    {
+        private final TransitionChromInfo _tci;
+        private final boolean _quantitative;
+
+        public TransitionChromInfoAndQuantitative(TransitionChromInfo tci, boolean quantitative)
+        {
+            _tci = tci;
+            _quantitative = quantitative;
+        }
+
+        public int getChromatogramIndex()
+        {
+            return _tci.getChromatogramIndex();
+        }
+
+        public boolean isQuantitative()
+        {
+            return _quantitative;
+        }
+
+        public Double getMassErrorPpm()
+        {
+            return _tci.getMassErrorPPM();
+        }
+
+        public boolean hasHeightAndIsQuantitative()
+        {
+            return isQuantitative() && getHeight() > 0;
+        }
+
+        public double getHeight()
+        {
+            return _tci.getHeight() == null ? 0 : _tci.getHeight();
+        }
+    }
+
+    @NotNull
+    private static List<GeneralTransition> getGeneralTransitionsForPrecursor(long precursorId)
+    {
+        return new TableSelector(TargetedMSManager.getTableInfoGeneralTransition(),
+                new SimpleFilter(FieldKey.fromParts("GeneralPrecursorId"), precursorId), new Sort("Id")).getArrayList(GeneralTransition.class);
     }
 
     @NotNull
@@ -207,7 +259,7 @@ public class TransitionManager
                                  new SimpleFilter(FieldKey.fromParts("TransitionId"), transitionId), null).getCollection(TransitionChromInfo.class);
     }
 
-    public static RtRange getPrecursorPeakRtRange(long precursorChromInfoId)
+    public static RtRange getTransitionPeakRtRange(long precursorChromInfoId)
     {
         // Get the min start time from the transition peaks
         SQLFragment sql = new SQLFragment("SELECT MIN(startTime) AS minRt, MAX(endTime) AS maxRt FROM ");
@@ -219,25 +271,52 @@ public class TransitionManager
 
     public static RtRange getGeneralMoleculeRtRange(long generalMoleculeId)
     {
-        // Get the min start time and max end time across all the samples for the given general molecule id.
-        // Use the the start and end time set on the transition peaks.
         return getGeneralMoleculeSampleRtSummary(generalMoleculeId, null);
     }
 
     public static RtRange getGeneralMoleculeSampleRtRange(long generalMoleculeId, long sampleFileId)
     {
         // Get the min start time and max end time for the given general molecule id in the given sample
-        // Use the the start and end time set on the transition peaks.
         return TransitionManager.getGeneralMoleculeSampleRtSummary(generalMoleculeId, sampleFileId);
     }
 
-    private static RtRange getGeneralMoleculeSampleRtSummary(long generalMoleculeId, Long sampleFileId)
+    // Get the min start time and max end time for the given general molecule id. Query PrecursorChromInfo first.
+    // If minStart and maxEnd columns are null for all precursors then query TransitionChromInfos.
+    private static RtRange getGeneralMoleculeSampleRtSummary(long generalMoleculeId, @Nullable Long sampleFileId)
     {
-        SQLFragment sql = new SQLFragment("SELECT ").append(" MIN (tci.startTime) AS minRt, MAX(tci.endTime) AS maxRt FROM ");
-        sql.append(TargetedMSManager.getTableInfoTransitionChromInfo(), "tci");
-        sql.append(" INNER JOIN ");
-        sql.append(TargetedMSManager.getTableInfoPrecursorChromInfo(), "pci");
-        sql.append(" ON pci.id = tci.precursorChrominfoId ");
+        // First query the PrecursorChromInfo table
+        SQLFragment sql = getGeneralMoleculeSampleRtSummarySql(generalMoleculeId, sampleFileId, false);
+        RtRange rtRange = getRtRange(sql);
+        if(!rtRange.isEmpty())
+        {
+            return rtRange;
+        }
+        else
+        {
+            // Query the TransitionChromInfo table
+            sql = getGeneralMoleculeSampleRtSummarySql(generalMoleculeId, sampleFileId, true);
+            return getRtRange(sql);
+        }
+    }
+
+    private static SQLFragment getGeneralMoleculeSampleRtSummarySql(long generalMoleculeId, @Nullable Long sampleFileId, boolean queryTransitions)
+    {
+        String minStartTimeCol = queryTransitions ? "tci.startTime" : "pci.minStartTime";
+        String maxEndTimecol = queryTransitions ? "tci.endTime" : "pci.maxEndTime";
+
+        SQLFragment sql = new SQLFragment("SELECT ").append(" MIN (").append(minStartTimeCol).append(") AS minRt, MAX(" ).append(maxEndTimecol).append(") AS maxRt FROM ");
+        if(queryTransitions)
+        {
+            sql.append(TargetedMSManager.getTableInfoTransitionChromInfo(), "tci");
+            sql.append(" INNER JOIN ");
+            sql.append(TargetedMSManager.getTableInfoPrecursorChromInfo(), "pci");
+            sql.append(" ON pci.id = tci.precursorChrominfoId ");
+        }
+        else
+        {
+            sql.append(TargetedMSManager.getTableInfoPrecursorChromInfo(), "pci");
+        }
+
         sql.append(" INNER JOIN ");
         sql.append(TargetedMSManager.getTableInfoGeneralMoleculeChromInfo(), "gmci");
         sql.append(" ON gmci.Id=pci.GeneralMoleculeChromInfoId");
@@ -248,8 +327,7 @@ public class TransitionManager
             sql.append(" AND ");
             sql.append("pci.SampleFileId = ?").add(sampleFileId);
         }
-
-        return getRtRange(sql);
+        return sql;
     }
 
     @NotNull

--- a/src/org/labkey/targetedms/query/TransitionManager.java
+++ b/src/org/labkey/targetedms/query/TransitionManager.java
@@ -168,19 +168,15 @@ public class TransitionManager
 
         if (pci.getTransitionChromatogramIndicesList() != null)
         {
-            List<Integer> chromatogramIndexList = pci.getTransitionChromatogramIndicesList();
-
-            if (transitions.size() != chromatogramIndexList.size())
+            if (transitions.size() != pci.getTransitionChromatogramIndicesList().size())
             {
-                throw new IllegalStateException("Mismatch in transitions and indices lengths: " + transitions.size() + " vs " + chromatogramIndexList.size());
+                throw new IllegalStateException("Mismatch in transitions and indices lengths: " + transitions.size() + " vs " + pci.getTransitionChromatogramIndicesList().size());
             }
-            int i = 0;
-            for (Integer index : chromatogramIndexList)
+            for (int i = 0; i < pci.getTransitionChromatogramIndicesList().size(); i++)
             {
                 // Transition list is sorted by the 'Id' column so should be in the same order as the chromatogram indices list
                 GeneralTransition transition = transitions.get(i);
-                result.add(new TransitionChromInfoAndQuantitative(pci.makeDummyTransitionChromInfo(index), transition.isQuantitative(fullScanSettings)));
-                i++;
+                result.add(new TransitionChromInfoAndQuantitative(pci.makeDummyTransitionChromInfo(i), transition.isQuantitative(fullScanSettings)));
             }
         }
         else

--- a/src/org/labkey/targetedms/query/TransitionManager.java
+++ b/src/org/labkey/targetedms/query/TransitionManager.java
@@ -128,7 +128,7 @@ public class TransitionManager
         if(fragmentType != Transition.Type.ALL)
         {
             sql.append(", ");
-            sql.append(TargetedMSManager.getTableInfoTransition(), "tran");
+            sql.append(TargetedMSManager.getTableInfoGeneralTransition(), "tran");
         }
         sql.append(" WHERE ");
         sql.append("gmci.Id = preci.GeneralMoleculeChromInfoId ");


### PR DESCRIPTION
#### Changes
- Populate a BestMassErrorPPM column on PrecursorChromInfo so that we can label peaks when we are not saving TransitionChromInfos
- If we cannot determine the peak boundary (e.g. when TransitionChromInfos are not saved, and all the transitions for a precursor are non-quantitative) display the full chromatogram range
- Label precursor peak with the mass_error_ppm of the tallest transition rather than the averageMassErrorPpm set on the PrecursorChromInfo
- Non-quantitative transitions are determined with GeneralTransition.isQuantitative(TransitionSettings.FullScanSettings settings).  This will return false for MS2 transitions where the Full Scan Acquisition method is set to "DDA"
- Shorten y-axis (intensity) tick labels with a multiplier added to the axis label (e.g. Intensity 10^3).  This was not working.
- Allow up to two decimal places for RT axis to avoid repeated tick labels

