### PR TITLE
Issue 42317: NPE in download column of replicates grid when instrument info is not available for a sample file

### DIFF
--- a/src/org/labkey/targetedms/datasource/MsDataSourceUtil.java
+++ b/src/org/labkey/targetedms/datasource/MsDataSourceUtil.java
@@ -203,9 +203,9 @@ public class MsDataSourceUtil
         {
             // We can get more than one source type by filename extension lookup. e.g. .raw extension is used both by Thermo and Waters
             // Try to resolve by looking up the instrument on which the data was acquired.
-            Instrument instrument = InstrumentManager.getInstrument(sampleFile.getInstrumentId());
-            if(instrument != null)
+            if(sampleFile.getInstrumentId() != null)
             {
+                Instrument instrument = InstrumentManager.getInstrument(sampleFile.getInstrumentId());
                 MsDataSource source = getSourceForInstrument(instrument);
                 if(source != null)
                 {


### PR DESCRIPTION
#### Rationale
Instrument info may not be available for replicates imported with very old versions of Skyline. 


