### PR TITLE
Small molecule chromatogram library column renaming

### DIFF
--- a/resources/schemas/dbscripts/postgresql/targetedms-21.001-21.002.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-21.001-21.002.sql
@@ -1,0 +1,20 @@
+
+UPDATE targetedms.PrecursorChromInfo SET IonMobilityType = 'drift_time_ms'
+    WHERE IonMobilityType IS NULL AND (DriftTimeMS1 IS NOT NULL OR DriftTimeFragment IS NOT NULL OR DriftTimeWindow IS NOT NULL);
+UPDATE targetedms.PrecursorChromInfo SET IonMobilityMS1 = DriftTimeMS1
+    WHERE IonMobilityMS1 IS NULL AND DriftTimeMS1 IS NOT NULL;
+UPDATE targetedms.PrecursorChromInfo SET IonMobilityFragment = DriftTimeFragment
+    WHERE IonMobilityFragment IS NULL AND DriftTimeFragment IS NOT NULL;
+UPDATE targetedms.PrecursorChromInfo SET IonMobilityWindow = DriftTimeWindow
+    WHERE IonMobilityWindow IS NULL AND DriftTimeWindow IS NOT NULL;
+
+ALTER TABLE targetedms.PrecursorChromInfo DROP COLUMN DriftTimeMS1, DriftTimeFragment, DriftTimeWindow;
+
+UPDATE targetedms.TransitionChromInfo SET IonMobilityType = 'drift_time_ms'
+    WHERE IonMobilityType IS NULL AND (DriftTime IS NOT NULL OR DriftTimeWindow IS NOT NULL);
+UPDATE targetedms.TransitionChromInfo SET IonMobility = DriftTime
+    WHERE IonMobility IS NULL AND DriftTime IS NOT NULL;
+UPDATE targetedms.TransitionChromInfo SET IonMobilityWindow = DriftTimeWindow
+    WHERE IonMobilityWindow IS NULL AND DriftTimeWindow IS NOT NULL;
+
+ALTER TABLE targetedms.TransitionChromInfo DROP COLUMN DriftTime, DriftTimeWindow;

--- a/resources/schemas/dbscripts/sqlserver/targetedms-21.001-21.002.sql
+++ b/resources/schemas/dbscripts/sqlserver/targetedms-21.001-21.002.sql
@@ -1,0 +1,20 @@
+
+UPDATE targetedms.PrecursorChromInfo SET IonMobilityType = 'drift_time_ms'
+    WHERE IonMobilityType IS NULL AND (DriftTimeMS1 IS NOT NULL OR DriftTimeFragment IS NOT NULL OR DriftTimeWindow IS NOT NULL);
+UPDATE targetedms.PrecursorChromInfo SET IonMobilityMS1 = DriftTimeMS1
+    WHERE IonMobilityMS1 IS NULL AND DriftTimeMS1 IS NOT NULL;
+UPDATE targetedms.PrecursorChromInfo SET IonMobilityFragment = DriftTimeFragment
+    WHERE IonMobilityFragment IS NULL AND DriftTimeFragment IS NOT NULL;
+UPDATE targetedms.PrecursorChromInfo SET IonMobilityWindow = DriftTimeWindow
+    WHERE IonMobilityWindow IS NULL AND DriftTimeWindow IS NOT NULL;
+
+ALTER TABLE targetedms.PrecursorChromInfo DROP COLUMN DriftTimeMS1, DriftTimeFragment, DriftTimeWindow;
+
+UPDATE targetedms.TransitionChromInfo SET IonMobilityType = 'drift_time_ms'
+    WHERE IonMobilityType IS NULL AND (DriftTime IS NOT NULL OR DriftTimeWindow IS NOT NULL);
+UPDATE targetedms.TransitionChromInfo SET IonMobility = DriftTime
+    WHERE IonMobility IS NULL AND DriftTime IS NOT NULL;
+UPDATE targetedms.TransitionChromInfo SET IonMobilityWindow = DriftTimeWindow
+    WHERE IonMobilityWindow IS NULL AND DriftTimeWindow IS NOT NULL;
+
+ALTER TABLE targetedms.TransitionChromInfo DROP COLUMN DriftTime, DriftTimeWindow;

--- a/resources/schemas/targetedms.xml
+++ b/resources/schemas/targetedms.xml
@@ -546,9 +546,6 @@
             <column columnName="qvalue"/>
             <column columnName="zscore"/>
             <column columnName="Ccs"/>
-            <column columnName="DriftTimeMs1"/>
-            <column columnName="DriftTimeFragment"/>
-            <column columnName="DriftTimeWindow"/>
             <column columnName="IonMobilityMs1"/>
             <column columnName="IonMobilityFragment"/>
             <column columnName="IonMobilityWindow"/>
@@ -695,8 +692,6 @@
             <column columnName="MassErrorPPM"/>
             <column columnName="PointsAcrossPeak"/>
             <column columnName="Ccs"/>
-            <column columnName="DriftTime"/>
-            <column columnName="DriftTimeWindow"/>
             <column columnName="IonMobility"/>
             <column columnName="IonMobilityWindow"/>
             <column columnName="IonMobilityType"/>

