### PR TITLE
Issue 42209: Add more ion mobility related columns to chromatogram libs

### DIFF
--- a/src/org/labkey/targetedms/chromlib/AbstractLibPrecursor.java
+++ b/src/org/labkey/targetedms/chromlib/AbstractLibPrecursor.java
@@ -4,10 +4,14 @@ import org.labkey.targetedms.TargetedMSRun;
 import org.labkey.targetedms.parser.GeneralPrecursor;
 import org.labkey.targetedms.parser.PrecursorChromInfo;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+
+import static org.labkey.targetedms.chromlib.BaseDaoImpl.readDouble;
 
 public class AbstractLibPrecursor<TransitionType extends AbstractLibTransition> extends AbstractLibEntity
 {
@@ -33,6 +37,13 @@ public class AbstractLibPrecursor<TransitionType extends AbstractLibTransition> 
     protected Integer _numTransitions;
     protected Integer _numPoints;
     protected Double _averageMassErrorPPM;
+    private String _explicitIonMobilityUnits;
+    private Double _explicitCcsSqa;
+    private Double _explicitCompensationVoltage;
+    private Double _precursorConcentration;
+    private Double _driftTimeMs1;
+    private Double _driftTimeFragment;
+    private Double _driftTimeWindow;
 
     public AbstractLibPrecursor() {}
 
@@ -49,8 +60,13 @@ public class AbstractLibPrecursor<TransitionType extends AbstractLibTransition> 
         setCharge(p.getCharge());
         setCollisionEnergy(p.getCollisionEnergy());
         setDeclusteringPotential(p.getDeclusteringPotential());
+        setExplicitIonMobility(p.getExplicitIonMobility());
+        setExplicitIonMobilityUnits(p.getExplicitIonMobilityUnits());
+        setExplicitCcsSqa(p.getExplicitCcsSqa());
+        setExplicitCompensationVoltage(p.getExplicitCompensationVoltage());
+        setPrecursorConcentration(p.getPrecursorConcentration());
 
-        if(bestChromInfo != null)
+        if (bestChromInfo != null)
         {
             setTotalArea(bestChromInfo.getTotalArea() == null ? 0.0 : bestChromInfo.getTotalArea());
             setChromatogram(bestChromInfo.getChromatogramBytes(run));
@@ -59,6 +75,14 @@ public class AbstractLibPrecursor<TransitionType extends AbstractLibTransition> 
             setNumTransitions(bestChromInfo.getNumTransitions());
             setNumPoints(bestChromInfo.getNumPoints());
             setAverageMassErrorPPM(bestChromInfo.getAverageMassErrorPPM());
+            setCcs(bestChromInfo.getCcs());
+            setIonMobilityFragment(bestChromInfo.getIonMobilityFragment());
+            setIonMobilityMS1(bestChromInfo.getIonMobilityMs1());
+            setIonMobilityType(bestChromInfo.getIonMobilityType());
+            setIonMobilityWindow(bestChromInfo.getIonMobilityWindow());
+            setDriftTimeMs1(bestChromInfo.getDriftTimeMs1());
+            setDriftTimeWindow(bestChromInfo.getDriftTimeWindow());
+            setDriftTimeFragment(bestChromInfo.getDriftTimeFragment());
 
             long sampleFileId = bestChromInfo.getSampleFileId();
             Integer libSampleFileId = sampleFileIdMap.get(sampleFileId);
@@ -80,6 +104,35 @@ public class AbstractLibPrecursor<TransitionType extends AbstractLibTransition> 
     protected List<LibPrecursorRetentionTime> _retentionTimes;
 
     protected List<TransitionType> _transitions;
+
+    public AbstractLibPrecursor(ResultSet rs) throws SQLException
+    {
+        setId(rs.getInt(Constants.PrecursorColumn.Id.baseColumn().name()));
+        setIsotopeLabel(rs.getString(Constants.MoleculePrecursorColumn.IsotopeLabel.baseColumn().name()));
+        setMz(rs.getDouble(Constants.PrecursorColumn.Mz.baseColumn().name()));
+        setCharge(rs.getInt(Constants.PrecursorColumn.Charge.baseColumn().name()));
+        setCollisionEnergy(readDouble(rs, Constants.MoleculePrecursorColumn.CollisionEnergy.baseColumn().name()));
+        setDeclusteringPotential(readDouble(rs, Constants.MoleculePrecursorColumn.DeclusteringPotential.baseColumn().name()));
+        setTotalArea(rs.getDouble(Constants.MoleculePrecursorColumn.TotalArea.baseColumn().name()));
+        setNumTransitions(rs.getInt(Constants.MoleculePrecursorColumn.NumTransitions.baseColumn().name()));
+        setNumPoints(rs.getInt(Constants.MoleculePrecursorColumn.NumPoints.baseColumn().name()));
+        setAverageMassErrorPPM(rs.getDouble(Constants.MoleculePrecursorColumn.AverageMassErrorPPM.baseColumn().name()));
+        setSampleFileId(rs.getInt(Constants.MoleculePrecursorColumn.SampleFileId.baseColumn().name()));
+        setChromatogram(rs.getBytes(Constants.MoleculePrecursorColumn.Chromatogram.baseColumn().name()));
+        setExplicitIonMobility(readDouble(rs, Constants.MoleculePrecursorColumn.ExplicitIonMobility.baseColumn().name()));
+        setCcs(readDouble(rs, Constants.MoleculePrecursorColumn.CCS.baseColumn().name()));
+        setIonMobilityMS1(readDouble(rs, Constants.MoleculePrecursorColumn.IonMobilityMS1.baseColumn().name()));
+        setIonMobilityFragment(readDouble(rs, Constants.MoleculePrecursorColumn.IonMobilityFragment.baseColumn().name()));
+        setIonMobilityWindow(readDouble(rs, Constants.MoleculePrecursorColumn.IonMobilityWindow.baseColumn().name()));
+        setIonMobilityType(rs.getString(Constants.MoleculePrecursorColumn.IonMobilityType.baseColumn().name()));
+        setExplicitIonMobilityUnits(rs.getString(Constants.MoleculePrecursorColumn.ExplicitIonMobilityUnits.baseColumn().name()));
+        setExplicitCcsSqa(readDouble(rs, Constants.MoleculePrecursorColumn.ExplicitCcsSqa.baseColumn().name()));
+        setExplicitCompensationVoltage(readDouble(rs, Constants.MoleculePrecursorColumn.ExplicitCompensationVoltage.baseColumn().name()));
+        setPrecursorConcentration(readDouble(rs, Constants.MoleculePrecursorColumn.PrecursorConcentration.baseColumn().name()));
+        setDriftTimeWindow(readDouble(rs, Constants.MoleculePrecursorColumn.DriftTimeWindow.baseColumn().name()));
+        setDriftTimeFragment(readDouble(rs, Constants.MoleculePrecursorColumn.DriftTimeFragment.baseColumn().name()));
+        setDriftTimeMs1(readDouble(rs, Constants.MoleculePrecursorColumn.DriftTimeMs1.baseColumn().name()));
+    }
 
     public String getIsotopeLabel()
     {
@@ -314,5 +367,75 @@ public class AbstractLibPrecursor<TransitionType extends AbstractLibTransition> 
                 getTransitions().stream().mapToInt(AbstractLibEntity::getCacheSize).sum() +
                 getRetentionTimes().stream().mapToInt(AbstractLibEntity::getCacheSize).sum();
 
+    }
+
+    public void setExplicitIonMobilityUnits(String explicitIonMobilityUnits)
+    {
+        _explicitIonMobilityUnits = explicitIonMobilityUnits;
+    }
+
+    public String getExplicitIonMobilityUnits()
+    {
+        return _explicitIonMobilityUnits;
+    }
+
+    public void setExplicitCcsSqa(Double explicitCcsSqa)
+    {
+        _explicitCcsSqa = explicitCcsSqa;
+    }
+
+    public Double getExplicitCcsSqa()
+    {
+        return _explicitCcsSqa;
+    }
+
+    public void setExplicitCompensationVoltage(Double explicitCompensationVoltage)
+    {
+        _explicitCompensationVoltage = explicitCompensationVoltage;
+    }
+
+    public Double getExplicitCompensationVoltage()
+    {
+        return _explicitCompensationVoltage;
+    }
+
+    public void setPrecursorConcentration(Double precursorConcentration)
+    {
+        _precursorConcentration = precursorConcentration;
+    }
+
+    public Double getPrecursorConcentration()
+    {
+        return _precursorConcentration;
+    }
+
+    public Double getDriftTimeMs1()
+    {
+        return _driftTimeMs1;
+    }
+
+    public void setDriftTimeMs1(Double driftTimeMs1)
+    {
+        _driftTimeMs1 = driftTimeMs1;
+    }
+
+    public Double getDriftTimeFragment()
+    {
+        return _driftTimeFragment;
+    }
+
+    public void setDriftTimeFragment(Double driftTimeFragment)
+    {
+        _driftTimeFragment = driftTimeFragment;
+    }
+
+    public Double getDriftTimeWindow()
+    {
+        return _driftTimeWindow;
+    }
+
+    public void setDriftTimeWindow(Double driftTimeWindow)
+    {
+        _driftTimeWindow = driftTimeWindow;
     }
 }

--- a/src/org/labkey/targetedms/chromlib/BaseDaoImpl.java
+++ b/src/org/labkey/targetedms/chromlib/BaseDaoImpl.java
@@ -24,6 +24,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Types;
 import java.util.Collection;
 import java.util.List;
 
@@ -212,7 +213,7 @@ public abstract class BaseDaoImpl<T extends AbstractLibEntity> implements Dao<T>
         }
     }
 
