### PR TITLE
Issue 43557: Avoid using ExtJS for Date parsing

### DIFF
--- a/src/org/labkey/targetedms/view/qcTrendPlotReport.jsp
+++ b/src/org/labkey/targetedms/view/qcTrendPlotReport.jsp
@@ -94,8 +94,8 @@
                 cls: 'qc-trend-plot-panel',
                 plotDivId: plotPanelId,
                 plotPaginationDivId: plotPaginationPanelId,
-                minAcquiredTime: Ext4.Date.parse(data.rows[0]['MinAcquiredTime'], LABKEY.Utils.getDateTimeFormatWithMS()),
-                maxAcquiredTime: Ext4.Date.parse(data.rows[0]['MaxAcquiredTime'], LABKEY.Utils.getDateTimeFormatWithMS())
+                minAcquiredTime: data.rows[0]['MinAcquiredTime'] ? new Date(data.rows[0]['MinAcquiredTime']) : null,
+                maxAcquiredTime: data.rows[0]['MaxAcquiredTime'] ? new Date(data.rows[0]['MaxAcquiredTime']) : null
             });
         }
 

--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -210,7 +210,7 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
 
         // Issue 31678: get the full set of dates values from the precursor data and from the annotations
         for (var j = 0; j < this.annotationData.length; j++) {
-            allPlotDateValues.push(this.formatDate(Ext4.Date.parse(this.annotationData[j].Date, LABKEY.Utils.getDateTimeFormatWithMS()), true));
+            allPlotDateValues.push(this.formatDate(new Date(this.annotationData[j].Date), true));
         }
         allPlotDateValues = Ext4.Array.unique(allPlotDateValues).sort();
 

--- a/webapp/TargetedMS/js/QCPlotHelperWrapper.js
+++ b/webapp/TargetedMS/js/QCPlotHelperWrapper.js
@@ -247,9 +247,9 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperWrapper", {
             PrecursorChromInfoId: row['PrecursorChromInfoId'], // keep in data for click handler
             FilePath: row['FilePath'], // keep in data for hover text display
             IgnoreInQC: row['IgnoreInQC'], // keep in data for hover text display
-            fullDate: row['AcquiredTime'] ? this.formatDate(Ext4.Date.parse(row['AcquiredTime'], LABKEY.Utils.getDateTimeFormatWithMS()), true) : null,
-            date: row['AcquiredTime'] ? this.formatDate(Ext4.Date.parse(row['AcquiredTime'], LABKEY.Utils.getDateTimeFormatWithMS())) : null,
-            groupedXTick: row['AcquiredTime'] ? this.formatDate(Ext4.Date.parse(row['AcquiredTime'], LABKEY.Utils.getDateTimeFormatWithMS())) : null,
+            fullDate: row['AcquiredTime'] ? this.formatDate(new Date(row['AcquiredTime']), true) : null,
+            date: row['AcquiredTime'] ? this.formatDate(new Date(row['AcquiredTime'])) : null,
+            groupedXTick: row['AcquiredTime'] ? this.formatDate(new Date(row['AcquiredTime'])) : null,
             dataType: dataType, //needed for plot point click handler
             SeriesType: seriesType
         };

--- a/webapp/TargetedMS/js/QCSummaryPanel.js
+++ b/webapp/TargetedMS/js/QCSummaryPanel.js
@@ -185,7 +185,7 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
         }
         else
         {
-            var modifiedFormatted = Ext4.util.Format.date(Ext4.Date.parse(autoQC.modified, LABKEY.Utils.getDateTimeFormatWithMS()), LABKEY.extDefaultDateTimeFormat || 'Y-m-d H:i:s');
+            var modifiedFormatted = Ext4.util.Format.date(new Date(autoQC.modified), LABKEY.extDefaultDateTimeFormat || 'Y-m-d H:i:s');
             content = autoQC.isRecent ? 'Was pinged recently on ' + modifiedFormatted : 'Was pinged on ' + modifiedFormatted;
             width = autoQC.isRecent ? 160 : 140;
         }
