### PR TITLE
Issue 43057: Avoid container filters on more single-document scoped grid views

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -3898,9 +3898,9 @@ public class TargetedMSController extends SpringActionController
         }
 
         @Override
-        protected QueryView createQueryView(RunDetailsForm form, BindException errors, boolean forExport, String dataRegion)
+        protected QueryView createQueryView(RunDetailsForm form, BindException errors, boolean forExport, @Nullable String dataRegion)
         {
-            if (dataRegion.equalsIgnoreCase(INSTRUMENT_SUMMARY_DATA_REGION_NAME))
+            if (INSTRUMENT_SUMMARY_DATA_REGION_NAME.equalsIgnoreCase(dataRegion))
             {
                 return new InstrumentSummaryWebPart(getViewContext());
             }
@@ -3908,8 +3908,7 @@ public class TargetedMSController extends SpringActionController
             {
                 QuerySettings settings = new QuerySettings(getViewContext(), REPLICATE_DATA_REGION_NAME, TargetedMSSchema.SAMPLE_FILE_RUN_PREFIX + _run.getRunId());
                 settings.setBaseSort(new Sort(FieldKey.fromParts("ReplicateId", "Name")));
-                TargetedMSSchema schema = new TargetedMSSchema(getUser(), getContainer());
-                return schema.createView(getViewContext(), settings, errors);
+                return createViewWithNoContainerFilterOptions(settings, errors);
             }
         }
 
@@ -4018,12 +4017,8 @@ public class TargetedMSController extends SpringActionController
         protected QueryView createQueryView(RunDetailsForm form, BindException errors, boolean forExport, String dataRegion)
         {
             QuerySettings settings = new QuerySettings(getViewContext(), _dataRegionName, "PeptideIds");
-            // Issue 40731- prevent expensive cross-folder queries when the results will always be scoped to the current
-            // run anyway
-            settings.setContainerFilterName(null);
             settings.setBaseFilter(new SimpleFilter(FieldKey.fromParts("PeptideGroupId", "RunId"), form.getId()));
-            TargetedMSSchema schema = new TargetedMSSchema(getUser(), getContainer());
-            return schema.createView(getViewContext(), settings, errors);
+            return createViewWithNoContainerFilterOptions(settings, errors);
         }
     }
 
@@ -4090,9 +4085,8 @@ public class TargetedMSController extends SpringActionController
         protected QueryView createQueryView(RunDetailsForm form, BindException errors, boolean forExport, String dataRegion)
         {
             QuerySettings settings = new QuerySettings(getViewContext(), _dataRegionName, LOG_QUERY_NAME);
-            TargetedMSSchema schema = new TargetedMSSchema(getUser(), getContainer());
             settings.setBaseFilter(new SimpleFilter(FieldKey.fromParts("RunId"), form.getId()));
-            return schema.createView(getViewContext(), settings, errors);
+            return createViewWithNoContainerFilterOptions(settings, errors);
         }
     }
 
@@ -4442,8 +4436,6 @@ public class TargetedMSController extends SpringActionController
 
             VBox result = new VBox(detailsView);
 
-            TargetedMSSchema schema = new TargetedMSSchema(getUser(), getContainer());
-
             // Protein sequence coverage
             if (group.getSequenceId() != null)
             {
@@ -4455,7 +4447,7 @@ public class TargetedMSController extends SpringActionController
                 }
 
                 ProteinService proteinService = ProteinService.get();
-                WebPartView sequenceView = proteinService.getProteinCoverageView(seqId, peptideSequences.toArray(new String[peptideSequences.size()]), 100, true);
+                WebPartView<?> sequenceView = proteinService.getProteinCoverageView(seqId, peptideSequences.toArray(new String[0]), 100, true);
 
                 sequenceView.setTitle("Sequence Coverage");
                 sequenceView.enableExpandCollapse("SequenceCoverage", false);
@@ -4471,7 +4463,7 @@ public class TargetedMSController extends SpringActionController
                 baseVisibleColumns.add(FieldKey.fromParts(ModifiedSequenceDisplayColumn.PEPTIDE_COLUMN_NAME));
                 baseVisibleColumns.add(FieldKey.fromParts("CalcNeutralMass"));
                 baseVisibleColumns.add(FieldKey.fromParts("NumMissedCleavages"));