-    public Double readDouble(ResultSet rs, String columnName) throws SQLException
+    public static Double readDouble(ResultSet rs, String columnName) throws SQLException
     {
         double value = rs.getDouble(columnName);
         if(!rs.wasNull())
@@ -275,4 +276,20 @@ public abstract class BaseDaoImpl<T extends AbstractLibEntity> implements Dao<T>
 
     protected abstract ColumnDef[] getColumns();
 
+    protected int setIonMobilityColumns(PreparedStatement stmt, int colIndex, AbstractLibPrecursor precursor) throws SQLException
+    {
+        stmt.setObject(colIndex++, precursor.getExplicitIonMobility(), Types.DOUBLE);
+        stmt.setObject(colIndex++, precursor.getCcs(), Types.DOUBLE);
+        stmt.setObject(colIndex++, precursor.getIonMobilityMS1(), Types.DOUBLE);
+        stmt.setObject(colIndex++, precursor.getIonMobilityFragment(), Types.DOUBLE);
+        stmt.setString(colIndex++, precursor.getIonMobilityType());
+        stmt.setString(colIndex++, precursor.getExplicitIonMobilityUnits());
+        stmt.setObject(colIndex++, precursor.getExplicitCcsSqa(), Types.DOUBLE);
+        stmt.setObject(colIndex++, precursor.getExplicitCompensationVoltage(), Types.DOUBLE);
+        stmt.setObject(colIndex++, precursor.getPrecursorConcentration(), Types.DOUBLE);
+        stmt.setObject(colIndex++, precursor.getDriftTimeMs1(), Types.DOUBLE);
+        stmt.setObject(colIndex++, precursor.getDriftTimeFragment(), Types.DOUBLE);
+        stmt.setObject(colIndex++, precursor.getDriftTimeWindow(), Types.DOUBLE);
+        return colIndex;
+    }
 }