--- a/src/org/labkey/targetedms/SkylineDocImporter.java
+++ b/src/org/labkey/targetedms/SkylineDocImporter.java
@@ -1965,7 +1965,7 @@ public class SkylineDocImporter
         try
         {
             _transitionChromInfoStmt = ensureStatement(_transitionChromInfoStmt,
-                    "INSERT INTO targetedms.transitionchrominfo(transitionid, samplefileid, precursorchrominfoid, retentiontime, starttime, endtime, height, area, background, fwhm, fwhmdegenerate, truncated, peakrank, optimizationstep, note, chromatogramindex, masserrorppm, userset, identified, pointsacrosspeak, ccs, drifttime, drifttimewindow, ionmobility, ionmobilitywindow, ionmobilitytype, rank, rankbylevel, forcedintegration) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    "INSERT INTO targetedms.transitionchrominfo(transitionid, samplefileid, precursorchrominfoid, retentiontime, starttime, endtime, height, area, background, fwhm, fwhmdegenerate, truncated, peakrank, optimizationstep, note, chromatogramindex, masserrorppm, userset, identified, pointsacrosspeak, ccs, ionmobility, ionmobilitywindow, ionmobilitytype, rank, rankbylevel, forcedintegration) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     true);
 
             int index = 1;
@@ -1990,8 +1990,6 @@ public class SkylineDocImporter
             _transitionChromInfoStmt.setString(index++, transChromInfo.getIdentified());
             setInteger(_transitionChromInfoStmt, index++, transChromInfo.getPointsAcrossPeak());
             setDouble(_transitionChromInfoStmt, index++, transChromInfo.getCcs());
-            setDouble(_transitionChromInfoStmt, index++, transChromInfo.getDriftTime());
-            setDouble(_transitionChromInfoStmt, index++, transChromInfo.getDriftTimeWindow());
             setDouble(_transitionChromInfoStmt, index++, transChromInfo.getIonMobility());
             setDouble(_transitionChromInfoStmt, index++, transChromInfo.getIonMobilityWindow());
             _transitionChromInfoStmt.setString(index++, transChromInfo.getIonMobilityType());
@@ -2016,7 +2014,7 @@ public class SkylineDocImporter
         try
         {
             _precursorChromInfoStmt = ensureStatement(_precursorChromInfoStmt,
-                    "INSERT INTO targetedms.precursorchrominfo( precursorid, samplefileid, generalmoleculechrominfoid, bestretentiontime, minstarttime, maxendtime, totalarea, totalbackground, maxfwhm, peakcountratio, numtruncated, librarydotp, optimizationstep, note, chromatogram, numtransitions, numpoints, maxheight, isotopedotp, averagemasserrorppm, bestmasserrorppm, userset, uncompressedsize, identified, container, chromatogramformat, chromatogramoffset, chromatogramlength, qvalue, zscore, ccs, drifttimems1, drifttimefragment, drifttimewindow, ionmobilityms1, ionmobilityfragment, ionmobilitywindow, ionmobilitytype) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    "INSERT INTO targetedms.precursorchrominfo( precursorid, samplefileid, generalmoleculechrominfoid, bestretentiontime, minstarttime, maxendtime, totalarea, totalbackground, maxfwhm, peakcountratio, numtruncated, librarydotp, optimizationstep, note, chromatogram, numtransitions, numpoints, maxheight, isotopedotp, averagemasserrorppm, bestmasserrorppm, userset, uncompressedsize, identified, container, chromatogramformat, chromatogramoffset, chromatogramlength, qvalue, zscore, ccs, ionmobilityms1, ionmobilityfragment, ionmobilitywindow, ionmobilitytype) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     true);
 
             int index = 1;
@@ -2051,9 +2049,6 @@ public class SkylineDocImporter
             setDouble(_precursorChromInfoStmt, index++, preChromInfo.getQvalue());
             setDouble(_precursorChromInfoStmt, index++, preChromInfo.getZscore());
             setDouble(_precursorChromInfoStmt, index++, preChromInfo.getCcs());
-            setDouble(_precursorChromInfoStmt, index++, preChromInfo.getDriftTimeMs1());
-            setDouble(_precursorChromInfoStmt, index++, preChromInfo.getDriftTimeFragment());
-            setDouble(_precursorChromInfoStmt, index++, preChromInfo.getDriftTimeWindow());
             setDouble(_precursorChromInfoStmt, index++, preChromInfo.getIonMobilityMs1());
             setDouble(_precursorChromInfoStmt, index++, preChromInfo.getIonMobilityFragment());
             setDouble(_precursorChromInfoStmt, index++, preChromInfo.getIonMobilityWindow());

--- a/src/org/labkey/targetedms/chromlib/AbstractLibPrecursor.java
+++ b/src/org/labkey/targetedms/chromlib/AbstractLibPrecursor.java
@@ -41,9 +41,6 @@ public class AbstractLibPrecursor<TransitionType extends AbstractLibTransition> 
     private Double _explicitCcsSqa;
     private Double _explicitCompensationVoltage;
     private Double _precursorConcentration;
-    private Double _driftTimeMs1;
-    private Double _driftTimeFragment;
-    private Double _driftTimeWindow;
 
     public AbstractLibPrecursor() {}
 
@@ -80,9 +77,6 @@ public class AbstractLibPrecursor<TransitionType extends AbstractLibTransition> 
             setIonMobilityMS1(bestChromInfo.getIonMobilityMs1());
             setIonMobilityType(bestChromInfo.getIonMobilityType());
             setIonMobilityWindow(bestChromInfo.getIonMobilityWindow());
-            setDriftTimeMs1(bestChromInfo.getDriftTimeMs1());
-            setDriftTimeWindow(bestChromInfo.getDriftTimeWindow());
-            setDriftTimeFragment(bestChromInfo.getDriftTimeFragment());
 
             long sampleFileId = bestChromInfo.getSampleFileId();
             Integer libSampleFileId = sampleFileIdMap.get(sampleFileId);
@@ -129,9 +123,6 @@ public class AbstractLibPrecursor<TransitionType extends AbstractLibTransition> 
         setExplicitCcsSqa(readDouble(rs, Constants.MoleculePrecursorColumn.ExplicitCcsSqa.baseColumn().name()));
         setExplicitCompensationVoltage(readDouble(rs, Constants.MoleculePrecursorColumn.ExplicitCompensationVoltage.baseColumn().name()));
         setPrecursorConcentration(readDouble(rs, Constants.MoleculePrecursorColumn.PrecursorConcentration.baseColumn().name()));
-        setDriftTimeWindow(readDouble(rs, Constants.MoleculePrecursorColumn.DriftTimeWindow.baseColumn().name()));
-        setDriftTimeFragment(readDouble(rs, Constants.MoleculePrecursorColumn.DriftTimeFragment.baseColumn().name()));
-        setDriftTimeMs1(readDouble(rs, Constants.MoleculePrecursorColumn.DriftTimeMs1.baseColumn().name()));
     }
 
     public String getIsotopeLabel()
@@ -407,35 +398,5 @@ public class AbstractLibPrecursor<TransitionType extends AbstractLibTransition> 
     public Double getPrecursorConcentration()
     {
         return _precursorConcentration;
-    }
-
-    public Double getDriftTimeMs1()
-    {
-        return _driftTimeMs1;
-    }
-
-    public void setDriftTimeMs1(Double driftTimeMs1)
-    {
-        _driftTimeMs1 = driftTimeMs1;
-    }
-
-    public Double getDriftTimeFragment()
-    {
-        return _driftTimeFragment;
-    }
-
-    public void setDriftTimeFragment(Double driftTimeFragment)
-    {
-        _driftTimeFragment = driftTimeFragment;
-    }
-
-    public Double getDriftTimeWindow()
-    {
-        return _driftTimeWindow;
-    }
-
-    public void setDriftTimeWindow(Double driftTimeWindow)
-    {
-        _driftTimeWindow = driftTimeWindow;
     }
 }

--- a/src/org/labkey/targetedms/chromlib/AbstractLibTransition.java
+++ b/src/org/labkey/targetedms/chromlib/AbstractLibTransition.java
@@ -1,5 +1,6 @@
 package org.labkey.targetedms.chromlib;
 
+import org.labkey.targetedms.parser.GeneralPrecursor;
 import org.labkey.targetedms.parser.GeneralTransition;
 import org.labkey.targetedms.parser.TransitionChromInfo;
 
@@ -21,10 +22,17 @@ public abstract class AbstractLibTransition extends AbstractLibEntity
 
     public AbstractLibTransition() {}
 
-    public AbstractLibTransition(GeneralTransition transition, TransitionChromInfo tci)
+    public AbstractLibTransition(GeneralTransition transition, TransitionChromInfo tci, GeneralPrecursor<?> precursor)
     {
         setMz(transition.getMz());
-        setCharge(transition.getCharge());
+        if (transition.getCharge() == null)
+        {
+            setCharge(precursor.getCharge());
+        }
+        else
+        {
+            setCharge(transition.getCharge());
+        }
         setFragmentType(transition.getFragmentType());
         setMassIndex(transition.getMassIndex());
 

--- a/src/org/labkey/targetedms/chromlib/BaseDaoImpl.java
+++ b/src/org/labkey/targetedms/chromlib/BaseDaoImpl.java
@@ -287,9 +287,6 @@ public abstract class BaseDaoImpl<T extends AbstractLibEntity> implements Dao<T>
         stmt.setObject(colIndex++, precursor.getExplicitCcsSqa(), Types.DOUBLE);
         stmt.setObject(colIndex++, precursor.getExplicitCompensationVoltage(), Types.DOUBLE);
         stmt.setObject(colIndex++, precursor.getPrecursorConcentration(), Types.DOUBLE);
-        stmt.setObject(colIndex++, precursor.getDriftTimeMs1(), Types.DOUBLE);
-        stmt.setObject(colIndex++, precursor.getDriftTimeFragment(), Types.DOUBLE);
-        stmt.setObject(colIndex++, precursor.getDriftTimeWindow(), Types.DOUBLE);
         return colIndex;
     }
 }

--- a/src/org/labkey/targetedms/chromlib/Constants.java
+++ b/src/org/labkey/targetedms/chromlib/Constants.java
@@ -178,6 +178,7 @@ class Constants
         Fwhm("DOUBLE"),
         MassErrorPPM("DOUBLE"),
         ChromatogramIndex("INTEGER"),
+        FragmentName("VARCHAR(100)"),
 
         IrtLibraryId("INTEGER NOT NULL", Table.IrtLibrary, Id),
         PeptideModSeq("TEXT NOT NULL"),
@@ -186,6 +187,7 @@ class Constants
         TimeSource("INT"),
 
         TransitionId("INTEGER NOT NULL", Table.Transition, Id),
+        MoleculeTransitionId("INTEGER NOT NULL", Table.MoleculeTransition, Id),
         OptimizationType("TEXT NOT NULL"),
         OptimizationValue("DOUBLE NOT NULL"),
         OptimizationStep("INTEGER"),
