### PR TITLE
Bump schema version to get new script to run

### DIFF
--- a/resources/schemas/dbscripts/postgresql/targetedms-21.001-21.002.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-21.001-21.002.sql
@@ -8,7 +8,9 @@ UPDATE targetedms.PrecursorChromInfo SET IonMobilityFragment = DriftTimeFragment
 UPDATE targetedms.PrecursorChromInfo SET IonMobilityWindow = DriftTimeWindow
     WHERE IonMobilityWindow IS NULL AND DriftTimeWindow IS NOT NULL;
 
-ALTER TABLE targetedms.PrecursorChromInfo DROP COLUMN DriftTimeMS1, DriftTimeFragment, DriftTimeWindow;
+ALTER TABLE targetedms.PrecursorChromInfo DROP COLUMN DriftTimeMS1,
+                                          DROP COLUMN DriftTimeFragment,
+                                          DROP COLUMN DriftTimeWindow;
 
 UPDATE targetedms.TransitionChromInfo SET IonMobilityType = 'drift_time_ms'
     WHERE IonMobilityType IS NULL AND (DriftTime IS NOT NULL OR DriftTimeWindow IS NOT NULL);
@@ -17,4 +19,5 @@ UPDATE targetedms.TransitionChromInfo SET IonMobility = DriftTime
 UPDATE targetedms.TransitionChromInfo SET IonMobilityWindow = DriftTimeWindow
     WHERE IonMobilityWindow IS NULL AND DriftTimeWindow IS NOT NULL;
 
-ALTER TABLE targetedms.TransitionChromInfo DROP COLUMN DriftTime, DriftTimeWindow;
+ALTER TABLE targetedms.TransitionChromInfo DROP COLUMN DriftTime,
+                                           DROP COLUMN DriftTimeWindow;

--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -214,7 +214,7 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
     @Override
     public Double getSchemaVersion()
     {
-        return 21.001;
+        return 21.002;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
We only run scripts when we bump the expected module. Previous PR worked fine because this is removing old columns.

#### Related Pull Requests
* https://github.com/LabKey/targetedms/pull/332

#### Changes
* Bump version to match already merged script and XML changes