### PR TITLE
Issue 43046: Return an empty list in PrecursorManager.getPrecursorsForPeptide()...

### DIFF
--- a/src/org/labkey/targetedms/SkylineDocImporter.java
+++ b/src/org/labkey/targetedms/SkylineDocImporter.java
@@ -251,26 +251,49 @@ public class SkylineDocImporter
         }
         catch (FileNotFoundException fnfe)
         {
-            logError("Skyline document import failed due to a missing file.", fnfe);
-            updateRunStatus("Import failed (see pipeline log)", STATUS_FAILED);
+            String logMessage = "Skyline document import failed due to a missing file.";
+            _systemLog.error(logMessage, fnfe);
+            addPostRollbackCommitTask(fnfe, logMessage, "Import failed (see pipeline log)");
             throw fnfe;
         }
         catch (CancelledException e)
         {
-            _log.info("Cancelled  Skyline document import.");
-            updateRunStatus("Import cancelled (see pipeline log)", STATUS_FAILED);
+            addPostRollbackCommitTask("Cancelled  Skyline document import.", "Import cancelled (see pipeline log)");
             throw e;
         }
         catch (IOException | XMLStreamException | RuntimeException | PipelineJobException | AuditLogException e)
         {
-            _log.error("Import failed", e);
-            updateRunStatus("Import failed (see pipeline log)", STATUS_FAILED);
+            addPostRollbackCommitTask(e, "Import failed", "Import failed (see pipeline log)");
             if (e instanceof PipelineJobException) throw e;
-            else throw new PipelineJobException(e); // Wrap in a PipelineJobException so that is does not show up as
+            else throw new PipelineJobException(e); // Wrap in a PipelineJobException so that it does not show up as
                                                     // "Uncaught exception in PipelineJob" in the "Info" column of the Data Pipeline grid
         }
     }
 
+    private void addPostRollbackCommitTask(String logMessage, String statusMessage)
+    {
+        addPostRollbackCommitTask(null, logMessage, statusMessage);
+    }
+
+    private void addPostRollbackCommitTask(Exception exception, String logMessage, String statusMessage)
+    {
+        // The entire document import code is executed inside a transaction.  If an exception is thrown by code in the transaction
+        // or in a nested transaction, the transaction is not committed and it is assumed that the whole transaction is hosed.
+        // The connection is rendered unusable. If the code that catches the exception attempts to do anything with the DB a SQLException is thrown:
+        // ExecutingSelector; uncategorized SQLException for SQL []; SQL state [null]; error code [0]; This connection has already been closed, and may have been left in a bad state
+        // We will execute any SQL updates in a CommitTask that runs it POSTROLLBACK.
+        TargetedMSManager.getSchema().getScope().addCommitTask(() -> {
+            if (exception != null)
+            {
+                _log.error(logMessage, exception);
+            }
+            else
+            {
+                _log.info(logMessage);
+            }
+            updateRunStatus(_runId, statusMessage, STATUS_FAILED);
+            }, DbScope.CommitTaskOption.POSTROLLBACK);
+    }
 
     private void importSkylineDoc(TargetedMSRun run, File f) throws XMLStreamException, IOException, PipelineJobException, AuditLogException
     {
@@ -418,11 +441,7 @@ public class SkylineDocImporter
                 // Persist the run so that the skydDataId is available when writing the updated chromatogram library.
                 // skydDataId is required to get to the skyd file for reading chromatograms when they are not saved in the db.
                 Table.update(_user, TargetedMSManager.getTableInfoRuns(), run, run.getId());
-                // The entire document import code is executed inside a wrapper transaction so do not begin a transaction while updating the representative state.
-                // If an exception is thrown in the inner transaction block it will leave the connection in an unusable state and the error in the
-                // pipeline log will look like this:
-                // ExecutingSelector; uncategorized SQLException for SQL []; SQL state [null]; error code [0]; This connection has already been closed, and may have been left in a bad state
-                RepresentativeStateManager.setRepresentativeStateNoTransaction(_user, _container, _localDirectory, run, run.getRepresentativeDataState());
+                RepresentativeStateManager.setRepresentativeState(_user, _container, _localDirectory, run, run.getRepresentativeDataState());
             }
 
             int calCurvesCount = quantifyRun(run, pepSettings, groupComparisons);

--- a/src/org/labkey/targetedms/chromlib/ChromatogramLibraryWriter.java
+++ b/src/org/labkey/targetedms/chromlib/ChromatogramLibraryWriter.java
@@ -152,6 +152,9 @@ public class ChromatogramLibraryWriter
     public void writeProtein(long rowId, LibProtein protein)
     {
         _libProteinCache.put(rowId, protein);
+        // When writing a Protein library (peptides ranked within proteins) we have to increment the
+        // peptide count here since the writePeptide() / writeMolecule() methods are not called.
+        _peptideCount += protein.getChildren().size();
     }
 
     public void writePeptide(LibPeptide libPeptide, Peptide peptide)

