### PR TITLE
Issue 42349: CalibrationCurvePrecursors.sql causing perf problems

### DIFF
--- a/resources/queries/targetedms/CalibrationCurveMoleculePrecursors.sql
+++ b/resources/queries/targetedms/CalibrationCurveMoleculePrecursors.sql
@@ -17,28 +17,20 @@ SELECT
   cc.Id AS CalibrationCurve,
   hpci.Id AS HeavyPrecursorChromInfo,
   hpci.SampleFileId,
-  hpre.Charge,
+  hpci.MoleculePrecursorId.Charge,
   lpci.Id AS LightPrecursorChromInfo,
-  CASE WHEN hpci.TotalArea <> 0 THEN
-    (lpci.TotalArea / hpci.TotalArea) ELSE NULL END AS Ratio
-FROM
-  targetedms.Molecule hmol
-INNER JOIN
-  targetedms.MoleculePrecursor hpre
-ON hpre.GeneralMoleculeId = hmol.Id AND hpre.IsotopeLabelId.name = 'heavy'
-INNER JOIN
-  targetedms.PrecursorChromInfo hpci
-ON hpci.MoleculePrecursorId = hpre.Id
-INNER JOIN
-  targetedms.CalibrationCurve cc
-ON cc.GeneralMoleculeId = hmol.Id
+  CASE WHEN hpci.TotalArea <> 0 THEN (lpci.TotalArea / hpci.TotalArea) END AS Ratio
 
-INNER JOIN
-  targetedms.Molecule lmol
-ON cc.GeneralMoleculeId = lmol.Id
-INNER JOIN
-  targetedms.MoleculePrecursor lpre
-ON lpre.GeneralMoleculeId = lmol.Id AND lpre.IsotopeLabelId.name = 'light'
-INNER JOIN
-  targetedms.PrecursorChromInfo lpci
-ON lpci.MoleculePrecursorId = lpre.Id AND hpci.SampleFileId = lpci.SampleFileId AND hpre.Charge = lpre.Charge
+FROM
+    targetedms.PrecursorChromInfo hpci
+    INNER JOIN targetedms.CalibrationCurve cc
+    ON
+        cc.GeneralMoleculeId = hpci.MoleculePrecursorId.MoleculeId AND
+        hpci.MoleculePrecursorId.IsotopeLabelId.name = 'heavy'
+
+    INNER JOIN targetedms.PrecursorChromInfo lpci
+    ON
+        cc.GeneralMoleculeId = lpci.MoleculePrecursorId.MoleculeId AND
+        hpci.SampleFileId = lpci.SampleFileId AND
+        hpci.MoleculePrecursorId.Charge = lpci.MoleculePrecursorId.Charge AND
+        lpci.MoleculePrecursorId.IsotopeLabelId.name = 'light'

--- a/resources/queries/targetedms/CalibrationCurvePrecursors.sql
+++ b/resources/queries/targetedms/CalibrationCurvePrecursors.sql
@@ -17,29 +17,20 @@ SELECT
   cc.Id AS CalibrationCurve,
   hpci.Id AS HeavyPrecursorChromInfo,
   hpci.SampleFileId,
-  hpre.Charge,
+  hpci.PrecursorId.Charge,
   lpci.Id AS LightPrecursorChromInfo,
-  case WHEN hpci.TotalArea <>0 THEN
-  (lpci.TotalArea / hpci.TotalArea) else null end AS Ratio
+  CASE WHEN hpci.TotalArea <> 0 THEN (lpci.TotalArea / hpci.TotalArea) END AS Ratio
 
 FROM
-  targetedms.Peptide hpep
-INNER JOIN
-  targetedms.Precursor hpre
-ON hpre.GeneralMoleculeId = hpep.Id AND hpre.IsotopeLabelId.name = 'heavy'
-INNER JOIN
-  targetedms.PrecursorChromInfo hpci
-ON hpci.PrecursorId = hpre.Id
-INNER JOIN
-  targetedms.CalibrationCurve cc
-ON cc.GeneralMoleculeId = hpep.Id
+    targetedms.PrecursorChromInfo hpci
+    INNER JOIN targetedms.CalibrationCurve cc
+    ON
+        cc.GeneralMoleculeId = hpci.PrecursorId.PeptideId AND
+        hpci.PrecursorId.IsotopeLabelId.name = 'heavy'
 
-INNER JOIN
-  targetedms.Peptide lpep
-ON cc.GeneralMoleculeId = lpep.Id
-INNER JOIN
-  targetedms.Precursor lpre
-ON lpre.GeneralMoleculeId = lpep.Id AND lpre.IsotopeLabelId.name = 'light'
-INNER JOIN
-  targetedms.PrecursorChromInfo lpci
-ON lpci.PrecursorId = lpre.Id AND hpci.SampleFileId = lpci.SampleFileId AND hpre.Charge = lpre.Charge
+    INNER JOIN targetedms.PrecursorChromInfo lpci
+    ON
+        cc.GeneralMoleculeId = lpci.PrecursorId.PeptideId AND
+        hpci.SampleFileId = lpci.SampleFileId AND
+        hpci.PrecursorId.Charge = lpci.PrecursorId.Charge AND
+        lpci.PrecursorId.IsotopeLabelId.name = 'light'


### PR DESCRIPTION
#### Rationale
These queries are taking many hours to run on PanoramaWeb

#### Changes
* Use lookup syntax for joins instead of explicit INNER JOINs, which lets our SQL generation avoid having to separately filter each table by Container
* Small misc SQL cleanup