@@ -270,7 +270,7 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
 
                 var iconCls = !sampleFile.IgnoreForAllMetric ? (totalOutliers === 0 ? 'fa-file-o qc-correct' : 'fa-file qc-error') : 'fa-file-o qc-none';
                 html += '<tr id="' + sampleFile.calloutId + '"><td><div class="sample-file-item">'
-                        + '<span class="fa ' + iconCls + '"></span> ' + Ext4.util.Format.htmlEncode(sampleFile.SampleFile) + '</div></td><td><div class="sample-file-item-acquired">' + Ext4.util.Format.date(Ext4.Date.parse(sampleFile.AcquiredTime, LABKEY.Utils.getDateTimeFormatWithMS()), LABKEY.extDefaultDateTimeFormat || 'Y-m-d H:i:s') + '</div></td>';
+                        + '<span class="fa ' + iconCls + '"></span> ' + Ext4.util.Format.htmlEncode(sampleFile.SampleFile) + '</div></td><td><div class="sample-file-item-acquired">' + Ext4.util.Format.date(sampleFile.AcquiredTime ? new Date(sampleFile.AcquiredTime) : null, LABKEY.extDefaultDateTimeFormat || 'Y-m-d H:i:s') + '</div></td>';
 
                 html += '<td style="text-align: right"><div class="sample-file-item-outliers">';
                 if (sampleFile.IgnoreForAllMetric) {
@@ -309,7 +309,7 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
 
         // generate the HTML content for the sample file display details
         content += '<span class="sample-file-field-label">Name:</span> <a href="' + sampleHREF + '">' + Ext4.util.Format.htmlEncode(sampleFile.SampleFile) + '</a>'
-                + '<br/><span class="sample-file-field-label">Acquired Date/Time:</span> ' + Ext4.util.Format.date(Ext4.Date.parse(sampleFile.AcquiredTime, LABKEY.Utils.getDateTimeFormatWithMS()), LABKEY.extDefaultDateTimeFormat || 'Y-m-d H:i:s')
+                + '<br/><span class="sample-file-field-label">Acquired Date/Time:</span> ' + Ext4.util.Format.date(sampleFile.AcquiredTime ? new Date(sampleFile.AcquiredTime) : null, LABKEY.extDefaultDateTimeFormat || 'Y-m-d H:i:s')
         if (sampleFile.IgnoreForAllMetric) {
             content += '<div>Not included in QC</div>';
         }

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -614,7 +614,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
             else
             {
                 paramValues['dateRangeOffset'] = -1; // force to custom date range selection
-                paramValues['startDate'] = this.formatDate(Ext4.Date.parse(urlParams['startDate'], LABKEY.Utils.getDateTimeFormatWithMS()));
+                paramValues['startDate'] = this.formatDate(new Date(urlParams['startDate']));
             }
         }
 
@@ -628,7 +628,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
             else
             {
                 paramValues['dateRangeOffset'] = -1; // force to custom date range selection
-                paramValues['endDate'] = this.formatDate(Ext4.Date.parse(urlParams['endDate'], LABKEY.Utils.getDateTimeFormatWithMS()));
+                paramValues['endDate'] = this.formatDate(new Date(urlParams['endDate']));
             }
         }
 
