### PR TITLE
Update dependencies for 21.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Generated files
 resources/credits/dependencies.txt
+resources/credits/jars.txt

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
-import org.labkey.gradle.util.BuildUtils;
+import org.labkey.gradle.util.BuildUtils
+import org.labkey.gradle.util.ExternalDependency
 
 plugins {
    id 'org.labkey.build.module'
@@ -6,10 +7,54 @@ plugins {
 
 dependencies
 {
-   external "com.google.protobuf:protobuf-java:${googleProtocolBufVersion}"
-   external "org.xerial:sqlite-jdbc:3.7.2"
-   external "org.apache.commons:commons-math3:${commonsMath3Version}"
-   external "org.jfree:jcommon:1.0.17"
+   BuildUtils.addExternalDependency(
+           project,
+           new ExternalDependency(
+                   "com.google.protobuf:protobuf-java:${googleProtocolBufVersion}",
+                   "Protocol Buffers",
+                   "Github Google",
+                   "https://github.com/google/protobuf/releases",
+                   "Custom",
+                   "https://github.com/google/protobuf/blob/master/LICENSE",
+                   "Binary data parsing"
+           )
+   )
+   BuildUtils.addExternalDependency(
+           project,
+           new ExternalDependency(
+                   "org.xerial:sqlite-jdbc:3.7.2",
+                   "SQLite JDBC Driver",
+                   "bitbucket.org",
+                   "https://bitbucket.org/xerial/sqlite-jdbc/wiki/Home",
+                   ExternalDependency.APACHE_2_LICENSE_NAME,
+                   ExternalDependency.APACHE_2_LICENSE_URL,
+                   "SQLite JDBC Driver"
+           )
+   )
+   BuildUtils.addExternalDependency(
+           project,
+           new ExternalDependency(
+                   "org.apache.commons:commons-math3:${commonsMath3Version}",
+                   "Commons Math",
+                   "Apache",
+                   "http://commons.apache.org/math/",
+                   ExternalDependency.APACHE_2_LICENSE_NAME,
+                   ExternalDependency.APACHE_2_LICENSE_URL,
+                   "Lightweight, self-contained mathematics and statistics components"
+           )
+   )
+   BuildUtils.addExternalDependency(
+           project,
+           new ExternalDependency(
+                   "org.jfree:jcommon:${jcommonVersion}",
+                   "JFree Chart",
+                   "JFreeChart",
+                   "http://www.jfree.org/jfreechart/",
+                   ExternalDependency.LGPL_LICENSE_NAME,
+                   ExternalDependency.LGPL_LICENSE_URL,
+                   "PNG encoder"
+           )
+   )
    implementation "org.apache.httpcomponents:httpmime:${httpmimeVersion}"
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath:  BuildUtils.getCommonAssayModuleProjectPath(project.gradle, "ms2"), depProjectConfig: "apiJarFile")
    BuildUtils.addLabKeyDependency(project: project, config: "jspImplementation", depProjectPath: BuildUtils.getCommonAssayModuleProjectPath(project.gradle, "ms2"), depProjectConfig: "apiJarFile")
@@ -18,7 +63,6 @@ dependencies
    
 }
 
-// TODO move resources files into resources directory to avoid this overlap
 sourceSets {
    main {
       resources {

--- a/resources/credits/jars.txt
+++ b/resources/credits/jars.txt
@@ -1,7 +1,0 @@
-{table}
-Filename|Component|Version|Source|License|LabKey Dev|Purpose
-commons-math3-3.6.1.jar|Commons Math|3.6.1|{link:Apache|http://commons.apache.org/math/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}||Lightweight, self-contained mathematics and statistics components
-jcommon-1.0.17.jar|JFree Chart|1.0.17|{link:JFreeChart|http://www.jfree.org/jfreechart/}|{link:LGPL|http://www.gnu.org/licenses/lgpl.txt}||PNG encoder
-protobuf-java-3.12.2.jar|Protocol Buffers|3.12.2|{link:Github Google|https://github.com/google/protobuf/releases}|{link:Custom|https://github.com/google/protobuf/blob/master/LICENSE}|nicksh|Binary data parsing
-sqlite-jdbc-3.7.2.jar|SQLite JDBC Driver|3.7.2|{link:bitbucket.org|https://bitbucket.org/xerial/sqlite-jdbc/wiki/Home}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|vsharma|SQLite JDBC Driver
-{table}


### PR DESCRIPTION
#### Rationale
Keeping dependency versions updated.  We also take this opportunity to transition some of the modules to use the new `BuildUtils.addExternalDependency` method that provides the information to be used in populating the `jars.txt` file so we can remove it from and ignore it in git.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2352

#### Changes
* Use `BuildUtils.addExternalDependency`, bringing in version updates.