### PR TITLE
Issue 42693: Updates to the Peptide Map to show intensity and parens

### DIFF
--- a/resources/queries/targetedms/PTMPercents.query.xml
+++ b/resources/queries/targetedms/PTMPercents.query.xml
@@ -8,6 +8,7 @@
                             <className>org.labkey.targetedms.query.ModifiedSequenceDisplayColumn$PeptideDisplayColumnFactory</className>
                             <properties>
                                 <property name="showNextAndPrevious">true</property>
+                                <property name="useParens">true</property>
                             </properties>
                         </displayColumnFactory>
                     </column>

--- a/resources/queries/targetedms/PeptideIds.query.xml
+++ b/resources/queries/targetedms/PeptideIds.query.xml
@@ -11,6 +11,7 @@
                             <className>org.labkey.targetedms.query.ModifiedSequenceDisplayColumn$PeptideDisplayColumnFactory</className>
                             <properties>
                                 <property name="showNextAndPrevious">true</property>
+                                <property name="useParens">true</property>
                             </properties>
                         </displayColumnFactory>
                     </column>
@@ -22,6 +23,10 @@
                     </column>
                     <column columnName="ExpectedPeptideMass">
                         <formatString>0.00</formatString>
+                    </column>
+                    <column columnName="TotalArea">
+                        <columnTitle>Intensity</columnTitle>
+                        <formatString>0,000</formatString>
                     </column>
                 </columns>
             </table>

--- a/src/org/labkey/targetedms/view/ModifiedPeptideHtmlMaker.java
+++ b/src/org/labkey/targetedms/view/ModifiedPeptideHtmlMaker.java
@@ -70,15 +70,15 @@ public class ModifiedPeptideHtmlMaker
 
     public HtmlString getPrecursorHtml(long peptideId, long isotopeLabelId, String peptideSequence, String precursorModifiedSequence, Long runId)
     {
-        return getHtml(peptideId, isotopeLabelId, peptideSequence, precursorModifiedSequence, runId, null, null);
+        return getHtml(peptideId, isotopeLabelId, peptideSequence, precursorModifiedSequence, runId, null, null, false);
     }
 
     public HtmlString getPeptideHtml(Peptide peptide, Long runId)
     {
-        return getPeptideHtml(peptide.getId(), peptide.getSequence(), peptide.getPeptideModifiedSequence(), runId, null, null);
+        return getPeptideHtml(peptide.getId(), peptide.getSequence(), peptide.getPeptideModifiedSequence(), runId, null, null, false);
     }
 
-    public HtmlString getPeptideHtml(long peptideId, String sequence, String peptideModifiedSequence, Long runId, @Nullable String previousAA, @Nullable String nextAA)
+    public HtmlString getPeptideHtml(long peptideId, String sequence, String peptideModifiedSequence, Long runId, @Nullable String previousAA, @Nullable String nextAA, boolean useParens)
     {
         String altSequence = peptideModifiedSequence;
         if(StringUtils.isBlank(altSequence))
@@ -86,10 +86,10 @@ public class ModifiedPeptideHtmlMaker
             altSequence = sequence;
         }
 
-        return getHtml(peptideId, null, sequence, altSequence, runId, previousAA, nextAA);
+        return getHtml(peptideId, null, sequence, altSequence, runId, previousAA, nextAA, useParens);
     }
 
-    private HtmlString getHtml(long peptideId,  @Nullable Long isotopeLabelId, String sequence, String altSequence, Long runId, @Nullable String previousAA, @Nullable String nextAA)
+    private HtmlString getHtml(long peptideId,  @Nullable Long isotopeLabelId, String sequence, String altSequence, Long runId, @Nullable String previousAA, @Nullable String nextAA, boolean useParens)
     {
         Long firstIsotopeLabelIdInDoc = null;
         if(runId != null)
@@ -132,8 +132,12 @@ public class ModifiedPeptideHtmlMaker
 
         if (previousAA != null)
         {
+            if (useParens)
+            {
+                result.append("(");
+            }
             result.append(PageFlowUtil.filter(previousAA));
-            result.append(".");
+            result.append(useParens ? ")" : ".");
         }
 
         for(int i = 0; i < sequence.length(); i++)
@@ -163,8 +167,12 @@ public class ModifiedPeptideHtmlMaker
 
         if (nextAA != null)
         {
-            result.append(".");
+            result.append(useParens ? "(" : ".");
             result.append(PageFlowUtil.filter(nextAA));
+            if (useParens)
+            {
+                result.append(")");
+            }
         }
 
         result.append("</span>");

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSMAMTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSMAMTest.java
@@ -64,7 +64,7 @@ public class TargetedMSMAMTest extends TargetedMSTest
         clickAndWait(Locator.linkContainingText("PTM Report"));
 
         assertElementPresent("Wrong modification count", Locator.xpath("//td[contains(text(), 'Carbamidomethyl Cysteine')]"), 9);
-        assertTextPresentInThisOrder("K.HDLDLICR.A", "K.YLECSALTQR.G", "R.YVDIAIPCNNK.G");
+        assertTextPresentInThisOrder("(K)HDLDLICR(A)", "(K)YLECSALTQR(G)", "(R)YVDIAIPCNNK(G)");
         assertTextPresentInThisOrder("C245", "C157", "C163");
         assertTextPresent("A_D110907_SiRT_HELA_11_nsMRM_150selected_2_30min-5-35", "A_D110907_SiRT_HELA_11_nsMRM_150selected_1_30min-5-35");
 
@@ -73,7 +73,7 @@ public class TargetedMSMAMTest extends TargetedMSTest
         assertTextPresentInThisOrder("1501.75", "1078.50", "1547.71");
         assertTextPresentInThisOrder("NU205", "NU205", "1433Z");
         assertTextPresentInThisOrder("70-84", "325-333", "28-41");
-        assertTextPresentInThisOrder("K.ASTEGVAIQGQQGTR.L", "K.AQYEDIANR.S", "K.SVTEQGAELSNEER.N");
+        assertTextPresentInThisOrder("(K)ASTEGVAIQGQQGTR(L)", "(K)AQYEDIANR(S)", "(K)SVTEQGAELSNEER(N)");
         assertTextPresentInThisOrder("Carbamidomethyl Cysteine @ C156", "Carbamidomethyl Cysteine @ C244", "Carbamidomethyl Cysteine @ C93");
     }
 }


### PR DESCRIPTION
#### Rationale
Small changes to the formatting of these reports to make them more directly usable by the group driving their development, without intermediate transformation steps

#### Changes
* Add intensity column to peptide map report
* Use parens around the previous and next amino acids instead of using a dot separator
* Include the previous and next AA info when exporting to TSV and Excel