### PR TITLE
Progress towards 5x5 reporting in chromatogram libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ dependencies
    external "org.xerial:sqlite-jdbc:3.7.2"
    external "org.apache.commons:commons-math3:${commonsMath3Version}"
    external "org.jfree:jcommon:1.0.17"
+   external "org.jfree:org.jfree.svg:4.2"
    implementation "org.apache.httpcomponents:httpmime:${httpmimeVersion}"
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath:  BuildUtils.getCommonAssayModuleProjectPath(project.gradle, "ms2"), depProjectConfig: "apiJarFile")
    BuildUtils.addLabKeyDependency(project: project, config: "jspImplementation", depProjectPath: BuildUtils.getCommonAssayModuleProjectPath(project.gradle, "ms2"), depProjectConfig: "apiJarFile")

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -1425,7 +1425,7 @@ public class TargetedMSController extends SpringActionController
             {
                 List<Map<String, Object>> series = new ArrayList<>();
                 XYPlot plot = chart.getXYPlot();
-                XYDataset dataset = chart.getXYPlot().getDataset();
+                XYDataset dataset = plot.getDataset();
                 for (int i = 0; i < dataset.getSeriesCount(); i++)
                 {
                     Map<String, Object> info = new HashMap<>();

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -24,17 +24,23 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jfree.chart.ChartColor;
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.ChartUtilities;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.axis.NumberAxis;
+import org.jfree.chart.plot.CategoryPlot;
 import org.jfree.chart.plot.PlotOrientation;
+import org.jfree.chart.plot.XYPlot;
 import org.jfree.chart.title.TextTitle;
 import org.jfree.data.category.DefaultCategoryDataset;
+import org.jfree.data.xy.XYDataset;
+import org.jfree.svg.SVGGraphics2D;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
+import org.labkey.api.action.ApiJsonWriter;
 import org.labkey.api.action.ApiResponse;
 import org.labkey.api.action.ApiSimpleResponse;
 import org.labkey.api.action.ApiUsageException;
@@ -148,6 +154,7 @@ import org.labkey.api.view.ViewContext;
 import org.labkey.api.view.WebPartView;
 import org.labkey.api.view.template.ClientDependency;
 import org.labkey.api.view.template.PageConfig;
+import org.labkey.api.visualization.VisualizationService;
 import org.labkey.targetedms.chart.ChromatogramChartMakerFactory;
 import org.labkey.targetedms.chart.ComparisonChartMaker;
 import org.labkey.targetedms.chromlib.ChromatogramLibraryUtils;
@@ -1365,7 +1372,7 @@ public class TargetedMSController extends SpringActionController
                 throw new NotFoundException("No Precursor or MoleculePrecursor found in this folder for id: " + pci.getPrecursorId());
             }
 
-            writePNG(form, response, chart);
+            writeChart(form, response, chart);
         }
     }
 
@@ -1386,6 +1393,7 @@ public class TargetedMSController extends SpringActionController
             factory.setSyncRt(form.isSyncX());
             factory.setSplitGraph(form.isSplitGraph());
             factory.setShowOptimizationPeaks(form.isShowOptimizationPeaks());
+            factory.setLegend(form.isLegend());
 
             JFreeChart chart;
             if (PrecursorManager.getPrecursor(getContainer(), pChromInfo.getPrecursorId(), getUser()) != null)
@@ -1401,35 +1409,108 @@ public class TargetedMSController extends SpringActionController
                 throw new NotFoundException("No Precursor or MoleculePrecursor found in this folder for id: " + pChromInfo.getPrecursorId());
             }
 
-            writePNG(form, response, chart);
+            writeChart(form, response, chart);
         }
     }
 
-    private void writePNG(AbstractChartForm form, HttpServletResponse response, JFreeChart chart)
-            throws IOException
+    private void writeChart(AbstractChartForm form, HttpServletResponse response, JFreeChart chart)
+            throws Exception
     {
-        response.setContentType("image/png");
-
-        if(!form.hasDpi())
+        if ("json".equals(form.getFormat()))
         {
-            ChartUtilities.writeChartAsPNG(response.getOutputStream(), chart, form.getChartWidth(), form.getChartHeight());
+            Map<String, Object> jsonPayload = new HashMap<>();
+
+            String xLabel = null;
+            if (chart.getPlot() instanceof XYPlot)
+            {
+                List<Map<String, Object>> series = new ArrayList<>();
+                XYPlot plot = chart.getXYPlot();
+                XYDataset dataset = chart.getXYPlot().getDataset();
+                for (int i = 0; i < dataset.getSeriesCount(); i++)
+                {
+                    Map<String, Object> info = new HashMap<>();
+                    info.put("label", dataset.getSeriesKey(i));
+                    ChartColor color = (ChartColor) plot.getRenderer().getSeriesPaint(i);
+                    info.put("color", String.format("%02X%02X%02X", color.getRed(), color.getGreen(), color.getBlue()));
+                    series.add(info);
+                }
+                jsonPayload.put("series", series);
+
+                if (plot.getDomainAxisCount() > 0)
+                {
+                    xLabel = plot.getDomainAxis().getLabel();
+                    plot.getDomainAxis().setLabel(null);
+                }
+            }
+            if (chart.getPlot() instanceof CategoryPlot)
+            {
+                CategoryPlot plot = chart.getCategoryPlot();
+                if (plot.getDomainAxisCount() > 0)
+                {
+                    xLabel = plot.getDomainAxis().getLabel();
+                    plot.getDomainAxis().setLabel(null);
+                }
+            }
+            if (xLabel != null)
+            {
+                jsonPayload.put("xLabel", xLabel);
+            }
+            jsonPayload.put("title", chart.getTitle().getText());
+            // Null out the title so that it's not part of the SVG and let the client render it as text via the DOM
+            chart.setTitle((String)null);
+            jsonPayload.put("svg", renderSVG(form, chart));
+            new ApiSimpleResponse(jsonPayload).render(new ApiJsonWriter(response));
+        }
+        else if ("svg".equalsIgnoreCase(form.getFormat()))
+        {
+            response.setContentType("image/svg+xml");
+            response.getWriter().write("<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n");
+            response.getWriter().write(renderSVG(form, chart));
+        }
+        else if ("pdf".equalsIgnoreCase(form.getFormat()))
+        {
+            VisualizationService.get().renderSvgAsPdf(renderSVG(form, chart), "PanoramaPlot.pdf", getViewContext().getResponse());
         }
         else
         {
-            int dpi = form.getDpi();
-            double scaleFactor = (double)dpi/(double)AbstractChartForm.SCREEN_RES;
-            int w = form.getChartWidth();
-            int h = form.getChartHeight();
-            int desiredWidth = (int) (w * scaleFactor);
-            int desiredHeight = (int) (h * scaleFactor);
+            response.setContentType("image/png");
 
-            BufferedImage image = chart.createBufferedImage(desiredWidth, desiredHeight, w, h, null);
+            if ("pngDownload".equalsIgnoreCase(form.getFormat()))
+            {
+                String filename = "PanoramaPlot.png";
+                response.addHeader("Content-Disposition", "attachment; filename=\"" + filename + "\"");
+            }
 
-            PngEncoder encoder = new PngEncoder(image);
-            encoder.setDpi(dpi, dpi);
-            byte[] bytes = encoder.pngEncode();
-            response.getOutputStream().write(bytes);
+            if (!form.hasDpi())
+            {
+                ChartUtilities.writeChartAsPNG(response.getOutputStream(), chart, form.getChartWidth(), form.getChartHeight(), false, 5);
+            }
+            else
+            {
+                int dpi = form.getDpi();
+                double scaleFactor = (double) dpi / (double) AbstractChartForm.SCREEN_RES;
+                int w = form.getChartWidth();
+                int h = form.getChartHeight();
+                int desiredWidth = (int) (w * scaleFactor);
+                int desiredHeight = (int) (h * scaleFactor);
+
+                BufferedImage image = chart.createBufferedImage(desiredWidth, desiredHeight, w, h, null);
+                PngEncoder encoder = new PngEncoder(image);
+                encoder.setDpi(dpi, dpi);
+                encoder.setCompressionLevel(5);
+                byte[] bytes = encoder.pngEncode();
+                response.getOutputStream().write(bytes);
+            }
         }
+    }
+
+    @NotNull
+    private String renderSVG(AbstractChartForm form, JFreeChart chart)
+    {
+        SVGGraphics2D g2 = new SVGGraphics2D(form.getChartWidth(), form.getChartHeight());
+        Rectangle r = new Rectangle(0, 0, form.getChartWidth(), form.getChartHeight());
+        chart.draw(g2, r);
+        return g2.getSVGElement();
     }
 
     @RequiresPermission(ReadPermission.class)