--- a/src/org/labkey/targetedms/chromlib/Constants.java
+++ b/src/org/labkey/targetedms/chromlib/Constants.java
@@ -147,6 +147,13 @@ class Constants
         IonMobilityFragment("DOUBLE"),
         IonMobilityWindow("DOUBLE"),
         IonMobilityType("VARCHAR(200)"),
+        ExplicitIonMobilityUnits("VARCHAR(200)"),
+        ExplicitCcsSqa("DOUBLE"),
+        ExplicitCompensationVoltage("DOUBLE"),
+        PrecursorConcentration("DOUBLE"),
+        DriftTimeMs1("DOUBLE"),
+        DriftTimeFragment("DOUBLE"),
+        DriftTimeWindow("DOUBLE"),
 
         PrecursorId("INTEGER NOT NULL", Table.Precursor, Id),
         IsotopeModId("INTEGER NOT NULL", Table.IsotopeModification, Id),
@@ -548,7 +555,14 @@ class Constants
         IonMobilityMS1(Column.IonMobilityMS1),
         IonMobilityFragment(Column.IonMobilityFragment),
         IonMobilityWindow(Column.IonMobilityWindow),
-        IonMobilityType(Column.IonMobilityType);
+        IonMobilityType(Column.IonMobilityType),
+        ExplicitIonMobilityUnits(Column.ExplicitIonMobilityUnits),
+        ExplicitCcsSqa(Column.ExplicitCcsSqa),
+        ExplicitCompensationVoltage(Column.ExplicitCompensationVoltage),
+        PrecursorConcentration(Column.PrecursorConcentration),
+        DriftTimeMs1(Column.DriftTimeMs1),
+        DriftTimeFragment(Column.DriftTimeFragment),
+        DriftTimeWindow(Column.DriftTimeWindow);
 
         private final Column _column;
         private final String _definition;
