### PR TITLE
Fix NPE in ComparisonCategory$MoleculeCategory.equals()

### DIFF
--- a/src/org/labkey/targetedms/chart/ComparisonChartInputMaker.java
+++ b/src/org/labkey/targetedms/chart/ComparisonChartInputMaker.java
@@ -103,12 +103,7 @@ public class ComparisonChartInputMaker
                 if (!StringUtils.isBlank(_groupByAnnotationName) && !categoryLabel.hasAnnotationValue())
                     continue;
 
-                List<PrecursorChromInfoLitePlus> categoryPciList = datasetMap.get(categoryLabel);
-                if (categoryPciList == null)
-                {
-                    categoryPciList = new ArrayList<>();
-                    datasetMap.put(categoryLabel, categoryPciList);
-                }
+                List<PrecursorChromInfoLitePlus> categoryPciList = datasetMap.computeIfAbsent(categoryLabel, k -> new ArrayList<>());
                 categoryPciList.add(pciPlus);
             }
 
@@ -169,12 +164,7 @@ public class ComparisonChartInputMaker
 
                 categoryLabelToSampleFileId.put(categoryLabel, pciPlus.getSampleFileId());
 
-                List<PrecursorChromInfoLitePlus> categoryPciList = datasetMap.get(categoryLabel);
-                if (categoryPciList == null)
-                {
-                    categoryPciList = new ArrayList<>();
-                    datasetMap.put(categoryLabel, categoryPciList);
-                }
+                List<PrecursorChromInfoLitePlus> categoryPciList = datasetMap.computeIfAbsent(categoryLabel, k -> new ArrayList<>());
                 categoryPciList.add(pciPlus);
             }
 
@@ -182,7 +172,7 @@ public class ComparisonChartInputMaker
 
             for (String categoryLabel : datasetMap.keySet())
             {
-                ComparisonCategory.ReplicateCategory replicateCategory = null;
+                ComparisonCategory.ReplicateCategory replicateCategory;
                 if(StringUtils.isBlank(_groupByAnnotationName))
                 {
                     // Display replicates in document order (replicate.getId()) if we are not grouping by annotations.

--- a/src/org/labkey/targetedms/chart/ComparisonChartMaker.java
+++ b/src/org/labkey/targetedms/chart/ComparisonChartMaker.java
@@ -24,7 +24,6 @@ import org.jfree.chart.axis.CategoryAxis;
 import org.jfree.chart.axis.CategoryLabelPositions;
 import org.jfree.chart.axis.LogarithmicAxis;
 import org.jfree.chart.axis.NumberAxis;
-import org.jfree.chart.axis.ValueAxis;
 import org.jfree.chart.plot.CategoryPlot;
 import org.jfree.chart.plot.Plot;
 import org.jfree.chart.plot.PlotOrientation;
@@ -389,7 +388,7 @@ public class ComparisonChartMaker
             pciPlusList = getPrecursorChromInfo(molecule, precursor, user, container);
         }
 
-        if (pciPlusList == null || pciPlusList.size() == 0)
+        if (pciPlusList.size() == 0)
         {
             return null;
         }

--- a/src/org/labkey/targetedms/chart/ComparisonDataset.java
+++ b/src/org/labkey/targetedms/chart/ComparisonDataset.java
@@ -110,7 +110,7 @@ public class ComparisonDataset
         categoryDatasets.sort((o1, o2) ->
         {
             if (_setSortByValues)
-                return Double.valueOf(o2.getSeriesMaxValue()).compareTo(o1.getSeriesMaxValue());
+                return Double.compare(o2.getSeriesMaxValue(), o1.getSeriesMaxValue());
             else
             {
                 if (_numericSort)
@@ -198,7 +198,7 @@ public class ComparisonDataset
 
     public static class ComparisonCategoryItem
     {
-        private ComparisonCategory _category;
+        private final ComparisonCategory _category;
         private Map<SeriesLabel, ComparisonSeriesItem> _seriesDatasetsMap;
         private double _maxCategoryValue;
 
@@ -239,12 +239,7 @@ public class ComparisonDataset
                 seriesLabel.setIsotopeLabel(pciPlus.getIsotopeLabel());
                 seriesLabel.setIsotopeLabelId(pciPlus.getIsotopeLabelId());
 
-                List<PrecursorChromInfoLitePlus> seriesData = seriesDataMap.get(seriesLabel);
-                if(seriesData == null)
-                {
-                    seriesData = new ArrayList<>();
-                    seriesDataMap.put(seriesLabel, seriesData);
-                }
+                List<PrecursorChromInfoLitePlus> seriesData = seriesDataMap.computeIfAbsent(seriesLabel, k -> new ArrayList<>());
                 seriesData.add(pciPlus);
             }
 
@@ -376,9 +371,7 @@ public class ComparisonDataset
             if (_charge != that._charge) return false;
             if (_isotopeLabel != null ? !_isotopeLabel.equals(that._isotopeLabel) : that._isotopeLabel != null)
                 return false;
-            if(_isotopeLabelId != that._isotopeLabelId) return false;
-
-            return true;
+            return _isotopeLabelId == that._isotopeLabelId;
         }
 
         @Override
@@ -394,14 +387,14 @@ public class ComparisonDataset
         @Override
         public int compareTo(@NotNull SeriesLabel o)
         {
-            int cmp = Integer.valueOf(this.getCharge()).compareTo(o.getCharge());
+            int cmp = Integer.compare(this.getCharge(), o.getCharge());
             if (cmp != 0)
             {
                 return cmp;
             }
             else
             {
-                return Integer.valueOf(this.getIsotopeLabelId()).compareTo(o.getIsotopeLabelId());
+                return Integer.compare(this.getIsotopeLabelId(), o.getIsotopeLabelId());
             }
         }
     }
@@ -522,11 +515,11 @@ public class ComparisonDataset
         return scale == 1 ? "" : (scale == 1000 ? "10^3" : "10^6");
     }
 
-    private static interface SeriesItemData
+    private interface SeriesItemData
     {
-        public double getValue();
+        double getValue();
 
-        public boolean isStatistical();
+        boolean isStatistical();
     }
 
     private static class BarChartSeriesItemData implements SeriesItemData
@@ -623,9 +616,9 @@ public class ComparisonDataset
         }
     }
 