@@ -1464,7 +1545,7 @@ public class TargetedMSController extends SpringActionController
                 throw new NotFoundException("No Peptide or Molecule found in this folder for id: " + gmChromInfo.getGeneralMoleculeId());
             }
 
-            writePNG(form, response, chart);
+            writeChart(form, response, chart);
         }
     }
 
@@ -1529,7 +1610,7 @@ public class TargetedMSController extends SpringActionController
             vbox.addView(gridView);
 
             // Summary charts for the precursor
-            SummaryChartBean summaryChartBean = new SummaryChartBean();
+            SummaryChartBean summaryChartBean = new SummaryChartBean(_run);
             summaryChartBean.setPeptideId(_precursor.getGeneralMoleculeId());
             summaryChartBean.setPrecursorId(_precursor.getId());
             summaryChartBean.setReplicateAnnotationNameList(ReplicateManager.getReplicateAnnotationNamesForRun(_run.getId()));
@@ -1612,7 +1693,7 @@ public class TargetedMSController extends SpringActionController
             gridView.setTitle("Chromatograms");
 
             // Summary charts for the molecule precursor
-            SummaryChartBean summaryChartBean = new SummaryChartBean();
+            SummaryChartBean summaryChartBean = new SummaryChartBean(_run);
             summaryChartBean.setMoleculeId(_precursor.getGeneralMoleculeId());
             summaryChartBean.setMoleculePrecursorId(_precursor.getId());
             summaryChartBean.setReplicateAnnotationNameList(ReplicateManager.getReplicateAnnotationNamesForRun(_run.getId()));
@@ -2178,7 +2259,7 @@ public class TargetedMSController extends SpringActionController
             vbox.addView(chromatogramsBox);
 
             // Summary charts for the peptide
-            SummaryChartBean summaryChartBean = new SummaryChartBean();
+            SummaryChartBean summaryChartBean = new SummaryChartBean(_run);
             summaryChartBean.setPeptideId(peptideId);
             summaryChartBean.setReplicateAnnotationNameList(ReplicateManager.getReplicateAnnotationNamesForRun(_run.getId()));
             summaryChartBean.setReplicateAnnotationValueList(ReplicateManager.getUniqueSortedAnnotationNameValue(_run.getId()));
@@ -2276,7 +2357,7 @@ public class TargetedMSController extends SpringActionController
             vbox.addView(chromatogramsBox);
 
             // Summary charts for the molecule
-            SummaryChartBean summaryChartBean = new SummaryChartBean();
+            SummaryChartBean summaryChartBean = new SummaryChartBean(_run);
             summaryChartBean.setMoleculeId(moleculeId);
             summaryChartBean.setReplicateAnnotationNameList(ReplicateManager.getReplicateAnnotationNamesForRun(_run.getId()));
             summaryChartBean.setReplicateAnnotationValueList(ReplicateManager.getUniqueSortedAnnotationNameValue(_run.getId()));
@@ -2693,7 +2774,7 @@ public class TargetedMSController extends SpringActionController
                 form.setChartWidth(300);
             }
 
-            writePNG(form, response, chart);
+            writeChart(form, response, chart);
         }
     }
 
@@ -2752,7 +2833,7 @@ public class TargetedMSController extends SpringActionController
                 form.setChartWidth(300);
             }
 
-            writePNG(form, response, chart);
+            writeChart(form, response, chart);
         }
     }
 
@@ -2767,6 +2848,9 @@ public class TargetedMSController extends SpringActionController
         private Integer _chartWidth = null;
         private Integer _chartHeight = null;
         private int _dpi = 144;
+
+        private String _format = "png";
+        private boolean _legend = true;
 
         public int getChartWidth()
         {
@@ -2817,6 +2901,26 @@ public class TargetedMSController extends SpringActionController
         public boolean hasDpi()
         {
             return _dpi > SCREEN_RES;
+        }
+
+        public String getFormat()
+        {
+            return _format;
+        }
+
+        public void setFormat(String format)
+        {
+            _format = format;
+        }
+
+        public boolean isLegend()
+        {
+            return _legend;
+        }
+
+        public void setLegend(boolean legend)
+        {
+            _legend = legend;
         }
     }
 
@@ -4208,7 +4312,7 @@ public class TargetedMSController extends SpringActionController
             ChromatogramChartMakerFactory factory = new ChromatogramChartMakerFactory();
             JFreeChart chart = factory.createSampleFileChromChart(chromInfo, getUser(), getContainer());
 
-            writePNG(form, response, chart);
+            writeChart(form, response, chart);
         }
     }
 
@@ -4291,7 +4395,7 @@ public class TargetedMSController extends SpringActionController
                 result.addView(getGeneralMoleculeQueryView(form, schema, errors, "Small Molecules", "Molecule", baseVisibleColumns));
             }
 
-            SummaryChartBean summaryChartBean = new SummaryChartBean();
+            SummaryChartBean summaryChartBean = new SummaryChartBean(_run);
             summaryChartBean.setPeptideGroupId(form.getId());
             summaryChartBean.setReplicateList(ReplicateManager.getReplicatesForRun(group.getRunId()));
             summaryChartBean.setReplicateAnnotationNameList(ReplicateManager.getReplicateAnnotationNamesForRun(group.getRunId()));