@@ -723,16 +737,23 @@ class Constants
         Chromatogram(Column.Chromatogram),
         UncompressedSize(Column.UncompressedSize),
         ChromatogramFormat(Column.ChromatogramFormat),
-        ExplicitIonMobility(Column.ExplicitIonMobility),
         MassMonoisotopic(Column.MassMonoisotopic),
         MassAverage(Column.MassAverage),
         IonFormula(Column.IonFormula),
         CustomIonName(Column.CustomIonName),
+        ExplicitIonMobility(Column.ExplicitIonMobility),
         CCS(Column.CCS),
         IonMobilityMS1(Column.IonMobilityMS1),
         IonMobilityFragment(Column.IonMobilityFragment),
         IonMobilityWindow(Column.IonMobilityWindow),
-        IonMobilityType(Column.IonMobilityType);
+        IonMobilityType(Column.IonMobilityType),
+        ExplicitIonMobilityUnits(Column.ExplicitIonMobilityUnits),
+        ExplicitCcsSqa(Column.ExplicitCcsSqa),
+        ExplicitCompensationVoltage(Column.ExplicitCompensationVoltage),
+        PrecursorConcentration(Column.PrecursorConcentration),
+        DriftTimeMs1(Column.DriftTimeMs1),
+        DriftTimeFragment(Column.DriftTimeFragment),
+        DriftTimeWindow(Column.DriftTimeWindow);
 
         private final Column _column;
         private final String _definition;

--- a/src/org/labkey/targetedms/chromlib/LibMoleculePrecursor.java
+++ b/src/org/labkey/targetedms/chromlib/LibMoleculePrecursor.java
@@ -4,7 +4,11 @@ import org.labkey.targetedms.TargetedMSRun;
 import org.labkey.targetedms.parser.MoleculePrecursor;
 import org.labkey.targetedms.parser.PrecursorChromInfo;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.Map;
