### PR TITLE
Assorted small exception report fixes

### DIFF
--- a/src/org/labkey/targetedms/chart/ChromatogramDataset.java
+++ b/src/org/labkey/targetedms/chart/ChromatogramDataset.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.targetedms.chart;
 
+import org.apache.log4j.Logger;
 import org.jfree.chart.ChartColor;
 import org.jfree.data.xy.XYSeries;
 import org.jfree.data.xy.XYSeriesCollection;
@@ -65,6 +66,8 @@ import java.util.stream.Collectors;
  */
 public abstract class ChromatogramDataset
 {
+    private static final Logger LOG = Logger.getLogger(ChromatogramDataset.class);
+
     XYSeriesCollection _jfreeDataset;
     Double _maxDisplayIntensity; // This is set only when we are synchronizing plots on intensity
     Double _minDisplayRt;
@@ -844,7 +847,8 @@ public abstract class ChromatogramDataset
             }
             else
             {
-                throw new IllegalStateException("Pipeline root not found.");
+                LOG.warn("Could not find pipeline root for container " + _container.getPath());
+                return Collections.emptyList();
             }
 
         }

--- a/src/org/labkey/targetedms/chart/ChromatogramDataset.java
+++ b/src/org/labkey/targetedms/chart/ChromatogramDataset.java
@@ -15,8 +15,8 @@
  */
 package org.labkey.targetedms.chart;
 
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jfree.chart.ChartColor;
 import org.jfree.data.xy.XYSeries;
 import org.jfree.data.xy.XYSeriesCollection;

--- a/src/org/labkey/targetedms/chart/ChromatogramDataset.java
+++ b/src/org/labkey/targetedms/chart/ChromatogramDataset.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.targetedms.chart;
 
+import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.jfree.chart.ChartColor;
 import org.jfree.data.xy.XYSeries;
@@ -66,7 +67,7 @@ import java.util.stream.Collectors;
  */
 public abstract class ChromatogramDataset
 {
-    private static final Logger LOG = Logger.getLogger(ChromatogramDataset.class);
+    private static final Logger LOG = LogManager.getLogger(ChromatogramDataset.class);
 
     XYSeriesCollection _jfreeDataset;
     Double _maxDisplayIntensity; // This is set only when we are synchronizing plots on intensity

--- a/src/org/labkey/targetedms/chart/ComparisonChartMaker.java
+++ b/src/org/labkey/targetedms/chart/ComparisonChartMaker.java
@@ -36,6 +36,8 @@ import org.jfree.data.category.CategoryDataset;
 import org.jfree.data.statistics.BoxAndWhiskerCategoryDataset;
 import org.labkey.api.data.Container;
 import org.labkey.api.security.User;
+import org.labkey.api.util.Pair;
+import org.labkey.api.view.NotFoundException;
 import org.labkey.targetedms.chart.ComparisonDataset.ValueType;
 import org.labkey.targetedms.model.PrecursorChromInfoLitePlus;
 import org.labkey.targetedms.parser.Molecule;
@@ -65,18 +67,7 @@ public class ComparisonChartMaker
                                          String groupByAnnotation, String filterByAnnotation,
                                          boolean cvValues, boolean logValues, User user, Container container)
     {
-        String title;
-        ComparisonDataset.ChartType chartType;
-        if (peptide == null)
-        {
-            title = peptideGroup.getLabel();
-            chartType = ComparisonDataset.ChartType.PEPTIDE_COMPARISON;
-        }
-        else
-        {
-            title = peptide.getSequence();
-            chartType = ComparisonDataset.ChartType.REPLICATE_COMPARISON;
-        }
+        Pair<String, ComparisonDataset.ChartType> chartConfig = getChartConfig(peptideGroup, peptide);
 
         String yLabel = cvValues ? "Peak Area CV(%)" : "Peak Area ";
         if(cvValues && logValues){
@@ -86,13 +77,13 @@ public class ComparisonChartMaker
             yLabel =   "Log Peak Area";
         }
 
-        List<PrecursorChromInfoLitePlus> pciPlusList = getInputData(peptideGroup, replicateId, peptide, precursor, chartType, user, container);
+        List<PrecursorChromInfoLitePlus> pciPlusList = getInputData(peptideGroup, replicateId, peptide, precursor, chartConfig.second, user, container);
         if (pciPlusList == null || pciPlusList.size() == 0)
         {
             return null;
         }
 
-        return makeChart(peptideGroup, title, chartType, pciPlusList, groupByAnnotation, filterByAnnotation, cvValues, logValues,
+        return makeChart(peptideGroup, chartConfig.first, chartConfig.second, pciPlusList, groupByAnnotation, filterByAnnotation, cvValues, logValues,
                 new ComparisonDataset.PeakAreasSeriesItemMaker(), yLabel, true, user, container);
     }
 
@@ -132,31 +123,35 @@ public class ComparisonChartMaker
                 new ComparisonDataset.PeakAreasSeriesItemMaker(), yLabel, true, user, container);
     }
 