--- a/src/org/labkey/targetedms/chromlib/ContainerChromatogramLibraryWriter.java
+++ b/src/org/labkey/targetedms/chromlib/ContainerChromatogramLibraryWriter.java
@@ -478,7 +478,11 @@ public class ContainerChromatogramLibraryWriter
         for(Peptide peptide: peptides)
         {
             List<Precursor> precursors = PrecursorManager.getPrecursorsForPeptide(peptide.getId(), schema);
-
+            if(precursors.size() == 0)
+            {
+                throw new IllegalStateException(String.format("No precursors found for peptide '%s'. Empty peptides are not allowed in library folders." +
+                        " Empty peptides can be removed in Skyline by selecting Refine > Remove Empty Peptides.", peptide.getSequence()));
+            }
             LibPeptide libPeptide = makeLibPeptide(peptide, precursors, run);
             protein.addChild(libPeptide);
         }

--- a/src/org/labkey/targetedms/query/PrecursorManager.java
+++ b/src/org/labkey/targetedms/query/PrecursorManager.java
@@ -31,7 +31,6 @@ import org.labkey.api.data.TableResultSet;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.security.User;
-import org.labkey.api.view.NotFoundException;
 import org.labkey.targetedms.TargetedMSManager;
 import org.labkey.targetedms.TargetedMSSchema;
 import org.labkey.targetedms.chart.ChromatogramDataset.RtRange;
@@ -119,12 +118,7 @@ public class PrecursorManager
         colNames.addAll(TargetedMSManager.getTableInfoPrecursor().getColumnNameSet());
         colNames.addAll(TargetedMSManager.getTableInfoGeneralPrecursor().getColumnNameSet());
 
-        List<Precursor> precursors = new TableSelector(new PrecursorTableInfo(targetedMSSchema, null, true), colNames, filter,  sort).getArrayList(Precursor.class);
-
-        if (precursors.isEmpty())
-            throw new NotFoundException(String.format("No precursors found for peptideId %d", peptideId));
-
-        return precursors;
+        return new TableSelector(new PrecursorTableInfo(targetedMSSchema, null, true), colNames, filter,  sort).getArrayList(Precursor.class);
     }
 
     @NotNull

--- a/src/org/labkey/targetedms/query/RepresentativeStateManager.java
+++ b/src/org/labkey/targetedms/query/RepresentativeStateManager.java
@@ -53,14 +53,6 @@ public class RepresentativeStateManager
     {
         try (DbScope.Transaction transaction = TargetedMSManager.getSchema().getScope().ensureTransaction())
         {
-            setRepresentativeStateNoTransaction(user, container, localDirectory, run, state);
-            transaction.commit();
-        }
-    }
-
-    public static void setRepresentativeStateNoTransaction(User user, Container container, LocalDirectory localDirectory,
-                                              TargetedMSRun run, TargetedMSRun.RepresentativeDataState state)
-    {
             int conflictCount = 0;
             if(state == TargetedMSRun.RepresentativeDataState.Representative_Protein)
             {
@@ -115,6 +107,9 @@ public class RepresentativeStateManager
                     "Updated representative state. Number of conflicts " + conflictCount);
 
             Table.update(user, TargetedMSManager.getTableInfoRuns(), run, run.getId());
+
+            transaction.commit();
+        }
     }
 
     private static void revertProteinRepresentativeState(User user, Container container, TargetedMSRun run)

--- a/src/org/labkey/targetedms/query/RepresentativeStateManager.java
+++ b/src/org/labkey/targetedms/query/RepresentativeStateManager.java
@@ -53,6 +53,14 @@ public class RepresentativeStateManager
     {
         try (DbScope.Transaction transaction = TargetedMSManager.getSchema().getScope().ensureTransaction())
         {
+            setRepresentativeStateNoTransaction(user, container, localDirectory, run, state);
+            transaction.commit();
+        }
+    }
+
+    public static void setRepresentativeStateNoTransaction(User user, Container container, LocalDirectory localDirectory,
+                                              TargetedMSRun run, TargetedMSRun.RepresentativeDataState state)
+    {
             int conflictCount = 0;
             if(state == TargetedMSRun.RepresentativeDataState.Representative_Protein)
             {
@@ -107,9 +115,6 @@ public class RepresentativeStateManager
                     "Updated representative state. Number of conflicts " + conflictCount);
 
             Table.update(user, TargetedMSManager.getTableInfoRuns(), run, run.getId());
-
-            transaction.commit();
-        }
     }
 
     private static void revertProteinRepresentativeState(User user, Container container, TargetedMSRun run)


### PR DESCRIPTION
… instead of throwing an exception if no precursors are found for a peptide

#### Rationale
This exception may have been added for chromatogram library folders so that users are unable to upload a Skyline document with empty peptides (no precursors) to a library folder. But this is causing group comparison calculations to fail in non-library folders.

#### Changes
- Protein library folders still require that Skyline documents not have any empty peptides (this will be fixed in Issue 43048)
- Fixed peptide count written to .clib for Protein Libraries
- Do not execute code that sets the representative states of precursors etc. in a transaction block since any exception thrown in the block leaves the connection in an unusable state. The entire document import happens inside a transaction.
