### PR TITLE
Issue 42688: Missing IonMobilityWindow data on Precursor and Molecule…

### DIFF
--- a/src/org/labkey/targetedms/chromlib/BaseDaoImpl.java
+++ b/src/org/labkey/targetedms/chromlib/BaseDaoImpl.java
@@ -276,12 +276,13 @@ public abstract class BaseDaoImpl<T extends AbstractLibEntity> implements Dao<T>
 
     protected abstract ColumnDef[] getColumns();
 
-    protected int setIonMobilityColumns(PreparedStatement stmt, int colIndex, AbstractLibPrecursor precursor) throws SQLException
+    protected int setIonMobilityColumns(PreparedStatement stmt, int colIndex, AbstractLibPrecursor<?> precursor) throws SQLException
     {
         stmt.setObject(colIndex++, precursor.getExplicitIonMobility(), Types.DOUBLE);
         stmt.setObject(colIndex++, precursor.getCcs(), Types.DOUBLE);
         stmt.setObject(colIndex++, precursor.getIonMobilityMS1(), Types.DOUBLE);
         stmt.setObject(colIndex++, precursor.getIonMobilityFragment(), Types.DOUBLE);
+        stmt.setObject(colIndex++, precursor.getIonMobilityWindow(), Types.DOUBLE);
         stmt.setString(colIndex++, precursor.getIonMobilityType());
         stmt.setString(colIndex++, precursor.getExplicitIonMobilityUnits());
         stmt.setObject(colIndex++, precursor.getExplicitCcsSqa(), Types.DOUBLE);


### PR DESCRIPTION
…Precursor .clib tables

#### Rationale
These tables need to be fully populated and this omission also messes up the following columns in the tables' list

#### Changes
* Pass through IonMobilityWindow value