-    public JFreeChart makeRetentionTimesChart(long replicateId, PeptideGroup peptideGroup,
-                                         Peptide peptide, Precursor precursor,
-                                         String groupByAnnotation, String filterByAnnotation, String value, boolean cvValues,
-                                         User user, Container container)
+    /** @return pair of the chart title and type */
+    private Pair<String, ComparisonDataset.ChartType> getChartConfig(PeptideGroup peptideGroup, Peptide peptide)
     {
         String title;
         ComparisonDataset.ChartType chartType;
         if (peptide == null)
         {
-            title = peptideGroup.getLabel();
-            chartType = ComparisonDataset.ChartType.PEPTIDE_COMPARISON;
+            if (peptideGroup == null)
+            {
+                throw new NotFoundException("Could not resolve peptide or peptide group");
+            }
+            return new Pair<>(peptideGroup.getLabel(), ComparisonDataset.ChartType.PEPTIDE_COMPARISON);
         }
-        else
-        {
-            title = peptide.getSequence();
-            chartType = ComparisonDataset.ChartType.REPLICATE_COMPARISON;
-        }
+        return new Pair<>(peptide.getSequence(), ComparisonDataset.ChartType.REPLICATE_COMPARISON);
+    }
 
-        List<PrecursorChromInfoLitePlus> pciPlusList = getInputData(peptideGroup, replicateId, peptide, precursor, chartType, user, container);
+    public JFreeChart makeRetentionTimesChart(long replicateId, PeptideGroup peptideGroup,
+                                         Peptide peptide, Precursor precursor,
+                                         String groupByAnnotation, String filterByAnnotation, String value, boolean cvValues,
+                                         User user, Container container)
+    {
+        Pair<String, ComparisonDataset.ChartType> chartConfig = getChartConfig(peptideGroup, peptide);
+        List<PrecursorChromInfoLitePlus> pciPlusList = getInputData(peptideGroup, replicateId, peptide, precursor, chartConfig.second, user, container);
         if (pciPlusList == null || pciPlusList.size() == 0)
         {
             return null;
         }
 
-        return makeRetentionTimesChart(peptideGroup, title, chartType, pciPlusList, groupByAnnotation,
+        return makeRetentionTimesChart(peptideGroup, chartConfig.first, chartConfig.second, pciPlusList, groupByAnnotation,
                                        filterByAnnotation,  value, cvValues, user, container);
     }
 

--- a/src/org/labkey/targetedms/chromlib/ChromatogramLibraryUtils.java
+++ b/src/org/labkey/targetedms/chromlib/ChromatogramLibraryUtils.java
@@ -23,6 +23,7 @@ import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.security.User;
 import org.labkey.api.settings.AppProps;
+import org.labkey.api.util.ConfigurationException;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.targetedms.TargetedMSController;
@@ -164,7 +165,10 @@ public class ChromatogramLibraryUtils
     private static Path getChromLibDir(Container container, boolean createLibDir) throws IOException
     {
         PipeRoot root = PipelineService.get().getPipelineRootSetting(container);
-        assert root != null;
+        if (root == null)
+        {
+            throw new ConfigurationException("Unable to resolve a pipeline root for " + container.getPath());
+        }
         Path chromLibDir = root.getRootNioPath().resolve(Constants.LIB_FILE_DIR);
         if(!Files.exists(chromLibDir) && createLibDir)
         {

--- a/src/org/labkey/targetedms/outliers/OutlierGenerator.java
+++ b/src/org/labkey/targetedms/outliers/OutlierGenerator.java
@@ -239,7 +239,7 @@ public class OutlierGenerator
     public List<SampleFileInfo> getSampleFiles(List<RawMetricDataSet> dataRows, Map<GuideSetKey, GuideSetStats> allStats, Map<Integer, QCMetricConfiguration> metrics, Container container, Integer limit)
     {
         List<SampleFileInfo> result = TargetedMSManager.getSampleFiles(container, new SQLFragment("sf.AcquiredTime IS NOT NULL")).stream().map(SampleFile::toSampleFileInfo).collect(Collectors.toList());
-        Map<Long, SampleFileInfo> sampleFiles = result.stream().collect(Collectors.toMap(SampleFileInfo::getSampleId, Function.identity()));
+        Map<Long, SampleFileInfo> sampleFiles = result.stream().collect(Collectors.toMap(SampleFileInfo::getSampleId, Function.identity(), (a, b) -> a));
 
         for (RawMetricDataSet dataRow : dataRows)
         {

--- a/src/org/labkey/targetedms/parser/AbstractChromInfo.java
+++ b/src/org/labkey/targetedms/parser/AbstractChromInfo.java
@@ -91,7 +91,8 @@ public abstract class AbstractChromInfo extends ChromInfo<PrecursorChromInfoAnno
         }
         catch (IOException e)
         {
-            throw new UnexpectedException(e);
+            LOG.warn("Unable to fetch chromatogram from " + path, e);
+            return null;
         }
     });
 

--- a/src/org/labkey/targetedms/passport/PassportController.java
+++ b/src/org/labkey/targetedms/passport/PassportController.java
@@ -16,8 +16,8 @@
 
 package org.labkey.targetedms.passport;
 
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.action.SimpleViewAction;
 import org.labkey.api.action.SpringActionController;
@@ -61,8 +61,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.labkey.targetedms.TargetedMSManager.getSqlDialect;
 

--- a/src/org/labkey/targetedms/passport/PassportController.java
+++ b/src/org/labkey/targetedms/passport/PassportController.java
@@ -16,6 +16,7 @@
 
 package org.labkey.targetedms.passport;
 
+import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.action.SimpleViewAction;
@@ -68,7 +69,7 @@ import static org.labkey.targetedms.TargetedMSManager.getSqlDialect;
 public class PassportController extends SpringActionController
 {
     private static final DefaultActionResolver _actionResolver = new DefaultActionResolver(PassportController.class);
-    private static final Logger LOG = Logger.getLogger(PassportController.class);
+    private static final Logger LOG = LogManager.getLogger(PassportController.class);
 
     public PassportController()
     {


### PR DESCRIPTION
#### Rationale
Issue 43328: NullPointerException in org.labkey.targetedms.chart.ComparisonChartMaker.makeRetentionTimesChart()

Issue 43326: Error handling improvements when SKYD files aren't available on disk

Issue 43325: IllegalStateException from org.labkey.targetedms.outliers.OutlierGenerator.getSampleFiles()

#### Changes
* Demote file system problem to logging or ConfigurationException to avoid reporting
* Fix NPEs
* Collapse duplicate SampleFile entries from query