@@ -4386,6 +4490,13 @@ public class TargetedMSController extends SpringActionController
         private long _moleculeId;
         private long _moleculePrecursorId;
         private List<Molecule> _moleculeList;
+
+        private final TargetedMSRun _run;
+
+        private SummaryChartBean(TargetedMSRun run)
+        {
+            _run = run;
+        }
 
         public boolean isShowControls()
         {
@@ -4515,6 +4626,11 @@ public class TargetedMSController extends SpringActionController
         public void setMoleculeList(List<Molecule> moleculeList)
         {
             _moleculeList = moleculeList;
+        }
+
+        public TargetedMSRun getRun()
+        {
+            return _run;
         }
     }
 
@@ -7042,7 +7158,7 @@ public class TargetedMSController extends SpringActionController
             curvePlotView.setTitle("Calibration Curve");
 
             // Summary charts for the precursor
-            SummaryChartBean summaryChartBean = new SummaryChartBean();
+            SummaryChartBean summaryChartBean = new SummaryChartBean(_run);
             summaryChartBean.setShowControls(false);
             summaryChartBean.setInitialHeight(300);
             summaryChartBean.setInitialWidth(1200);

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -1455,7 +1455,8 @@ public class TargetedMSController extends SpringActionController
             {
                 jsonPayload.put("xLabel", xLabel);
             }
-            jsonPayload.put("title", chart.getTitle().getText());
+            TextTitle title = chart.getTitle();
+            jsonPayload.put("title", title == null ? null : title.getText());
             // Null out the title so that it's not part of the SVG and let the client render it as text via the DOM
             chart.setTitle((String)null);
             jsonPayload.put("svg", renderSVG(form, chart));

--- a/src/org/labkey/targetedms/chart/ChromatogramChartMaker.java
+++ b/src/org/labkey/targetedms/chart/ChromatogramChartMaker.java
@@ -78,10 +78,15 @@ class ChromatogramChartMaker
 
     public JFreeChart make(final ChromatogramDataset chromatogramDataset)
     {
-        return make(chromatogramDataset, "Retention Time", "Intensity", true);
+        return make(chromatogramDataset, true, "Retention Time", "Intensity");
     }
 
-    public JFreeChart make(final ChromatogramDataset chromatogramDataset, String xLabel, String yLabel, boolean legend)
+    public JFreeChart make(final ChromatogramDataset chromatogramDataset, boolean legend)
+    {
+        return make(chromatogramDataset, legend, "Retention Time", "Intensity");
+    }
+
+    public JFreeChart make(final ChromatogramDataset chromatogramDataset, boolean legend, String xLabel, String yLabel)
     {
         chromatogramDataset.build();
 
@@ -206,15 +211,15 @@ class ChromatogramChartMaker
         }
     }
 
-    public JFreeChart make(ChromatogramDataset dataset1, ChromatogramDataset dataset2)
+    public JFreeChart make(ChromatogramDataset dataset1, ChromatogramDataset dataset2, boolean legend)
     {
-        JFreeChart precursorChart = make(dataset1);
-        JFreeChart productChart = make(dataset2);
-        if(precursorChart.getXYPlot().getDataset().getSeriesCount() == 0)
+        JFreeChart precursorChart = make(dataset1, legend);
+        JFreeChart productChart = make(dataset2, legend);
+        if(precursorChart.getXYPlot().getDataset() == null || precursorChart.getXYPlot().getDataset().getSeriesCount() == 0)
         {
             return productChart;
         }
-        if(productChart.getXYPlot().getDataset().getSeriesCount() == 0)
+        if(productChart.getXYPlot().getDataset() == null || productChart.getXYPlot().getDataset().getSeriesCount() == 0)
         {
             return precursorChart;
         }

--- a/src/org/labkey/targetedms/chart/ChromatogramChartMakerFactory.java
+++ b/src/org/labkey/targetedms/chart/ChromatogramChartMakerFactory.java
@@ -37,6 +37,7 @@ public class ChromatogramChartMakerFactory
     private boolean _syncRt;
     private boolean _splitGraph;
     private boolean _showOptimizationPeaks;
+    private boolean _legend = true;
 
     public void setSyncIntensity(boolean syncIntensity)
     {
@@ -58,6 +59,11 @@ public class ChromatogramChartMakerFactory
         _showOptimizationPeaks = showOptimizationPeaks;
     }
 
+    public void setLegend(boolean legend)
+    {
+        _legend = legend;
+    }
+
     public JFreeChart createTransitionChromChart(TransitionChromInfo tChromInfo, PrecursorChromInfo pChromInfo, User user, Container container)
     {
         return new ChromatogramChartMaker().make(new ChromatogramDataset.TransitionDataset(pChromInfo, tChromInfo, user, container));
@@ -74,12 +80,11 @@ public class ChromatogramChartMakerFactory
         {
             // Split graph setting will be ignored if we are showing optimization peaks.
             return new ChromatogramChartMaker().make(new ChromatogramDataset.PrecursorOptimizationPeakDataset(pChromInfo,
-                    _syncIntensity, _syncRt, user, container));
-
+                    _syncIntensity, _syncRt, user, container), _legend);
         }
         else if(!_splitGraph)
         {
-            return new ChromatogramChartMaker().make(new ChromatogramDataset.PrecursorDataset(pChromInfo, _syncIntensity, _syncRt, user, container));
+            return new ChromatogramChartMaker().make(new ChromatogramDataset.PrecursorDataset(pChromInfo, _syncIntensity, _syncRt, user, container), _legend);
         }
         else
         {
@@ -92,7 +97,7 @@ public class ChromatogramChartMakerFactory
                     return jfreePrecIonDataset != null ? jfreePrecIonDataset.getSeriesCount() : 0;
                 }
             };
-            return new ChromatogramChartMaker().make(precursorIonDataset, productIonDataset);
+            return new ChromatogramChartMaker().make(precursorIonDataset, productIonDataset, _legend);
         }
     }
 
@@ -137,7 +142,7 @@ public class ChromatogramChartMakerFactory
                     return jfreePrecIonDataset != null ? jfreePrecIonDataset.getSeriesCount() : 0;
                 }
             };
-            return new ChromatogramChartMaker().make(precursorIonDataset, productIonDataset);
+            return new ChromatogramChartMaker().make(precursorIonDataset, productIonDataset, _legend);
         }
     }
 
@@ -153,6 +158,6 @@ public class ChromatogramChartMakerFactory
 
     public JFreeChart createSampleFileChromChart(SampleFileChromInfo chromInfo, User user, Container container)
     {
-        return new ChromatogramChartMaker().make(new ChromatogramDataset.SampleFileDataset(chromInfo, user, container), "Time", "Value", false);
+        return new ChromatogramChartMaker().make(new ChromatogramDataset.SampleFileDataset(chromInfo, user, container), false, "Time", "Value");
     }
 }

