### PR TITLE
Issue 42839: Link to QC folder from experimental folder doesn't zoom date range

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -1321,7 +1321,9 @@ public class TargetedMSController extends SpringActionController
             GuideSet gs = null;
             for (GuideSet guideSet : guideSets)
             {
-                if (!guideSet.isDefault() && guideSet.getTrainingEnd().before(startDate))
+                // guideset end date should be before or equal start date
+                if (!guideSet.isDefault() &&
+                        (guideSet.getTrainingEnd().before(startDate) || DateUtil.getDateOnly(guideSet.getTrainingEnd()).compareTo(startDate) == 0))
                 {
                     if (null == gs)
                     {

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentalQCLinkTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentalQCLinkTest.java
@@ -72,8 +72,7 @@ public class TargetedMSExperimentalQCLinkTest extends TargetedMSTest
         checker().verifyTrue("Instruments Summary webpart is missing",
                 isElementPresent(Locator.tagWithAttribute("h3", "title", "Instruments Summary")));
         table = new DataRegionTable("InstrumentSummary", getDriver());
-        checker().verifyEquals("Invalid QC Folder Name ", QC_FOLDER_1,
-                table.getDataAsText(0, "QCFolders"));
+        checker().verifyTrue("Invalid QC Folder Name ", table.getDataAsText(0, "QCFolders").contains(QC_FOLDER_1));
 
         setUpFolder(QC_FOLDER_2, FolderType.QC);
         importData(SKY_FILE_QC);
@@ -86,8 +85,8 @@ public class TargetedMSExperimentalQCLinkTest extends TargetedMSTest
         table = new DataRegionTable("InstrumentSummary", getDriver());
         checker().verifyEquals("Invalid Instrument serial number", "Exactive Series slot #2384",
                 table.getDataAsText(0, "SerialNumber"));
-        checker().verifyEquals("Invalid QC Folder Name ", QC_FOLDER_1 + "\n" + QC_FOLDER_2,
-                table.getDataAsText(0, "QCFolders"));
+        checker().verifyTrue("Invalid QC Folder Name ",
+                table.getDataAsText(0, "QCFolders").contains(QC_FOLDER_1 + "\n" + QC_FOLDER_2));
 
         clickAndWait(Locator.linkWithText(QC_FOLDER_1));
         checker().verifyEquals("Did not navigate to QC folder ", QC_FOLDER_1, getCurrentContainer());

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentalQCLinkTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentalQCLinkTest.java
@@ -102,8 +102,6 @@ public class TargetedMSExperimentalQCLinkTest extends TargetedMSTest
     public void testLinkExperimentalQC()
     {
         String expRange = "Skyline File: " + SKY_FILE_EXPERIMENT + ", " +
-                "Serial No: Exactive Series slot #2384, " +
-                "Instrument Name: Q Exactive, " +
                 "Start: 2013-08-09 11:39:00, " +
                 "End: 2013-08-27 14:45:49, " +
                 "Mean: 14.669, Std Dev: 0.501, " +

--- a/webapp/TargetedMS/js/BaseQCPlotPanel.js
+++ b/webapp/TargetedMS/js/BaseQCPlotPanel.js
@@ -203,14 +203,14 @@ Ext4.define('LABKEY.targetedms.BaseQCPlotPanel', {
     queryQCInstruments: function(successCallback, callbackScope) {
         LABKEY.Query.executeSql({
             schemaName: 'targetedms',
-            sql: 'SELECT DISTINCT instrumentSerialNumber FROM samplefile',
+            sql: 'SELECT DISTINCT instrumentSerialNumber, instrumentId.model FROM samplefile',
             containerFilter: LABKEY.Query.containerFilter.current,
             scope: this,
             success: function (response) {
 
                 if (response.rows && response.rows.length > 0) {
                     this.qcIntrumentsArr = response.rows.map(function (row) {
-                        return row.instrumentSerialNumber;
+                        return row.instrumentSerialNumber + (row.model ? ' - ' + row.model : '');
                     })
                 }
 

--- a/webapp/TargetedMS/js/BaseQCPlotPanel.js
+++ b/webapp/TargetedMS/js/BaseQCPlotPanel.js
@@ -210,7 +210,15 @@ Ext4.define('LABKEY.targetedms.BaseQCPlotPanel', {
 
                 if (response.rows && response.rows.length > 0) {
                     this.qcIntrumentsArr = response.rows.map(function (row) {
-                        return row.instrumentSerialNumber + (row.model ? ' - ' + row.model : '');
+                        if (row.instrumentSerialNumber && row.model) {
+                            return row.instrumentSerialNumber + ' - ' + row.model;
+                        }
+                        else if (row.instrumentSerialNumber && !row.model) {
+                            return row.instrumentSerialNumber;
+                        }
+                        else if (!row.instrumentSerialNumber && row.model) {
+                            return row.model;
+                        }
                     })
                 }
 

--- a/webapp/TargetedMS/js/BaseQCPlotPanel.js
+++ b/webapp/TargetedMS/js/BaseQCPlotPanel.js
@@ -200,6 +200,26 @@ Ext4.define('LABKEY.targetedms.BaseQCPlotPanel', {
         });
     },
 
+    queryQCInstruments: function(successCallback, callbackScope) {
+        LABKEY.Query.executeSql({
+            schemaName: 'targetedms',
+            sql: 'SELECT DISTINCT instrumentSerialNumber FROM samplefile',
+            containerFilter: LABKEY.Query.containerFilter.current,
+            scope: this,
+            success: function (response) {
+
+                if (response.rows && response.rows.length > 0) {
+                    this.qcIntrumentsArr = response.rows.map(function (row) {
+                        return row.instrumentSerialNumber;
+                    })
+                }
+
+                successCallback.call(callbackScope);
+            },
+            failure: this.failureHandler
+        });
+    },
+
     formatValue: function(value) {
         return Math.round(value * 10000) / 10000;
     }

--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -201,17 +201,19 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
             }
         }
 
-        // no need to filter if less than 6 data points are present between reference end of guideset and startdate
-        if (this.filterPointsLastIndex - this.filterPointsFirstIndex < 6) {
-            this.filterQCPoints = false;
-            // set the startDate field = acquired time of the 1st point of 5 points before the experiment run range
-            this.getStartDateField().setValue(this.formatDate(tempData.data[this.filterPointsFirstIndex].AcquiredTime));
-        }
-        else if (this.showExpRunRange){ // skip 5 points
-            this.filterPointsLastIndex = this.filterPointsLastIndex - 6;
-            // set the startDate field = acquired time of the 1st point of 5 points before the experiment run range
-            // adding 1 as the point is right after filter last index
-            this.getStartDateField().setValue(this.formatDate(tempData.data[this.filterPointsLastIndex + 1].AcquiredTime));
+        if (this.showExpRunRange) {
+            // no need to filter if less than 6 data points are present between reference end of guideset and startdate
+            if (this.filterPointsLastIndex - this.filterPointsFirstIndex < 6) {
+                this.filterQCPoints = false;
+                // set the startDate field = acquired time of the 1st point of 5 points before the experiment run range
+                this.getStartDateField().setValue(this.formatDate(tempData.data[this.filterPointsFirstIndex].AcquiredTime));
+            }
+            else { // skip 5 points
+                this.filterPointsLastIndex = this.filterPointsLastIndex - 6;
+                // set the startDate field = acquired time of the 1st point of 5 points before the experiment run range
+                // adding 1 as the point is right after filter last index
+                this.getStartDateField().setValue(this.formatDate(tempData.data[this.filterPointsLastIndex + 1].AcquiredTime));
+            }
         }
 
         // Issue 31678: get the full set of dates values from the precursor data and from the annotations

--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -204,6 +204,8 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
         // no need to filter if less than 6 data points are present between reference end of guideset and startdate
         if (this.filterPointsLastIndex - this.filterPointsFirstIndex < 6) {
             this.filterQCPoints = false;
+            // set the startDate field = acquired time of the 1st point of 5 points before the experiment run range
+            this.getStartDateField().setValue(this.formatDate(tempData.data[this.filterPointsFirstIndex].AcquiredTime));
         }
         else if (this.showExpRunRange){ // skip 5 points
             this.filterPointsLastIndex = this.filterPointsLastIndex - 6;

--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -201,7 +201,7 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
             }
         }
 
-        if (this.showExpRunRange) {
+        if (this.showExpRunRange && this.filterPointsLastIndex && this.filterPointsFirstIndex) {
             // no need to filter if less than 6 data points are present between reference end of guideset and startdate
             if (this.filterPointsLastIndex - this.filterPointsFirstIndex < 6) {
                 this.filterQCPoints = false;
@@ -681,7 +681,8 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
             disableRangeDisplay: this.isMultiSeries()
         };
 
-        if (this.filterQCPoints) {
+        // lines are not separated when indices are not present
+        if (this.filterQCPoints && this.filterPointsLastIndex && this.filterPointsFirstIndex) {
             trendLineProps.lineColor = '#000000';
             trendLineProps.groupBy = "ReferenceRangeSeries";
         }

--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -158,8 +158,10 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
             this.processRawGuideSetData(plotDataRows);
         }
 
+        var tempData; // temp variable to store data for setting the date
         for (var i = this.pagingStartIndex; i < this.pagingEndIndex; i++) {
             var plotDataRow = plotDataRows[i];
+            tempData = plotDataRow;
             var fragment = plotDataRow.SeriesLabel;
             Ext4.iterate(plotDataRow.data, function (plotData) {
                 Ext4.iterate(sampleFiles, function (sampleFile) {
@@ -195,10 +197,6 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
                             this.filterPointsLastIndex = j;
                         }
                     }
-
-                    if (j === this.filterPointsFirstIndex) {
-                        this.getStartDateField().setValue(this.formatDate(plotDataRow.data[this.filterPointsFirstIndex].AcquiredTime));
-                    }
                 }
             }
         }
@@ -207,8 +205,11 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
         if (this.filterPointsLastIndex - this.filterPointsFirstIndex < 6) {
             this.filterQCPoints = false;
         }
-        else { // skip 5 points
+        else if (this.showExpRunRange){ // skip 5 points
             this.filterPointsLastIndex = this.filterPointsLastIndex - 6;
+            // set the startDate field = acquired time of the 1st point of 5 points before the experiment run range
+            // adding 1 as the point is right after filter last index
+            this.getStartDateField().setValue(this.formatDate(tempData.data[this.filterPointsLastIndex + 1].AcquiredTime));
         }
 
         // Issue 31678: get the full set of dates values from the precursor data and from the annotations

--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -192,9 +192,12 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
                     // for truncating out of range guideset data find last index of plotData starting from this.startDate
                     if (plotData.AcquiredTime >= this.startDate) {
                         if (!this.filterPointsLastIndex) {
-                            // skip 5 points
                             this.filterPointsLastIndex = j;
                         }
+                    }
+
+                    if (j === this.filterPointsFirstIndex) {
+                        this.getStartDateField().setValue(this.formatDate(plotDataRow.data[this.filterPointsFirstIndex].AcquiredTime));
                     }
                 }
             }
@@ -204,7 +207,7 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
         if (this.filterPointsLastIndex - this.filterPointsFirstIndex < 6) {
             this.filterQCPoints = false;
         }
-        else {
+        else { // skip 5 points
             this.filterPointsLastIndex = this.filterPointsLastIndex - 6;
         }
 

--- a/webapp/TargetedMS/js/QCSummaryPanel.js
+++ b/webapp/TargetedMS/js/QCSummaryPanel.js
@@ -20,25 +20,27 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
         this.numSampleFileStats = config ? config.sampleLimit : 3;
     },
 
-    initPanel : function(){
+    initPanel : function() {
+        this.qcPlotPanel.queryQCInstruments(this.getQCSummary, this);
+    },
 
+    getQCSummary: function () {
         LABKEY.Ajax.request({
             url: LABKEY.ActionURL.buildURL('targetedms', 'getQCSummary.api'),
             params: {
                 includeSubfolders: true
             },
             scope: this,
-            success: LABKEY.Utils.getCallbackWrapper(function (response)
-            {
+            success: LABKEY.Utils.getCallbackWrapper(function (response) {
                 var containers = response['containers'],
-                    container,
-                    childPanelItems = [],
-                    hasChildren = containers.length > 1;
+                        container,
+                        childPanelItems = [],
+                        hasChildren = containers.length > 1;
 
                 // determine the summaryView width
                 var portalWebpart = document.querySelector('.panel.panel-portal'),
-                    minWidth = 750,
-                    width = portalWebpart ? Math.max(portalWebpart.clientWidth - 50, minWidth) : minWidth;
+                        minWidth = 750,
+                        width = portalWebpart ? Math.max(portalWebpart.clientWidth - 50, minWidth) : minWidth;
                 if (hasChildren && containers.length > 1 && (width/2) > minWidth) {
                     width = (width / 2) - 5;
                 }
@@ -48,13 +50,19 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
                 container.showName = hasChildren;
                 container.isParent = true;
                 container.parentOnly = containers.length == 1;
+                if (this.qcPlotPanel.qcIntrumentsArr) {
+                    if (this.qcPlotPanel.qcIntrumentsArr.length > 1) {
+                        container.instrument = 'multiple instruments. QC folders should have data from only one instrument.'
+                    }
+                    else if (this.qcPlotPanel.qcIntrumentsArr.length === 1) {
+                        container.instrument = this.qcPlotPanel.qcIntrumentsArr[0];
+                    }
+                }
                 this.add(this.getContainerSummaryView(container, hasChildren, width));
 
                 // Add the set of child containers in an hbox layout
-                if (hasChildren)
-                {
-                    for (var i = 1; i < containers.length; i++)
-                    {
+                if (hasChildren) {
+                    for (var i = 1; i < containers.length; i++) {
                         container = containers[i];
                         container.showName = true;
                         container.parentOnly = false;
@@ -69,8 +77,7 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
                 }
 
             }, this, false),
-            failure: LABKEY.Utils.getCallbackWrapper(function (response)
-            {
+            failure: LABKEY.Utils.getCallbackWrapper(function (response) {
                 this.add(Ext4.create('Ext.Component', {
                     autoEl: 'span',
                     cls: 'labkey-error',
@@ -80,8 +87,7 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
         });
     },
 
-    getContainerSummaryView: function (container, hasChildren, width)
-    {
+    getContainerSummaryView: function (container, hasChildren, width) {
         container.viewCmpId = Ext4.id();
         container.autoQcCalloutId = Ext4.id();
 
@@ -91,8 +97,7 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
             tpl: this.getSummaryDisplayTpl(),
             listeners: {
                 scope: this,
-                render: function ()
-                {
+                render: function () {
                     this.queryContainerSampleFileStats(container);
 
                     // add hover event listeners for showing AutoQC message
@@ -101,14 +106,12 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
             }
         };
 
-        if (Ext4.isDefined(hasChildren))
-        {
+        if (Ext4.isDefined(hasChildren)) {
             config.cls = hasChildren ? 'summary-view' : '';
             config.width = hasChildren ? width : undefined;
             config.minHeight = 21;
         }
-        else
-        {
+        else {
             config.cls = 'summary-view subfolder-view';
             config.width = width;
             config.minHeight = 136;
@@ -119,8 +122,7 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
         return Ext4.create('Ext.view.View', config);
     },
 
-    getSummaryDisplayTpl: function ()
-    {
+    getSummaryDisplayTpl: function () {
         return new Ext4.XTemplate(
             '<tpl if="showName !== undefined">',
                 '<tpl if="showName === true &amp;&amp; (isParent !== true || docCount &gt; 0)">',
@@ -136,7 +138,7 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
                 '<tpl elseif="docCount &gt; 0">',
                     '<div class="qc-summary-text">',
                         '<a href="{path:this.getSampleFileLink}">{fileCount} sample file{fileCount:this.pluralize}</a> ' +
-                            'tracking {precursorCount} precursor{precursorCount:this.pluralize} with {metricCount} metric{metricCount:this.pluralize}',
+                            'tracking {precursorCount} precursor{precursorCount:this.pluralize} with {metricCount} metric{metricCount:this.pluralize} for {instrument}',
                     '</div>',
                     '<div class="item-text sample-file-details sample-file-details-loading" id="qc-summary-samplefiles-{id}">Loading...</div>',
                     '<div class="auto-qc-ping" id="{autoQcCalloutId}">AutoQC <span class="{autoQCPing:this.getAutoQCPingClass}"></span></div>',
@@ -170,21 +172,18 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
         );
     },
 
-    showAutoQCMessage : function(divId, autoQC, hasChildren)
-    {
+    showAutoQCMessage : function(divId, autoQC, hasChildren) {
         var divEl = Ext4.get(divId),
             content = '', width = undefined;
 
         if (!divEl)
             return;
 
-        if (autoQC == null)
-        {
+        if (autoQC == null) {
             content = 'Has never been pinged';
             width = 155;
         }
-        else
-        {
+        else {
             var modifiedFormatted = Ext4.util.Format.date(Ext4.Date.parse(autoQC.modified, LABKEY.Utils.getDateTimeFormatWithMS()), LABKEY.extDefaultDateTimeFormat || 'Y-m-d H:i:s');
             content = autoQC.isRecent ? 'Was pinged recently on ' + modifiedFormatted : 'Was pinged on ' + modifiedFormatted;
             width = autoQC.isRecent ? 160 : 140;
@@ -212,10 +211,8 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
         }, this);
     },
 
-    queryContainerSampleFileStats: function (container)
-    {
-        if (container.fileCount > 0)
-        {
+    queryContainerSampleFileStats: function (container) {
+        if (container.fileCount > 0) {
             LABKEY.Ajax.request({
                 url: LABKEY.ActionURL.buildURL('targetedms', 'GetQCMetricOutliers.api', container.path),
                 params: {sampleLimit: this.sampleLimit},
@@ -245,8 +242,7 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
                 scope: this
             });
         }
-        else if (container.docCount > 0)
-        {
+        else if (container.docCount > 0) {
            this.removeSampleFilesDetailsDiv(container);
         }
     },
@@ -261,8 +257,7 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
         var container = params.container;
             var html = '<table class="table-condensed labkey-data-region-legacy labkey-show-borders"><thead><tr><td class="labkey-column-header">Sample Name</td><td class="labkey-column-header">Acquired</td><td class="labkey-column-header">Total outliers</td></tr></thead>';
             var sampleFiles = params.sampleFiles;
-            Ext4.iterate(sampleFiles, function (sampleFile)
-            {
+            Ext4.iterate(sampleFiles, function (sampleFile) {
                 // create a new div id for each sampleFile to use for the hover details callout
                 sampleFile.calloutId = Ext4.id();
 
@@ -293,14 +288,12 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
             this.doLayout();
 
             // add a hover listener for each of the sample file divs
-            Ext4.iterate(sampleFiles, function (sampleFile)
-            {
+            Ext4.iterate(sampleFiles, function (sampleFile) {
                 this.showSampleFileStatsDetails(sampleFile.calloutId, sampleFile);
             }, this);
     },
 
-    showSampleFileStatsDetails : function(divId, sampleFile)
-    {
+    showSampleFileStatsDetails : function(divId, sampleFile) {
         var task = new Ext4.util.DelayedTask(),
             divEl = Ext4.get(divId),
             content = '';

--- a/webapp/TargetedMS/js/QCSummaryPanel.js
+++ b/webapp/TargetedMS/js/QCSummaryPanel.js
@@ -52,7 +52,9 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
                 container.parentOnly = containers.length == 1;
                 if (this.qcPlotPanel.qcIntrumentsArr) {
                     if (this.qcPlotPanel.qcIntrumentsArr.length > 1) {
-                        container.instrument = 'multiple instruments. We recommend that each instrument use its own QC folder.'
+                        var msg = 'We recommend that each instrument use its own QC folder.'
+                        container.instrument = 'multiple instruments - ' + this.qcPlotPanel.qcIntrumentsArr.join(', ') + '. ' + msg;
+
                     }
                     else if (this.qcPlotPanel.qcIntrumentsArr.length === 1) {
                         container.instrument = this.qcPlotPanel.qcIntrumentsArr[0];

--- a/webapp/TargetedMS/js/QCSummaryPanel.js
+++ b/webapp/TargetedMS/js/QCSummaryPanel.js
@@ -52,7 +52,7 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
                 container.parentOnly = containers.length == 1;
                 if (this.qcPlotPanel.qcIntrumentsArr) {
                     if (this.qcPlotPanel.qcIntrumentsArr.length > 1) {
-                        container.instrument = 'multiple instruments. QC folders should have data from only one instrument.'
+                        container.instrument = 'multiple instruments. We recommend that each instrument use its own QC folder.'
                     }
                     else if (this.qcPlotPanel.qcIntrumentsArr.length === 1) {
                         container.instrument = this.qcPlotPanel.qcIntrumentsArr[0];

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -549,8 +549,8 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
             var htmlStr = this.showExpRunRange
                     ? "<a href=" + Ext4.String.htmlEncode(returnUrl) + ">"
                     + Ext4.String.htmlEncode(this.expRunDetails.fileName) + " : "
-                    + Ext4.String.htmlEncode(this.formatDate(this.expRunDetails.startDate)) + " through "
-                    + Ext4.String.htmlEncode(this.formatDate(this.expRunDetails.endDate))
+                    + Ext4.String.htmlEncode(this.formatDate(this.expRunDetails.startDate, false)) + " through "
+                    + Ext4.String.htmlEncode(this.formatDate(this.expRunDetails.endDate, false))
                     + "</a>"
                     : "";
             this.experimentRunDateRangeToolbar = Ext4.create('Ext.toolbar.Toolbar', {
@@ -1741,8 +1741,8 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                 return Ext4.util.Format.date(d, 'Y-m-d');
             }
         }
-        else if (typeof(d) === 'string' && d.length === 19) {
-            // support format of strings like "2013-08-27 14:45:49"
+        else if (typeof(d) === 'string' && (d.length === 19 || d.length === 23)) {
+            // support format of strings like "2013-08-27 14:45:49" or "2013-08-16 20:26:28.000"
             return includeTime ? d : d.substring(0, d.indexOf(' '));
         }
         else {

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -51,8 +51,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         // min and max acquired date must be provided
         if (this.minAcquiredTime == null || this.maxAcquiredTime == null)
             Ext4.get(this.plotDivId).update("<span class='labkey-error'>Unable to render report. Missing min and max AcquiredTime from data query.</span>");
-        else
-        {
+        else {
             // Load replicate annotations in the callback.
             this.queryInitialQcMetrics(this.queryContainerReplicateAnnotations, this);
         }
@@ -64,26 +63,21 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
             url: LABKEY.ActionURL.buildURL('targetedms', 'leveyJenningsPlotOptions.api'),
             method: 'POST',
             scope: this,
-            success: LABKEY.Utils.getCallbackWrapper(function(response)
-            {
+            success: LABKEY.Utils.getCallbackWrapper(function(response) {
                 // convert the boolean and integer values from strings
                 var initValues = {};
                 Ext4.iterate(response.properties, function(key, value)
                 {
-                    if (value === "true" || value === "false")
-                    {
+                    if (value === "true" || value === "false") {
                         value = value === "true";
                     }
-                    else if (value != undefined && value.length > 0 && !isNaN(Number(value)))
-                    {
+                    else if (value != undefined && value.length > 0 && !isNaN(Number(value))) {
                         value = +value;
                     }
-                    else if (key == 'plotTypes') // convert string to array
-                    {
+                    else if (key == 'plotTypes') { // convert string to array
                         value = value.split(',');
                     }
-                    if(key === 'selectedAnnotations')
-                    {
+                    if(key === 'selectedAnnotations') {
                         var annotations = {};
 
                         var a = value.split(',');
@@ -103,8 +97,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                         }
                         initValues[key] = annotations;
                     }
-                    else
-                    {
+                    else {
                         initValues[key] = value;
                     }
 
@@ -124,8 +117,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
             url: LABKEY.ActionURL.buildURL('targetedms', 'GetContainerReplicateAnnotations.api'),
             method: 'GET',
             scope: this,
-            success: LABKEY.Utils.getCallbackWrapper(function(response)
-            {
+            success: LABKEY.Utils.getCallbackWrapper(function(response) {
                 var annotationNodes = [];
                 Ext4.iterate(response.replicateAnnotations, function(annotation)
                 {
@@ -143,16 +135,14 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                 this.queryInitialPlotOptions();
 
             }, this, false),
-            failure: LABKEY.Utils.getCallbackWrapper(function (response)
-            {
+            failure: LABKEY.Utils.getCallbackWrapper(function (response) {
                 this.failureHandler(response);
             }, null, true)
         });
     },
 
     calculateStartDateByOffset : function() {
-        if (this.dateRangeOffset > 0)
-        {
+        if (this.dateRangeOffset > 0) {
             var todayMinusOffset = new Date();
             todayMinusOffset.setDate(todayMinusOffset.getDate() - this.dateRangeOffset);
             return todayMinusOffset;
@@ -173,8 +163,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         Ext4.apply(this, initValues);
 
         // if we have a dateRangeOffset, we need to calculate the start and end date
-        if (this.dateRangeOffset > -1)
-        {
+        if (this.dateRangeOffset > -1) {
             this.startDate = this.formatDate(this.calculateStartDateByOffset());
             this.endDate = this.formatDate(this.calculateEndDateByOffset());
         }
@@ -196,6 +185,46 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         }
     },
 
+    getExperimentRunDetails: function (runId) {
+        var sql = "Select MIN(sf.AcquiredTime) AS StartDate,\n" +
+                "       MAX(sf.AcquiredTime) AS EndDate,\n" +
+                "       r.FileName,\n" +
+                "       sf.InstrumentSerialNumber,\n" +
+                "       sf.InstrumentId.model\n" +
+                "FROM targetedms.Replicate rep\n" +
+                "INNER JOIN targetedms.SampleFile sf ON rep.Id = sf.ReplicateId\n" +
+                "INNER JOIN targetedms.Runs r on r.Id = rep.RunId\n" +
+                "where rep.RunId ='" + runId + "'\n" +
+                "GROUP BY r.FileName, sf.InstrumentSerialNumber, sf.InstrumentId.model";
+
+        LABKEY.Query.executeSql({
+            schemaName: 'targetedms',
+            sql: sql,
+            containerFilter: LABKEY.Query.containerFilter.allFolders,
+            scope: this,
+            success: function (response) {
+
+                var runDetails = response.rows[0];
+                this.expRunDetails = {};
+                this.expRunDetails['instrumentName'] = runDetails.model;
+                this.expRunDetails['serialNumber'] = runDetails.InstrumentSerialNumber;
+                this.expRunDetails['fileName'] = runDetails.FileName;
+                this.expRunDetails['startDate'] = runDetails.StartDate;
+                this.expRunDetails['endDate'] = runDetails.EndDate;
+
+                Ext4.apply(this, {
+                    startDate: this.formatDate(this.expRunDetails['startDate'], false), // change to date of 1st point
+                    endDate: this.formatDate(this.expRunDetails['endDate'], false)
+                });
+
+                // initialize the form panel toolbars and display the plot
+                this.add(this.initPlotFormToolbars());
+                this.displayTrendPlot();
+            },
+            failure: this.failureHandler
+        });
+    },
+
     initPlotFormToolbars : function() {
         var toolbarArr = [
             { tbar: this.getMainPlotOptionsToolbar() },
@@ -207,8 +236,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
             { tbar: this.getExperimentRunDateRangeToolbar() }
         ];
 
-        if(this.replicateAnnotationsNodes.length > 0)
-        {
+        if(this.replicateAnnotationsNodes.length > 0) {
             toolbarArr.splice(2, 0, {tbar: this.getAnnotationFiltersToolbar()});
             toolbarArr.splice(3, 0, {tbar: this.getSelectedAnnotationsToolbar()});
         }
@@ -216,8 +244,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     },
 
     getFirstPlotOptionsToolbar: function() {
-        if (!this.plotTypeOptionsToolbar)
-        {
+        if (!this.plotTypeOptionsToolbar) {
             this.plotTypeOptionsToolbar = Ext4.create('Ext.toolbar.Toolbar', {
                 ui: 'footer',
                 cls: 'levey-jennings-toolbar',
@@ -241,8 +268,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     },
 
     getSecondPlotOptionsToolbar: function() {
-      if(!this.plotTypeWithoutYOptionsToolbar)
-      {
+      if(!this.plotTypeWithoutYOptionsToolbar) {
           this.plotTypeWithoutYOptionsToolbar =  Ext4.create('Ext.toolbar.Toolbar', {
               ui: 'footer',
               cls: 'levey-jennings-toolbar',
@@ -256,8 +282,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
               ],
               listeners: {
                   scope: this,
-                  render: function(cmp)
-                  {
+                  render: function(cmp) {
                       cmp.doLayout();
                   }
               }
@@ -290,8 +315,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
             cls: 'plot-size-radio-group',
             listeners: {
                 scope: this,
-                change: function(cmp, newVal, oldVal)
-                {
+                change: function(cmp, newVal, oldVal) {
                     this.largePlot = newVal.largePlot;
                     this.havePlotOptionsChanged = true;
 
@@ -313,8 +337,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                 cls: 'qc-plot-type-checkbox',
                 checked: this.isPlotTypeSelected(plotType),
                 listeners: {
-                    render: function(cmp)
-                    {
+                    render: function(cmp) {
                         cmp.getEl().on('mouseover', function () {
                             var calloutMgr = hopscotch.getCalloutManager();
                             calloutMgr.removeAllCallouts();
@@ -349,8 +372,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
             width: (withYOptions ? 300 : undefined),
             listeners: {
                 scope: this,
-                change: function(cmp, newVal, oldVal)
-                {
+                change: function(cmp, newVal, oldVal) {
                     var newValues = newVal[withYOptions ? 'plotTypes' : 'plotTypesWithoutYOptions'];
                     var otherPlotTypeOptions = (withYOptions ? 'plotTypesWithoutYOptions' : 'plotTypes');
 
@@ -373,8 +395,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     },
 
     getMainPlotOptionsToolbar : function() {
-        if (!this.mainPlotOptionsToolbar)
-        {
+        if (!this.mainPlotOptionsToolbar) {
             this.mainPlotOptionsToolbar = Ext4.create('Ext.toolbar.Toolbar', {
                 ui: 'footer',
                 cls: 'levey-jennings-toolbar',
@@ -392,13 +413,11 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     },
 
     getThirdPlotOptionsToolbar : function() {
-        if (!this.otherPlotOptionsToolbar)
-        {
+        if (!this.otherPlotOptionsToolbar) {
             var  toolbarItems = [];
 
             // only add the create guide set button if the user has the proper permissions to insert/update guide sets
-            if (this.canUserEdit())
-            {
+            if (this.canUserEdit()) {
                 toolbarItems.push(this.getGuideSetCreateButton());
                 toolbarItems.push({xtype: 'tbspacer'}, {xtype: 'tbseparator'}, {xtype: 'tbspacer'});
             }
@@ -410,8 +429,6 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
             toolbarItems.push(this.getShowExcludedCheckbox());
             toolbarItems.push({xtype: 'tbspacer'}, {xtype: 'tbseparator'}, {xtype: 'tbspacer'});
             toolbarItems.push(this.getShowReferenceCheckbox());
-            // toolbarItems.push({xtype: 'tbspacer'}, {xtype: 'tbseparator'}, {xtype: 'tbspacer'});
-            // toolbarItems.push(this.getShowPlotLegendButton());
 
             this.otherPlotOptionsToolbar = Ext4.create('Ext.toolbar.Toolbar', {
                 ui: 'footer',
@@ -437,8 +454,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     },
 
     getAnnotationFiltersToolbar : function() {
-        if (!this.annotationFiltersToolbar)
-        {
+        if (!this.annotationFiltersToolbar) {
             this.annotationFiltersToolbar = Ext4.create('Ext.toolbar.Toolbar', {
                 ui: 'footer',
                 cls: 'levey-jennings-toolbar',
@@ -453,8 +469,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                 ]
             });
 
-            if(this.replicateAnnotationsNodes.length > 0)
-            {
+            if(this.replicateAnnotationsNodes.length > 0) {
                 var annotationsTree = this.getAnnotationListTree();
                 var rootNode = annotationsTree.getRootNode();
                 var annotations = this.selectedAnnotations;
@@ -483,8 +498,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     },
 
     getSelectedAnnotationsToolbar: function() {
-        if (!this.selectedAnnotationsToolbar)
-        {
+        if (!this.selectedAnnotationsToolbar) {
             this.selectedAnnotationsToolbar = Ext4.create('Ext.toolbar.Toolbar', {
                 ui: 'footer',
                 cls: 'levey-jennings-toolbar',
@@ -494,8 +508,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                 items: []
             });
 
-            if(Object.keys(this.selectedAnnotations).length > 0)
-            {
+            if(Object.keys(this.selectedAnnotations).length > 0) {
                 this.updateSelectedAnnotationsToolbar();
             }
         }
@@ -503,8 +516,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     },
 
     getCustomDateRangeToolbar : function() {
-        if (!this.customDateRangeToolbar)
-        {
+        if (!this.customDateRangeToolbar) {
             this.customDateRangeToolbar = Ext4.create('Ext.toolbar.Toolbar', {
                 ui: 'footer',
                 cls: 'levey-jennings-toolbar',
@@ -523,8 +535,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     },
 
     getGuideSetMessageToolbar : function() {
-        if (!this.guideSetMessageToolbar)
-        {
+        if (!this.guideSetMessageToolbar) {
             this.guideSetMessageToolbar = Ext4.create('Ext.toolbar.Toolbar', {
                 ui: 'footer',
                 cls: 'guideset-toolbar-msg',
@@ -542,8 +553,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     },
 
     getExperimentRunDateRangeToolbar : function() {
-        if (!this.experimentRunDateRangeToolbar)
-        {
+        if (!this.experimentRunDateRangeToolbar) {
             var hidden = !this.showExpRunRange;
             var returnUrl = LABKEY.ActionURL.getReturnUrl();
             var htmlStr = this.showExpRunRange
@@ -572,8 +582,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     isValidQCPlotType: function(plotType) {
         var valid = false;
         Ext4.each(LABKEY.targetedms.QCPlotHelperBase.qcPlotTypesWithYOptions.concat(LABKEY.targetedms.QCPlotHelperBase.qcPlotTypesWithoutYOptions), function(type){
-            if (plotType == type)
-            {
+            if (plotType == type) {
                 valid = true;
                 return;
             }
@@ -589,85 +598,69 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
             metric;
 
         paramValue = urlParams['metric'];
-        if (paramValue != undefined)
-        {
+        if (paramValue != undefined) {
             metric = this.validateMetricId(paramValue);
-            if(metric == null)
-            {
+            if(metric == null) {
                 alertMessage += "Invalid Metric, reverting to default metric.";
                 sep = ' ';
             }
-            else
-            {
+            else {
                 paramValues['metric'] = metric;
             }
         }
 
-        if (urlParams['startDate'] != undefined)
-        {
+        if (urlParams['startDate'] != undefined) {
             paramValue = new Date(urlParams['startDate']);
-            if(paramValue == "Invalid Date")
-            {
+            if(paramValue == "Invalid Date") {
                 alertMessage += sep + "Invalid Start Date, reverting to default start date.";
                 sep = ' ';
             }
-            else
-            {
+            else {
                 paramValues['dateRangeOffset'] = -1; // force to custom date range selection
                 paramValues['startDate'] = this.formatDate(Ext4.Date.parse(urlParams['startDate'], LABKEY.Utils.getDateTimeFormatWithMS()));
             }
         }
 
-        if (urlParams['endDate'] != undefined)
-        {
+        if (urlParams['endDate'] != undefined) {
             paramValue = new Date(urlParams['endDate']);
-            if(paramValue == "Invalid Date")
-            {
+            if(paramValue == "Invalid Date") {
                 alertMessage += sep + "Invalid End Date, reverting to default end date.";
             }
-            else
-            {
+            else {
                 paramValues['dateRangeOffset'] = -1; // force to custom date range selection
                 paramValues['endDate'] = this.formatDate(Ext4.Date.parse(urlParams['endDate'], LABKEY.Utils.getDateTimeFormatWithMS()));
             }
         }
 
         paramValue = urlParams['plotTypes'];
-        if (paramValue != undefined)
-        {
+        if (paramValue != undefined) {
             var plotTypes = [];
             if (!Ext4.isArray(paramValue))
                 paramValue = paramValue.split(',');
 
-            Ext4.each(paramValue, function (value)
-            {
+            Ext4.each(paramValue, function (value) {
                 if (this.isValidQCPlotType(value.trim()))
                     plotTypes.push(value.trim());
             }, this);
 
 
-            if (plotTypes.length == 0)
-            {
+            if (plotTypes.length == 0) {
                 alertMessage += sep + "Invalid Plot Type, reverting to default plot type.";
             }
-            else
-            {
+            else {
                 paramValues['plotTypes'] = plotTypes;
             }
         }
 
         paramValue = urlParams['largePlot'];
-        if (paramValue !== undefined && paramValue !== null)
-        {
+        if (paramValue !== undefined && paramValue !== null) {
             paramValues['largePlot'] = paramValue.toString().toLowerCase() === 'true';
         }
 
-        if (alertMessage.length > 0)
-        {
+        if (alertMessage.length > 0) {
             LABKEY.Utils.alert('Invalid URL Parameter(s)', alertMessage);
         }
-        else if (Object.keys(paramValues).length > 0)
-        {
+        else if (Object.keys(paramValues).length > 0) {
             this.havePlotOptionsChanged = true;
             return paramValues;
         }
@@ -676,10 +669,8 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     },
 
     validateMetricId : function(id) {
-        for (var i = 0; i < this.metricPropArr.length; i++)
-        {
-            if (this.metricPropArr[i].id == id)
-            {
+        for (var i = 0; i < this.metricPropArr.length; i++) {
+            if (this.metricPropArr[i].id == id) {
                 return this.metricPropArr[i].id;
             }
         }
@@ -694,8 +685,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     },
 
     getScaleCombo : function() {
-        if (!this.scaleCombo)
-        {
+        if (!this.scaleCombo) {
             this.scaleCombo = Ext4.create('Ext.form.field.ComboBox', {
                 id: 'scale-combo-box',
                 width: 255,
@@ -711,8 +701,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                 editable: false,
                 listeners: {
                     scope: this,
-                    change: function(cmp, newVal, oldVal)
-                    {
+                    change: function(cmp, newVal, oldVal) {
                         this.yAxisScale = newVal;
                         this.havePlotOptionsChanged = true;
 
@@ -728,8 +717,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     },
 
     getDateRangeCombo : function() {
-        if (!this.dateRangeCombo)
-        {
+        if (!this.dateRangeCombo) {
             this.dateRangeCombo = Ext4.create('Ext.form.field.ComboBox', {
                 id: 'daterange-combo-box',
                 width: 225,
@@ -757,16 +745,14 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                 editable: false,
                 listeners: {
                     scope: this,
-                    change: function(cmp, newVal, oldVal)
-                    {
+                    change: function(cmp, newVal, oldVal) {
                         this.dateRangeOffset = newVal;
                         this.havePlotOptionsChanged = true;
 
-                        var showCustomRangeItems = this.dateRangeOffset == -1;
+                        var showCustomRangeItems = this.dateRangeOffset === -1;
                         this.getCustomDateRangeToolbar().setVisible(showCustomRangeItems);
 
-                        if (!showCustomRangeItems)
-                        {
+                        if (!showCustomRangeItems) {
                             // either use the min and max values based on the data
                             // or calculate range based on today's date and the offset
                             this.startDate = this.formatDate(this.calculateStartDateByOffset());
@@ -784,8 +770,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     },
 
     getStartDateField : function() {
-        if (!this.startDateField)
-        {
+        if (!this.startDateField) {
             this.startDateField = Ext4.create('Ext.form.field.Date', {
                 id: 'start-date-field',
                 width: 180,
@@ -808,20 +793,18 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     },
 
     getEndDateField : function() {
-        if (!this.endDateField)
-        {
+        if (!this.endDateField) {
             this.endDateField = Ext4.create('Ext.form.field.Date', {
                 id: 'end-date-field',
                 width: 175,
                 labelWidth: 60,
                 fieldLabel: 'End Date',
-                value: this.endDate,
+                value: this.showExpRunRange ? this.formatDate(this.expRunDetails.endDate, false) : this.endDate,
                 allowBlank: false,
                 format: 'Y-m-d',
                 listeners: {
                     scope: this,
-                    validitychange: function (df, isValid)
-                    {
+                    validitychange: function (df, isValid) {
                         this.getApplyDateRangeButton().setDisabled(!isValid);
                     }
                 }
@@ -832,8 +815,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     },
 
     getApplyDateRangeButton : function() {
-        if (!this.applyFilterButton)
-        {
+        if (!this.applyFilterButton) {
             this.applyFilterButton = Ext4.create('Ext.button.Button', {
                 text: 'Apply',
                 handler: this.applyGraphFilterBtnClick,
@@ -859,8 +841,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     },
 
     getMetricCombo : function() {
-        if (!this.metricField)
-        {
+        if (!this.metricField) {
             this.assignDefaultMetricIfNull();
 
             this.metricField = Ext4.create('Ext.form.field.ComboBox', {
@@ -883,8 +864,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                 editable: false,
                 listeners: {
                     scope: this,
-                    change: function(cmp, newVal, oldVal)
-                    {
+                    change: function(cmp, newVal, oldVal) {
                         this.metric = newVal;
                         this.havePlotOptionsChanged = true;
                         var items = this.otherPlotOptionsToolbar.items.items;
@@ -909,8 +889,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     },
 
     getAnnotationListTree : function() {
-        if (!this.annotationFiltersField)
-        {
+        if (!this.annotationFiltersField) {
             var store = Ext4.create('Ext.data.TreeStore', {
                 root: {expanded: false, children: this.replicateAnnotationsNodes},
             });
@@ -934,8 +913,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     },
 
     getApplyAnnotationFiltersButton : function() {
-        if (!this.applyAnnotationFiltersButton)
-        {
+        if (!this.applyAnnotationFiltersButton) {
             this.applyAnnotationFiltersButton = Ext4.create('Ext.button.Button', {
                 text: 'Apply',
                 handler: this.applyAnnotationFiltersBtnClick,
@@ -947,8 +925,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     },
 
     getClearAnnotationFiltersButton : function() {
-        if (!this.clearAnnotationFiltersButton)
-        {
+        if (!this.clearAnnotationFiltersButton) {
             this.clearAnnotationFiltersButton = Ext4.create('Ext.button.Button', {
                 text: 'Clear',
                 handler: this.clearAnnotationFiltersBtnClick,
@@ -961,8 +938,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     },
 
     getGroupedXCheckbox : function() {
-        if (!this.groupedXCheckbox)
-        {
+        if (!this.groupedXCheckbox) {
             this.groupedXCheckbox = Ext4.create('Ext.form.field.Checkbox', {
                 id: 'grouped-x-field',
                 boxLabel: 'Group X-Axis Values by Date',
@@ -985,8 +961,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     },
 
     getSinglePlotCheckbox : function() {
-        if (!this.peptidesInSinglePlotCheckbox)
-        {
+        if (!this.peptidesInSinglePlotCheckbox) {
             this.peptidesInSinglePlotCheckbox = Ext4.create('Ext.form.field.Checkbox', {
                 id: 'peptides-single-plot',
                 boxLabel: 'Show All Series in a Single Plot',
@@ -1010,8 +985,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     },
 
     getShowExcludedCheckbox : function() {
-        if (!this.showExcludedPointsCheckbox)
-        {
+        if (!this.showExcludedPointsCheckbox) {
             this.showExcludedPointsCheckbox = Ext4.create('Ext.form.field.Checkbox', {
                 id: 'show-excluded-points',
                 boxLabel: 'Show Excluded Points',
@@ -1056,8 +1030,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     },
 
     getGuideSetCreateButton : function() {
-        if (!this.createGuideSetToggleButton)
-        {
+        if (!this.createGuideSetToggleButton) {
             this.createGuideSetToggleButton = Ext4.create('Ext.button.Button', {
                 text: 'Create Guide Set',
                 tooltip: 'Enable/disable guide set creation mode',
@@ -1071,77 +1044,6 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         }
 
         return this.createGuideSetToggleButton;
-    },
-
-    getShowPlotLegendButton : function() {
-        if (!this.showPlotLegendButton)
-        {
-            var cmpId = Ext4.id();
-            this.showPlotLegendButton = Ext4.create('Ext.button.Button', {
-                text: 'View Legend',
-                tooltip: 'View legends used for all plots',
-                enableToggle: true,
-                handler: function (btn)
-                {
-                    var plotHeight = this.singlePlot ? 500 : 300;
-                    var me = this;
-                    if (!btn.pressed)
-                    {
-                        if (this.plotLegendPopup)
-                        {
-                            this.plotLegendPopup.destroy();
-                        }
-                        return;
-                    }
-
-                    this.plotLegendPopup = Ext4.create('Ext.window.Window', {
-                        buttonAlign: 'right',
-                        width: 300,
-                        height: plotHeight + 50,
-                        border: false,
-                        closable: false,
-                        title: 'Legends',
-                        draggable: true,
-                        resizable: false,
-                        cls: 'headerlegendpopup',
-                        items: [{
-                            html: {
-                                tag: 'div', id: cmpId, width: '300', height: '\'' + plotHeight + '\''
-                            }
-                        }],
-                        buttons: [{
-                            text: 'Close',
-                            onClick: function ()
-                            {
-                                me.plotLegendPopup.destroy();
-                                btn.toggle();
-                            }
-                        }],
-                        listeners: {
-                            show: {
-                                fn: function (cmp)
-                                {
-                                    this.lastPlotConfig.renderTo = cmpId;
-                                    this.lastPlotConfig.height = plotHeight;
-                                    var plot = LABKEY.vis.TrendingLinePlot(this.lastPlotConfig);
-                                    plot.renderer.initCanvas();
-                                    plot.grid = {topEdge: 30, rightEdge: 0};
-                                    plot.renderer.renderLegend();
-                                    cmp.doLayout();
-
-                                }, scope: this
-                            }
-                        }
-
-                    });
-
-                    this.plotLegendPopup.show();
-                },
-                scope: this
-            });
-        }
-
-        return this.showPlotLegendButton;
     },
 
     setBrushingEnabled : function(enabled) {
@@ -1292,16 +1194,14 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
             this.legendData = [];
 
             // if more than one type of legend present, add a legend header for annotations
-        if (this.annotationData.length > 0 && (this.singlePlot || this.showMeanCUSUMPlot() || this.showVariableCUSUMPlot()))
-        {
+        if (this.annotationData.length > 0 && (this.singlePlot || this.showMeanCUSUMPlot() || this.showVariableCUSUMPlot())) {
                 this.legendData.push({
                     text: 'Annotations',
                     separator: true
                 });
-            }
+        }
 
-        for (var i = 0; i < this.annotationData.length; i++)
-        {
+        for (var i = 0; i < this.annotationData.length; i++) {
                 var annotation = this.annotationData[i];
                 var annotationDate = this.formatDate(Ext4.Date.parse(annotation['Date'], LABKEY.Utils.getDateTimeFormatWithMS()), !this.groupedX);
 
@@ -1313,8 +1213,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                 dateCount[annotationDate]++;
 
                 // get unique annotation names and colors for the legend
-            if (Ext4.Array.pluck(this.legendData, "text").indexOf(annotation['Name']) == -1)
-            {
+            if (Ext4.Array.pluck(this.legendData, "text").indexOf(annotation['Name']) == -1) {
                     this.legendData.push({
                         text: annotation['Name'],
                         color: '#' + annotation['Color'],
@@ -1338,8 +1237,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     },
 
     showInvalidLogMsg : function(id, toShow) {
-        if (toShow)
-        {
+        if (toShow) {
             Ext4.get(id).update("<span style='font-style: italic;'>Log scale invalid for values &le; 0. "
                     + "Reverting to linear y-axis scale.</span>");
         }
@@ -1419,8 +1317,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     plotBrushEvent : function(extent, plot, layers) {
         Ext4.each(layers, function(layer){
             var points = layer.selectAll('.point path');
-            if (points[0].length > 0)
-            {
+            if (points[0].length > 0) {
                 var colorAcc = function(d) {
                     var x = plot.scales.x.scale(d.seqValue);
                     d.isInSelection = (x > extent[0][0] && x < extent[1][0]);
@@ -1437,8 +1334,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         this.plotBrushSelection = {plot: plot, points: selectedPoints};
 
         // add the guide set create and cancel buttons over the brushed region
-        if (selectedPoints.length > 0)
-        {
+        if (selectedPoints.length > 0) {
             var me = this;
             var xMid = extent[0][0] + (extent[1][0] - extent[0][0]) / 2;
 
@@ -1521,8 +1417,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         var guideSetTrainingData = [];
 
         // find the x-axis starting and ending index based on the guide set information attached to each data point
-        Ext4.Object.each(this.guideSetDataMap, function(guideSetId, guideSetData)
-        {
+        Ext4.Object.each(this.guideSetDataMap, function(guideSetId, guideSetData) {
             // only compare guide set info for matching precursor fragment
             if (!this.singlePlot && guideSetData.Series[precursorInfo.fragment] === undefined) {
                 return true; // continue
@@ -1537,11 +1432,9 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
 
             var gs = {GuideSetId: guideSetId,
                       series: seriesTypes[0]};
-            for (var j = 0; j < precursorInfo.data.length; j++)
-            {
+            for (var j = 0; j < precursorInfo.data.length; j++) {
                 // only use data points that match the GuideSet RowId and are in the training set range
-                if (precursorInfo.data[j].guideSetId == gs.GuideSetId && precursorInfo.data[j].inGuideSetTrainingRange)
-                {
+                if (precursorInfo.data[j].guideSetId == gs.GuideSetId && precursorInfo.data[j].inGuideSetTrainingRange) {
                     if (gs.StartIndex == undefined)
                     {
                         gs.StartIndex = precursorInfo.data[j].seqValue;
@@ -1550,8 +1443,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                 }
             }
 
-            if (gs.StartIndex != undefined)
-            {
+            if (gs.StartIndex != undefined) {
                 guideSetTrainingData.push(gs);
             }
         }, this);
@@ -1632,8 +1524,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                     showGuideSetStats = !me.singlePlot && numRecs > 0,
                     mean, stdDev, percentCV;
 
-                if (showGuideSetStats)
-                {
+                if (showGuideSetStats) {
                     mean = me.formatNumeric(seriesGuideSetInfo.Mean);
                     stdDev = me.formatNumeric(seriesGuideSetInfo.StdDev);
                     percentCV = me.formatNumeric((stdDev / mean) * 100);
@@ -1677,16 +1568,13 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         // Issue 38270. Get unique dates just in case there are two replicates with the same acquired time. 
         // This can happen e.g. if a raw file is imported from different locations.
         var xAxisLabels = Ext4.Array.unique(Ext4.Array.pluck(precursorInfo.data, "fullDate"));
-        if (this.groupedX)
-        {
+        if (this.groupedX) {
             xAxisLabels = [];
 
             // determine the annotation index based on the "date" but unique values are based on "groupedXTick"
             var prevGroupedXTick = null;
-            Ext4.each(precursorInfo.data, function(row)
-            {
-                if (row['groupedXTick'] != prevGroupedXTick)
-                {
+            Ext4.each(precursorInfo.data, function(row) {
+                if (row['groupedXTick'] != prevGroupedXTick) {
                     xAxisLabels.push(row['date']);
                 }
                 prevGroupedXTick = row['groupedXTick'];
@@ -1780,8 +1668,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
             endDateValue = this.getEndDateField().getValue();
 
         // make sure that at least one filter field is not null
-        if (startDateRawValue == '' && endDateRawValue == '')
-        {
+        if (startDateRawValue == '' && endDateRawValue == '') {
             Ext4.Msg.show({
                 title:'ERROR',
                 msg: 'Please enter a value for filtering.',
@@ -1790,8 +1677,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
             });
         }
         // verify that the start date is not after the end date
-        else if (startDateValue > endDateValue && endDateValue != '')
-        {
+        else if (startDateValue > endDateValue && endDateValue != '') {
             Ext4.Msg.show({
                 title:'ERROR',
                 msg: 'Please enter an end date that does not occur before the start date.',
@@ -1799,8 +1685,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                 icon: Ext4.MessageBox.ERROR
             });
         }
-        else
-        {
+        else {
             // get date values without the time zone info
             this.startDate = startDateRawValue;
             this.endDate = endDateRawValue;
@@ -1831,8 +1716,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
 
     applyAnnotationFiltersBtnClick: function() {
         // make sure that at least one filter is selected
-        if (this.getAnnotationListTree().getChecked().length == 0)
-        {
+        if (this.getAnnotationListTree().getChecked().length == 0) {
             Ext4.Msg.show({
                 title:'ERROR',
                 msg: 'Please select a replicate annotation.',
@@ -1841,8 +1725,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
             });
         }
 
-        else
-        {
+        else {
             this.setBrushingEnabled(false);
             this.displayTrendPlot();
         }
@@ -1857,8 +1740,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
 
         this.selectedAnnotations = {};
 
-        for(var i = 0; i < filters.length; i++)
-        {
+        for(var i = 0; i < filters.length; i++) {
             var annotation = filters[i];
             var annotationName = annotation.parentNode.get('text');
             var annotationValue = annotation.get('text');
@@ -1873,12 +1755,10 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
             selected.push(annotationValue);
         }
 
-        if(Object.keys(this.selectedAnnotations).length > 0)
-        {
+        if(Object.keys(this.selectedAnnotations).length > 0) {
             this.clearAnnotationFiltersButton.show();
         }
-        else
-        {
+        else {
             this.clearAnnotationFiltersButton.hide();
         }
 
@@ -1895,8 +1775,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         selectedAnnotationsTb.removeAll();
         var selectedDisplay = '';
         var and = '';
-        Ext4.Object.each(this.selectedAnnotations, function(name, values)
-        {
+        Ext4.Object.each(this.selectedAnnotations, function(name, values) {
             selectedDisplay += and;
             and = 'AND ';
             selectedDisplay += (name + ' (');
@@ -1907,14 +1786,12 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
             }
             selectedDisplay += ') ';
         });
-        if(selectedDisplay.length > 0)
-        {
+        if(selectedDisplay.length > 0) {
             selectedDisplay = "Selected annotations: " + selectedDisplay;
             selectedAnnotationsTb.add(selectedDisplay);
             selectedAnnotationsTb.show();
         }
-        else
-        {
+        else {
             selectedAnnotationsTb.hide();
         }
     },
@@ -1925,13 +1802,11 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         var annotationsTree = this.getAnnotationListTree();
         var records = annotationsTree.getChecked();
 
-        if(records.length == 0)
-        {
+        if(records.length == 0) {
             return;
         }
 
-        for(var i = 0; i < records.length; i++)
-        {
+        for(var i = 0; i < records.length; i++) {
             records[i].set('checked', false);
         }
 
@@ -1945,8 +1820,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     createGuideSetBtnClick: function() {
         var minGuideSetPointCount = 5; // to warn user if less than this many points are selected for the new guide set
 
-        if (this.plotBrushSelection && this.plotBrushSelection.points.length > 0)
-        {
+        if (this.plotBrushSelection && this.plotBrushSelection.points.length > 0) {
             var startDate = this.plotBrushSelection.points[0]['fullDate'];
             var endDate = this.plotBrushSelection.points[this.plotBrushSelection.points.length - 1]['fullDate'];
 
@@ -1997,8 +1871,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     },
 
     persistSelectedFormOptions : function() {
-        if (this.havePlotOptionsChanged)
-        {
+        if (this.havePlotOptionsChanged) {
             this.havePlotOptionsChanged = false;
             LABKEY.Ajax.request({
                 url: LABKEY.ActionURL.buildURL('targetedms', 'leveyJenningsPlotOptions.api'),
@@ -2011,8 +1884,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     getSelectedPlotFormOptions : function() {
         var annotationsProp = [];
 
-        Ext4.Object.each(this.selectedAnnotations, function(name, values)
-        {
+        Ext4.Object.each(this.selectedAnnotations, function(name, values) {
             for(var i = 0; i < values.length; i++)
             {
                 annotationsProp.push(name + ":" + values[i]);

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -188,14 +188,10 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     getExperimentRunDetails: function (runId) {
         var sql = "Select MIN(sf.AcquiredTime) AS StartDate,\n" +
                 "       MAX(sf.AcquiredTime) AS EndDate,\n" +
-                "       r.FileName,\n" +
-                "       sf.InstrumentSerialNumber,\n" +
-                "       sf.InstrumentId.model\n" +
-                "FROM targetedms.Replicate rep\n" +
-                "INNER JOIN targetedms.SampleFile sf ON rep.Id = sf.ReplicateId\n" +
-                "INNER JOIN targetedms.Runs r on r.Id = rep.RunId\n" +
-                "where rep.RunId ='" + runId + "'\n" +
-                "GROUP BY r.FileName, sf.InstrumentSerialNumber, sf.InstrumentId.model";
+                "       sf.ReplicateId.RunId.FileName\n" +
+                "FROM targetedms.SampleFile sf\n" +
+                "WHERE sf.ReplicateId.RunId ='" + runId + "'\n" +
+                "GROUP BY sf.ReplicateId.RunId.FileName";
 
         LABKEY.Query.executeSql({
             schemaName: 'targetedms',
@@ -206,8 +202,6 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
 
                 var runDetails = response.rows[0];
                 this.expRunDetails = {};
-                this.expRunDetails['instrumentName'] = runDetails.model;
-                this.expRunDetails['serialNumber'] = runDetails.InstrumentSerialNumber;
                 this.expRunDetails['fileName'] = runDetails.FileName;
                 this.expRunDetails['startDate'] = runDetails.StartDate;
                 this.expRunDetails['endDate'] = runDetails.EndDate;
@@ -1520,8 +1514,6 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                 // TODO: look into setting background color of title tooltip
                 expRange.append("title").text(function (d) {
                     return "Skyline File: " + Ext4.String.htmlEncode(me.expRunDetails.fileName)
-                            + ", \nSerial No: " + Ext4.String.htmlEncode(me.expRunDetails.serialNumber)
-                            + ", \nInstrument Name: " + Ext4.String.htmlEncode(me.expRunDetails.instrumentName)
                             + ", \nStart: " + Ext4.String.htmlEncode(me.formatDate(Ext4.Date.parse(me.expRunDetails.startDate, LABKEY.Utils.getDateTimeFormatWithMS()), true))
                             + ", \nEnd: " + Ext4.String.htmlEncode(me.formatDate(Ext4.Date.parse(me.expRunDetails.endDate, LABKEY.Utils.getDateTimeFormatWithMS()), true))
                             + ", \nMean: " + Ext4.String.htmlEncode(expMean)

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -207,8 +207,8 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                 this.expRunDetails['endDate'] = runDetails.EndDate;
 
                 Ext4.apply(this, {
-                    startDate: this.formatDate(this.expRunDetails['startDate'], false),
-                    endDate: this.formatDate(this.expRunDetails['endDate'], false),
+                    startDate: this.formatDate(this.expRunDetails['startDate']),
+                    endDate: this.formatDate(this.expRunDetails['endDate']),
                     dateRangeOffset: -1
                 });
 
@@ -1027,8 +1027,8 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                             if (newValue) {
                                 this.resetFilterPointsIndices();
                                 Ext4.apply(this, {
-                                    startDate: this.formatDate(this.expRunDetails.startDate, false),
-                                    endDate: this.formatDate(this.expRunDetails.endDate, false),
+                                    startDate: this.formatDate(this.expRunDetails.startDate),
+                                    endDate: this.formatDate(this.expRunDetails.endDate),
                                     dateRangeOffset: -1
                                 });
                             }


### PR DESCRIPTION
#### Rationale
* When coming from experiment folder to QC folder - 
   If reference guideset is present - display 5 points before the experimental folder start date and reference guideset . Date range filter will have the start date as the date of acquired time of 1st point out of five points. We will auto-check the box to include the reference guide set.
  if reference guideset is not present - still display the 5 points before the experimental folder start date . Date range filter will have the start date as the date of acquired time of 1st point out of five points that will be shown.
 End date in both cases will be the end date of experimental folder.
 Experiment range toolbar will show the experimental folder start and end date without the timestamp.

* When filtering the dates in QC folder - do not display the 5 points before the selected start date but will show the reference guideset if present.
