### PR TITLE
Issue 43088: Pressure trace metric title doubled up in QC plots

### DIFF
--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -565,7 +565,10 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
     },
 
     getSubtitle: function(precursor) {
-        return precursor + ' - ' + this.getMetricPropsById(this.metric).name;;
+        if (precursor === this.getMetricPropsById(this.metric).name)
+            return precursor;
+        else
+            return precursor + ' - ' + this.getMetricPropsById(this.metric).name;
     },
 
     addEachCombinedPrecusorPlot: function(plotIndex, id, combinePlotData, groupColors, yAxisCount, metricProps, showLogInvalid, legendMargin, plotType, isCUSUMMean) {


### PR DESCRIPTION
#### Rationale
Titles are getting duplicated and doubled up in QC plots for trace metrics. This fixes the title in QC plots.