--- a/src/org/labkey/targetedms/chart/ComparisonChartMaker.java
+++ b/src/org/labkey/targetedms/chart/ComparisonChartMaker.java
@@ -261,7 +261,7 @@ public class ComparisonChartMaker
         else
         {
             // X-axis label for the "replicate comparison" graph
-            xLabel = noAnnotation(groupByAnnotation) ? "Replicate" : groupByAnnotation;
+            xLabel = noAnnotation(groupByAnnotation) ? "Replicates" : groupByAnnotation;
         }
 
         JFreeChart chart;

--- a/src/org/labkey/targetedms/parser/AnnotatedEntity.java
+++ b/src/org/labkey/targetedms/parser/AnnotatedEntity.java
@@ -49,7 +49,9 @@ public abstract class AnnotatedEntity<AnnotationType extends AbstractAnnotation>
         }
         if (!ionFormula.contains("[") || !ionFormula.endsWith("]"))
         {
-            throw new IllegalStateException("Invalid ion formula: " + ionFormula);
+            // Skyline shouldn't be writing out formulas without adducts but a to-be-fixed bug in the compact,
+            // BASE64-encoded format means that some documents
+            return null;
         }
         // Pull out the text between the brackets at the end
         String adduct = ionFormula.substring(ionFormula.lastIndexOf("[") + 1);
@@ -66,7 +68,9 @@ public abstract class AnnotatedEntity<AnnotationType extends AbstractAnnotation>
         }
         if (!ionFormula.contains("[") || !ionFormula.endsWith("]"))
         {
-            throw new IllegalStateException("Invalid ion formula: " + ionFormula);
+            // Skyline shouldn't be writing out formulas without adducts but a to-be-fixed bug in the compact,
+            // BASE64-encoded format means that some documents
+            return ionFormula;
         }
         // Pull out the text before the last bracket
         return ionFormula.substring(0, ionFormula.lastIndexOf("["));

--- a/src/org/labkey/targetedms/view/passport/ProteinWebPart.jsp
+++ b/src/org/labkey/targetedms/view/passport/ProteinWebPart.jsp
@@ -21,7 +21,7 @@
     @Override
     public void addClientDependencies(ClientDependencies dependencies)
     {
-        dependencies.add("vis/lib/d3-3.5.17.min.js");
+        dependencies.add("vis/vis");
         dependencies.add("passport/js/util.js");
         dependencies.add("passport/js/settings.js");
         dependencies.add("passport/js/protein.js");
@@ -31,6 +31,7 @@
         dependencies.add("internal/jQuery");
         dependencies.add("passport/jQuery/jquery-ui.min.css");
         dependencies.add("passport/jQuery/jquery-ui.min.js");
+        dependencies.add("TargetedMS/js/svgChart.js");
 
     }
 %>
@@ -47,6 +48,8 @@
             break;
         }
     }
+    // Temporary bridge between original and new reporting approach
+    boolean showCV = me.getViewContext().getActionURL().getParameter("showNewPlot") != null;
     %>
     <!--START IMPORTS-->
 
@@ -170,6 +173,9 @@
                     <select id="peptideSort" name="peptideSort">
                         <option value="intensity">Intensity</option>
                         <option value="sequencelocation">Sequence Location</option>
+                        <% if (showCV) { %>
+                        <option value="cv">Coefficient of Variation</option>
+                        <% } %>
                     </select>
                 </p>
                 <% if (hasBeforeAndAfter) { %>
@@ -202,15 +208,19 @@
     <!-- FILTER OPTIONS END -->
     <!-- CHART START -->
         <div id="chart"></div>
+        <div id="visChart"></div>
         <div id="peptide"></div>
         <div id="protein"></div>
     <!-- CHART END -->
 
         <div id="selectedPeptideChromatogramContainer">
-            <img id="selectedPeptideChromatogramBefore" src="" alt="Chromatogram not available for the selected peptide"/>
-            <img id="selectedPeptideChromatogramAfter" src="" alt="Chromatogram not available for the selected peptide"/>
-            <img id="selectedPeptideChromatogram" src="" alt="Chromatogram not available for the selected peptide"/>
+            <div>
+                <span width="350" height="400" id="selectedPeptideChromatogramBefore"></span>
+                <span width="350" height="400" id="selectedPeptideChromatogramAfter"></span>
+                <span width="350" height="400" id="selectedPeptideChromatogram"></span>
+            </div>
         </div>
+        <div id="seriesLegend" style="width: 500px; margin: auto"></div>
         <div id="peptideinfo" class="peptideDetails"></div>
         <div class="peptideDetails"><a id="selectedPeptideLink" href="">View peptide details</a></div>
     </div>

--- a/src/org/labkey/targetedms/view/summaryChartsView.jsp
+++ b/src/org/labkey/targetedms/view/summaryChartsView.jsp
@@ -401,7 +401,7 @@
                 chartHeight: chartHeightTb.getValue()
             };
 
-            var pearAreaUrl =  LABKEY.ActionURL.buildURL(
+            var peakAreaUrl =  LABKEY.ActionURL.buildURL(
                     'targetedms',  // controller
                     'showPeakAreas', // action
                     LABKEY.ActionURL.getContainer(),
@@ -421,9 +421,9 @@
 
             // change the src of the image
             var areaElement = document.getElementById('peakAreasGraph');
-            requestAndRenderSVG(pearAreaUrl, areaElement);
+            LABKEY.targetedms.SVGChart.requestAndRenderSVG(peakAreaUrl, areaElement, null, document.getElementById('peakAreasGraphLabel'));
             var timeElement = document.getElementById('retentionTimesGraph');
-            requestAndRenderSVG(retentionTimesUrl, timeElement);
+            LABKEY.targetedms.SVGChart.requestAndRenderSVG(retentionTimesUrl, timeElement, null, document.getElementById('retentionTimesGraphLabel'));
             areaElement.style.width = parseInt(chartWidthTb.getValue());
             areaElement.style.height = parseInt(chartHeightTb.getValue());
             timeElement.style.width = parseInt(chartWidthTb.getValue());

--- a/src/org/labkey/targetedms/view/summaryChartsView.jsp
+++ b/src/org/labkey/targetedms/view/summaryChartsView.jsp
@@ -31,6 +31,7 @@
     public void addClientDependencies(ClientDependencies dependencies)
     {
         dependencies.add("Ext4");
+        dependencies.add("TargetedMS/js/svgChart.js");
     }
 %>
 <%
@@ -44,6 +45,9 @@
 
     ActionURL peakAreaUrl = new ActionURL(TargetedMSController.ShowPeakAreasAction.class, getContainer());
     ActionURL retentionTimesUrl = new ActionURL(TargetedMSController.ShowRetentionTimesChartAction.class, getContainer());
+
+    ActionURL replicateListAction = new ActionURL(TargetedMSController.ShowReplicatesAction.class, getContainer());
+    replicateListAction.addParameter("id", bean.getRun().getId());
 
     // for proteomics summary charts
     List<Peptide> peptideList = bean.getPeptideList();
@@ -375,19 +379,8 @@
     });
 
     // peak areas graph
