### PR TITLE
Issue 43099: Add new usage metric for guidesets in Panorama QC plots

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -470,7 +470,10 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
             svc.registerUsageMetrics(MODULE_NAME, () ->
             {
                 Map<String, Object> metric = new HashMap<>();
-                metric.put("runCount", new SqlSelector(DbSchema.get("TargetedMS", DbSchemaType.Module), "SELECT COUNT(*) FROM TargetedMS.Runs WHERE Deleted = ?", Boolean.FALSE).getObject(Long.class));
+                DbSchema schema = TargetedMSManager.getSchema();
+                metric.put("runCount", new SqlSelector(schema, "SELECT COUNT(*) FROM TargetedMS.Runs WHERE Deleted = ?", Boolean.FALSE).getObject(Long.class));
+                metric.put("guideSetCount", new SqlSelector(schema, "SELECT COUNT(*) FROM TargetedMS.GuideSet").getObject(Long.class));
+                metric.put("guideSetContainerCount", new SqlSelector(schema, "SELECT COUNT(DISTINCT Container) FROM TargetedMS.GuideSet").getObject(Long.class));
                 return metric;
             });
         }

--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -22,7 +22,8 @@ import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DbSchema;
-import org.labkey.api.data.DbSchemaType;
+import org.labkey.api.data.PropertySchema;
+import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.UpgradeCode;
 import org.labkey.api.exp.ExperimentRunType;
@@ -474,6 +475,21 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
                 metric.put("runCount", new SqlSelector(schema, "SELECT COUNT(*) FROM TargetedMS.Runs WHERE Deleted = ?", Boolean.FALSE).getObject(Long.class));
                 metric.put("guideSetCount", new SqlSelector(schema, "SELECT COUNT(*) FROM TargetedMS.GuideSet").getObject(Long.class));
                 metric.put("guideSetContainerCount", new SqlSelector(schema, "SELECT COUNT(DISTINCT Container) FROM TargetedMS.GuideSet").getObject(Long.class));
+
+                SQLFragment folderTypeSQL = new SQLFragment("SELECT p.value, COUNT(*) AS FolderCount FROM ");
+                folderTypeSQL.append(PropertySchema.getInstance().getTableInfoProperties(), "p");
+                folderTypeSQL.append(" INNER JOIN ");
+                folderTypeSQL.append(PropertySchema.getInstance().getTableInfoPropertySets(), "ps");
+                folderTypeSQL.append(" ON p.\"set\" = ps.\"set\" WHERE ps.category = 'moduleProperties.TargetedMS' ");
+                folderTypeSQL.append(" AND p.name = ? GROUP BY value");
+                folderTypeSQL.add(FOLDER_TYPE_PROP_NAME);
+
+                Map<String, Long> folderCounts = new HashMap<>();
+                new SqlSelector(PropertySchema.getInstance().getSchema(), folderTypeSQL).forEach(rs ->
+                        folderCounts.put(rs.getString("value"), rs.getLong("FolderCount")));
+
+                metric.put("folderCounts", folderCounts);
+
                 return metric;
             });
         }


### PR DESCRIPTION
#### Rationale
We're curious about real-world guide set usage in Panorama

#### Changes
* Capture the total number of guide sets defined on a server and the number of containers that have them defined
* Also capture folder type breakdown