### PR TITLE
Issue 42669: MoleculePrecursorRetentionTime data going into wrong table

### DIFF
--- a/src/org/labkey/targetedms/chromlib/ChromatogramLibraryWriter.java
+++ b/src/org/labkey/targetedms/chromlib/ChromatogramLibraryWriter.java
@@ -96,13 +96,13 @@ public class ChromatogramLibraryWriter
         _isotopeModificationDao = new LibIsotopeModificationDao();
 
         Dao<LibPrecursor> precursorDao = new LibPrecursorDao(new LibPrecursorIsotopeModificationDao(),
-                new LibPrecursorRetentionTimeDao(Constants.Column.PrecursorId),
+                new LibPrecursorRetentionTimeDao(Constants.Table.PrecursorRetentionTime, Constants.Column.PrecursorId, Constants.PrecursorRetentionTimeColumn.values()),
                 new LibTransitionDao(new LibTransitionOptimizationDao()));
         _peptideDao = new LibPeptideDao(new LibPeptideStructuralModDao(), precursorDao);
         _proteinDao = new LibProteinDao(_peptideDao);
 
         Dao<LibMoleculePrecursor> moleculePrecursorDao = new LibMoleculePrecursorDao(
-                new LibPrecursorRetentionTimeDao(Constants.Column.MoleculePrecursorId),
+                new LibPrecursorRetentionTimeDao(Constants.Table.MoleculePrecursorRetentionTime, Constants.Column.MoleculePrecursorId, Constants.MoleculePrecursorRetentionTimeColumn.values()),
                 new LibMoleculeTransitionDao(new LibMoleculeTransitionOptimizationDao()));
         _moleculeDao = new LibMoleculeDao(moleculePrecursorDao);
         _moleculeListDao = new LibMoleculeListDao(_moleculeDao);

--- a/src/org/labkey/targetedms/chromlib/LibPrecursorRetentionTimeDao.java
+++ b/src/org/labkey/targetedms/chromlib/LibPrecursorRetentionTimeDao.java
@@ -32,10 +32,14 @@ import java.util.List;
  */
 public class LibPrecursorRetentionTimeDao extends BaseDaoImpl<LibPrecursorRetentionTime>
 {
+    private final Table _table;
+    private final Constants.ColumnDef[] _columns;
     private final Constants.Column _precursorCol;
 
-    public LibPrecursorRetentionTimeDao(Constants.Column precursorCol)
+    public LibPrecursorRetentionTimeDao(Table table, Constants.Column precursorCol, Constants.ColumnDef[] columns)
     {
+        _table = table;
+        _columns = columns;
         _precursorCol = precursorCol;
     }
 
@@ -53,13 +57,13 @@ public class LibPrecursorRetentionTimeDao extends BaseDaoImpl<LibPrecursorRetent
     @Override
     public String getTableName()
     {
-        return Table.PrecursorRetentionTime.name();
+        return _table.name();
     }
 
     @Override
     protected Constants.ColumnDef[] getColumns()
     {
-        return PrecursorRetentionTimeColumn.values();
+        return _columns;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
When creating a small molecule chromatogram library in Panorama, the data that's supposed to be going into MoleculePrecursorRetentionTime is being stored in PrecursorRetentionTime. Because the tables have such similar structures we have shared codepath that's handling them both, but it's hard-coded to use PrecursorRetentionTime in a couple of places.

#### Changes
* Use appropriate table name and column list based on data type