### PR TITLE
Propagate ContainerFilter when creating GuideSetTable instances

### DIFF
--- a/src/org/labkey/targetedms/query/GuideSetTable.java
+++ b/src/org/labkey/targetedms/query/GuideSetTable.java
@@ -43,7 +43,7 @@ public class GuideSetTable extends FilteredTable<TargetedMSSchema>
 {
     public GuideSetTable(TargetedMSSchema schema, ContainerFilter cf)
     {
-        super(TargetedMSManager.getTableInfoGuideSet(), schema);
+        super(TargetedMSManager.getTableInfoGuideSet(), schema, cf);
 
         wrapAllColumns(true);
         TargetedMSTable.fixupLookups(this);


### PR DESCRIPTION
#### Rationale
GuideSetTable doesn't work with container filters

#### Changes
* Pass constructor argument into super() call