### PR TITLE
Issue 42694 followup: Remove redundant columns from Precursor .clib table

### DIFF
--- a/src/org/labkey/targetedms/chromlib/Constants.java
+++ b/src/org/labkey/targetedms/chromlib/Constants.java
@@ -534,8 +534,6 @@ class Constants
         ExplicitCompensationVoltage(Column.ExplicitCompensationVoltage),
         PrecursorConcentration(Column.PrecursorConcentration),
 
-        MassMonoisotopic(Column.MassMonoisotopic),
-        MassAverage(Column.MassAverage),
         Adduct(Column.Adduct);
 
         private final Column _column;

--- a/src/org/labkey/targetedms/chromlib/LibPrecursor.java
+++ b/src/org/labkey/targetedms/chromlib/LibPrecursor.java
@@ -76,8 +76,6 @@ public class LibPrecursor extends AbstractLibEntity
     private List<LibPrecursorIsotopeModification> _isotopeModifications;
 
     // Small molecule fields
-    private Double _massMonoisotopic;
-    private Double _massAverage;
     private String _adduct;
 
 
@@ -146,8 +144,6 @@ public class LibPrecursor extends AbstractLibEntity
     {
         this((GeneralPrecursor<?>) p, isotopeLabelMap, chromInfo, run, sampleFileIdMap);
         setAdduct(p.getAdduct());
-        setMassMonoisotopic(p.getMassMonoisotopic());
-        setMassAverage(p.getMassAverage());
     }
 
 
@@ -180,8 +176,6 @@ public class LibPrecursor extends AbstractLibEntity
         setPrecursorConcentration(readDouble(rs, Constants.PrecursorColumn.PrecursorConcentration.baseColumn().name()));
 
         // Small molecule
-        setMassMonoisotopic(readDouble(rs, Constants.PrecursorColumn.MassMonoisotopic.baseColumn().name()));
-        setMassAverage(readDouble(rs, Constants.PrecursorColumn.MassAverage.baseColumn().name()));
         setAdduct(rs.getString(Constants.PrecursorColumn.Adduct.baseColumn().name()));
     }
 
@@ -507,26 +501,6 @@ public class LibPrecursor extends AbstractLibEntity
     public Double getPrecursorConcentration()
     {
         return _precursorConcentration;
-    }
-
-    public Double getMassMonoisotopic()
-    {
-        return _massMonoisotopic;
-    }
-
-    public void setMassMonoisotopic(Double massMonoisotopic)
-    {
-        _massMonoisotopic = massMonoisotopic;
-    }
-
-    public Double getMassAverage()
-    {
-        return _massAverage;
-    }
-
-    public void setMassAverage(Double massAverage)
-    {
-        _massAverage = massAverage;
     }
 
     public String getAdduct()

--- a/src/org/labkey/targetedms/chromlib/LibPrecursorDao.java
+++ b/src/org/labkey/targetedms/chromlib/LibPrecursorDao.java
@@ -17,7 +17,6 @@ package org.labkey.targetedms.chromlib;
 
 import org.labkey.targetedms.chromlib.Constants.PrecursorColumn;
 import org.labkey.targetedms.chromlib.Constants.Table;
-import org.labkey.targetedms.query.TransitionManager;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -114,8 +113,6 @@ public class LibPrecursorDao extends BaseDaoImpl<LibPrecursor>
         stmt.setObject(colIndex++, precursor.getExplicitCompensationVoltage(), Types.DOUBLE);
         stmt.setObject(colIndex++, precursor.getPrecursorConcentration(), Types.DOUBLE);
 
-        stmt.setObject(colIndex++, precursor.getMassMonoisotopic(), Types.DOUBLE);
-        stmt.setObject(colIndex++, precursor.getMassAverage(), Types.DOUBLE);
         stmt.setString(colIndex++, precursor.getAdduct());
     }
 


### PR DESCRIPTION
#### Rationale
The Precursor table's MassAverage and MassMonoisotopic columns are present in the Skyline XML file but are redundant with the molecule's values, so we don't need to include them here too

#### Changes
* Drop columns from .clib schema