-    var peakAreasImg = Ext4.create('Ext.Img', {
-        src: <%=q(peakAreaUrl)%>,
-        renderTo: Ext4.get('peakAreasGraphImg'),
-        width: <%= bean.getInitialWidth() %>,
-        height: <%= bean.getInitialHeight()%>
-    });
-
-    var retentionTimesImg = Ext4.create('Ext.Img', {
-        src: <%=q(retentionTimesUrl)%>,
-        renderTo: Ext4.get('retentionTimesGraphImg'),
-        width: <%= bean.getInitialWidth() %>,
-        height: <%= bean.getInitialHeight()%>
-    });
+    LABKEY.targetedms.SVGChart.requestAndRenderSVG(<%= q(peakAreaUrl) %>, document.getElementById('peakAreasGraph'), null, document.getElementById('peakAreasGraphLabel'));
+    LABKEY.targetedms.SVGChart.requestAndRenderSVG(<%= q(retentionTimesUrl) %>, document.getElementById('retentionTimesGraph'), null, document.getElementById('retentionTimesGraphLabel'));
 
     // buttons
     var updateBtn = Ext4.create('Ext.button.Button', {
@@ -427,12 +420,14 @@
             );
 
             // change the src of the image
-            peakAreasImg.setSrc(pearAreaUrl);
-            retentionTimesImg.setSrc(retentionTimesUrl);
-            peakAreasImg.setHeight(parseInt(chartHeightTb.getValue()));
-            peakAreasImg.setWidth(parseInt(chartWidthTb.getValue()));
-            retentionTimesImg.setHeight(parseInt(chartHeightTb.getValue()));
-            retentionTimesImg.setWidth(parseInt(chartWidthTb.getValue()));
+            var areaElement = document.getElementById('peakAreasGraph');
+            requestAndRenderSVG(pearAreaUrl, areaElement);
+            var timeElement = document.getElementById('retentionTimesGraph');
+            requestAndRenderSVG(retentionTimesUrl, timeElement);
+            areaElement.style.width = parseInt(chartWidthTb.getValue());
+            areaElement.style.height = parseInt(chartHeightTb.getValue());
+            timeElement.style.width = parseInt(chartWidthTb.getValue());
+            timeElement.style.height = parseInt(chartHeightTb.getValue());
         }
     });
 
@@ -522,11 +517,13 @@
     <div id="peakAreasFormDiv" class="summary_form_box" style="display: <%=h(bean.isShowControls() ? "block" : "none")%>;"></div>
     <div class="summary_title_box">
         <h3 class="title">Peak Areas</h3>
-        <div id="peakAreasGraphImg"></div>
+        <div id="peakAreasGraph"></div>
+        <a href="<%= h(replicateListAction)%>"><div style="text-align: center" id="peakAreasGraphLabel"></div></a>
     </div>
     <div class="summary_title_box">
         <h3 class="title">Retention Times</h3>
-        <div id="retentionTimesGraphImg"></div>
+        <div id="retentionTimesGraph"></div>
+        <a href="<%= h(replicateListAction)%>"><div style="text-align: center" id="retentionTimesGraphLabel"></div></a>
     </div>
 </div>
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentTest.java
@@ -346,8 +346,8 @@ public class TargetedMSExperimentTest extends TargetedMSTest
         assertEquals("703.9755", drt.getDataAsText(5, "Mass Average"));
         assertEquals("703.5152", drt.getDataAsText(5, "Mass Monoisotopic"));
         assertEquals(" ", drt.getDataAsText(5, "Avg. Measured RT"));
-        assertElementPresent(Locator.xpath("//img[contains(@src, 'showPeakAreas.view')]"));
-        assertElementPresent(Locator.xpath("//img[contains(@src, 'showRetentionTimesChart.view')]"));
+        ensureComparisonPlots("PC");
+
 
         //Click on a value under Custom Ion Name
         clickAndWait(Locator.linkContainingText("PC aa C26:0").index(0)); //two links with this text, want the first one under Custom Ion Name hence index(0).
@@ -361,8 +361,7 @@ public class TargetedMSExperimentTest extends TargetedMSTest
 
         assertElementPresent(Locator.xpath("//img[contains(@src, 'generalMoleculeChromatogramChart.view')]"));
         assertElementPresent(Locator.xpath("//img[contains(@src, 'precursorChromatogramChart.view')]"));
-        assertElementPresent(Locator.xpath("//img[contains(@src, 'showPeakAreas.view')]"));
-        assertElementPresent(Locator.xpath("//img[contains(@src, 'showRetentionTimesChart.view')]"));
+        ensureComparisonPlots("PC aa C26:0");
 
         //Click on Molecule Precursor Chromatogram link
         clickAndWait(Locator.xpath("//a[contains(@href, 'moleculePrecursorAllChromatogramsChart.view')]"));
@@ -375,8 +374,7 @@ public class TargetedMSExperimentTest extends TargetedMSTest
         assertElementPresent(Locator.xpath("//tr[td[text()='m/z']][td[normalize-space()='650.4755']]"));
 
         assertElementPresent(Locator.xpath("//img[contains(@src, 'precursorChromatogramChart.view')]"), 4);
-        assertElementPresent(Locator.xpath("//img[contains(@src, 'showPeakAreas.view')]"));
-        assertElementPresent(Locator.xpath("//img[contains(@src, 'showRetentionTimesChart.view')]"));
+        ensureComparisonPlots("PC aa C26:0");
 
         //Go back to Document Summary page
         clickAndWait(Locator.linkContainingText(SKY_FILE_SMALLMOL_PEP));
@@ -396,8 +394,7 @@ public class TargetedMSExperimentTest extends TargetedMSTest
         assertTextPresent("Small Molecule Summary");
         assertElementPresent(Locator.xpath("//img[contains(@src, 'generalMoleculeChromatogramChart.view')]"));
         assertElementPresent(Locator.xpath("//img[contains(@src, 'precursorChromatogramChart.view')]"));
-        assertElementPresent(Locator.xpath("//img[contains(@src, 'showPeakAreas.view')]"));
-        assertElementPresent(Locator.xpath("//img[contains(@src, 'showRetentionTimesChart.view')]"));
+        ensureComparisonPlots("lysoPC a C14:0");
         assertElementPresent(Locator.xpath("//a[contains(@href, 'moleculePrecursorAllChromatogramsChart.view')]"));
 
         clickAndWait(Locator.linkContainingText(SKY_FILE_SMALLMOL_PEP));
@@ -405,8 +402,7 @@ public class TargetedMSExperimentTest extends TargetedMSTest
         clickAndWait(Locator.linkContainingText("lysoPC a C14:0").index(1));
         assertTextPresent("Molecule Precursor Chromatograms");
         assertElementPresent(Locator.xpath("//img[contains(@src, 'precursorChromatogramChart.view')]"), 4);
