### PR TITLE
Issue 43787: Add use-case guidance to Loggers page of admin console

### DIFF
--- a/src/org/labkey/targetedms/parser/PrecursorChromInfo.java
+++ b/src/org/labkey/targetedms/parser/PrecursorChromInfo.java
@@ -16,12 +16,12 @@
 package org.labkey.targetedms.parser;
 
 import org.apache.commons.io.output.ByteArrayOutputStream;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.util.UnexpectedException;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.targetedms.TargetedMSModule;
 import org.labkey.targetedms.TargetedMSRun;
 
@@ -39,7 +39,7 @@ import java.util.List;
  */
 public class PrecursorChromInfo extends AbstractChromInfo implements Comparable<PrecursorChromInfo>
 {
-    private static final Logger LOG = LogManager.getLogger(PrecursorChromInfo.class);
+    private static final Logger LOG = LogHelper.getLogger(PrecursorChromInfo.class, "Messages about fetching chromatograms, either from the cache-in memory, or from S3/local files.");
 
     private long _precursorId;
     private long _generalMoleculeChromInfoId;

--- a/src/org/labkey/targetedms/parser/PrecursorChromInfo.java
+++ b/src/org/labkey/targetedms/parser/PrecursorChromInfo.java
@@ -39,7 +39,7 @@ import java.util.List;
  */
 public class PrecursorChromInfo extends AbstractChromInfo implements Comparable<PrecursorChromInfo>
 {
-    private static final Logger LOG = LogHelper.getLogger(PrecursorChromInfo.class, "Messages about fetching chromatograms, either from the cache (in memory or from S3/local files)");
+    private static final Logger LOG = LogHelper.getLogger(PrecursorChromInfo.class, "Messages about fetching chromatograms (from the cache or loading from S3/local files)");
 
     private long _precursorId;
     private long _generalMoleculeChromInfoId;

--- a/src/org/labkey/targetedms/parser/PrecursorChromInfo.java
+++ b/src/org/labkey/targetedms/parser/PrecursorChromInfo.java
@@ -39,7 +39,7 @@ import java.util.List;
  */
 public class PrecursorChromInfo extends AbstractChromInfo implements Comparable<PrecursorChromInfo>
 {
-    private static final Logger LOG = LogHelper.getLogger(PrecursorChromInfo.class, "Messages about fetching chromatograms, either from the cache-in memory, or from S3/local files.");
+    private static final Logger LOG = LogHelper.getLogger(PrecursorChromInfo.class, "Messages about fetching chromatograms, either from the cache (in memory or from S3/local files)");
 
     private long _precursorId;
     private long _generalMoleculeChromInfoId;


### PR DESCRIPTION
#### Rationale
Users like to know what loggers may have debug logging of interest. They can currently find some guidance at https://www.labkey.org/Documentation/wiki-page.view?name=loggers

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2618

#### Changes
* Add some notes about loggers