### PR TITLE
Issue 43061: Ignore zero byte spectrum library files

### DIFF
--- a/src/org/labkey/targetedms/parser/speclib/BlibSpectrumReader.java
+++ b/src/org/labkey/targetedms/parser/speclib/BlibSpectrumReader.java
@@ -482,7 +482,7 @@ public class BlibSpectrumReader extends LibSpectrumReader
                 continue;
 
             Path path = entry.getValue();
-            String blibFilePath = getLocalLibPath(run.getContainer(), path);
+            String blibFilePath = getNonEmptyLocalLibPath(run.getContainer(), path);
             if (null == blibFilePath)
                 continue;
 


### PR DESCRIPTION
#### Rationale
Some folders on PanoramaWeb have zero byte spectrum library (.blib) files.  It is not yet clear how they got created.  They are not included in the .sky.zip files even though the spectrum library was listed in the Skyline XML settings. Attempting to read these files throws an exception. We will ignore zero byte files. The code that is creating them will be fixed once we know what it is.
