### PR TITLE
Issue 42644: UnsupportedOperationException when importing a Skyline doc with transition annotations

### DIFF
--- a/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
+++ b/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
@@ -1944,9 +1944,11 @@ public class SkylineDocumentParser implements AutoCloseable
                     if (!StringUtils.isEmpty(transitionProto.getAnnotations().getNote())) {
                         transition.setNote(transitionProto.getAnnotations().getNote());
                     }
+                    List<TransitionAnnotation> annotations = new ArrayList<>();
                     for (SkylineDocument.SkylineDocumentProto.AnnotationValue transitionValue : transitionProto.getAnnotations().getValuesList()) {
-                        transition.getAnnotations().add(readAnnotationValue(transitionValue, new TransitionAnnotation()));
+                        annotations.add(readAnnotationValue(transitionValue, new TransitionAnnotation()));
                     }
+                    transition.setAnnotations(annotations);
                 }
                 list.add(transition);
             }


### PR DESCRIPTION
Exception occurs when transition data is read from a protobuf, and transition annotations are added to an unmodifiable collection.