-        assertElementPresent(Locator.xpath("//img[contains(@src, 'showPeakAreas.view')]"));
-        assertElementPresent(Locator.xpath("//img[contains(@src, 'showRetentionTimesChart.view')]"));
+        ensureComparisonPlots("lysoPC a C14:0");
 
         //Go to Small Molecule Transition List
         clickAndWait(Locator.linkContainingText(SKY_FILE_SMALLMOL_PEP));

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSLibraryTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSLibraryTest.java
@@ -199,7 +199,7 @@ public class TargetedMSLibraryTest extends TargetedMSTest
         assertEquals("Wrong decoy value", "false", getText(Locator.tagWithClass("td", "lk-form-label").withText("Decoy:").followingSibling("td")));
         assertEquals("Wrong File", SKY_FILE1, getText(Locator.tagWithClass("td", "lk-form-label").withText("File:").followingSibling("td")));
         assertElementPresent(Locator.xpath("//table[contains(@id, 'peptideMap')]"));
-        assertElementPresent(Locator.xpath("//div[@id = 'peakAreasGraphImg']/img"));
+        ensureComparisonPlots("CTCF");
 
         log("Testing chart interactivity");
         WebElement height= getDriver().findElement(By.xpath("//input[contains(@id, 'chartHeight-inputEl')]"));
@@ -209,7 +209,7 @@ public class TargetedMSLibraryTest extends TargetedMSTest
         width.clear();
         width.sendKeys("500");
         click(Locator.xpath("//a[contains(@class, 'x4-btn x-unselectable x4-box-item x4-toolbar-item x4-btn-default-small x4-noicon x4-btn-noicon x4-btn-default-small-noicon')]"));
-        assertElementPresent(Locator.xpath("//div[@id = 'peakAreasGraphImg']/img"));
+        ensureComparisonPlots("CTCF");
     }
 
     @LogMethod

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSTest.java
@@ -296,6 +296,13 @@ public abstract class TargetedMSTest extends BaseWebDriverTest
         clickButton("Finish");
     }
 
+    /** Verify that the comparison plots have been AJAX'd into place */
+    protected void ensureComparisonPlots(String title)
+    {
+        waitForElement(Locator.xpath("//div[@id ='peakAreasGraph']/div[normalize-space()='" + title + "']"));
+        waitForElement(Locator.xpath("//div[@id ='retentionTimesGraph']/div[normalize-space()='" + title + "']"));
+    }
+
     protected void verifyQcSummary(int docCount, int sampleFileCount, int precursorCount)
     {
         QCSummaryWebPart qcSummaryWebPart = new PanoramaDashboard(this).getQcSummaryWebPart();

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -189,7 +189,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
 
     getExpRunRangeDetails: function() {
         var urlParams = LABKEY.ActionURL.getParameters();
-        this.showExpRunRange = urlParams['RunId'] !== undefined && urlParams['RunId'] !== "";
+        this.showExpRunRange = parseInt(urlParams['RunId']) > 0;
 
         if (this.showExpRunRange) {
             this.getExperimentRunDetails(urlParams['RunId'])

--- a/webapp/TargetedMS/js/svgChart.js
+++ b/webapp/TargetedMS/js/svgChart.js
@@ -32,7 +32,7 @@ if (!LABKEY.targetedms.SVGChart) {
                             labelElement.innerText = parsedResponse.xLabel;
                         }
                         else {
-                            plotAndTitleHtml += '<div style="text-align: center">' + LABKEY.Utils.encodeHtml(parsedResponse.xLabel).replaceAll('\n', '<br/>') + '</div>';
+                            plotAndTitleHtml += '<div style="text-align: center">' + LABKEY.Utils.encodeHtml(parsedResponse.xLabel).split('\n').join('<br>') + '</div>';
                         }
                     }
 

--- a/webapp/TargetedMS/js/svgChart.js
+++ b/webapp/TargetedMS/js/svgChart.js
@@ -20,7 +20,7 @@ if (!LABKEY.targetedms.SVGChart) {
                     var parsedResponse = JSON.parse(xhr.responseText);
 
                     var plotAndTitleHtml = '<div style="text-align: center">' +
-                            LABKEY.Utils.encodeHtml(parsedResponse.title).replaceAll('\n', '<br/>') + ' ' +
+                            LABKEY.Utils.encodeHtml(parsedResponse.title).split('\n').join('<br>') + ' ' +
                             this.createExportIcon(targetElement.id, 'fa-file-pdf-o', 'Export to PDF', originalUrl + '&format=pdf') + ' ' +
                             this.createExportIcon(targetElement.id, 'fa-file-image-o', 'Export to PNG', originalUrl + '&format=pngDownload') +
                             '</div>';

--- a/webapp/TargetedMS/js/svgChart.js
+++ b/webapp/TargetedMS/js/svgChart.js
@@ -1,0 +1,58 @@
+if (!LABKEY.targetedms) {
+    LABKEY.targetedms = {};
+}
+
+if (!LABKEY.targetedms.SVGChart) {
+    LABKEY.targetedms.SVGChart = {
+        createExportIcon: function (divId, iconCls, tooltip, url) {
+            return '<span id="' + divId + iconCls + '" ><a href="' + LABKEY.Utils.encodeHtml(url) + '"' +
+                            '<i class="fa ' + iconCls + '" title="' + tooltip + '"></i></a></span>';
+        },
+        requestAndRenderSVG: function (originalUrl, targetElement, legendElement, labelElement) {
+            var url = originalUrl  + '&format=json' + (legendElement ? '&legend=false' : '');
+
+            targetElement.innerText = 'Loading...';
+
+            LABKEY.Ajax.request({
+                url: url,
+                scope: this,
+                success: function (xhr) {
+                    var parsedResponse = JSON.parse(xhr.responseText);
+
+                    var plotAndTitleHtml = '<div style="text-align: center">' +
+                            LABKEY.Utils.encodeHtml(parsedResponse.title).replaceAll('\n', '<br/>') + ' ' +
+                            this.createExportIcon(targetElement.id, 'fa-file-pdf-o', 'Export to PDF', originalUrl + '&format=pdf') + ' ' +
+                            this.createExportIcon(targetElement.id, 'fa-file-image-o', 'Export to PNG', originalUrl + '&format=pngDownload') +
+                            '</div>';
+                    plotAndTitleHtml += parsedResponse.svg;
+
+                    if (parsedResponse.xLabel)
+                    {
+                        if (labelElement) {
+                            labelElement.innerText = parsedResponse.xLabel;
+                        }
+                        else {
+                            plotAndTitleHtml += '<div style="text-align: center">' + LABKEY.Utils.encodeHtml(parsedResponse.xLabel).replaceAll('\n', '<br/>') + '</div>';
+                        }
+                    }
+
+                    targetElement.innerHTML = plotAndTitleHtml;
+
+                    if (legendElement) {
+                        var legend = parsedResponse.series;
+                        var h = '<table><tr>';
+                        for (var i = 0; i < legend.length; i++) {
+                            h += (i % 3 === 0 && i !== 0) ? '</tr><tr>' : '';
+                            h += '<td style="white-space:nowrap; padding: 0px 10px"><span style="color: #' + legend[i].color + '">&block; &nbsp;</span>' + LABKEY.Utils.encodeHtml(legend[i].label) + '</td> ';
+                        }
+                        h += '</tr></table>';
+                        legendElement.innerHTML = h;
+                    }
+                }
+            });
+        }
+    }
+}
+
+
+

--- a/webapp/passport/css/protein.css
+++ b/webapp/passport/css/protein.css
@@ -241,20 +241,13 @@
     height:400px;
     display: table;
     margin: auto;
-    position:relative;
-}
-
-#selectedPeptideChromatogramContainer img {
-    max-width:250px;
-   float:left;
 }
 
 #selectedPeptideChromatogramContainer span
 {
-    color:#808080;
-    font-size:12px;
-    display:block;
-    float:right;
+    text-align: center;
+    width: 250px;
+    display: inline-grid;
 }
 
 .peptideDetails {

--- a/webapp/passport/js/peakareachart.js
+++ b/webapp/passport/js/peakareachart.js
@@ -31,7 +31,7 @@ peakareachart = {
             .style("text-anchor", "middle")
             .attr("x", relativeStart + relativeWidth/2)
             .attr("y", yRelative(31 - 12 - 8)) //12px font  8px for highlight_peptide_bounds
-            .text(start +  " - " + (start + sequence.length -1)); // subtract 1 because end index will be base 2
+            .text((start + 1) +  " - " + (start + sequence.length)); // subtract 1 because end index will be base 2
 
     },
     paintPeptide: function paintPeptide(d) {

--- a/webapp/passport/js/protein.js
+++ b/webapp/passport/js/protein.js
@@ -286,15 +286,13 @@ protein =
                 var cvBarLayer = new LABKEY.vis.Layer({
                     geom: new LABKEY.vis.Geom.BarPlot({
                         opacity: 0.2,
-                        hoverText: function (x, stats) {
-                            console.log('hover');
-                            return 'test';
+                        hoverFn: function (row) {
+                            return 'Peptide: ' + row.x + '\nCV: ' + (row.cv * 100).toFixed(2) + '%';
                         }
                     }),
                     aes: {
                         x: 'x',
-                        yRight: 'cv',
-
+                        yRight: 'cv'
                     },
                     data: cvLineData
                 });
@@ -327,9 +325,6 @@ protein =
                                     '\nMean: ' + stats.Q2.toExponential(3) +
                                     '\nStd dev: ' + sd.toExponential(3) +
                                     '\n%CV: ' + (stats.Q2 ? ((sd / stats.Q2) * 100).toFixed(1) : 'N/A');
-                        },
-                        clickFn: function (event, data) {
-                            console.log(data);
                         }
                     }
                 });

