### PR TITLE
Issue 43791: Restrict ModifiedAreaProportion calculation to protein

### DIFF
--- a/resources/schemas/dbscripts/postgresql/targetedms-21.005-21.006.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-21.005-21.006.sql
@@ -1,0 +1,13 @@
+-- FileNameHint for a Skyline document with a "document" library will be one character more than the name of the .sky file
+-- Look at PeptideSettingsParser.getDocumentLibrary()
+-- Example:      Stergachis-SupplementaryData_2_a.sky
+-- FileNameHint: Stergachis-SupplementaryData_2_a.blib
+-- Current limit on the targetedms.runs FileName column that stores the name of the .sky.zip file (e.g. Stergachis-SupplementaryData_2_a.sky.zip)
+-- is 300. Set FileNameHint to be the same.
+ALTER TABLE targetedms.spectrumlibrary ALTER COLUMN FileNameHint TYPE VARCHAR(300);
+
+-- Users can enter a comma-separated list of amino acids for both structural and isotopic modifications in Skyline.
+-- If they enter all 20 standard amino acids plus O	(Pyrrolysine) and U (Selenocysteine) the length of the string
+-- we need to store in the AminoAcid column will be 64: A, C, D, E, F, G, H, I, K, L, M, N, O, P, Q, R, S, T, U, V, W, Y
+ALTER TABLE targetedms.IsotopeModification ALTER COLUMN AminoAcid TYPE VARCHAR(100);
+ALTER TABLE targetedms.StructuralModification ALTER COLUMN AminoAcid TYPE VARCHAR(100);

--- a/resources/schemas/dbscripts/postgresql/targetedms-21.006-21.007.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-21.006-21.007.sql
@@ -1,0 +1,1 @@
+SELECT core.executeJavaInitializationCode('recalculateAreaProportions');

--- a/resources/schemas/dbscripts/sqlserver/targetedms-21.005-21.006.sql
+++ b/resources/schemas/dbscripts/sqlserver/targetedms-21.005-21.006.sql
@@ -1,0 +1,13 @@
+-- FileNameHint for a Skyline document with a "document" library will be one character more than the name of the .sky file
+-- Look at PeptideSettingsParser.getDocumentLibrary()
+-- Example:      Stergachis-SupplementaryData_2_a.sky
+-- FileNameHint: Stergachis-SupplementaryData_2_a.blib
+-- Current limit on the targetedms.runs FileName column that stores the name of the .sky.zip file (e.g. Stergachis-SupplementaryData_2_a.sky.zip)
+-- is 300. Set FileNameHint to be the same.
+ALTER TABLE targetedms.spectrumlibrary ALTER COLUMN FileNameHint NVARCHAR(300);
+
+-- Users can enter a comma-separated list of amino acids for both structural and isotopic modifications in Skyline.
+-- If they enter all 20 standard amino acids plus O (Pyrrolysine) and U (Selenocysteine) the length of the string
+-- we need to store in the AminoAcid column will be 64: A, C, D, E, F, G, H, I, K, L, M, N, O, P, Q, R, S, T, U, V, W, Y
+ALTER TABLE targetedms.IsotopeModification ALTER COLUMN AminoAcid NVARCHAR(100);
+ALTER TABLE targetedms.StructuralModification ALTER COLUMN AminoAcid NVARCHAR(100);

--- a/resources/schemas/dbscripts/sqlserver/targetedms-21.006-21.007.sql
+++ b/resources/schemas/dbscripts/sqlserver/targetedms-21.006-21.007.sql
@@ -1,0 +1,1 @@
+EXEC core.executeJavaInitializationCode 'recalculateAreaProportions';

--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -217,7 +217,7 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
     @Override
     public Double getSchemaVersion()
     {
-        return 21.005;
+        return 21.007;
     }
 
     @Override

