### PR TITLE
File --> Path refactor to support cloud based File Watchers

### DIFF
--- a/src/org/labkey/targetedms/pipeline/TargetedMSPipelineProvider.java
+++ b/src/org/labkey/targetedms/pipeline/TargetedMSPipelineProvider.java
@@ -57,7 +57,7 @@ public class TargetedMSPipelineProvider extends PipelineProvider
 
         String actionId = getActionId();
         addAction(actionId, TargetedMSController.SkylineDocUploadAction.class, ACTION_LABEL,
-                directory, directory.listFiles(new UploadFileFilter()), true, false, includeAll);
+                directory, directory.listPaths(new UploadFileFilter()), true, false, includeAll);
     }
 
     public static class UploadFileFilter implements DirectoryStream.Filter<Path>


### PR DESCRIPTION
#### Rationale
New feature work to add support for using File Watchers on containers backed by Cloud pipeline roots. 
https://docs.google.com/document/d/1adCI1KteCV-vNuCJ6Okz1lVcsO6AgZIKXZeSSg2cKQ0/

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2663

#### Changes
* io.File--> nio.Path refactor
