### PR TITLE
Update `testZipOfFiles` to catch error

### DIFF
--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -224,7 +224,7 @@ public class TargetedMSQCTest extends TargetedMSTest
         clickTab("Raw Data");
 
         log("Drops the dataTransferItems object");
-        _fileBrowserHelper.dragDropUpload(single);
+        _fileBrowserHelper.dragDropUpload(single, "TestZipMeDir.zip");
 
         log("Verifying if the file is uploaded and zipped");
         waitForElement(Locator.tagWithText("span", "TestZipMeDir.zip"),WAIT_FOR_PAGE);

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -224,7 +224,7 @@ public class TargetedMSQCTest extends TargetedMSTest
         clickTab("Raw Data");
 
         log("Drops the dataTransferItems object");
-        dragAndDropFileInDropZone(single);
+        _fileBrowserHelper.dragDropUpload(single);
 
         log("Verifying if the file is uploaded and zipped");
         waitForElement(Locator.tagWithText("span", "TestZipMeDir.zip"),WAIT_FOR_PAGE);


### PR DESCRIPTION
#### Rationale
As written this `TargetedMSQCTest.testZipOfFiles` is missing an alert that pops up: "Relative path of file - first.zipme is incorrect"
_Note: This will require a product update to get the test passing_

#### Changes
* Use `FileBrowserHelper` to upload 'zipme' file

<details>
<summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/5263798/130673550-592e5140-a795-4df3-822b-97a891c6d794.png)

</details>
