### PR TITLE
Issue 43375: Use exp.data.DataFileUrl column instead of the Name column to find matching raw files

### DIFF
--- a/src/org/labkey/targetedms/datasource/MsDataSourceUtil.java
+++ b/src/org/labkey/targetedms/datasource/MsDataSourceUtil.java
@@ -176,16 +176,21 @@ public class MsDataSourceUtil
 
         TableInfo expDataTInfo = expSvc.getTinfoData();
         SimpleFilter filter = MsDataSource.getExpDataFilter(container, pathPrefixString);
-        filter.addCondition(FieldKey.fromParts("name"), fileName, CompareType.STARTS_WITH);
+        // Issue 43375: Use exp.data.DataFileUrl column instead of the Name column to find matching raw files
+        // filter.addCondition(FieldKey.fromParts("name"), fileName, CompareType.STARTS_WITH);
+        String encodedPath = pathPrefix.resolve(fileName).toUri().toString();
+        String encodedName = org.labkey.api.util.Path.parse(encodedPath).getName();
+        filter.addCondition(FieldKey.fromParts("datafileurl"), encodedName, CompareType.CONTAINS);
 
         // Get the rowId and name of matching rows.
         Map<Integer, String> expDatas = new TableSelector(expDataTInfo,
-                expDataTInfo.getColumns("RowId", "Name"), filter, null).getValueMap();
+                expDataTInfo.getColumns("RowId", "DataFileUrl"), filter, null).getValueMap();
 
         List<Integer> expDataIds = new ArrayList<>();
+        expDatas.entrySet().forEach(e -> e.setValue(org.labkey.api.util.Path.parse(e.getValue()).getName())); // Replace path with file name
         // Look for the file and file.zip (e.g. sample_1.raw and sample_1.raw.zip)
         expDatas.entrySet().stream()
-                           .filter(e -> fileName.equals(e.getValue()) || (isZip(e.getValue()) && fileName.equals(FileUtil.getBaseName(e.getValue()))))
+                           .filter(e -> encodedName.equals(e.getValue()) || (isZip(e.getValue()) && encodedName.equals(FileUtil.getBaseName(e.getValue()))))
                            .forEach(e -> expDataIds.add(e.getKey()));
 
         return expSvc.getExpDatas(expDataIds);
@@ -608,6 +613,25 @@ public class MsDataSourceUtil
             data.setDataFileURI(rawDataDir.resolve(subfolder).resolve(fileName).toUri());
             data.save(_user);
             return data;
+        }
+
+        @Test
+        public void testEncodedDataFileUrl() throws IOException
+        {
+            Lsid lsid = new Lsid(ExperimentService.get().generateGuidLSID(_container, new DataType("UploadedFile")));
+            String fileName = "Space !#$%&'(+)+,;=@[+].raw";
+            ExpData data = ExperimentService.get().createData(_container, fileName, lsid.toString());
+
+            data.setContainer(_container);
+            Path rawDataDir = JunitUtil.getSampleData(ModuleLoader.getInstance().getModule(TargetedMSModule.class), TEST_DATA_FOLDER).toPath();
+            data.setDataFileURI(rawDataDir.resolve(fileName).toUri());
+            data.save(_user);
+
+            SampleFile sf = new SampleFile();
+            sf.setFilePath("C:\\rawfiles\\" + fileName);
+            sf.setInstrumentId(_thermo.getId());
+
+            assertNotNull("Expected row in exp.data for " + fileName, _util.getDataForSampleFile(sf, _container, rawDataDir, ExperimentService.get(), false));
         }
 
         @Test

--- a/src/org/labkey/targetedms/parser/speclib/BlibSpectrumReader.java
+++ b/src/org/labkey/targetedms/parser/speclib/BlibSpectrumReader.java
@@ -494,14 +494,17 @@ public class BlibSpectrumReader extends LibSpectrumReader
                     continue;
                 }
                 Map<Integer, Set<String>> scoreTypes = new HashMap<>(); // file id -> score types
-                try (Statement stmt = conn.createStatement(); ResultSet rs = stmt.executeQuery("SELECT DISTINCT r.fileID, s.scoreType FROM RefSpectra as r JOIN ScoreTypes s ON r.scoreType = s.id"))
+                if(hasTable(conn, "ScoreTypes"))
                 {
-                    while (rs.next())
+                    try (Statement stmt = conn.createStatement(); ResultSet rs = stmt.executeQuery("SELECT DISTINCT r.fileID, s.scoreType FROM RefSpectra as r JOIN ScoreTypes s ON r.scoreType = s.id"))
                     {
-                        int fileId = rs.getInt(1);
-                        String scoreType = rs.getString(2);
-                        scoreTypes.putIfAbsent(fileId, new HashSet<>());
-                        scoreTypes.get(fileId).add(scoreType);
+                        while (rs.next())
+                        {
+                            int fileId = rs.getInt(1);
+                            String scoreType = rs.getString(2);
+                            scoreTypes.putIfAbsent(fileId, new HashSet<>());
+                            scoreTypes.get(fileId).add(scoreType);
+                        }
                     }
                 }
                 try (Statement stmt = conn.createStatement(); ResultSet rs = stmt.executeQuery("SELECT * FROM SpectrumSourceFiles"))


### PR DESCRIPTION
#### Rationale
We query the Name column of exp.data to find a match when generating download links in the Replicates grid. There have been a couple of instances on PanoramaWeb where the value in the Name column does not match the raw file name:
- '+' characters in file names are getting replaced with spaces in the Name column when the folder is copied to Panorama Public (fixed in PR https://github.com/LabKey/platform/pull/2374)
- File rename sometime does not update the value in the Name column. As a result raw file links in the Replicates grid work in a user's folder but not in the folder copy on Panorama Public. 

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/2374
- https://github.com/LabKey/platform/pull/2408

#### Changes
- Also includes a fix for reading older .blib files that did not have the "ScoreTypes" table