--- a/webapp/passport/js/protein.js
+++ b/webapp/passport/js/protein.js
@@ -4,6 +4,7 @@
 var barChartData = []; // d3 peptide chart DO NOT MODIFY ONLY SORT
 var peakAreaDiv, proteinBarDiv; // viz module div containers
 
+var showNewPlot = LABKEY.ActionURL.getParameter('showNewPlot');
 
 protein =
 {
@@ -149,6 +150,21 @@ protein =
         return protein.selectedPeptide;
     },
 
+    requestSVG: function(chromatogramReference, svgParentId) {
+        var chromatogram = protein.selectedPeptide[chromatogramReference];
+        var parentElement = $('#' + svgParentId);
+        if (chromatogram) {
+            parentElement.empty();
+            parentElement.show();
+            LABKEY.targetedms.SVGChart.requestAndRenderSVG(chromatogramUrl + "id=" + chromatogram + "&syncY=true&syncX=false&chartWidth=250&chartHeight=400", parentElement[0], $('#seriesLegend')[0])
+            return true;
+        }
+        else {
+            parentElement.hide();
+            return false;
+        }
+    },
+
     selectPeptide: function(p) {
         if(p == null)
             return;
@@ -163,34 +179,12 @@ protein =
                 break;
         }
 
-        var showLink = false;
+        $('#seriesLegend').empty();
+
         // sets panorama chromatogram to that of the newly selected peptide