@@ -1303,7 +1303,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         for (var i = 0; i < this.annotationData.length; i++)
         {
                 var annotation = this.annotationData[i];
-                var annotationDate = this.formatDate(Ext4.Date.parse(annotation['Date'], LABKEY.Utils.getDateTimeFormatWithMS()), !this.groupedX);
+                var annotationDate = this.formatDate(new Date(annotation['Date']), !this.groupedX);
 
                 // track if we need to stack annotations that fall on the same date
                 if (!dateCount[annotationDate]) {
@@ -1606,8 +1606,8 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                     return "Skyline File: " + Ext4.String.htmlEncode(me.expRunDetails.fileName)
                             + ", \nSerial No: " + Ext4.String.htmlEncode(me.expRunDetails.serialNumber)
                             + ", \nInstrument Name: " + Ext4.String.htmlEncode(me.expRunDetails.instrumentName)
-                            + ", \nStart: " + Ext4.String.htmlEncode(me.formatDate(Ext4.Date.parse(me.expRunDetails.startDate, LABKEY.Utils.getDateTimeFormatWithMS()), true))
-                            + ", \nEnd: " + Ext4.String.htmlEncode(me.formatDate(Ext4.Date.parse(me.expRunDetails.endDate, LABKEY.Utils.getDateTimeFormatWithMS()), true))
+                            + ", \nStart: " + Ext4.String.htmlEncode(me.formatDate(new Date(me.expRunDetails.startDate), true))
+                            + ", \nEnd: " + Ext4.String.htmlEncode(me.formatDate(new Date(me.expRunDetails.endDate), true))
                             + ", \nMean: " + Ext4.String.htmlEncode(expMean)
                             + ", \nStd Dev: " + Ext4.String.htmlEncode(expStdDev)
                             + ", \n%CV: " + Ext4.String.htmlEncode(expPercentCV);
@@ -1640,8 +1640,8 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                 }
 
                 return "Guide Set ID: " + Ext4.String.htmlEncode(d.GuideSetId) + ","
-                    + "\nStart: " + Ext4.String.htmlEncode(me.formatDate(Ext4.Date.parse(guideSetInfo.TrainingStart, LABKEY.Utils.getDateTimeFormatWithMS()), true))
-                    + ",\nEnd: " + Ext4.String.htmlEncode(me.formatDate(Ext4.Date.parse(guideSetInfo.TrainingEnd, LABKEY.Utils.getDateTimeFormatWithMS()), true))
+                    + "\nStart: " + Ext4.String.htmlEncode(me.formatDate(new Date(guideSetInfo.TrainingStart), true))
+                    + ",\nEnd: " + Ext4.String.htmlEncode(me.formatDate(new Date(guideSetInfo.TrainingEnd), true))
                     + (showGuideSetStats ? ",\n# Runs: " + Ext4.String.htmlEncode(numRecs) : "")
                     + (showGuideSetStats ? ",\nMean: " + Ext4.String.htmlEncode(mean) : "")
                     + (showGuideSetStats ? ",\nStd Dev: " + Ext4.String.htmlEncode(stdDev) : "")
@@ -1695,7 +1695,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
 
         // use direct D3 code to inject the annotation icons to the rendered SVG
         var xAcc = function(d) {
-            var annotationDate = me.formatDate(Ext4.Date.parse(d['Date'], LABKEY.Utils.getDateTimeFormatWithMS()), !me.groupedX);
+            var annotationDate = me.formatDate(new Date(d['Date']), !me.groupedX);
             return plot.scales.x.scale(xAxisLabels.indexOf(annotationDate));
         };
         var yAcc = function(d) {
@@ -1717,7 +1717,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
             .text(function(d) {
                 return "Created By: " + d['DisplayName'] + ", "
                         + "\nType: " + d['Name'] + ", "
-                    + "\nDate: " + me.formatDate(Ext4.Date.parse(d['Date'], LABKEY.Utils.getDateTimeFormatWithMS()), true) + ", "
+                    + "\nDate: " + me.formatDate(new Date(d['Date']), true) + ", "
                     + "\nDescription: " + d['Description'];
             });
 


### PR DESCRIPTION
#### Rationale
We introduced our code that used ExtJS to parse dates because IE didn't like our ISO-like dates with milliseconds. We no longer support IE and we want the flexibility to use different date formats on different browsers

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2457

#### Changes
* Use JS Date constructor instead of ExtJS parsing