-                result.addView(getGeneralMoleculeQueryView(form, schema, errors, "Peptides", "Peptide", baseVisibleColumns));
+                result.addView(getGeneralMoleculeQueryView(form, errors, "Peptides", "Peptide", baseVisibleColumns));
             }
 
             // List of small molecules
@@ -4483,7 +4475,7 @@ public class TargetedMSController extends SpringActionController
                 baseVisibleColumns.add(FieldKey.fromParts("IonFormula"));
                 baseVisibleColumns.add(FieldKey.fromParts("MassAverage"));
                 baseVisibleColumns.add(FieldKey.fromParts("MassMonoisotopic"));
-                result.addView(getGeneralMoleculeQueryView(form, schema, errors, "Small Molecules", "Molecule", baseVisibleColumns));
+                result.addView(getGeneralMoleculeQueryView(form, errors, "Small Molecules", "Molecule", baseVisibleColumns));
             }
 
             SummaryChartBean summaryChartBean = new SummaryChartBean(_run);
@@ -4513,13 +4505,13 @@ public class TargetedMSController extends SpringActionController
             return result;
         }
 
-        private QueryView getGeneralMoleculeQueryView(ProteinDetailForm form, TargetedMSSchema schema, BindException errors,
+        private QueryView getGeneralMoleculeQueryView(ProteinDetailForm form, BindException errors,
                                                       String title, String queryName, List<FieldKey> baseVisibleColumns)
         {
             String dataRegionName = title.replaceAll(" ", "");
             QuerySettings settings = new QuerySettings(getViewContext(), dataRegionName, queryName);
             settings.getBaseFilter().addAllClauses(new SimpleFilter(FieldKey.fromParts("PeptideGroupId"), form.getId()));
-            QueryView view = new QueryView(schema, settings, errors);
+            QueryView view = createViewWithNoContainerFilterOptions(settings, errors);
 
             if (null == view.getCustomView())
             {
@@ -4543,6 +4535,16 @@ public class TargetedMSController extends SpringActionController
                 root.addChild(_proteinLabel);
             }
         }
+    }
+
+    /** Issue 40731- prevent expensive cross-folder queries when the results will always be scoped to the current run anyway */
+    private QueryView createViewWithNoContainerFilterOptions(QuerySettings settings, BindException errors)
+    {
+        TargetedMSSchema schema = new TargetedMSSchema(getUser(), getContainer());
+        settings.setContainerFilterName(null);
+        QueryView result = schema.createView(getViewContext(), settings, errors);
+        result.setAllowableContainerFilterTypes();
+        return result;
     }
 
     public static class ProteinDetailForm
@@ -4753,7 +4755,7 @@ public class TargetedMSController extends SpringActionController
                 searchURL.addParameter("seqId", group.getSequenceId().intValue());
                 searchURL.addParameter("identifier", group.getLabel());
                 getViewContext().getResponse().getWriter().write("<a href=\"" + searchURL + "\">Search for other references to this protein</a><br/>");
-                view = proteinService.getProteinCoverageView(seqId, peptideSequences.toArray(new String[peptideSequences.size()]), 40, true);
+                view = proteinService.getProteinCoverageView(seqId, peptideSequences.toArray(new String[0]), 40, true);
             }
             else
             {
@@ -5718,7 +5720,6 @@ public class TargetedMSController extends SpringActionController
 
             ViewContext viewContext = getViewContext();
             QuerySettings settings = new QuerySettings(viewContext, "TargetedMSMatches", "Precursor");
-//            QuerySettings settings = new QuerySettings(viewContext, "TargetedMSMatches");
 
             if (form.isIncludeSubfolders())
                 settings.setContainerFilterName(ContainerFilter.Type.CurrentAndSubfolders.name());
@@ -7222,14 +7223,11 @@ public class TargetedMSController extends SpringActionController
         @Override
         protected QueryView createQueryView(CalibrationCurveForm form, BindException errors, boolean forExport, @Nullable String dataRegion)
         {
-            UserSchema schema = new TargetedMSSchema(getUser(), getContainer());
             String queryName = _asProteomics ? "CalibrationCurvePrecursors" : "CalibrationCurveMoleculePrecursors";
             QuerySettings settings = new QuerySettings(getViewContext(), "curveDetail", queryName);
-            // Issue 43057 - avoid query perf problems with alternate folder filters since the data is always scoped to the current container
-            settings.setContainerFilterName(null);
             settings.getBaseFilter().addCondition(FieldKey.fromParts("CalibrationCurve"), form.getCalibrationCurveId());
             settings.setBaseSort(new Sort("SampleFileId/SampleName"));
-            QueryView result = QueryView.create(getViewContext(), schema, settings, errors);
+            QueryView result = createViewWithNoContainerFilterOptions(settings, errors);
             result.setTitle("Quantitation Ratios");
             return result;
         }

--- a/src/org/labkey/targetedms/view/InstrumentSummaryWebPart.java
+++ b/src/org/labkey/targetedms/view/InstrumentSummaryWebPart.java
@@ -22,12 +22,15 @@ public class InstrumentSummaryWebPart extends QueryView
                 try
                 {
                     instrumentSummaryQS.setBaseFilter(new SimpleFilter(FieldKey.fromString("runId"), Long.valueOf(runId.getValue().toString())));
+                    // Avoid perf problems doing a cross-folder query when all data is scoped to this container
+                    setAllowableContainerFilterTypes();
+                    instrumentSummaryQS.setContainerFilterName(null);
                 }
                 catch (NumberFormatException ignored) {}
             }
         }
         setSettings(instrumentSummaryQS);