-        if(protein.selectedPeptide["ChromatogramBeforeId"]) {
-            $('#selectedPeptideChromatogramBefore').attr("src", chromatogramUrl + "id=" + protein.selectedPeptide["ChromatogramBeforeId"] + "&chartWidth=250&chartHeight=400&syncY=false&syncX=false");
-            $('#selectedPeptideChromatogramBefore').show();
-            showLink = true;
-        }
-        else {
-            $('#selectedPeptideChromatogramBefore').hide();
-        }
-
-        if (protein.selectedPeptide["ChromatogramAfterId"]) {
-            $('#selectedPeptideChromatogramAfter').attr("src", chromatogramUrl + "id=" + protein.selectedPeptide["ChromatogramAfterId"] + "&chartWidth=250&chartHeight=400&syncY=false&syncX=false")
-            $('#selectedPeptideChromatogramAfter').show();
-            showLink = true;
-        }
-        else {
-            $('#selectedPeptideChromatogramAfter').hide();
-        }
-
-        if (protein.selectedPeptide["ChromatogramId"]) {
-            $('#selectedPeptideChromatogram').attr("src", chromatogramUrl + "id=" + protein.selectedPeptide["ChromatogramId"] + "&chartWidth=250&chartHeight=400&syncY=false&syncX=false")
-            $('#selectedPeptideChromatogram').show();
-            showLink = true;
-        }
-        else {
-            $('#selectedPeptideChromatogram').hide();
-        }
+        var showLink = this.requestSVG('ChromatogramBeforeId', 'selectedPeptideChromatogramBefore');
+        showLink |= this.requestSVG('ChromatogramAfterId', 'selectedPeptideChromatogramAfter');
+        showLink |= this.requestSVG('ChromatogramId', 'selectedPeptideChromatogram');
 
         if (showLink) {
             $('#selectedPeptideLink').show();
@@ -206,7 +200,7 @@ protein =
         var value = protein.selectedPeptide["Before Incubation"] ? protein.selectedPeptide["Before Incubation"] : protein.selectedPeptide["Total Area"];
         var totalPeakAreaWithCommas = value.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
         $('#peptideinfo').append('<span style="font-weight:600">Sequence:</span>&nbsp;<span style="font-family: monospace;">' + LABKEY.Utils.encodeHtml(protein.selectedPeptide.Sequence) + "</span><br />" +
-                '<span style="font-weight:600">Location:</span>&nbsp;<span style="font-family: monospace;">[' + LABKEY.Utils.encodeHtml(protein.selectedPeptide.StartIndex) +","+ LABKEY.Utils.encodeHtml(protein.selectedPeptide.EndIndex) + "]</span> <br />" +
+                '<span style="font-weight:600">Location:</span>&nbsp;<span style="font-family: monospace;">[' + LABKEY.Utils.encodeHtml(protein.selectedPeptide.StartIndex + 1) +","+ LABKEY.Utils.encodeHtml(protein.selectedPeptide.EndIndex) + "]</span> <br />" +
                 '<span style="font-weight:600">Length:</span>&nbsp;<span style="font-family: monospace;">' + LABKEY.Utils.encodeHtml(protein.selectedPeptide.Sequence.length)+ "</span> <br />" +
                 '<span style="font-weight:600">Total Peak Area:</span>&nbsp;<span style="font-family: monospace;">' + LABKEY.Utils.encodeHtml(totalPeakAreaWithCommas) + "</span> ");
 
@@ -224,6 +218,176 @@ protein =
     updateUI: function(){
         var parentWidth = parseInt(d3.select('#chart').style('width'), 10);
         peakareachart.draw("#chart", "#protein", parentWidth);
+
+        if (showNewPlot) {
+
+            var visChartElement = document.getElementById("visChart");
+
+            while (visChartElement.firstChild) {
+                visChartElement.removeChild(visChartElement.firstChild);
+            }
+
+            if (this.peptides && this.peptides.length) {
+                var plotData = [];
+                for (var i = 0; i < this.peptides.length; i++) {
+                    var abbreviatedSequence = this.peptides[i].sequence.substring(0, Math.min(this.peptides[i].sequence.length, 3));
+                    plotData.push({
+                        timepoint: 'Before',
+                        intensity: this.peptides[i].beforeintensity,
+                        sequence: this.peptides[i].sequence,
+                        xLabel: abbreviatedSequence
+                    });
+                    plotData.push({
+                        timepoint: 'After',
+                        intensity: this.peptides[i].normalizedafterintensity ? this.peptides[i].normalizedafterintensity : 0.0,
+                        sequence: this.peptides[i].sequence,
+                        xLabel: abbreviatedSequence
+                    });
+                }
+
+                var groupedBoxData = LABKEY.vis.groupData(plotData, function (row) {
+                    return row.sequence
+                });
+
+                var medians = {};
+                var cvLineData = [];
+                var cvs = {};
+
+                for (var groupName in groupedBoxData) {
+                    var stats = LABKEY.vis.Stat.summary(groupedBoxData[groupName], function (row) {
+                        return row.intensity
+                    });
+                    var sd = LABKEY.vis.Stat.getStdDev(stats.sortedValues);
+                    medians[groupName] = stats.Q2;
+                    var cv = stats.Q2 ? (sd / stats.Q2) : null;
+                    cvLineData.push({x: groupName, cv: cv, color: 'median'});
+                    cvs[groupName] = cv;
+                }
+
+                var sortBy = this.settings.getSortBy();
+                if (sortBy === "Sequence Location") {
+                    plotData.sort(function (a, b) {
+                        return a["StartIndex"] - b["StartIndex"];
+                    });
+                }
+
+                if (sortBy === "Intensity") {
+                    plotData.sort(function (a, b) {
+                        return medians[b.sequence] - medians[a.sequence];
+                    });
+                }
+
+                if (sortBy === "Coefficient of Variation") {
+                    plotData.sort(function (a, b) {
+                        return cvs[b.sequence] - cvs[a.sequence];
+                    });
+                }
+
+                var cvBarLayer = new LABKEY.vis.Layer({
+                    geom: new LABKEY.vis.Geom.BarPlot({
+                        opacity: 0.2,
+                        hoverText: function (x, stats) {
+                            console.log('hover');
+                            return 'test';
+                        }
+                    }),
+                    aes: {
+                        x: 'x',
+                        yRight: 'cv',
+
+                    },
+                    data: cvLineData
+                });
+
+                var pointLayer = new LABKEY.vis.Layer({
+                    geom: new LABKEY.vis.Geom.Point({
+                        position: 'jitter',
+                        color: 'timepoint',
+                        opacity: 0.6,
+                        size: 3
+                    }),
+                    aes: {
+                        hoverText: function (row) {
+                            return row.intensity.toExponential(3) + '\n' + row.timepoint;
+                        }
+                    }
+                });
+
+                var boxLayer = new LABKEY.vis.Layer({
+                    geom: new LABKEY.vis.Geom.Boxplot({
+                        showOutliers: false
+                    }),
+                    aes: {
+                        hoverText: function (x, stats) {
+                            var sd = LABKEY.vis.Stat.getStdDev(stats.sortedValues);
+
+                            return 'Peptide: ' + x +
+                                    '\nMin: ' + stats.min.toExponential(3) +
+                                    '\nMax: ' + stats.max.toExponential(3) +
+                                    '\nMean: ' + stats.Q2.toExponential(3) +
+                                    '\nStd dev: ' + sd.toExponential(3) +
+                                    '\n%CV: ' + (stats.Q2 ? ((sd / stats.Q2) * 100).toFixed(1) : 'N/A');
+                        },
+                        clickFn: function (event, data) {
+                            console.log(data);
+                        }
+                    }
+                });
+
+                var plot = new LABKEY.vis.Plot({
+                    renderTo: 'visChart',
+                    rendererType: 'd3',
+                    clipRect: true,
+                    width: 1200,
+                    height: 400,
+                    gridLineColor: '#777777',
+                    labels: {
+                        yLeft: {value: 'Peak Area'},
+                        yRight: {value: '% Coefficient of Variation'}
+                    },
+                    data: plotData,
+                    gridLinesVisible: 'none',
+                    layers: [cvBarLayer, boxLayer, pointLayer],
+                    aes: {
+                        yLeft: 'intensity',
+                        yRight: 'cv',
+                        x: 'sequence',
+                        color: 'timepoint'
+                    },
+                    scales: {
+                        x: {
+                            scaleType: 'discrete',
+                            tickFormat: function (v) {
+                                return v.substring(0, Math.min(v.length, 3));
+                            }
+                        },
+                        yLeft: {
+                            scaleType: 'continuous',
+                            trans: 'linear',
+                            tickFormat: function (d) {
+                                if (d === 0)
+                                    return 0;
+                                return d.toExponential();
+                            }
+                        },
+                        yRight: {
+                            scaleType: 'continuous',
+                            trans: 'linear',
+                            tickFormat: function (d) {
+                                if (d === 0)
+                                    return 0;
+                                return (d * 100).toFixed(0);
+                            }
+                        }
+                    },
+                    margins: {
+                        bottom: 50
+                    }
+                });
+
+                plot.render();
+            }
+        }
     },
 
     initialize: function() {

--- a/webapp/passport/js/settings.js
+++ b/webapp/passport/js/settings.js
@@ -35,7 +35,7 @@ function Settings(updateCallback) {
             .change(function () {
                 $( "select option:selected" ).each(function() {
                     var newSort = $( this ).text();
-                    if(newSort != sortBy && (newSort == 'Intensity' || newSort == 'Sequence Location')) {
+                    if(newSort !== sortBy) {
                         sortBy = newSort;
                         update();
                     }


### PR DESCRIPTION
#### Rationale
We're extending Passport's special reporting to handle 3x3 or 5x5 replicate comparisons

#### Changes
* Overlaid scatter plot, box plot, and CV bar plot for peptides within a protein
* Offer SVG-based plotting for all Panorama JFreeChart rendered plots
* Client side code to offer PDF and PNG downloads of SVG-based plots
* Pull titles and x-axis labels out of plot into surrounding HTML
* Link to replicates list from comparison plots

