### PR TITLE
Issue 42319: Make the Skyline software version available through the targetedms api

### DIFF
--- a/api-src/org/labkey/api/targetedms/ITargetedMSRun.java
+++ b/api-src/org/labkey/api/targetedms/ITargetedMSRun.java
@@ -34,4 +34,5 @@ public interface ITargetedMSRun
     public long getId();
     public Integer getDataId();
     public Integer getSkydDataId();
+    public String getSoftwareVersion();
 }

--- a/src/org/labkey/targetedms/TargetedMSRun.java
+++ b/src/org/labkey/targetedms/TargetedMSRun.java
@@ -375,6 +375,7 @@ public class TargetedMSRun implements Serializable, ITargetedMSRun
         _iRTscaleId = iRTscaleId;
     }
 
+    @Override
     public String getSoftwareVersion()
     {
         return _softwareVersion;


### PR DESCRIPTION
#### Rationale
We need the Skyline version for a document in the panoramapublic module to recognize Bibliospec libraries built with Prosit predictions