-        setTitle("Instruments Summary");
+        setTitle("Instrument Summary");
         setShowDetailsColumn(false);
 
         setShowBorders(true);

--- a/src/org/labkey/targetedms/view/QuantificationView.java
+++ b/src/org/labkey/targetedms/view/QuantificationView.java
@@ -36,6 +36,8 @@ public abstract class QuantificationView extends DocumentPrecursorsView
         super(ctx, schema, tableName, form.getId(), forExport,
                 new QueryNestingOption(FieldKey.fromParts("PeptideGroupId"),
                         FieldKey.fromParts("PeptideGroupId", "Id"), null), dataRegionName);
+        setAllowableContainerFilterTypes();
+        getSettings().setContainerFilterName(null);
     }
 
     public boolean isSmallMolecule()

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentalQCLinkTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentalQCLinkTest.java
@@ -69,8 +69,8 @@ public class TargetedMSExperimentalQCLinkTest extends TargetedMSTest
         DataRegionTable table = new DataRegionTable("TargetedMSRuns", getDriver());
         clickAndWait(table.link(0, "Replicates"));
 
-        checker().verifyTrue("Instruments Summary webpart is missing",
-                isElementPresent(Locator.tagWithAttribute("h3", "title", "Instruments Summary")));
+        checker().verifyTrue("Instrument Summary webpart is missing",
+                isElementPresent(Locator.tagWithAttribute("h3", "title", "Instrument Summary")));
         table = new DataRegionTable("InstrumentSummary", getDriver());
         checker().verifyEquals("Invalid QC Folder Name ", QC_FOLDER_1,
                 table.getDataAsText(0, "QCFolders"));
@@ -81,8 +81,8 @@ public class TargetedMSExperimentalQCLinkTest extends TargetedMSTest
         table = new DataRegionTable("TargetedMSRuns", getDriver());
         clickAndWait(table.link(0, "Replicates"));
 
-        checker().verifyTrue("Instruments Summary webpart is missing",
-                isElementPresent(Locator.tagWithAttribute("h3", "title", "Instruments Summary")));
+        checker().verifyTrue("Instrument Summary webpart is missing",
+                isElementPresent(Locator.tagWithAttribute("h3", "title", "Instrument Summary")));
         table = new DataRegionTable("InstrumentSummary", getDriver());
         checker().verifyEquals("Invalid Instrument serial number", "Exactive Series slot #2384",
                 table.getDataAsText(0, "SerialNumber"));


### PR DESCRIPTION
#### Rationale
Two separate actions have had perf problems on PanoramaWeb when a bot requested AllFolders as the container filter. While lower risk due to the queries being run, there are a few more action that follow a similar pattern and we can restrict how they're queried to keep performance happy without any change in the results.

#### Related Pull Requests
* https://github.com/LabKey/targetedms/pull/372

#### Changes
* Hide Folder Filter menu on document-scoped grid views
* Ignore any non-default container filter values passed on the URL
* Rename Instruments Summary -> Instrument Summary