### PR TITLE
Issue 42281: IllegalFormatArgumentIndexException expanding Skyline audit logs under JDK 16

### DIFF
--- a/src/org/labkey/targetedms/parser/skyaudit/AuditLogMessageExpander.java
+++ b/src/org/labkey/targetedms/parser/skyaudit/AuditLogMessageExpander.java
@@ -141,8 +141,9 @@ public class AuditLogMessageExpander
         boolean hasMatches = false;
         int lastPos = 0;
         while(match.find()){
-            resultBuilder.append(s.substring(lastPos, match.start()));
-            resultBuilder.append( String.format("%%%s$s", match.group(1)));
+            resultBuilder.append(s, lastPos, match.start());
+            // Issue 42281: C# is zero-based, Java is one-based
+            resultBuilder.append( String.format("%%%s$s", Integer.parseInt(match.group(1)) + 1));
             lastPos = match.end();
             hasMatches = true;
         }


### PR DESCRIPTION
#### Rationale
JDK 16 has gotten stricter about what you can pass to String.format(). Earlier versions somehow interpreted our 0-based arguments as we intended, even though they're supposed to 1-based. Under JDK 16 this causes an exception, and a variety of TargetedMS test failures

#### Changes
* Add one!