### PR TITLE
Attempt to fix intermittent test failure on TargetedMSRun leak

### DIFF
--- a/src/org/labkey/targetedms/datasource/MsDataSourceUtil.java
+++ b/src/org/labkey/targetedms/datasource/MsDataSourceUtil.java
@@ -375,16 +375,9 @@ public class MsDataSourceUtil
         private static final String[] agilentData = new String[] {"pTE219_0 hr_R2.d", "pTE219_0 hr_R2_flatzip.d", "pTE219_0 hr_R2_nestedzip.d"};
 
         @BeforeClass
-        public static void setup()
+        public static void setup() throws ExperimentException
         {
-            try
-            {
-                cleanDatabase();
-            }
-            catch (ExperimentException e)
-            {
-                fail("Failed to clean up database before running tests. Error was: " + e.getMessage());
-            }
+            cleanDatabase();
 
             _user = TestContext.get().getUser();
             _container = ContainerManager.ensureContainer(JunitUtil.getTestContainer(), FOLDER_NAME);
@@ -749,16 +742,10 @@ public class MsDataSourceUtil
         }
 
         @AfterClass
-        public static void cleanup()
+        public static void cleanup() throws ExperimentException
         {
-            try
-            {
-                cleanDatabase();
-            }
-            catch (ExperimentException e)
-            {
-                fail("Failed to clean up database after running tests. Error was: " + e.getMessage());
-            }
+            cleanDatabase();
+            _run = null;
         }
     }
 }


### PR DESCRIPTION
#### Rationale
We've seen at least one downstream test fail with a reported leak of a TargetedMSRun from MsDataSourceUtil.TestCase

https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_BvtBSqlserver/1200925?buildTab=overview

#### Changes
* Null out the reference, clean up exception handling a bit