--- a/src/org/labkey/targetedms/pipeline/AreaProportionRecalcJob.java
+++ b/src/org/labkey/targetedms/pipeline/AreaProportionRecalcJob.java
@@ -1,0 +1,82 @@
+package org.labkey.targetedms.pipeline;
+
+import org.apache.commons.lang3.mutable.MutableLong;
+import org.jetbrains.annotations.NotNull;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.ContainerManager;
+import org.labkey.api.data.RuntimeSQLException;
+import org.labkey.api.data.SimpleFilter;
+import org.labkey.api.data.Sort;
+import org.labkey.api.data.TableSelector;
+import org.labkey.api.pipeline.PipeRoot;
+import org.labkey.api.pipeline.PipelineJob;
+import org.labkey.api.query.FieldKey;
+import org.labkey.api.util.FileUtil;
+import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.util.URLHelper;
+import org.labkey.api.view.ViewBackgroundInfo;
+import org.labkey.targetedms.TargetedMSManager;
+import org.labkey.targetedms.TargetedMSRun;
+import org.labkey.targetedms.TargetedMSSchema;
+import org.labkey.targetedms.parser.Chromatogram;
+import org.labkey.targetedms.parser.PrecursorChromInfo;
+import org.labkey.targetedms.parser.SampleFile;
+import org.labkey.targetedms.query.PrecursorManager;
+
+import java.io.File;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class AreaProportionRecalcJob extends PipelineJob
+{
+    @SuppressWarnings("unused")  // for serialization
+    protected AreaProportionRecalcJob()
+    {
+
+    }
+
+    public AreaProportionRecalcJob(ViewBackgroundInfo info, @NotNull PipeRoot root)
+    {
+        super(TargetedMSPipelineProvider.name, info, root);
+        setLogFile(new File(root.getRootPath(), FileUtil.makeFileNameWithTimestamp("AreaProportionRecalcJob", "log")));
+    }
+
+    @Override
+    public void run()
+    {
+        setStatus(TaskStatus.running);
+        TableSelector selector = new TableSelector(TargetedMSManager.getTableInfoRuns());
+        long totalRuns = selector.getRowCount();
+
+        getLogger().info("Starting to recalculate area proportions for " + totalRuns + " Skyline documents");
+
+        MutableLong count = new MutableLong(0);
+
+        selector.forEach(TargetedMSRun.class, run ->
+        {
+            if (count.incrementAndGet() % 100 == 0)
+            {
+                getLogger().info("Updating Skyline document " + count);
+            }
+            TargetedMSManager.updateModifiedAreaProportions(null, run);
+        });
+
+        getLogger().info("All done!");
+        setStatus(TaskStatus.complete);
+    }
+
+    @Override
+    public URLHelper getStatusHref()
+    {
+        return null;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Recalculating area proportions";
+    }
+}

--- a/webapp/TargetedMS/js/QCSummaryPanel.js
+++ b/webapp/TargetedMS/js/QCSummaryPanel.js
@@ -53,11 +53,11 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
                 if (this.qcPlotPanel.qcIntrumentsArr) {
                     if (this.qcPlotPanel.qcIntrumentsArr.length > 1) {
                         var msg = 'We recommend that each instrument use its own QC folder.'
-                        container.instrument = 'multiple instruments - ' + this.qcPlotPanel.qcIntrumentsArr.join(', ') + '. ' + msg;
+                        container.instrument = ' for multiple instruments - ' + this.qcPlotPanel.qcIntrumentsArr.join(', ') + '. ' + msg;
 
                     }
                     else if (this.qcPlotPanel.qcIntrumentsArr.length === 1) {
-                        container.instrument = this.qcPlotPanel.qcIntrumentsArr[0];
+                        container.instrument = ' for ' + this.qcPlotPanel.qcIntrumentsArr[0];
                     }
                 }
                 this.add(this.getContainerSummaryView(container, hasChildren, width));


### PR DESCRIPTION
#### Rationale
In testing with some new Skyline documents where different proteins share the same peptides, we discovered that the ModifiedAreaProportion calculations (intended to see the percent of a given peptide that has a certain modification, for example) is looking at all peptides across the whole document. It should be restricted to the current protein (or molecule group for small molecule data) so that you don't get bizarre results, where the denominator (the summed area across all peptides within the group) is doubled or tripled from the multiple instances in different proteins.

#### Changes
* Recalculate all of the existing data via a pipeline job
* Update our calculation for newly imported data
* Backport 21.005-21.006 upgrade script to avoid upgrade version conflicts