### PR TITLE
Issue 42694 followup: Remove unwanted PrecursorConcentration column

### DIFF
--- a/src/org/labkey/targetedms/chromlib/Constants.java
+++ b/src/org/labkey/targetedms/chromlib/Constants.java
@@ -145,7 +145,6 @@ class Constants
         ExplicitIonMobilityUnits("VARCHAR(200)"),
         ExplicitCcsSqa("DOUBLE"),
         ExplicitCompensationVoltage("DOUBLE"),
-        PrecursorConcentration("DOUBLE"),
 
         PrecursorId("INTEGER NOT NULL", Table.Precursor, Id),
         IsotopeModId("INTEGER NOT NULL", Table.IsotopeModification, Id),
@@ -532,7 +531,6 @@ class Constants
         ExplicitIonMobilityUnits(Column.ExplicitIonMobilityUnits),
         ExplicitCcsSqa(Column.ExplicitCcsSqa),
         ExplicitCompensationVoltage(Column.ExplicitCompensationVoltage),
-        PrecursorConcentration(Column.PrecursorConcentration),
 
         Adduct(Column.Adduct);
 

--- a/src/org/labkey/targetedms/chromlib/LibPrecursor.java
+++ b/src/org/labkey/targetedms/chromlib/LibPrecursor.java
@@ -64,7 +64,6 @@ public class LibPrecursor extends AbstractLibEntity
     private String _explicitIonMobilityUnits;
     private Double _explicitCcsSqa;
     private Double _explicitCompensationVoltage;
-    private Double _precursorConcentration;
 
     protected List<LibPrecursorRetentionTime> _retentionTimes;
     protected List<LibTransition> _transitions;
@@ -98,7 +97,6 @@ public class LibPrecursor extends AbstractLibEntity
         setExplicitIonMobilityUnits(p.getExplicitIonMobilityUnits());
         setExplicitCcsSqa(p.getExplicitCcsSqa());
         setExplicitCompensationVoltage(p.getExplicitCompensationVoltage());
-        setPrecursorConcentration(p.getPrecursorConcentration());
 
         if (bestChromInfo != null)
         {
@@ -173,7 +171,6 @@ public class LibPrecursor extends AbstractLibEntity
         setExplicitIonMobilityUnits(rs.getString(Constants.PrecursorColumn.ExplicitIonMobilityUnits.baseColumn().name()));
         setExplicitCcsSqa(readDouble(rs, Constants.PrecursorColumn.ExplicitCcsSqa.baseColumn().name()));
         setExplicitCompensationVoltage(readDouble(rs, Constants.PrecursorColumn.ExplicitCompensationVoltage.baseColumn().name()));
-        setPrecursorConcentration(readDouble(rs, Constants.PrecursorColumn.PrecursorConcentration.baseColumn().name()));
 
         // Small molecule
         setAdduct(rs.getString(Constants.PrecursorColumn.Adduct.baseColumn().name()));
@@ -491,16 +488,6 @@ public class LibPrecursor extends AbstractLibEntity
     public Double getExplicitCompensationVoltage()
     {
         return _explicitCompensationVoltage;
-    }
-
-    public void setPrecursorConcentration(Double precursorConcentration)
-    {
-        _precursorConcentration = precursorConcentration;
-    }
-
-    public Double getPrecursorConcentration()
-    {
-        return _precursorConcentration;
     }
 
     public String getAdduct()

--- a/src/org/labkey/targetedms/chromlib/LibPrecursorDao.java
+++ b/src/org/labkey/targetedms/chromlib/LibPrecursorDao.java
@@ -111,7 +111,6 @@ public class LibPrecursorDao extends BaseDaoImpl<LibPrecursor>
         stmt.setString(colIndex++, precursor.getExplicitIonMobilityUnits());
         stmt.setObject(colIndex++, precursor.getExplicitCcsSqa(), Types.DOUBLE);
         stmt.setObject(colIndex++, precursor.getExplicitCompensationVoltage(), Types.DOUBLE);
-        stmt.setObject(colIndex++, precursor.getPrecursorConcentration(), Types.DOUBLE);
 
         stmt.setString(colIndex++, precursor.getAdduct());
     }


### PR DESCRIPTION
#### Rationale
The PrecursorConcentration column isn't needed in .clib files and may cause confusion, so let's banish it.

#### Changes
* Drop the Precursor.PrecursorConcentration column