### PR TITLE
Import all TransitionChromInfos when there are < 1000 precursors

### DIFF
--- a/src/org/labkey/targetedms/SkylineDocImporter.java
+++ b/src/org/labkey/targetedms/SkylineDocImporter.java
@@ -378,7 +378,10 @@ public class SkylineDocImporter
 
             if (!parser.shouldSaveTransitionChromInfos())
             {
-                _log.info("None of the " + parser.getTransitionChromInfoCount() + " TransitionChromInfos in the file were imported because they exceed the limit of " + SkylineDocumentParser.MAX_TRANSITION_CHROM_INFOS);
+                _log.info("None of the " + parser.getTransitionChromInfoCount() + " TransitionChromInfos in the file " +
+                        "were imported because they exceed the limit of " +
+                        SkylineDocumentParser.MAX_TRANSITION_CHROM_INFOS + " and there are more than " +
+                        SkylineDocumentParser.MAX_PRECURSORS + " precursors");
                 SQLFragment whereClause = new SQLFragment("WHERE r.Id = ?", _runId);
 
                 // Clear out any of the TransitionChromInfo and related tables that we inserted before we exceeded

--- a/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
+++ b/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
@@ -183,7 +183,8 @@ public class SkylineDocumentParser implements AutoCloseable
 
     /**
      * To prevent giant DIA documents from overwhelming the DB, we skip importing TransitionChromInfos if the document
-     * has more than 100,000 AND has more than 1,000 precursors
+     * has more than 100,000 AND has more than 1,000 precursors. We use both because a document may have a lot of
+     * replicates, so the TransitionChromInfo count by itself isn't sufficient to do the desired screening
      */
     public static final int MAX_TRANSITION_CHROM_INFOS = 100_000;
     public static final int MAX_PRECURSORS = 1_000;
@@ -238,7 +239,8 @@ public class SkylineDocumentParser implements AutoCloseable
         readDocumentVersion(_reader);
     }
 
-    /** @return if we've exceeded the maximum count of TransitionChromInfos that we want to store for a run */
+    /** @return false if we've exceeded the maximum count of TransitionChromInfos that we want to store for a run,
+     * or true if we're below the threshold and should retain them */
     public boolean shouldSaveTransitionChromInfos()
     {
         return _transitionChromInfoCount < MAX_TRANSITION_CHROM_INFOS || _precursorCount < MAX_PRECURSORS;

--- a/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
+++ b/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
@@ -183,9 +183,10 @@ public class SkylineDocumentParser implements AutoCloseable
 
     /**
      * To prevent giant DIA documents from overwhelming the DB, we skip importing TransitionChromInfos if the document
-     * has more than 100,000
+     * has more than 100,000 AND has more than 1,000 precursors
      */
     public static final int MAX_TRANSITION_CHROM_INFOS = 100_000;
+    public static final int MAX_PRECURSORS = 1_000;
 
     /** Null if we haven't found a SKYD to parse */
     @Nullable
@@ -240,7 +241,7 @@ public class SkylineDocumentParser implements AutoCloseable
     /** @return if we've exceeded the maximum count of TransitionChromInfos that we want to store for a run */
     public boolean shouldSaveTransitionChromInfos()
     {
-        return _transitionChromInfoCount < MAX_TRANSITION_CHROM_INFOS;
+        return _transitionChromInfoCount < MAX_TRANSITION_CHROM_INFOS || _precursorCount < MAX_PRECURSORS;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
We recently instituted a cutoff so that we don't import TransitionChromInfos for very large documents. We want to be more selective about applying the cutoff

#### Changes
* Only skip importing TransitionChromInfos if there are more than 100,000 AND there are at least 1,000 precursors