+
+import static org.labkey.targetedms.chromlib.BaseDaoImpl.readDouble;
 
 public class LibMoleculePrecursor extends AbstractLibPrecursor<LibMoleculeTransition>
 {
@@ -25,6 +29,16 @@ public class LibMoleculePrecursor extends AbstractLibPrecursor<LibMoleculeTransi
         setCustomIonName(p.getCustomIonName());
         setMassMonoisotopic(p.getMassMonoisotopic());
         setMassAverage(p.getMassAverage());
+    }
+
+    public LibMoleculePrecursor(ResultSet rs) throws SQLException
+    {
+        super(rs);
+        setMoleculeId(rs.getInt(Constants.MoleculePrecursorColumn.MoleculeId.baseColumn().name()));
+        setMassMonoisotopic(readDouble(rs, Constants.MoleculePrecursorColumn.MassMonoisotopic.baseColumn().name()));
+        setMassAverage(readDouble(rs, Constants.MoleculePrecursorColumn.MassAverage.baseColumn().name()));
+        setIonFormula(rs.getString(Constants.MoleculePrecursorColumn.IonFormula.baseColumn().name()));
+        setCustomIonName(rs.getString(Constants.MoleculePrecursorColumn.CustomIonName.baseColumn().name()));
     }
 
     public long getMoleculeId()

--- a/src/org/labkey/targetedms/chromlib/LibMoleculePrecursorDao.java
+++ b/src/org/labkey/targetedms/chromlib/LibMoleculePrecursorDao.java
@@ -88,16 +88,12 @@ public class LibMoleculePrecursorDao extends BaseDaoImpl<LibMoleculePrecursor>
         stmt.setInt(colIndex++, precursor.getUncompressedSize());
         stmt.setInt(colIndex++, precursor.getChromatogramFormat());
 
-        stmt.setObject(colIndex++, precursor.getExplicitIonMobility(), Types.DOUBLE);
         stmt.setObject(colIndex++, precursor.getMassMonoisotopic(), Types.DOUBLE);
         stmt.setObject(colIndex++, precursor.getMassAverage(), Types.DOUBLE);
         stmt.setString(colIndex++, precursor.getIonFormula());
         stmt.setString(colIndex++, precursor.getCustomIonName());
 
-        stmt.setObject(colIndex++, precursor.getCcs(), Types.DOUBLE);
-        stmt.setObject(colIndex++, precursor.getIonMobilityMS1(), Types.DOUBLE);
-        stmt.setObject(colIndex++, precursor.getIonMobilityFragment(), Types.DOUBLE);
-        stmt.setString(colIndex++, precursor.getIonMobilityType());
+        colIndex = setIonMobilityColumns(stmt, colIndex, precursor);
     }
 
     @Override