@@ -824,8 +826,9 @@ class Constants
     {
         Id(Column.Id),
         MoleculePrecursorId(Column.MoleculePrecursorId),
-        MoleculeName(Column.MoleculeName),
+        FragmentName(Column.MoleculeName),
         ChemicalFormula(Column.ChemicalFormula),
+        Adduct(Column.Adduct),
         Mz(Column.Mz, "DOUBLE"),
         Charge(Column.Charge, "INTEGER"),
         FragmentType(Column.FragmentType),
@@ -925,7 +928,7 @@ class Constants
     public enum MoleculeTransitionOptimizationColumn implements ColumnDef
     {
         Id(Column.Id),
-        TransitionId(Column.TransitionId),
+        MoleculeTransitionId(Column.MoleculeTransitionId),
         OptimizationType(Column.OptimizationType),
         OptimizationValue(Column.OptimizationValue);
 

--- a/src/org/labkey/targetedms/chromlib/Constants.java
+++ b/src/org/labkey/targetedms/chromlib/Constants.java
@@ -121,8 +121,8 @@ class Constants
         CalcNeutralMass("DOUBLE NOT NULL"),
         NumMissedCleavages("INTEGER NOT NULL"),
 
-        IonFormula("VARCHAR(100)"),
-        CustomIonName("VARCHAR(100)"),
+        ChemicalFormula("VARCHAR(100)"),
+        MoleculeName("VARCHAR(100)"),
         MassMonoisotopic("DOUBLE"),
         MassAverage("DOUBLE"),
 
@@ -147,6 +147,7 @@ class Constants
         Chromatogram("BLOB"),
         UncompressedSize("INTEGER"),
         ChromatogramFormat("INTEGER"),
+        Adduct("VARCHAR(200)"),
         ExplicitIonMobility("DOUBLE"),
         CCS("DOUBLE"),
         IonMobilityMS1("DOUBLE"),
@@ -157,9 +158,6 @@ class Constants
         ExplicitCcsSqa("DOUBLE"),
         ExplicitCompensationVoltage("DOUBLE"),
         PrecursorConcentration("DOUBLE"),
-        DriftTimeMs1("DOUBLE"),
-        DriftTimeFragment("DOUBLE"),
-        DriftTimeWindow("DOUBLE"),
 
         PrecursorId("INTEGER NOT NULL", Table.Precursor, Id),
         IsotopeModId("INTEGER NOT NULL", Table.IsotopeModification, Id),
@@ -575,10 +573,7 @@ class Constants
         ExplicitIonMobilityUnits(Column.ExplicitIonMobilityUnits),
         ExplicitCcsSqa(Column.ExplicitCcsSqa),
         ExplicitCompensationVoltage(Column.ExplicitCompensationVoltage),
-        PrecursorConcentration(Column.PrecursorConcentration),
-        DriftTimeMs1(Column.DriftTimeMs1),
-        DriftTimeFragment(Column.DriftTimeFragment),
-        DriftTimeWindow(Column.DriftTimeWindow);
+        PrecursorConcentration(Column.PrecursorConcentration);
 
         private final Column _column;
         private final String _definition;
@@ -710,8 +705,8 @@ class Constants
     {
         Id(Column.Id),
         MoleculeListId(Column.MoleculeListId),
-        IonFormula(Column.IonFormula),
-        CustomIonName(Column.CustomIonName),
+        IonFormula(Column.ChemicalFormula),
+        CustomIonName(Column.MoleculeName),
         MassMonoisotopic(Column.MassMonoisotopic),
         MassAverage(Column.MassAverage),
         MoleculeAccession(Column.MoleculeAccession);
@@ -756,8 +751,7 @@ class Constants
         ChromatogramFormat(Column.ChromatogramFormat),
         MassMonoisotopic(Column.MassMonoisotopic),
         MassAverage(Column.MassAverage),
-        IonFormula(Column.IonFormula),
-        CustomIonName(Column.CustomIonName),
+        Adduct(Column.Adduct),
         ExplicitIonMobility(Column.ExplicitIonMobility),
         CCS(Column.CCS),
         IonMobilityMS1(Column.IonMobilityMS1),
@@ -767,10 +761,7 @@ class Constants
         ExplicitIonMobilityUnits(Column.ExplicitIonMobilityUnits),
         ExplicitCcsSqa(Column.ExplicitCcsSqa),
         ExplicitCompensationVoltage(Column.ExplicitCompensationVoltage),
-        PrecursorConcentration(Column.PrecursorConcentration),
-        DriftTimeMs1(Column.DriftTimeMs1),
-        DriftTimeFragment(Column.DriftTimeFragment),
-        DriftTimeWindow(Column.DriftTimeWindow);
+        PrecursorConcentration(Column.PrecursorConcentration);
 
         private final Column _column;
         private final String _definition;
@@ -833,6 +824,8 @@ class Constants
     {
         Id(Column.Id),
         MoleculePrecursorId(Column.MoleculePrecursorId),
+        MoleculeName(Column.MoleculeName),
+        ChemicalFormula(Column.ChemicalFormula),
         Mz(Column.Mz, "DOUBLE"),
         Charge(Column.Charge, "INTEGER"),
         FragmentType(Column.FragmentType),

--- a/src/org/labkey/targetedms/chromlib/Constants.java
+++ b/src/org/labkey/targetedms/chromlib/Constants.java
@@ -707,8 +707,8 @@ class Constants
     {
         Id(Column.Id),
         MoleculeListId(Column.MoleculeListId),
-        IonFormula(Column.ChemicalFormula),
-        CustomIonName(Column.MoleculeName),
+        ChemicalFormula(Column.ChemicalFormula),
+        MoleculeName(Column.MoleculeName),
         MassMonoisotopic(Column.MassMonoisotopic),
         MassAverage(Column.MassAverage),
         MoleculeAccession(Column.MoleculeAccession);
@@ -826,7 +826,7 @@ class Constants
     {
         Id(Column.Id),
         MoleculePrecursorId(Column.MoleculePrecursorId),
-        FragmentName(Column.MoleculeName),
+        FragmentName(Column.FragmentName),
         ChemicalFormula(Column.ChemicalFormula),
         Adduct(Column.Adduct),
         Mz(Column.Mz, "DOUBLE"),

--- a/src/org/labkey/targetedms/chromlib/ContainerChromatogramLibraryWriter.java
+++ b/src/org/labkey/targetedms/chromlib/ContainerChromatogramLibraryWriter.java
@@ -569,8 +569,8 @@ public class ContainerChromatogramLibraryWriter
     private LibMolecule makeLibMolecule(Molecule molecule)
     {
         LibMolecule libMolecule = new LibMolecule();
-        libMolecule.setIonFormula(molecule.getIonFormula());
-        libMolecule.setCustomIonName(molecule.getCustomIonName());
+        libMolecule.setChemicalFormula(molecule.getIonFormula());
+        libMolecule.setMoleculeName(molecule.getCustomIonName());
         libMolecule.setMassMonoisotopic(molecule.getMassMonoisotopic());
         libMolecule.setMassAverage(molecule.getMassAverage());
         libMolecule.setMoleculeAccession(molecule.getMoleculeId());

--- a/src/org/labkey/targetedms/chromlib/ContainerChromatogramLibraryWriter.java
+++ b/src/org/labkey/targetedms/chromlib/ContainerChromatogramLibraryWriter.java
@@ -608,12 +608,7 @@ public class ContainerChromatogramLibraryWriter
 
         // Add transitions.
         Collection<Transition> transitions = TransitionManager.getTransitionsForPrecursor(precursor.getId(), _user, _container);
-        addTransitions(libPrecursor, transitions, bestChromInfo, (t, tci) -> {
-                LibTransition transitionToSave = new LibTransition(t, tci);
-                _transitionCount++;
-                return transitionToSave;
-        });
-
+        addTransitions(libPrecursor, transitions, bestChromInfo, (t, tci) -> new LibTransition(t, tci, precursor));
         _precursorCount++;
         return libPrecursor;
     }
@@ -628,7 +623,7 @@ public class ContainerChromatogramLibraryWriter
 
         Collection<MoleculeTransition> transitions = MoleculeTransitionManager.getTransitionsForPrecursor(precursor.getId(), _user, _container);
         // Add transitions.
-        addTransitions(libPrecursor, transitions, bestChromInfo, LibMoleculeTransition::new);
+        addTransitions(libPrecursor, transitions, bestChromInfo, (t, tci) -> new LibMoleculeTransition(t, tci, precursor));
         _precursorCount++;
         return libPrecursor;
     }

--- a/src/org/labkey/targetedms/chromlib/LibMolecule.java
+++ b/src/org/labkey/targetedms/chromlib/LibMolecule.java
@@ -3,30 +3,30 @@ package org.labkey.targetedms.chromlib;
 public class LibMolecule extends AbstractLibMolecule<LibMoleculePrecursor>
 {
     private Integer _moleculeListId;
-    private String _ionFormula;
-    private String _customIonName;
+    private String _chemicalFormula;
+    private String _moleculeName;
     private double _massMonoisotopic;
     private double _massAverage;
     private String _moleculeAccession;
 
-    public String getIonFormula()
+    public String getChemicalFormula()
     {
-        return _ionFormula;
+        return _chemicalFormula;
     }
 
-    public void setIonFormula(String ionFormula)
+    public void setChemicalFormula(String chemicalFormula)
     {
-        _ionFormula = ionFormula;
+        _chemicalFormula = chemicalFormula;
     }
 
-    public String getCustomIonName()
+    public String getMoleculeName()
     {
-        return _customIonName;
+        return _moleculeName;
     }
 
-    public void setCustomIonName(String customIonName)
+    public void setMoleculeName(String moleculeName)
     {
-        _customIonName = customIonName;
+        _moleculeName = moleculeName;
     }
 
     public double getMassMonoisotopic()

--- a/src/org/labkey/targetedms/chromlib/LibMoleculeDao.java
+++ b/src/org/labkey/targetedms/chromlib/LibMoleculeDao.java
@@ -122,8 +122,8 @@ public class LibMoleculeDao extends BaseDaoImpl<LibMolecule>
         {
             LibMolecule molecule = new LibMolecule();
             molecule.setId(rs.getInt(PeptideColumn.Id.baseColumn().name()));
-            molecule.setChemicalFormula(rs.getString(Constants.MoleculeColumn.IonFormula.baseColumn().name()));
-            molecule.setMoleculeName(rs.getString(Constants.MoleculeColumn.CustomIonName.baseColumn().name()));
+            molecule.setChemicalFormula(rs.getString(Constants.MoleculeColumn.ChemicalFormula.baseColumn().name()));
+            molecule.setMoleculeName(rs.getString(Constants.MoleculeColumn.MoleculeName.baseColumn().name()));
             molecule.setMassMonoisotopic(readDouble(rs, Constants.MoleculeColumn.MassMonoisotopic.baseColumn().name()));
             molecule.setMassAverage(readDouble(rs, Constants.MoleculeColumn.MassAverage.baseColumn().name()));
             molecule.setMoleculeAccession(rs.getString(Constants.MoleculeColumn.MoleculeAccession.baseColumn().name()));

--- a/src/org/labkey/targetedms/chromlib/LibMoleculeDao.java
+++ b/src/org/labkey/targetedms/chromlib/LibMoleculeDao.java
@@ -64,8 +64,8 @@ public class LibMoleculeDao extends BaseDaoImpl<LibMolecule>
     {
         int colIndex = 1;
         stmt.setObject(colIndex++, molecule.getMoleculeListId(), Types.INTEGER);
-        stmt.setObject(colIndex++, molecule.getIonFormula(), Types.VARCHAR);
-        stmt.setObject(colIndex++, molecule.getCustomIonName(), Types.VARCHAR);
+        stmt.setObject(colIndex++, molecule.getChemicalFormula(), Types.VARCHAR);
+        stmt.setObject(colIndex++, molecule.getMoleculeName(), Types.VARCHAR);
         stmt.setObject(colIndex++, molecule.getMassMonoisotopic(), Types.DOUBLE);
         stmt.setObject(colIndex++, molecule.getMassAverage(), Types.DOUBLE);
         stmt.setString(colIndex, molecule.getMoleculeAccession());
@@ -122,8 +122,8 @@ public class LibMoleculeDao extends BaseDaoImpl<LibMolecule>
         {
             LibMolecule molecule = new LibMolecule();
             molecule.setId(rs.getInt(PeptideColumn.Id.baseColumn().name()));
-            molecule.setIonFormula(rs.getString(Constants.MoleculeColumn.IonFormula.baseColumn().name()));
-            molecule.setCustomIonName(rs.getString(Constants.MoleculeColumn.CustomIonName.baseColumn().name()));
+            molecule.setChemicalFormula(rs.getString(Constants.MoleculeColumn.IonFormula.baseColumn().name()));
+            molecule.setMoleculeName(rs.getString(Constants.MoleculeColumn.CustomIonName.baseColumn().name()));
             molecule.setMassMonoisotopic(readDouble(rs, Constants.MoleculeColumn.MassMonoisotopic.baseColumn().name()));
             molecule.setMassAverage(readDouble(rs, Constants.MoleculeColumn.MassAverage.baseColumn().name()));
             molecule.setMoleculeAccession(rs.getString(Constants.MoleculeColumn.MoleculeAccession.baseColumn().name()));

--- a/src/org/labkey/targetedms/chromlib/LibMoleculePrecursor.java
+++ b/src/org/labkey/targetedms/chromlib/LibMoleculePrecursor.java
@@ -16,8 +16,7 @@ public class LibMoleculePrecursor extends AbstractLibPrecursor<LibMoleculeTransi
 
     private Double _massMonoisotopic;
     private Double _massAverage;
-    private String _ionFormula;
-    private String _customIonName;
+    private String _adduct;
 
     public LibMoleculePrecursor() {}
 
@@ -25,8 +24,7 @@ public class LibMoleculePrecursor extends AbstractLibPrecursor<LibMoleculeTransi
                                 TargetedMSRun run, Map<Long, Integer> sampleFileIdMap)
     {
         super(p, isotopeLabelMap, chromInfo, run, sampleFileIdMap);
-        setIonFormula(p.getIonFormula());
-        setCustomIonName(p.getCustomIonName());
+        setAdduct(p.getAdduct());
         setMassMonoisotopic(p.getMassMonoisotopic());
         setMassAverage(p.getMassAverage());
     }
@@ -37,8 +35,7 @@ public class LibMoleculePrecursor extends AbstractLibPrecursor<LibMoleculeTransi
         setMoleculeId(rs.getInt(Constants.MoleculePrecursorColumn.MoleculeId.baseColumn().name()));
         setMassMonoisotopic(readDouble(rs, Constants.MoleculePrecursorColumn.MassMonoisotopic.baseColumn().name()));
         setMassAverage(readDouble(rs, Constants.MoleculePrecursorColumn.MassAverage.baseColumn().name()));
-        setIonFormula(rs.getString(Constants.MoleculePrecursorColumn.IonFormula.baseColumn().name()));
-        setCustomIonName(rs.getString(Constants.MoleculePrecursorColumn.CustomIonName.baseColumn().name()));
+        setAdduct(rs.getString(Constants.MoleculePrecursorColumn.Adduct.baseColumn().name()));
     }
 
     public long getMoleculeId()
@@ -71,23 +68,13 @@ public class LibMoleculePrecursor extends AbstractLibPrecursor<LibMoleculeTransi
         _massAverage = massAverage;
     }
 
-    public String getIonFormula()
+    public String getAdduct()
     {
-        return _ionFormula;
+        return _adduct;
     }
 
-    public void setIonFormula(String ionFormula)
+    public void setAdduct(String adduct)
     {
-        _ionFormula = ionFormula;
-    }
-
-    public String getCustomIonName()
-    {
-        return _customIonName;
-    }
-
-    public void setCustomIonName(String customIonName)
-    {
-        _customIonName = customIonName;
+        _adduct = adduct;
     }
 }

--- a/src/org/labkey/targetedms/chromlib/LibMoleculePrecursorDao.java
+++ b/src/org/labkey/targetedms/chromlib/LibMoleculePrecursorDao.java
@@ -90,8 +90,7 @@ public class LibMoleculePrecursorDao extends BaseDaoImpl<LibMoleculePrecursor>
 
         stmt.setObject(colIndex++, precursor.getMassMonoisotopic(), Types.DOUBLE);
         stmt.setObject(colIndex++, precursor.getMassAverage(), Types.DOUBLE);
-        stmt.setString(colIndex++, precursor.getIonFormula());
-        stmt.setString(colIndex++, precursor.getCustomIonName());
+        stmt.setString(colIndex++, precursor.getAdduct());
 
         colIndex = setIonMobilityColumns(stmt, colIndex, precursor);
     }

--- a/src/org/labkey/targetedms/chromlib/LibMoleculeTransition.java
+++ b/src/org/labkey/targetedms/chromlib/LibMoleculeTransition.java
@@ -15,8 +15,8 @@
  */
 package org.labkey.targetedms.chromlib;
 
+import org.labkey.targetedms.parser.MoleculePrecursor;
 import org.labkey.targetedms.parser.MoleculeTransition;
-import org.labkey.targetedms.parser.Transition;
 import org.labkey.targetedms.parser.TransitionChromInfo;
 
 /**
@@ -27,16 +27,18 @@ import org.labkey.targetedms.parser.TransitionChromInfo;
 public class LibMoleculeTransition extends AbstractLibTransition
 {
     private long _moleculePrecursorId;
-    private String _moleculeName;
+    private String _fragmentName;
     private String _chemicalFormula;
+    private String _adduct;
 
     public LibMoleculeTransition() {}
 
-    public LibMoleculeTransition(MoleculeTransition transition, TransitionChromInfo tci)
+    public LibMoleculeTransition(MoleculeTransition transition, TransitionChromInfo tci, MoleculePrecursor precursor)
     {
-        super(transition, tci);
-        setMoleculeName(transition.getCustomIonName());
-        setChemicalFormula(transition.getIonFormula());
+        super(transition, tci, precursor);
+        setFragmentName(transition.getCustomIonName());
+        setChemicalFormula(transition.getChemicalFormula());
+        setAdduct(transition.getAdduct());
     }
 
     public long getMoleculePrecursorId()
@@ -49,14 +51,14 @@ public class LibMoleculeTransition extends AbstractLibTransition
         _moleculePrecursorId = moleculePrecursorId;
     }
 
-    public String getMoleculeName()
+    public String getFragmentName()
     {
-        return _moleculeName;
+        return _fragmentName;
     }
 
-    public void setMoleculeName(String moleculeName)
+    public void setFragmentName(String fragmentName)
     {
-        _moleculeName = moleculeName;
+        _fragmentName = fragmentName;
     }
 
     public String getChemicalFormula()
@@ -67,6 +69,16 @@ public class LibMoleculeTransition extends AbstractLibTransition
     public void setChemicalFormula(String chemicalFormula)
     {
         _chemicalFormula = chemicalFormula;
+    }
+
+    public String getAdduct()
+    {
+        return _adduct;
+    }
+
+    public void setAdduct(String adduct)
+    {
+        _adduct = adduct;
     }
 
     @Override
@@ -91,7 +103,8 @@ public class LibMoleculeTransition extends AbstractLibTransition
         if (_mz != null ? !_mz.equals(that._mz) : that._mz != null) return false;
         if (_massErrorPPM != null ? !_massErrorPPM.equals(that._massErrorPPM) : that._massErrorPPM != null) return false;
         if (_chemicalFormula != null ? !_chemicalFormula.equals(that._chemicalFormula) : that._chemicalFormula != null) return false;
-        if (_moleculeName != null ? !_moleculeName.equals(that._moleculeName) : that._moleculeName != null) return false;
+        if (_fragmentName != null ? !_fragmentName.equals(that._fragmentName) : that._fragmentName != null) return false;
+        if (_adduct != null ? !_adduct.equals(that._adduct) : that._adduct != null) return false;
 
         return true;
     }
@@ -111,7 +124,8 @@ public class LibMoleculeTransition extends AbstractLibTransition
         result = 31 * result + (_chromatogramIndex != null ? _chromatogramIndex.hashCode() : 0);
         result = 31 * result + (_massErrorPPM != null ? _massErrorPPM.hashCode() : 0);
         result = 31 * result + (_chemicalFormula != null ? _chemicalFormula.hashCode() : 0);
-        result = 31 * result + (_moleculeName != null ? _moleculeName.hashCode() : 0);
+        result = 31 * result + (_fragmentName != null ? _fragmentName.hashCode() : 0);
+        result = 31 * result + (_adduct != null ? _adduct.hashCode() : 0);
         return result;
     }
 }

--- a/src/org/labkey/targetedms/chromlib/LibMoleculeTransition.java
+++ b/src/org/labkey/targetedms/chromlib/LibMoleculeTransition.java
@@ -27,12 +27,16 @@ import org.labkey.targetedms.parser.TransitionChromInfo;
 public class LibMoleculeTransition extends AbstractLibTransition
 {
     private long _moleculePrecursorId;
+    private String _moleculeName;
+    private String _chemicalFormula;
 
     public LibMoleculeTransition() {}
 
     public LibMoleculeTransition(MoleculeTransition transition, TransitionChromInfo tci)
     {
         super(transition, tci);
+        setMoleculeName(transition.getCustomIonName());
+        setChemicalFormula(transition.getIonFormula());
     }
 
     public long getMoleculePrecursorId()
@@ -43,6 +47,26 @@ public class LibMoleculeTransition extends AbstractLibTransition
     public void setMoleculePrecursorId(long moleculePrecursorId)
     {
         _moleculePrecursorId = moleculePrecursorId;
+    }
+
+    public String getMoleculeName()
+    {
+        return _moleculeName;
+    }
+
+    public void setMoleculeName(String moleculeName)
+    {
+        _moleculeName = moleculeName;
+    }
+
+    public String getChemicalFormula()
+    {
+        return _chemicalFormula;
+    }
+
+    public void setChemicalFormula(String chemicalFormula)
+    {
+        _chemicalFormula = chemicalFormula;
     }
 
     @Override
@@ -66,6 +90,8 @@ public class LibMoleculeTransition extends AbstractLibTransition
         if (_massIndex != null ? !_massIndex.equals(that._massIndex) : that._massIndex != null) return false;
         if (_mz != null ? !_mz.equals(that._mz) : that._mz != null) return false;
         if (_massErrorPPM != null ? !_massErrorPPM.equals(that._massErrorPPM) : that._massErrorPPM != null) return false;
+        if (_chemicalFormula != null ? !_chemicalFormula.equals(that._chemicalFormula) : that._chemicalFormula != null) return false;
+        if (_moleculeName != null ? !_moleculeName.equals(that._moleculeName) : that._moleculeName != null) return false;
 
         return true;
     }
@@ -84,6 +110,8 @@ public class LibMoleculeTransition extends AbstractLibTransition
         result = 31 * result + _fwhm.hashCode();
         result = 31 * result + (_chromatogramIndex != null ? _chromatogramIndex.hashCode() : 0);
         result = 31 * result + (_massErrorPPM != null ? _massErrorPPM.hashCode() : 0);
+        result = 31 * result + (_chemicalFormula != null ? _chemicalFormula.hashCode() : 0);
+        result = 31 * result + (_moleculeName != null ? _moleculeName.hashCode() : 0);
         return result;
     }
 }

--- a/src/org/labkey/targetedms/chromlib/LibMoleculeTransitionDao.java
+++ b/src/org/labkey/targetedms/chromlib/LibMoleculeTransitionDao.java
@@ -46,6 +46,8 @@ public class LibMoleculeTransitionDao extends BaseDaoImpl<LibMoleculeTransition>
     {
         int colIndex = 1;
         stmt.setLong(colIndex++, transition.getMoleculePrecursorId());
+        stmt.setString(colIndex++, transition.getMoleculeName());
+        stmt.setString(colIndex++, transition.getChemicalFormula());
         stmt.setObject(colIndex++, transition.getMz(), Types.DOUBLE);
         stmt.setObject(colIndex++, transition.getCharge(), Types.INTEGER);
         stmt.setString(colIndex++, transition.getFragmentType());
@@ -78,6 +80,8 @@ public class LibMoleculeTransitionDao extends BaseDaoImpl<LibMoleculeTransition>
             LibMoleculeTransition transition = new LibMoleculeTransition();
             transition.setId(rs.getInt(Constants.MoleculeTransitionColumn.Id.baseColumn().name()));
             transition.setMoleculePrecursorId(rs.getInt(Constants.MoleculeTransitionColumn.MoleculePrecursorId.baseColumn().name()));
+            transition.setMoleculeName(rs.getString(Constants.MoleculeTransitionColumn.MoleculeName.baseColumn().name()));
+            transition.setChemicalFormula(rs.getString(Constants.MoleculeTransitionColumn.ChemicalFormula.baseColumn().name()));
             transition.setMz(readDouble(rs, Constants.MoleculeTransitionColumn.Mz.baseColumn().name()));
             transition.setCharge(readInteger(rs, Constants.MoleculeTransitionColumn.Charge.baseColumn().name()));
             transition.setFragmentType(rs.getString(Constants.MoleculeTransitionColumn.FragmentType.baseColumn().name()));

--- a/src/org/labkey/targetedms/chromlib/LibMoleculeTransitionDao.java
+++ b/src/org/labkey/targetedms/chromlib/LibMoleculeTransitionDao.java
@@ -33,7 +33,6 @@ import java.util.List;
  */
 public class LibMoleculeTransitionDao extends BaseDaoImpl<LibMoleculeTransition>
 {
-
     private final Dao<LibMoleculeTransitionOptimization> _moleculeTransitionOptimizationDao;
 
     public LibMoleculeTransitionDao(Dao<LibMoleculeTransitionOptimization> moleculeTransitionOptimizationDao)
@@ -46,8 +45,9 @@ public class LibMoleculeTransitionDao extends BaseDaoImpl<LibMoleculeTransition>
     {
         int colIndex = 1;
         stmt.setLong(colIndex++, transition.getMoleculePrecursorId());
-        stmt.setString(colIndex++, transition.getMoleculeName());
+        stmt.setString(colIndex++, transition.getFragmentName());
         stmt.setString(colIndex++, transition.getChemicalFormula());
+        stmt.setString(colIndex++, transition.getAdduct());
         stmt.setObject(colIndex++, transition.getMz(), Types.DOUBLE);
         stmt.setObject(colIndex++, transition.getCharge(), Types.INTEGER);
         stmt.setString(colIndex++, transition.getFragmentType());
@@ -80,8 +80,9 @@ public class LibMoleculeTransitionDao extends BaseDaoImpl<LibMoleculeTransition>
             LibMoleculeTransition transition = new LibMoleculeTransition();
             transition.setId(rs.getInt(Constants.MoleculeTransitionColumn.Id.baseColumn().name()));
             transition.setMoleculePrecursorId(rs.getInt(Constants.MoleculeTransitionColumn.MoleculePrecursorId.baseColumn().name()));
-            transition.setMoleculeName(rs.getString(Constants.MoleculeTransitionColumn.MoleculeName.baseColumn().name()));
+            transition.setFragmentName(rs.getString(Constants.MoleculeTransitionColumn.FragmentName.baseColumn().name()));
             transition.setChemicalFormula(rs.getString(Constants.MoleculeTransitionColumn.ChemicalFormula.baseColumn().name()));
+            transition.setAdduct(rs.getString(Constants.MoleculeTransitionColumn.Adduct.baseColumn().name()));
             transition.setMz(readDouble(rs, Constants.MoleculeTransitionColumn.Mz.baseColumn().name()));
             transition.setCharge(readInteger(rs, Constants.MoleculeTransitionColumn.Charge.baseColumn().name()));
             transition.setFragmentType(rs.getString(Constants.MoleculeTransitionColumn.FragmentType.baseColumn().name()));

--- a/src/org/labkey/targetedms/chromlib/LibMoleculeTransitionOptimizationDao.java
+++ b/src/org/labkey/targetedms/chromlib/LibMoleculeTransitionOptimizationDao.java
@@ -16,9 +16,9 @@ public class LibMoleculeTransitionOptimizationDao extends BaseDaoImpl<LibMolecul
         while (rs.next())
         {
             LibMoleculeTransitionOptimization moleculeTransitionOptimization = new LibMoleculeTransitionOptimization();
-            moleculeTransitionOptimization.setTransitionId(rs.getInt(Constants.TransitionOptimizationColumn.TransitionId.name()));
-            moleculeTransitionOptimization.setOptimizationValue(readDouble(rs, Constants.TransitionOptimizationColumn.OptimizationValue.name()));
-            moleculeTransitionOptimization.setOptimizationType(rs.getString(Constants.TransitionOptimizationColumn.OptimizationType.name()));
+            moleculeTransitionOptimization.setTransitionId(rs.getInt(Constants.MoleculeTransitionOptimizationColumn.MoleculeTransitionId.name()));
+            moleculeTransitionOptimization.setOptimizationValue(readDouble(rs, Constants.MoleculeTransitionOptimizationColumn.OptimizationValue.name()));
+            moleculeTransitionOptimization.setOptimizationType(rs.getString(Constants.MoleculeTransitionOptimizationColumn.OptimizationType.name()));
 
             moleculeTransitionOptimizations.add(moleculeTransitionOptimization);
         }

--- a/src/org/labkey/targetedms/chromlib/LibTransition.java
+++ b/src/org/labkey/targetedms/chromlib/LibTransition.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.targetedms.chromlib;
 
+import org.labkey.targetedms.parser.Precursor;
 import org.labkey.targetedms.parser.Transition;
 import org.labkey.targetedms.parser.TransitionChromInfo;
 
@@ -32,13 +33,12 @@ public class LibTransition extends AbstractLibTransition
 
     public LibTransition() {}
 
-    public LibTransition(Transition transition, TransitionChromInfo transitionChromInfo)
+    public LibTransition(Transition transition, TransitionChromInfo transitionChromInfo, Precursor precursor)
     {
-        super(transition, transitionChromInfo);
+        super(transition, transitionChromInfo, precursor);
         setNeutralMass(transition.getNeutralMass());
         setNeutralLossMass(transition.getNeutralLossMass());
         setFragmentOrdinal(transition.getFragmentOrdinal());
-
     }
 
     public long getPrecursorId()

--- a/src/org/labkey/targetedms/parser/AnnotatedEntity.java
+++ b/src/org/labkey/targetedms/parser/AnnotatedEntity.java
@@ -35,4 +35,27 @@ public abstract class AnnotatedEntity<AnnotationType extends AbstractAnnotation>
     {
         _annotations = Collections.unmodifiableList(annotations);
     }
+
+    /** Utility for small molecules to separate adducts from the rest of the formula */
+    protected String extractAdduct(String ionFormula)
+    {
+        if (ionFormula == null || !ionFormula.contains("[") || !ionFormula.endsWith("]"))
+        {
+            throw new IllegalStateException("Invalid ion formula: " + ionFormula);
+        }
+        // Pull out the text between the brackets at the end
+        String adduct = ionFormula.substring(ionFormula.lastIndexOf("[") + 1);
+        return adduct.substring(0, adduct.length() - 1);
+    }
+
+    /** Utilities for small molecules to drop the adducts from the rest of the formula */
+    protected String stripAdduct(String ionFormula)
+    {
+        if (ionFormula == null || !ionFormula.contains("[") || !ionFormula.endsWith("]"))
+        {
+            throw new IllegalStateException("Invalid ion formula: " + ionFormula);
+        }
+        // Pull out the text before the last bracket
+        return ionFormula.substring(0, ionFormula.lastIndexOf("["));
+    }
 }

--- a/src/org/labkey/targetedms/parser/AnnotatedEntity.java
+++ b/src/org/labkey/targetedms/parser/AnnotatedEntity.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.targetedms.parser;
 
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 
@@ -37,9 +38,14 @@ public abstract class AnnotatedEntity<AnnotationType extends AbstractAnnotation>
     }
 
     /** Utility for small molecules to separate adducts from the rest of the formula */
+    @Nullable
     protected String extractAdduct(String ionFormula)
     {
-        if (ionFormula == null || !ionFormula.contains("[") || !ionFormula.endsWith("]"))
+        if (ionFormula == null)
+        {
+            return null;
+        }
+        if (!ionFormula.contains("[") || !ionFormula.endsWith("]"))
         {
             throw new IllegalStateException("Invalid ion formula: " + ionFormula);
         }
@@ -49,9 +55,14 @@ public abstract class AnnotatedEntity<AnnotationType extends AbstractAnnotation>
     }
 
     /** Utilities for small molecules to drop the adducts from the rest of the formula */
+    @Nullable
     protected String stripAdduct(String ionFormula)
     {
-        if (ionFormula == null || !ionFormula.contains("[") || !ionFormula.endsWith("]"))
+        if (ionFormula == null)
+        {
+            return null;
+        }
+        if (!ionFormula.contains("[") || !ionFormula.endsWith("]"))
         {
             throw new IllegalStateException("Invalid ion formula: " + ionFormula);
         }

--- a/src/org/labkey/targetedms/parser/AnnotatedEntity.java
+++ b/src/org/labkey/targetedms/parser/AnnotatedEntity.java
@@ -15,6 +15,8 @@
  */
 package org.labkey.targetedms.parser;
 
+import org.apache.commons.lang3.StringUtils;
+
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
@@ -41,7 +43,7 @@ public abstract class AnnotatedEntity<AnnotationType extends AbstractAnnotation>
     @Nullable
     protected String extractAdduct(String ionFormula)
     {
-        if (ionFormula == null)
+        if (StringUtils.stripToNull(ionFormula) == null)
         {
             return null;
         }
@@ -58,7 +60,7 @@ public abstract class AnnotatedEntity<AnnotationType extends AbstractAnnotation>
     @Nullable
     protected String stripAdduct(String ionFormula)
     {
-        if (ionFormula == null)
+        if (StringUtils.stripToNull(ionFormula) == null)
         {
             return null;
         }

--- a/src/org/labkey/targetedms/parser/MoleculePrecursor.java
+++ b/src/org/labkey/targetedms/parser/MoleculePrecursor.java
@@ -71,6 +71,17 @@ public class MoleculePrecursor extends GeneralPrecursor<MoleculeTransition>
         _massAverage = massAverage;
     }
 
+    public String getAdduct()
+    {
+        if (_ionFormula == null || !_ionFormula.contains("[") || !_ionFormula.endsWith("]"))
+        {
+            throw new IllegalStateException("Invalid ion formula: " + _ionFormula);
+        }
+        // Pull out the text between the brackets at the end
+        String adduct = _ionFormula.substring(_ionFormula.lastIndexOf("[") + 1);
+        return adduct.substring(0, adduct.length() - 1);
+    }
+
     @Override
     public String toString()
     {

--- a/src/org/labkey/targetedms/parser/MoleculePrecursor.java
+++ b/src/org/labkey/targetedms/parser/MoleculePrecursor.java
@@ -73,13 +73,7 @@ public class MoleculePrecursor extends GeneralPrecursor<MoleculeTransition>
 
     public String getAdduct()
     {
-        if (_ionFormula == null || !_ionFormula.contains("[") || !_ionFormula.endsWith("]"))
-        {
-            throw new IllegalStateException("Invalid ion formula: " + _ionFormula);
-        }
-        // Pull out the text between the brackets at the end
-        String adduct = _ionFormula.substring(_ionFormula.lastIndexOf("[") + 1);
-        return adduct.substring(0, adduct.length() - 1);
+        return extractAdduct(_ionFormula);
     }
 
     @Override

--- a/src/org/labkey/targetedms/parser/MoleculeTransition.java
+++ b/src/org/labkey/targetedms/parser/MoleculeTransition.java
@@ -57,6 +57,16 @@ public class MoleculeTransition extends GeneralTransition
         _ionFormula = ionFormula;
     }
 
+    public String getAdduct()
+    {
+        return extractAdduct(_ionFormula);
+    }
+
+    public String getChemicalFormula()
+    {
+        return stripAdduct(_ionFormula);
+    }
+
     public String getCustomIonName()
     {
         return _customIonName;

--- a/src/org/labkey/targetedms/parser/PrecursorChromInfo.java
+++ b/src/org/labkey/targetedms/parser/PrecursorChromInfo.java
@@ -67,9 +67,6 @@ public class PrecursorChromInfo extends AbstractChromInfo
     private int _numTransitions;
 
     private Double _ccs;
-    private Double _driftTimeMs1;
-    private Double _driftTimeFragment;
-    private Double _driftTimeWindow;
     private Double _ionMobilityMs1;
     private Double _ionMobilityFragment;
     private Double _ionMobilityWindow;
@@ -309,36 +306,6 @@ public class PrecursorChromInfo extends AbstractChromInfo
     public void setCcs(Double ccs)
     {
         _ccs = ccs;
-    }
-
-    public Double getDriftTimeMs1()
-    {
-        return _driftTimeMs1;
-    }
-
-    public void setDriftTimeMs1(Double driftTimeMs1)
-    {
-        _driftTimeMs1 = driftTimeMs1;
-    }
-
-    public Double getDriftTimeFragment()
-    {
-        return _driftTimeFragment;
-    }
-
-    public void setDriftTimeFragment(Double driftTimeFragment)
-    {
-        _driftTimeFragment = driftTimeFragment;
-    }
-
-    public Double getDriftTimeWindow()
-    {
-        return _driftTimeWindow;
-    }
-
-    public void setDriftTimeWindow(Double driftTimeWindow)
-    {
-        _driftTimeWindow = driftTimeWindow;
     }
 
     public Double getIonMobilityMs1()

--- a/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
+++ b/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
@@ -2195,13 +2195,26 @@ public class SkylineDocumentParser implements AutoCloseable
         chromInfo.setQvalue(XmlUtil.readDoubleAttribute(reader, "qvalue"));
         chromInfo.setZscore(XmlUtil.readDoubleAttribute(reader, "zscore"));
         chromInfo.setCcs(XmlUtil.readDoubleAttribute(reader, "ccs"));
-        chromInfo.setDriftTimeMs1(XmlUtil.readDoubleAttribute(reader, "drift_time_ms1"));
-        chromInfo.setDriftTimeFragment(XmlUtil.readDoubleAttribute(reader, "drift_time_fragment"));
-        chromInfo.setDriftTimeWindow(XmlUtil.readDoubleAttribute(reader, "drift_time_window"));
-        chromInfo.setIonMobilityMs1(XmlUtil.readDoubleAttribute(reader, "ion_mobility_ms1"));
-        chromInfo.setIonMobilityFragment(XmlUtil.readDoubleAttribute(reader, "ion_mobility_fragment"));
-        chromInfo.setIonMobilityWindow(XmlUtil.readDoubleAttribute(reader, "ion_mobility_window"));
-        chromInfo.setIonMobilityType(XmlUtil.readAttribute(reader, "ion_mobility_type"));
+
+        // Support old Skyline documents that used "drift time" instead of "ion mobility"
+        Double driftTimeMs1 = XmlUtil.readDoubleAttribute(reader, "drift_time_ms1");
+        Double driftTimeWindow = XmlUtil.readDoubleAttribute(reader, "drift_time_window");
+        Double driftTimeFragment = XmlUtil.readDoubleAttribute(reader, "drift_time_fragment");
+
+        if (driftTimeMs1 != null || driftTimeWindow != null || driftTimeFragment != null)
+        {
+            chromInfo.setIonMobilityMs1(driftTimeMs1);
+            chromInfo.setIonMobilityMs1(driftTimeFragment);
+            chromInfo.setIonMobilityWindow(driftTimeWindow);
+            chromInfo.setIonMobilityType("drift_time_ms");
+        }
+        else
+        {
+            chromInfo.setIonMobilityMs1(XmlUtil.readDoubleAttribute(reader, "ion_mobility_ms1"));
+            chromInfo.setIonMobilityFragment(XmlUtil.readDoubleAttribute(reader, "ion_mobility_fragment"));
+            chromInfo.setIonMobilityWindow(XmlUtil.readDoubleAttribute(reader, "ion_mobility_window"));
+            chromInfo.setIonMobilityType(XmlUtil.readAttribute(reader, "ion_mobility_type"));
+        }
 
         while(reader.hasNext())
         {
@@ -2608,11 +2621,23 @@ public class SkylineDocumentParser implements AutoCloseable
         chromInfo.setUserSet(XmlUtil.readAttribute(reader, "user_set"));
         chromInfo.setPointsAcrossPeak(XmlUtil.readIntegerAttribute(reader, "points_across", null));
         chromInfo.setCcs(XmlUtil.readDoubleAttribute(reader, "ccs"));
-        chromInfo.setDriftTime(XmlUtil.readDoubleAttribute(reader, "drift_time"));
-        chromInfo.setDriftTimeWindow(XmlUtil.readDoubleAttribute(reader, "drift_time_window"));
-        chromInfo.setIonMobility(XmlUtil.readDoubleAttribute(reader, "ion_mobility"));
-        chromInfo.setIonMobilityWindow(XmlUtil.readDoubleAttribute(reader, "ion_mobility_window"));
-        chromInfo.setIonMobilityType(XmlUtil.readAttribute(reader, "ion_mobility_type"));
+
+        Double driftTime = XmlUtil.readDoubleAttribute(reader, "drift_time");
+        Double driftTimeWindow = XmlUtil.readDoubleAttribute(reader, "drift_time_window");
+        if (driftTime != null || driftTimeWindow != null)
+        {
+            // Support old Skyline documents
+            chromInfo.setIonMobility(driftTime);
+            chromInfo.setIonMobilityWindow(driftTimeWindow);
+            chromInfo.setIonMobilityType("drift_time_ms");
+        }
+        else
+        {
+            chromInfo.setIonMobility(XmlUtil.readDoubleAttribute(reader, "ion_mobility"));
+            chromInfo.setIonMobilityWindow(XmlUtil.readDoubleAttribute(reader, "ion_mobility_window"));
+            chromInfo.setIonMobilityType(XmlUtil.readAttribute(reader, "ion_mobility_type"));
+        }
+
         chromInfo.setRank(XmlUtil.readIntegerAttribute(reader, "rank"));
         chromInfo.setRankByLevel(XmlUtil.readIntegerAttribute(reader, "rank_by_level"));
         chromInfo.setForcedIntegration(XmlUtil.readBooleanAttribute(reader, "forced_integration"));
@@ -2683,9 +2708,7 @@ public class SkylineDocumentParser implements AutoCloseable
             chromInfo.setArea((double) transitionPeak.getArea());
             chromInfo.setBackground((double) transitionPeak.getBackgroundArea());
             chromInfo.setHeight((double) transitionPeak.getHeight());
-            if (null != transitionPeak.getMassError()) {
-                chromInfo.setMassErrorPPM((double) transitionPeak.getMassError().getValue());
-            }
+            chromInfo.setMassErrorPPM((double) transitionPeak.getMassError().getValue());
             chromInfo.setFwhm((double) transitionPeak.getFwhm());
             chromInfo.setFwhmDegenerate(transitionPeak.getIsFwhmDegenerate());
             chromInfo.setTruncated(fromOptional(transitionPeak.getTruncated()));
@@ -2693,13 +2716,11 @@ public class SkylineDocumentParser implements AutoCloseable
             chromInfo.setPeakRank(transitionPeak.getRank());
             chromInfo.setUserSet(userSetToString(transitionPeak.getUserSet()));
             chromInfo.setPointsAcrossPeak(fromOptional(transitionPeak.getPointsAcrossPeak()));
-            if (null != transitionPeak.getAnnotations()) {
-                if (!StringUtils.isEmpty(transitionPeak.getAnnotations().getNote())) {
-                    chromInfo.setNote(transitionPeak.getAnnotations().getNote());
-                }
-                for (SkylineDocument.SkylineDocumentProto.AnnotationValue annotationValue : transitionPeak.getAnnotations().getValuesList()) {
-                    annotations.add(readAnnotationValue(annotationValue, new TransitionChromInfoAnnotation()));
-                }
+            if (!StringUtils.isEmpty(transitionPeak.getAnnotations().getNote())) {
+                chromInfo.setNote(transitionPeak.getAnnotations().getNote());
+            }
+            for (SkylineDocument.SkylineDocumentProto.AnnotationValue annotationValue : transitionPeak.getAnnotations().getValuesList()) {
+                annotations.add(readAnnotationValue(annotationValue, new TransitionChromInfoAnnotation()));
             }
 
             for(String missingAnotName: _dataSettings.getMissingBooleanAnnotations(annotations,
@@ -2737,15 +2758,13 @@ public class SkylineDocumentParser implements AutoCloseable
     }
 
     private static Boolean fromOptional(SkylineDocument.SkylineDocumentProto.OptionalBool optionalBool) {
-        switch (optionalBool) {
-            case OPTIONAL_BOOL_MISSING:
-                return null;
-            case OPTIONAL_BOOL_TRUE:
-                return true;
-            case OPTIONAL_BOOL_FALSE:
-                return false;
-        }
-        return null;
+        return switch (optionalBool)
+                {
+                    case OPTIONAL_BOOL_MISSING -> null;
+                    case OPTIONAL_BOOL_TRUE -> true;
+                    case OPTIONAL_BOOL_FALSE -> false;
+                    default -> null;
+                };
     }
 
     private static Integer fromOptional(SkylineDocument.SkylineDocumentProto.OptionalInt optionalInt) {
@@ -2765,53 +2784,40 @@ public class SkylineDocumentParser implements AutoCloseable
     }
 
     private static String peakIdentificationToString(SkylineDocument.SkylineDocumentProto.PeakIdentification peakIdentification) {
-        switch (peakIdentification) {
-            case PEAK_IDENTIFICATION_ALIGNED:
-                return "ALIGNED";
-            case PEAK_IDENTIFICATION_TRUE:
-                return "TRUE";
-            case PEAK_IDENTIFICATION_FALSE:
-                return "FALSE";
-        }
-        return null;
+        return switch (peakIdentification)
+                {
+                    case PEAK_IDENTIFICATION_ALIGNED -> "ALIGNED";
+                    case PEAK_IDENTIFICATION_TRUE -> "TRUE";
+                    case PEAK_IDENTIFICATION_FALSE -> "FALSE";
+                    default -> null;
+                };
     }
 
     private static String ionTypeToString(SkylineDocument.SkylineDocumentProto.IonType ionType) {
-        switch (ionType) {
-            case ION_TYPE_a:
-                return "a";
-            case ION_TYPE_b:
-                return "b";
-            case ION_TYPE_c:
-                return "c";
-            case ION_TYPE_x:
-                return "x";
-            case ION_TYPE_y:
-                return "y";
-            case ION_TYPE_z:
-                return "z";
-            case ION_TYPE_precursor:
-                return "precursor";
-            case ION_TYPE_custom:
-                return "custom";
-        }
-        return null;
+        return switch (ionType)
+                {
+                    case ION_TYPE_a -> "a";
+                    case ION_TYPE_b -> "b";
+                    case ION_TYPE_c -> "c";
+                    case ION_TYPE_x -> "x";
+                    case ION_TYPE_y -> "y";
+                    case ION_TYPE_z -> "z";
+                    case ION_TYPE_precursor -> "precursor";
+                    case ION_TYPE_custom -> "custom";
+                    default -> null;
+                };
     }
 
     private static String userSetToString(SkylineDocument.SkylineDocumentProto.UserSet userSet) {
-        switch (userSet) {
-            case USER_SET_TRUE:
-                return "TRUE";
-            case USER_SET_FALSE:
-                return "FALSE";
-            case USER_SET_IMPORTED:
-                return "IMPORTED";
-            case USER_SET_REINTEGRATED:
-                return "REINTEGRATED";
-            case USER_SET_MATCHED:
-                return "MATCHED";
-        }
-        return null;
+        return switch (userSet)
+                {
+                    case USER_SET_TRUE -> "TRUE";
+                    case USER_SET_FALSE -> "FALSE";
+                    case USER_SET_IMPORTED -> "IMPORTED";
+                    case USER_SET_REINTEGRATED -> "REINTEGRATED";
+                    case USER_SET_MATCHED -> "MATCHED";
+                    default -> null;
+                };
     }
 
     private int findEntry(SignedMz precursorMz, double tolerance, ChromGroupHeaderInfo[] chromatograms, int left, int right)

--- a/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
+++ b/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
@@ -2204,7 +2204,7 @@ public class SkylineDocumentParser implements AutoCloseable
         if (driftTimeMs1 != null || driftTimeWindow != null || driftTimeFragment != null)
         {
             chromInfo.setIonMobilityMs1(driftTimeMs1);
-            chromInfo.setIonMobilityMs1(driftTimeFragment);
+            chromInfo.setIonMobilityFragment(driftTimeFragment);
             chromInfo.setIonMobilityWindow(driftTimeWindow);
             chromInfo.setIonMobilityType("drift_time_ms");
         }

--- a/src/org/labkey/targetedms/parser/TransitionChromInfo.java
+++ b/src/org/labkey/targetedms/parser/TransitionChromInfo.java
@@ -43,8 +43,6 @@ public class TransitionChromInfo extends ChromInfo<TransitionChromInfoAnnotation
     private int _chromatogramIndex;
     private Integer _pointsAcrossPeak;
     private Double _ccs;
-    private Double _driftTime;
-    private Double _driftTimeWindow;
     private Double _ionMobility;
     private Double _ionMobilityWindow;
     private String _ionMobilityType;
@@ -255,26 +253,6 @@ public class TransitionChromInfo extends ChromInfo<TransitionChromInfoAnnotation
     public void setCcs(Double ccs)
     {
         _ccs = ccs;
-    }
-
-    public Double getDriftTime()
-    {
-        return _driftTime;
-    }
-
-    public void setDriftTime(Double driftTime)
-    {
-        _driftTime = driftTime;
-    }
-
-    public Double getDriftTimeWindow()
-    {
-        return _driftTimeWindow;
-    }
-
-    public void setDriftTimeWindow(Double driftTimeWindow)
-    {
-        _driftTimeWindow = driftTimeWindow;
     }
 
     public Double getIonMobility()


### PR DESCRIPTION
#### Rationale
We can freely improve naming in the small molecule chromatogram schema for CLIB files since they're not in use in the wild yet. Also, we can consolidate the DriftTimeXXX columns on PrecursorChromInfo and TransitionChromInfo into the newer IonMobilityXXX columns

#### Changes
* Rename from CustomIonName->MoleculeName and IonFormula->ChemicalFormula
* Extract Adduct part of MoleculePrecursor formula
* Migrate any existing Panorama DriftTimeXXX values into IonMobilityXXX columns and drop the old ones