### PR TITLE
Switch to use Batik for SVG rendering so we don't need another dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,6 @@ dependencies
    external "org.xerial:sqlite-jdbc:3.7.2"
    external "org.apache.commons:commons-math3:${commonsMath3Version}"
    external "org.jfree:jcommon:1.0.17"
-   external "org.jfree:org.jfree.svg:4.2"
    implementation "org.apache.httpcomponents:httpmime:${httpmimeVersion}"
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath:  BuildUtils.getCommonAssayModuleProjectPath(project.gradle, "ms2"), depProjectConfig: "apiJarFile")
    BuildUtils.addLabKeyDependency(project: project, config: "jspImplementation", depProjectPath: BuildUtils.getCommonAssayModuleProjectPath(project.gradle, "ms2"), depProjectConfig: "apiJarFile")


### PR DESCRIPTION
#### Rationale
My recent commit added SVG rendering to JFreeChart plots generated on the server via a new third-party dependency. We can leverage our existing Batik dependency instead, which fixes BasicTest's JAR credits check

#### Related Pull Requests
* https://github.com/LabKey/targetedms/pull/341

#### Changes
* Switch to Batik SVG rendering
* Adjust XML generation slightly