@@ -155,31 +151,7 @@ public class LibMoleculePrecursorDao extends BaseDaoImpl<LibMoleculePrecursor>
         List<LibMoleculePrecursor> precursors = new ArrayList<>();
         while(rs.next())
         {
-            LibMoleculePrecursor precursor = new LibMoleculePrecursor();
-            precursor.setId(rs.getInt(Constants.MoleculePrecursorColumn.Id.baseColumn().name()));
-            precursor.setMoleculeId(rs.getInt(Constants.MoleculePrecursorColumn.MoleculeId.baseColumn().name()));
-            precursor.setIsotopeLabel(rs.getString(Constants.MoleculePrecursorColumn.IsotopeLabel.baseColumn().name()));
-            precursor.setMz(rs.getDouble(Constants.MoleculePrecursorColumn.Mz.baseColumn().name()));
-            precursor.setCharge(rs.getInt(Constants.MoleculePrecursorColumn.Charge.baseColumn().name()));
-            precursor.setCollisionEnergy(readDouble(rs, Constants.MoleculePrecursorColumn.CollisionEnergy.baseColumn().name()));
-            precursor.setDeclusteringPotential(readDouble(rs, Constants.MoleculePrecursorColumn.DeclusteringPotential.baseColumn().name()));
-            precursor.setTotalArea(rs.getDouble(Constants.MoleculePrecursorColumn.TotalArea.baseColumn().name()));
-            precursor.setNumTransitions(rs.getInt(Constants.MoleculePrecursorColumn.NumTransitions.baseColumn().name()));
-            precursor.setNumPoints(rs.getInt(Constants.MoleculePrecursorColumn.NumPoints.baseColumn().name()));
-            precursor.setAverageMassErrorPPM(rs.getDouble(Constants.MoleculePrecursorColumn.AverageMassErrorPPM.baseColumn().name()));
-            precursor.setSampleFileId(rs.getInt(Constants.MoleculePrecursorColumn.SampleFileId.baseColumn().name()));
-            precursor.setChromatogram(rs.getBytes(Constants.MoleculePrecursorColumn.Chromatogram.baseColumn().name()));
-            precursor.setExplicitIonMobility(readDouble(rs, Constants.MoleculePrecursorColumn.ExplicitIonMobility.baseColumn().name()));
-            precursor.setMassMonoisotopic(readDouble(rs, Constants.MoleculePrecursorColumn.MassMonoisotopic.baseColumn().name()));
-            precursor.setMassAverage(readDouble(rs, Constants.MoleculePrecursorColumn.MassAverage.baseColumn().name()));
-            precursor.setIonFormula(rs.getString(Constants.MoleculePrecursorColumn.IonFormula.baseColumn().name()));
-            precursor.setCustomIonName(rs.getString(Constants.MoleculePrecursorColumn.CustomIonName.baseColumn().name()));
-            precursor.setCcs(readDouble(rs, Constants.MoleculePrecursorColumn.CCS.baseColumn().name()));
-            precursor.setIonMobilityMS1(readDouble(rs, Constants.MoleculePrecursorColumn.IonMobilityMS1.baseColumn().name()));
-            precursor.setIonMobilityFragment(readDouble(rs, Constants.MoleculePrecursorColumn.IonMobilityFragment.baseColumn().name()));
-            precursor.setIonMobilityWindow(readDouble(rs, Constants.MoleculePrecursorColumn.IonMobilityWindow.baseColumn().name()));
-            precursor.setIonMobilityType(rs.getString(Constants.MoleculePrecursorColumn.IonMobilityType.baseColumn().name()));
-
+            LibMoleculePrecursor precursor = new LibMoleculePrecursor(rs);
             precursors.add(precursor);
         }
         return precursors;

--- a/src/org/labkey/targetedms/chromlib/LibPrecursor.java
+++ b/src/org/labkey/targetedms/chromlib/LibPrecursor.java
@@ -19,6 +19,8 @@ import org.labkey.targetedms.TargetedMSRun;
 import org.labkey.targetedms.parser.Precursor;
 import org.labkey.targetedms.parser.PrecursorChromInfo;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -45,6 +47,14 @@ public class LibPrecursor extends AbstractLibPrecursor<LibTransition>
         super(precursor, isotopeLabelMap, bestChromInfo, run, sampleFileIdMap);
         setNeutralMass(precursor.getNeutralMass());
         setModifiedSequence(precursor.getModifiedSequence());
+    }
+
+    public LibPrecursor(ResultSet rs) throws SQLException
+    {
+        super(rs);
+        setPeptideId(rs.getInt(Constants.PrecursorColumn.PeptideId.baseColumn().name()));
+        setNeutralMass(rs.getDouble(Constants.PrecursorColumn.NeutralMass.baseColumn().name()));
+        setModifiedSequence(rs.getString(Constants.PrecursorColumn.ModifiedSequence.baseColumn().name()));
     }
 
     public long getPeptideId()

--- a/src/org/labkey/targetedms/chromlib/LibPrecursorDao.java
+++ b/src/org/labkey/targetedms/chromlib/LibPrecursorDao.java
@@ -102,12 +102,7 @@ public class LibPrecursorDao extends BaseDaoImpl<LibPrecursor>
         stmt.setInt(colIndex++, precursor.getUncompressedSize());
         stmt.setInt(colIndex++, precursor.getChromatogramFormat());
 
