### PR TITLE
Issue 42869: SamplePivotCustomizer using wrong table for grabbing pivot columns

### DIFF
--- a/src/org/labkey/targetedms/query/SamplePivotCustomizer.java
+++ b/src/org/labkey/targetedms/query/SamplePivotCustomizer.java
@@ -67,7 +67,7 @@ public class SamplePivotCustomizer implements TableCustomizer
                         TargetedMSSchema schema = new TargetedMSSchema(context.getUser(), context.getContainer());
                         TableInfo sampleFileTable = schema.getTable(TargetedMSSchema.TABLE_SAMPLE_FILE);
                         for (Map<String, Object> sampleInfo : new TableSelector(sampleFileTable,
-                                QueryService.get().getColumns(tableInfo, Set.of(FieldKey.fromParts("SampleName"), FieldKey.fromParts("ReplicateId", "Name"))).values(),
+                                QueryService.get().getColumns(sampleFileTable, Set.of(FieldKey.fromParts("SampleName"), FieldKey.fromParts("ReplicateId", "Name"))).values(),
                                 new SimpleFilter(FieldKey.fromParts("ReplicateId", "RunId"), runId), null).getMapCollection())
                         {
                             for (Object sampleName : sampleInfo.values())


### PR DESCRIPTION
#### Rationale
Our intent is to filter the visible pivot columns based on the replicates and/or samples in the selected run. But because I typo'd we're not finding any matches

#### Changes
* Use the correct TableInfo to fetch the replicate and sample names