### PR TITLE
Fix TargetedMSExperimentalQCLinkTest - don't show undefined in tooltip

### DIFF
--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -1515,8 +1515,8 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                 // TODO: look into setting background color of title tooltip
                 expRange.append("title").text(function (d) {
                     return "Skyline File: " + Ext4.String.htmlEncode(me.expRunDetails.fileName)
-                            + ", \nSerial No: " + Ext4.String.htmlEncode(me.expRunDetails.serialNumber)
-                            + ", \nInstrument Name: " + Ext4.String.htmlEncode(me.expRunDetails.instrumentName)
+                            + (me.expRunDetails.serialNumber ? (", \nSerial No: " + Ext4.String.htmlEncode(me.expRunDetails.serialNumber)) : "")
+                            + (me.expRunDetails.instrumentName ? (", \nInstrument Name: " + Ext4.String.htmlEncode(me.expRunDetails.instrumentName)) : "")
                             + ", \nStart: " + Ext4.String.htmlEncode(me.formatDate(new Date(me.expRunDetails.startDate), true))
                             + ", \nEnd: " + Ext4.String.htmlEncode(me.formatDate(new Date(me.expRunDetails.endDate), true))
                             + ", \nMean: " + Ext4.String.htmlEncode(expMean)


### PR DESCRIPTION
#### Rationale
Something happened in the 21.3->21.7->develop merge where the tooltip for the Skyline document's date range in the QC folder started including the serial number and instrument, even if the value is undefined. I haven't tracked down what went wrong, but we shouldn't show bogus values like that

#### Changes
* Omit serial number and instrument model if they're not available