-    static interface SeriesItemMaker
+    interface SeriesItemMaker
     {
-        public SeriesItemData make(List<PrecursorChromInfoLitePlus> pciPlusList, boolean cvValues);
+        SeriesItemData make(List<PrecursorChromInfoLitePlus> pciPlusList, boolean cvValues);
     }
 
     public static abstract class BarChartSeriesItemMaker implements SeriesItemMaker
@@ -760,8 +753,8 @@ public class ComparisonDataset
 
     public static class RetentionTimeDatasetItem extends BoxAndWhiskerItem
     {
-        private Number _fwhmStart;
-        private Number _fwhmEnd;
+        private final Number _fwhmStart;
+        private final Number _fwhmEnd;
 
         public RetentionTimeDatasetItem(Number rtAtPeak, Number minRt, Number maxRt, Number fwhmStart, Number fwhmEnd)
         {

--- a/src/org/labkey/targetedms/chart/MultiLineXYPointerAnnotation.java
+++ b/src/org/labkey/targetedms/chart/MultiLineXYPointerAnnotation.java
@@ -25,17 +25,16 @@ import org.jfree.ui.RectangleEdge;
 
 import java.awt.*;
 import java.awt.geom.Rectangle2D;
-import java.util.ArrayList;
 import java.util.List;
 
 /**
- * The base class {@Link XYPointerAnnotation} draws the arrow at (x,y).
+ * The base class {@link XYPointerAnnotation} draws the arrow at (x,y).
  * The labels are drawn by the draw() method override, which accepts a List of String labels.
  * The labels are drawn one below the other.
  */
 public class MultiLineXYPointerAnnotation extends XYPointerAnnotation
 {
-    private java.util.List<String> _labels = new ArrayList<>();
+    private final java.util.List<String> _labels;
 
     /**
      * Creates a new multi line label.


### PR DESCRIPTION
#### Rationale
The crawler discovered a NPE in an equals() method. IntelliJ pointed out a bunch of minor code cleanup that was an auto-refactor to improve

https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailySuites_DailyEPostgres/1421489?buildTab=tests&name=TargetedMSSmall&pager.currentPage=1&expandedTest=4609028065209533007

#### Changes
* Use Objects.equals() on _customIonName to avoid NPE
* Do suggested auto-refactor cleanup on related files
