### PR TITLE
Issue 43512: Expand FileNameHint and AminoAcid columns

### DIFF
--- a/resources/schemas/dbscripts/postgresql/targetedms-21.005-21.006.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-21.005-21.006.sql
@@ -1,0 +1,13 @@
+-- FileNameHint for a Skyline document with a "document" library will be one character more than the name of the .sky file
+-- Look at PeptideSettingsParser.getDocumentLibrary()
+-- Example:      Stergachis-SupplementaryData_2_a.sky
+-- FileNameHint: Stergachis-SupplementaryData_2_a.blib
+-- Current limit on the targetedms.runs FileName column that stores the name of the .sky.zip file (e.g. Stergachis-SupplementaryData_2_a.sky.zip)
+-- is 300. Set FileNameHint to be the same.
+ALTER TABLE targetedms.spectrumlibrary ALTER COLUMN FileNameHint TYPE VARCHAR(300);
+
+-- Users can enter a comma-separated list of amino acids for both structural and isotopic modifications in Skyline.
+-- If they enter all 20 standard amino acids plus O	(Pyrrolysine) and U (Selenocysteine) the length of the string
+-- we need to store in the AminoAcid column will be 64: A, C, D, E, F, G, H, I, K, L, M, N, O, P, Q, R, S, T, U, V, W, Y
+ALTER TABLE targetedms.IsotopeModification ALTER COLUMN AminoAcid TYPE VARCHAR(100);
+ALTER TABLE targetedms.StructuralModification ALTER COLUMN AminoAcid TYPE VARCHAR(100);

--- a/resources/schemas/dbscripts/sqlserver/targetedms-21.005-21.006.sql
+++ b/resources/schemas/dbscripts/sqlserver/targetedms-21.005-21.006.sql
@@ -1,0 +1,13 @@
+-- FileNameHint for a Skyline document with a "document" library will be one character more than the name of the .sky file
+-- Look at PeptideSettingsParser.getDocumentLibrary()
+-- Example:      Stergachis-SupplementaryData_2_a.sky
+-- FileNameHint: Stergachis-SupplementaryData_2_a.blib
+-- Current limit on the targetedms.runs FileName column that stores the name of the .sky.zip file (e.g. Stergachis-SupplementaryData_2_a.sky.zip)
+-- is 300. Set FileNameHint to be the same.
+ALTER TABLE targetedms.spectrumlibrary ALTER COLUMN FileNameHint NVARCHAR(300);
+
+-- Users can enter a comma-separated list of amino acids for both structural and isotopic modifications in Skyline.
+-- If they enter all 20 standard amino acids plus O (Pyrrolysine) and U (Selenocysteine) the length of the string
+-- we need to store in the AminoAcid column will be 64: A, C, D, E, F, G, H, I, K, L, M, N, O, P, Q, R, S, T, U, V, W, Y
+ALTER TABLE targetedms.IsotopeModification ALTER COLUMN AminoAcid NVARCHAR(100);
+ALTER TABLE targetedms.StructuralModification ALTER COLUMN AminoAcid NVARCHAR(100);

--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -217,7 +217,7 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
     @Override
     public Double getSchemaVersion()
     {
-        return 21.005;
+        return 21.006;
     }
 
     @Override

--- a/src/org/labkey/targetedms/chromlib/Constants.java
+++ b/src/org/labkey/targetedms/chromlib/Constants.java
@@ -292,7 +292,7 @@ class Constants
     {
         Id(Column.Id),
         Name(Column.Name, "VARCHAR(100) NOT NULL"),
-        AminoAcid(Column.AminoAcid, "VARCHAR(30)"),
+        AminoAcid(Column.AminoAcid, "VARCHAR(100)"),
         Terminus(Column.Terminus),
         Formula(Column.Formula),
         MassDiffMono(Column.MassDiffMono),
@@ -361,7 +361,7 @@ class Constants
         Id(Column.Id),
         Name(Column.Name, "VARCHAR(100) NOT NULL"),
         IsotopeLabel(Column.IsotopeLabel),
-        AminoAcid(Column.AminoAcid, "VARCHAR(30)"),
+        AminoAcid(Column.AminoAcid, "VARCHAR(100)"),
         Terminus(Column.Terminus),
         Formula(Column.Formula),
         MassDiffMono(Column.MassDiffMono),


### PR DESCRIPTION
#### Rationale
Users reported failed Skyline document imports due to insufficient limits on the following columns:
SpectrumLibrary.FileNameHint
and
StructuralModification.AminoAcid
IsotopeModificaiton.AminoAcid
