### PR TITLE
Item 8387: Reduce memory usage when importing Skyline files

### DIFF
--- a/src/org/labkey/targetedms/parser/SkylineBinaryParser.java
+++ b/src/org/labkey/targetedms/parser/SkylineBinaryParser.java
@@ -254,8 +254,8 @@ public class SkylineBinaryParser
         }
 
         var start = header.getStartTransitionIndex();
-        var end = start + header.getNumTransitions();
-        var numChromTransitions = end - start + 1;
+        var numChromTransitions = header.getNumTransitions();
+        var end = start + numChromTransitions;
         var chromTransitionPosition = _cacheHeaderStruct.getLocationTransitions() + ((long) _cacheHeaderStruct.getChromTransitionSize() * start);
         ChromTransition[] chromTransitions;
 

--- a/src/org/labkey/targetedms/parser/skyd/CacheHeaderStruct.java
+++ b/src/org/labkey/targetedms/parser/skyd/CacheHeaderStruct.java
@@ -146,6 +146,11 @@ public class CacheHeaderStruct
         return 108;
     }
 
+    public int getChromTransitionSize()
+    {
+        return chromTransitionSize;
+    }
+
     public static StructSerializer<CacheHeaderStruct> getStructSerializer(CacheFormatVersion cacheFormatVersion) {
         return new StructSerializer<CacheHeaderStruct>(
                 CacheHeaderStruct.class, getStructSize(CacheFormatVersion.CURRENT), getStructSize(cacheFormatVersion))

--- a/src/org/labkey/targetedms/parser/skyd/ChromGroupHeaderInfo.java
+++ b/src/org/labkey/targetedms/parser/skyd/ChromGroupHeaderInfo.java
@@ -230,14 +230,13 @@ public class ChromGroupHeaderInfo
     @Nullable
     public Float getStartTime()
     {
-        //
-        return startTime;
+        return startTime == Float.MIN_VALUE ? null : startTime;
     }
 
     @Nullable
     public Float getEndTime()
     {
-        return endTime;
+        return endTime == Float.MIN_VALUE ? null : endTime;
     }
 
     public SignedMz getPrecursor() {

--- a/src/org/labkey/targetedms/parser/skyd/ChromGroupHeaderInfo.java
+++ b/src/org/labkey/targetedms/parser/skyd/ChromGroupHeaderInfo.java
@@ -45,21 +45,23 @@ public class ChromGroupHeaderInfo
     private double precursor;
     private long locationPoints;
     private int uncompressedSize;
-    private Float startTime;
-    private Float endTime;
+    private float startTime;
+    private float endTime;
     private float collisionalCrossSection;
 
     public ChromGroupHeaderInfo(CacheFormatVersion cacheFormatVersion, LittleEndianInput dataInputStream)
     {
+        // For reducing memory usage, following assignments to the above instance variables are commented out because of
+        // absence of accessors and reading from inputStream is left to correctly advance the size of the fields
         if (cacheFormatVersion.compareTo(CacheFormatVersion.Five) < 0) {
             precursor = Float.intBitsToFloat(dataInputStream.readInt());
             fileIndex = checkUShort(dataInputStream.readInt());
             numTransitions = checkUShort(dataInputStream.readInt());
             startTransitionIndex = dataInputStream.readInt();
-            numPeaks = checkByte(dataInputStream.readInt());
-            startPeakIndex = dataInputStream.readInt();
-            int maxPeakIndexInt = dataInputStream.readInt();
-            maxPeakIndex = maxPeakIndexInt == -1 ? (byte) 0xff : checkByte(maxPeakIndexInt);
+            /*numPeaks =*/ checkByte(dataInputStream.readInt());
+            /*startPeakIndex =*/ dataInputStream.readInt();
+            /*int maxPeakIndexInt = */dataInputStream.readInt();
+            /*maxPeakIndex = maxPeakIndexInt == -1 ? (byte) 0xff : checkByte(maxPeakIndexInt);*/
             numPoints = dataInputStream.readInt();
             compressedSize = dataInputStream.readInt();
             dataInputStream.readInt(); // ignore these four bytes
@@ -67,30 +69,32 @@ public class ChromGroupHeaderInfo
         } else {
             textIdIndex = dataInputStream.readInt();
             startTransitionIndex = dataInputStream.readInt();
-            startPeakIndex = dataInputStream.readInt();
-            startScoreIndex = dataInputStream.readInt();
+            /*startPeakIndex =*/ dataInputStream.readInt();
+            /*startScoreIndex =*/ dataInputStream.readInt();
             numPoints = dataInputStream.readInt();
             compressedSize = dataInputStream.readInt();
             flagBits = dataInputStream.readShort();
             fileIndex = dataInputStream.readShort();
             textIdLen = dataInputStream.readShort();
             numTransitions = dataInputStream.readShort();
-            numPeaks = dataInputStream.readByte();
-            maxPeakIndex = dataInputStream.readByte();
-            isProcessedScans = dataInputStream.readByte();
-            align1 = dataInputStream.readByte();
-            statusId = dataInputStream.readShort();
-            statusRank = dataInputStream.readShort();
+            /*numPeaks =*/ dataInputStream.readByte();
+            /*maxPeakIndex =*/ dataInputStream.readByte();
+            /*isProcessedScans =*/ dataInputStream.readByte();
+            /*align1 =*/ dataInputStream.readByte();
+            /*statusId =*/ dataInputStream.readShort();
+            /*statusRank =*/ dataInputStream.readShort();
             precursor = dataInputStream.readDouble();
             locationPoints = dataInputStream.readLong();
         }
         if (cacheFormatVersion.compareTo(CacheFormatVersion.Eleven) < 0) {
             uncompressedSize = -1;
+            startTime = Float.MIN_VALUE;
+            endTime = Float.MIN_VALUE;
         } else {
             uncompressedSize = dataInputStream.readInt();
             startTime = Float.intBitsToFloat(dataInputStream.readInt());
             endTime = Float.intBitsToFloat(dataInputStream.readInt());
-            collisionalCrossSection = Float.intBitsToFloat(dataInputStream.readInt());
+            /*collisionalCrossSection =*/ Float.intBitsToFloat(dataInputStream.readInt());
         }
     }
 
@@ -149,6 +153,9 @@ public class ChromGroupHeaderInfo
         return startTransitionIndex;
     }
 
+    // leaving commented out as these getters are not being accessed and for future usage
+/*
+
     public int getStartPeakIndex()
     {
         return startPeakIndex;
@@ -158,6 +165,7 @@ public class ChromGroupHeaderInfo
     {
         return startScoreIndex;
     }
+*/
 
     public int getNumPoints()
     {
@@ -178,11 +186,13 @@ public class ChromGroupHeaderInfo
     {
         return numTransitions;
     }
+/*
 
     public byte getNumPeaks()
     {
         return numPeaks;
     }
+*/
 
     public long getLocationPoints()
     {
@@ -209,15 +219,18 @@ public class ChromGroupHeaderInfo
         return sizeTotal;
 
     }
+/*
 
     public byte getMaxPeakIndex()
     {
         return maxPeakIndex;
     }
+*/
 
     @Nullable
     public Float getStartTime()
     {
+        //
         return startTime;
     }
 
@@ -247,9 +260,6 @@ public class ChromGroupHeaderInfo
     }
 
     public boolean excludesTime(double time) {
-        if (null == startTime || null == endTime) {
-            return false;
-        }
         return startTime > time || endTime < time;
     }
 

--- a/src/org/labkey/targetedms/parser/skyd/ChromGroupHeaderInfo.java
+++ b/src/org/labkey/targetedms/parser/skyd/ChromGroupHeaderInfo.java
@@ -26,33 +26,36 @@ import java.util.EnumSet;
  */
 public class ChromGroupHeaderInfo
 {
+    // using this in the constructor for floats to avoid using non-primitive Float objects to reduce memory footprint
+    private static final float NULL_PLACEHOLDER = Float.NEGATIVE_INFINITY;
+
+    // For reducing memory usage, following instance variables are commented out because of the
+    // absence of accessors and reading from inputStream is left to correctly advance the size of the fields
     private int textIdIndex;
     private int startTransitionIndex;
-    private int startPeakIndex;
-    private int startScoreIndex;
+//    private int startPeakIndex;
+//    private int startScoreIndex;
     private int numPoints;
     private int compressedSize;
     private short flagBits;
     private short fileIndex;
     private short textIdLen;
     private short numTransitions;
-    private byte numPeaks;
-    private byte maxPeakIndex;
-    private byte isProcessedScans;
-    private byte align1;
-    private short statusId;
-    private short statusRank;
+//    private byte numPeaks;
+//    private byte maxPeakIndex;
+//    private byte isProcessedScans;
+//    private byte align1;
+//    private short statusId;
+//    private short statusRank;
     private double precursor;
     private long locationPoints;
     private int uncompressedSize;
     private float startTime;
     private float endTime;
-    private float collisionalCrossSection;
+//    private float collisionalCrossSection;
 
     public ChromGroupHeaderInfo(CacheFormatVersion cacheFormatVersion, LittleEndianInput dataInputStream)
     {
-        // For reducing memory usage, following assignments to the above instance variables are commented out because of
-        // absence of accessors and reading from inputStream is left to correctly advance the size of the fields
         if (cacheFormatVersion.compareTo(CacheFormatVersion.Five) < 0) {
             precursor = Float.intBitsToFloat(dataInputStream.readInt());
             fileIndex = checkUShort(dataInputStream.readInt());
@@ -88,8 +91,8 @@ public class ChromGroupHeaderInfo
         }
         if (cacheFormatVersion.compareTo(CacheFormatVersion.Eleven) < 0) {
             uncompressedSize = -1;
-            startTime = Float.MIN_VALUE;
-            endTime = Float.MIN_VALUE;
+            startTime = NULL_PLACEHOLDER;
+            endTime = NULL_PLACEHOLDER;
         } else {
             uncompressedSize = dataInputStream.readInt();
             startTime = Float.intBitsToFloat(dataInputStream.readInt());
@@ -230,13 +233,13 @@ public class ChromGroupHeaderInfo
     @Nullable
     public Float getStartTime()
     {
-        return startTime == Float.MIN_VALUE ? null : startTime;
+        return startTime == NULL_PLACEHOLDER ? null : startTime;
     }
 
     @Nullable
     public Float getEndTime()
     {
-        return endTime == Float.MIN_VALUE ? null : endTime;
+        return endTime == NULL_PLACEHOLDER ? null : endTime;
     }
 
     public SignedMz getPrecursor() {
@@ -259,6 +262,9 @@ public class ChromGroupHeaderInfo
     }
 
     public boolean excludesTime(double time) {
+        if (NULL_PLACEHOLDER == startTime || NULL_PLACEHOLDER == endTime) {
+            return false;
+        }
         return startTime > time || endTime < time;
     }
 

--- a/src/org/labkey/targetedms/parser/skyd/ChromTransition.java
+++ b/src/org/labkey/targetedms/parser/skyd/ChromTransition.java
@@ -23,7 +23,11 @@ import org.labkey.targetedms.parser.SignedMz;
 public class ChromTransition
 {
     double _product;
+    private float _extractionWidth;
+    private float _driftTime;
+    private float _driftTimeExtractionWidth;
     private short _flagBits;
+    private short _align1;
 
     public ChromTransition(CacheFormatVersion cacheFormatVersion, LittleEndianInput dataInputStream)
     {
@@ -31,10 +35,16 @@ public class ChromTransition
             _product = Float.intBitsToFloat(dataInputStream.readInt());
         } else if (cacheFormatVersion.compareTo(CacheFormatVersion.Six) <= 0) {
             _product = dataInputStream.readDouble();
+            _extractionWidth = Float.intBitsToFloat(dataInputStream.readInt());
             _flagBits = dataInputStream.readShort();
+            _align1 = dataInputStream.readShort();
         } else {
             _product = dataInputStream.readDouble();
+            _extractionWidth = Float.intBitsToFloat(dataInputStream.readInt());
+            _driftTime = Float.intBitsToFloat(dataInputStream.readInt());
+            _driftTimeExtractionWidth = Float.intBitsToFloat(dataInputStream.readInt());
             _flagBits = dataInputStream.readShort();
+            _align1 = dataInputStream.readShort();
         }
     }
 

--- a/src/org/labkey/targetedms/parser/skyd/ChromTransition.java
+++ b/src/org/labkey/targetedms/parser/skyd/ChromTransition.java
@@ -23,11 +23,7 @@ import org.labkey.targetedms.parser.SignedMz;
 public class ChromTransition
 {
     double _product;
-    private float _extractionWidth;
-    private float _driftTime;
-    private float _driftTimeExtractionWidth;
     private short _flagBits;
-    private short _align1;
 
     public ChromTransition(CacheFormatVersion cacheFormatVersion, LittleEndianInput dataInputStream)
     {
@@ -35,16 +31,10 @@ public class ChromTransition
             _product = Float.intBitsToFloat(dataInputStream.readInt());
         } else if (cacheFormatVersion.compareTo(CacheFormatVersion.Six) <= 0) {
             _product = dataInputStream.readDouble();
-            _extractionWidth = Float.intBitsToFloat(dataInputStream.readInt());
             _flagBits = dataInputStream.readShort();
-            _align1 = dataInputStream.readShort();
         } else {
             _product = dataInputStream.readDouble();
-            _extractionWidth = Float.intBitsToFloat(dataInputStream.readInt());
-            _driftTime = Float.intBitsToFloat(dataInputStream.readInt());
-            _driftTimeExtractionWidth = Float.intBitsToFloat(dataInputStream.readInt());
             _flagBits = dataInputStream.readShort();
-            _align1 = dataInputStream.readShort();
         }
     }
 


### PR DESCRIPTION
#### Rationale
During import of large Skyline files into Panorama, much of the document is held in memory which is causing OutOfMemoryErrors for some really large documents. This PR aims to optimize the memory usage during import process.

#### Changes
* Optimize ChromTransition readings
* Reduce in-memory footprint of ChromGroupHeaderInfo