-        stmt.setObject(colIndex++, precursor.getExplicitIonMobility(), Types.DOUBLE);
-        stmt.setObject(colIndex++, precursor.getCcs(), Types.DOUBLE);
-        stmt.setObject(colIndex++, precursor.getIonMobilityMS1(), Types.DOUBLE);
-        stmt.setObject(colIndex++, precursor.getIonMobilityFragment(), Types.DOUBLE);
-        stmt.setString(colIndex++, precursor.getIonMobilityType());
-
+        colIndex = setIonMobilityColumns(stmt, colIndex, precursor);
     }
 
     @Override
@@ -178,29 +173,7 @@ public class LibPrecursorDao extends BaseDaoImpl<LibPrecursor>
         List<LibPrecursor> precursors = new ArrayList<>();
         while(rs.next())
         {
-            LibPrecursor precursor = new LibPrecursor();
-            precursor.setId(rs.getInt(PrecursorColumn.Id.baseColumn().name()));
-            precursor.setPeptideId(rs.getInt(PrecursorColumn.PeptideId.baseColumn().name()));
-            precursor.setIsotopeLabel(rs.getString(PrecursorColumn.IsotopeLabel.baseColumn().name()));
-            precursor.setMz(rs.getDouble(PrecursorColumn.Mz.baseColumn().name()));
-            precursor.setCharge(rs.getInt(PrecursorColumn.Charge.baseColumn().name()));
-            precursor.setNeutralMass(rs.getDouble(PrecursorColumn.NeutralMass.baseColumn().name()));
-            precursor.setModifiedSequence(rs.getString(PrecursorColumn.ModifiedSequence.baseColumn().name()));
-            precursor.setCollisionEnergy(readDouble(rs, PrecursorColumn.CollisionEnergy.baseColumn().name()));
-            precursor.setDeclusteringPotential(readDouble(rs, PrecursorColumn.DeclusteringPotential.baseColumn().name()));
-            precursor.setTotalArea(rs.getDouble(PrecursorColumn.TotalArea.baseColumn().name()));
-            precursor.setNumTransitions(rs.getInt(PrecursorColumn.NumTransitions.baseColumn().name()));
-            precursor.setNumPoints(rs.getInt(PrecursorColumn.NumPoints.baseColumn().name()));
-            precursor.setAverageMassErrorPPM(rs.getDouble(PrecursorColumn.AverageMassErrorPPM.baseColumn().name()));
-            precursor.setSampleFileId(rs.getInt(PrecursorColumn.SampleFileId.baseColumn().name()));
-            precursor.setChromatogram(rs.getBytes(PrecursorColumn.Chromatogram.baseColumn().name()));
-            precursor.setExplicitIonMobility(readDouble(rs, Constants.MoleculePrecursorColumn.ExplicitIonMobility.baseColumn().name()));
-            precursor.setCcs(readDouble(rs, Constants.MoleculePrecursorColumn.CCS.baseColumn().name()));
-            precursor.setIonMobilityMS1(readDouble(rs, Constants.MoleculePrecursorColumn.IonMobilityMS1.baseColumn().name()));
-            precursor.setIonMobilityFragment(readDouble(rs, Constants.MoleculePrecursorColumn.IonMobilityFragment.baseColumn().name()));
-            precursor.setIonMobilityWindow(readDouble(rs, Constants.MoleculePrecursorColumn.IonMobilityWindow.baseColumn().name()));
-            precursor.setIonMobilityType(rs.getString(Constants.MoleculePrecursorColumn.IonMobilityType.baseColumn().name()));
-
+            LibPrecursor precursor = new LibPrecursor(rs);
             precursors.add(precursor);
         }
         return precursors;


### PR DESCRIPTION
#### Rationale
20.11 introduced small molecule chromatogram libraries. We can augment the info they include for ion-mobility scenarios.

#### Changes
* Add eight new columns to the SQLite files that we generate for both Precursor and MoleculePrecursor tables
* Fix scenario were CCS and other columns are not being populated