### PR TITLE
Issue 43057: Perf issues with targetedms-showCalibrationCurve.view with ContainerFilter = AllFolders

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -7225,6 +7225,8 @@ public class TargetedMSController extends SpringActionController
             UserSchema schema = new TargetedMSSchema(getUser(), getContainer());
             String queryName = _asProteomics ? "CalibrationCurvePrecursors" : "CalibrationCurveMoleculePrecursors";
             QuerySettings settings = new QuerySettings(getViewContext(), "curveDetail", queryName);
+            // Issue 43057 - avoid query perf problems with alternate folder filters since the data is always scoped to the current container
+            settings.setContainerFilterName(null);
             settings.getBaseFilter().addCondition(FieldKey.fromParts("CalibrationCurve"), form.getCalibrationCurveId());
             settings.setBaseSort(new Sort("SampleFileId/SampleName"));
             QueryView result = QueryView.create(getViewContext(), schema, settings, errors);


### PR DESCRIPTION
#### Rationale
This is a report backed by a custom query, and the action is always filtering it to show a specific run's data. Thus, the folder filter isn't meaningful, but it's causing the query to be incredibly expensive to run

#### Changes
* Throw out any folder filter from the URL, so we get the same results in a much better query plan
