### PR TITLE
Show multi-peptide/molecule, per-replicate plots 

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -1320,7 +1320,7 @@ public class TargetedMSController extends SpringActionController
 
             Map<Integer, QCMetricConfiguration> metricMap = qcMetricConfigurations.stream().collect(Collectors.toMap(QCMetricConfiguration::getId, Function.identity()));
             List<SampleFileInfo> sampleFiles = OutlierGenerator.get().getSampleFiles(rawMetricDataSets, targetedStats, metricMap, getContainer(), null);
-            List<QCPlotFragment> qcPlotFragments = OutlierGenerator.get().getQCPlotFragment(rawMetricDataSets, targetedStats);
+            List<QCPlotFragment> qcPlotFragments = OutlierGenerator.get().getQCPlotFragment(rawMetricDataSets, targetedStats, getContainer(), getUser());
 
             response.put("sampleFiles", sampleFiles.stream().map(SampleFileInfo::toQCPlotJSON).collect(Collectors.toList()));
             response.put("plotDataRows", qcPlotFragments

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -1683,11 +1683,15 @@ public class TargetedMSController extends SpringActionController
         HttpSession session = getViewContext().getRequest().getSession(true);
         if (session != null)
         {
-            SVGIDGenerator idGen = (SVGIDGenerator) session.getAttribute(SVG_ID_GENERATOR_ATTRIBUTE_NAME);
-            if (idGen == null)
+            SVGIDGenerator idGen = null;
+            synchronized (TargetedMSController.class)
             {
-                idGen = new SVGIDGenerator();
-                session.setAttribute(SVG_ID_GENERATOR_ATTRIBUTE_NAME, idGen);
+                idGen = (SVGIDGenerator) session.getAttribute(SVG_ID_GENERATOR_ATTRIBUTE_NAME);
+                if (idGen == null)
+                {
+                    idGen = new SVGIDGenerator();
+                    session.setAttribute(SVG_ID_GENERATOR_ATTRIBUTE_NAME, idGen);
+                }
             }
             context.setIDGenerator(idGen);
         }

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -71,6 +71,7 @@ import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DataRegion;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.PropertyManager;
+import org.labkey.api.data.RenderContext;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
@@ -238,6 +239,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
@@ -272,7 +274,6 @@ import static org.labkey.api.targetedms.TargetedMSService.RAW_FILES_TAB;
 import static org.labkey.api.util.DOM.A;
 import static org.labkey.api.util.DOM.Attribute.height;
 import static org.labkey.api.util.DOM.Attribute.href;
-import static org.labkey.api.util.DOM.Attribute.id;
 import static org.labkey.api.util.DOM.Attribute.method;
 import static org.labkey.api.util.DOM.Attribute.src;
 import static org.labkey.api.util.DOM.Attribute.width;
@@ -4569,7 +4570,17 @@ public class TargetedMSController extends SpringActionController
                     ChromatogramsDataRegion.GROUP_CHROM_DATA_REGION);
             chromatogramRegion.setLegendElementId("groupChromatogramLegend");
             tableInfo.addGroupFilter(group);
-            ChromatogramGridView chromatogramView = new ChromatogramGridView(chromatogramRegion, errors);
+            ChromatogramGridView chromatogramView = new ChromatogramGridView(chromatogramRegion, errors)
+            {
+                @Override
+                public void renderView(RenderContext model, PrintWriter out) throws IOException
+                {
+                    out.write("<div style=\"display: inline-block\">\n");
+                    out.write("<div id=\"groupChromatogramLegend\"></div>\n");
+                    super.renderView(model, out);
+                    out.write("</div>\n");
+                }
+            };
 
             GeneralMoleculeChromatogramsViewBean bean = new GeneralMoleculeChromatogramsViewBean();
             bean.setResultsUri(new ActionURL(ShowProteinAction.class, getContainer()).getLocalURIString());
@@ -4583,7 +4594,6 @@ public class TargetedMSController extends SpringActionController
             chromatogramsBox.setTitle("Chromatograms");
             chromatogramsBox.enableExpandCollapse("Chromatograms", false);
             chromatogramsBox.addView(chartForm);
-            chromatogramsBox.addView(new HtmlView(DOM.DIV(at(id, "groupChromatogramLegend"))));
             chromatogramsBox.addView(chromatogramView);
             chromatogramsBox.setShowTitle(true);
             chromatogramsBox.setFrame(WebPartView.FrameType.PORTAL);

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -137,6 +137,7 @@ import org.labkey.api.util.ContainerContext;
 import org.labkey.api.util.DOM;
 import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.FileUtil;
+import org.labkey.api.util.HelpTopic;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.Link;
 import org.labkey.api.util.PageFlowUtil;

--- a/src/org/labkey/targetedms/TargetedMSManager.java
+++ b/src/org/labkey/targetedms/TargetedMSManager.java
@@ -1157,6 +1157,7 @@ public class TargetedMSManager
         return run;
     }
 
+    @NotNull
     public static TargetedMSRun getRunForGeneralMolecule(long id)
     {
         String sql = "SELECT run.* FROM "+

--- a/src/org/labkey/targetedms/TargetedMSSchema.java
+++ b/src/org/labkey/targetedms/TargetedMSSchema.java
@@ -141,6 +141,7 @@ public class TargetedMSSchema extends UserSchema
     public static final String TABLE_GENERAL_MOLECULE_CHROM_INFO = "GeneralMoleculeChromInfo";
     public static final String TABLE_PEPTIDE_CHROM_INFO = "PeptideChromInfo";
     public static final String TABLE_PRECURSOR_CHROM_INFO = "PrecursorChromInfo";
+    public static final String TABLE_GROUP_CHROM_INFO = "GroupChromInfo";
     public static final String TABLE_SAMPLE_FILE_CHROM_INFO = "SampleFileChromInfo";
     public static final String TABLE_PRECURSOR_CHROM_INFO_ANNOTATION = "PrecursorChromInfoAnnotation";
     public static final String TABLE_PEPTIDE_AREA_RATIO = "PeptideAreaRatio";

--- a/src/org/labkey/targetedms/calculations/RunQuantifier.java
+++ b/src/org/labkey/targetedms/calculations/RunQuantifier.java
@@ -24,7 +24,6 @@ import org.labkey.api.util.Tuple3;
 import org.labkey.targetedms.SkylineDocImporter.IProgressStatus;
 import org.labkey.targetedms.TargetedMSManager;
 import org.labkey.targetedms.TargetedMSRun;
-import org.labkey.targetedms.TargetedMSSchema;
 import org.labkey.targetedms.calculations.quantification.CalibrationCurve;
 import org.labkey.targetedms.calculations.quantification.CalibrationCurveDataSet;
 import org.labkey.targetedms.calculations.quantification.GroupComparisonDataSet;
@@ -110,7 +109,6 @@ public class RunQuantifier
             return Collections.emptyList();
         }
 
-        TargetedMSSchema schema = new TargetedMSSchema(_user, _container);
         List<CalibrationCurveEntity> calibrationCurves = new ArrayList<>();
         Collection<PeptideGroup> peptideGroups = listPeptideGroups();
         int done = 0;
@@ -122,7 +120,7 @@ public class RunQuantifier
 
             List<GeneralMolecule> generalMolecules = new ArrayList<>();
             generalMolecules.addAll(MoleculeManager.getMoleculesForGroup(peptideGroup.getId()));
-            generalMolecules.addAll(PeptideManager.getPeptidesForGroup(peptideGroup.getId(), schema));
+            generalMolecules.addAll(PeptideManager.getPeptidesForGroup(peptideGroup.getId()));
             for (GeneralMolecule molecule : generalMolecules)
             {
                 NormalizationMethod normalizationMethod
@@ -306,9 +304,8 @@ public class RunQuantifier
 
     private List<GeneralMolecule> getGeneralMoleculesForGroup(PeptideGroup peptideGroup)
     {
-        TargetedMSSchema schema = new TargetedMSSchema(_user, _container);
         List<GeneralMolecule> list = new ArrayList<>();
-        list.addAll(PeptideManager.getPeptidesForGroup(peptideGroup.getId(), schema));
+        list.addAll(PeptideManager.getPeptidesForGroup(peptideGroup.getId()));
         list.addAll(MoleculeManager.getMoleculesForGroup(peptideGroup.getId()));
         return list;
     }

--- a/src/org/labkey/targetedms/chart/ChromatogramChartMakerFactory.java
+++ b/src/org/labkey/targetedms/chart/ChromatogramChartMakerFactory.java
@@ -19,9 +19,12 @@ import org.jfree.chart.JFreeChart;
 import org.jfree.data.xy.XYSeriesCollection;
 import org.labkey.api.data.Container;
 import org.labkey.api.security.User;
+import org.labkey.api.view.ViewContext;
 import org.labkey.targetedms.parser.GeneralMoleculeChromInfo;
 import org.labkey.targetedms.parser.GeneralTransition;
+import org.labkey.targetedms.parser.PeptideGroup;
 import org.labkey.targetedms.parser.PrecursorChromInfo;
+import org.labkey.targetedms.parser.SampleFile;
 import org.labkey.targetedms.parser.SampleFileChromInfo;
 import org.labkey.targetedms.parser.Transition;
 import org.labkey.targetedms.parser.TransitionChromInfo;
@@ -159,5 +162,10 @@ public class ChromatogramChartMakerFactory
     public JFreeChart createSampleFileChromChart(SampleFileChromInfo chromInfo, User user, Container container)
     {
         return new ChromatogramChartMaker().make(new ChromatogramDataset.SampleFileDataset(chromInfo, user, container), false, "Time", "Value");
+    }
+
+    public JFreeChart createGroupChart(PeptideGroup group, SampleFile sampleFile, ViewContext context)
+    {
+        return new ChromatogramChartMaker().make(new ChromatogramDataset.GroupDataset(group, sampleFile, context, _syncIntensity, _syncRt), false, "Time", "Value");
     }
 }

--- a/src/org/labkey/targetedms/chart/ChromatogramChartMakerFactory.java
+++ b/src/org/labkey/targetedms/chart/ChromatogramChartMakerFactory.java
@@ -166,6 +166,6 @@ public class ChromatogramChartMakerFactory
 
     public JFreeChart createGroupChart(PeptideGroup group, SampleFile sampleFile, ViewContext context)
     {
-        return new ChromatogramChartMaker().make(new ChromatogramDataset.GroupDataset(group, sampleFile, context, _syncIntensity, _syncRt), false, "Time", "Value");
+        return new ChromatogramChartMaker().make(new ChromatogramDataset.GroupDataset(group, sampleFile, context, _syncIntensity, _syncRt), false, "Retention Time", "Intensity");
     }
 }

--- a/src/org/labkey/targetedms/chart/ChromatogramDataset.java
+++ b/src/org/labkey/targetedms/chart/ChromatogramDataset.java
@@ -1540,7 +1540,7 @@ public abstract class ChromatogramDataset
                 if (selectedIds.contains(generalMolecule.getId()))
                 {
                     // As soon as we find a single match in the selection filter the molecules based on the selected ids
-                    Map<GeneralMolecule, List<PrecursorChromInfoPlus>> filtered = new HashMap<>();
+                    Map<GeneralMolecule, List<PrecursorChromInfoPlus>> filtered = new LinkedHashMap<>();
                     for (Map.Entry<GeneralMolecule, List<PrecursorChromInfoPlus>> entry : _allMolecules.entrySet())
                     {
                         if (selectedIds.contains(entry.getKey().getId()))

--- a/src/org/labkey/targetedms/chart/ChromatogramDataset.java
+++ b/src/org/labkey/targetedms/chart/ChromatogramDataset.java
@@ -66,6 +66,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -1517,7 +1518,7 @@ public abstract class ChromatogramDataset
 
         protected List<PrecursorChromInfoPlus> getPrecursorChromInfos()
         {
-            _allMolecules = new HashMap<>();
+            _allMolecules = new LinkedHashMap<>();
             String peptideSelectionKey = DataRegionSelection.getSelectionKey(TargetedMSSchema.SCHEMA_NAME, TargetedMSSchema.TABLE_PEPTIDE, null, "Peptides");
             String moleculeSelectionKey = DataRegionSelection.getSelectionKey(TargetedMSSchema.SCHEMA_NAME, TargetedMSSchema.TABLE_MOLECULE, null, "SmallMolecules");
 

--- a/src/org/labkey/targetedms/chart/ChromatogramDataset.java
+++ b/src/org/labkey/targetedms/chart/ChromatogramDataset.java
@@ -1528,11 +1528,19 @@ public abstract class ChromatogramDataset
 
             for (Molecule molecule : MoleculeManager.getMoleculesForGroup(_group.getId()))
             {
-                _allMolecules.put(molecule, MoleculePrecursorManager.getPrecursorChromInfosForMolecule(molecule.getId(), _sampleFile.getId(), _user, _container));
+                List<PrecursorChromInfoPlus> chromInfos = MoleculePrecursorManager.getPrecursorChromInfosForMolecule(molecule.getId(), _sampleFile.getId(), _user, _container);
+                if (!chromInfos.isEmpty())
+                {
+                    _allMolecules.put(molecule, chromInfos);
+                }
             }
             for (Peptide peptide : PeptideManager.getPeptidesForGroup(_group.getId()))
             {
-                _allMolecules.put(peptide, PrecursorManager.getPrecursorChromInfosForPeptide(peptide.getId(), _sampleFile.getId(), _user, _container));
+                List<PrecursorChromInfoPlus> chromInfos = PrecursorManager.getPrecursorChromInfosForPeptide(peptide.getId(), _sampleFile.getId(), _user, _container);
+                if (!chromInfos.isEmpty())
+                {
+                    _allMolecules.put(peptide, chromInfos);
+                }
             }
 
             for (GeneralMolecule generalMolecule : _allMolecules.keySet())

--- a/src/org/labkey/targetedms/chart/ChromatogramDataset.java
+++ b/src/org/labkey/targetedms/chart/ChromatogramDataset.java
@@ -21,19 +21,26 @@ import org.jfree.chart.ChartColor;
 import org.jfree.data.xy.XYSeries;
 import org.jfree.data.xy.XYSeriesCollection;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.DataRegionSelection;
 import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.security.User;
 import org.labkey.api.util.Formats;
+import org.labkey.api.view.ViewContext;
 import org.labkey.targetedms.TargetedMSManager;
 import org.labkey.targetedms.TargetedMSRun;
+import org.labkey.targetedms.TargetedMSSchema;
 import org.labkey.targetedms.model.PrecursorChromInfoPlus;
 import org.labkey.targetedms.model.PrecursorComparator;
 import org.labkey.targetedms.parser.Chromatogram;
+import org.labkey.targetedms.parser.GeneralMolecule;
 import org.labkey.targetedms.parser.GeneralMoleculeChromInfo;
 import org.labkey.targetedms.parser.GeneralTransition;
+import org.labkey.targetedms.parser.Molecule;
 import org.labkey.targetedms.parser.MoleculePrecursor;
 import org.labkey.targetedms.parser.MoleculeTransition;
+import org.labkey.targetedms.parser.Peptide;
+import org.labkey.targetedms.parser.PeptideGroup;
 import org.labkey.targetedms.parser.Precursor;
 import org.labkey.targetedms.parser.PrecursorChromInfo;
 import org.labkey.targetedms.parser.Replicate;
@@ -42,8 +49,10 @@ import org.labkey.targetedms.parser.SampleFileChromInfo;
 import org.labkey.targetedms.parser.Transition;
 import org.labkey.targetedms.parser.TransitionChromInfo;
 import org.labkey.targetedms.parser.TransitionSettings;
+import org.labkey.targetedms.query.MoleculeManager;
 import org.labkey.targetedms.query.MoleculePrecursorManager;
 import org.labkey.targetedms.query.MoleculeTransitionManager;
+import org.labkey.targetedms.query.PeptideManager;
 import org.labkey.targetedms.query.PrecursorManager;
 import org.labkey.targetedms.query.ReplicateManager;
 import org.labkey.targetedms.query.TransitionManager;
@@ -55,8 +64,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -85,9 +96,20 @@ public abstract class ChromatogramDataset
     // Quantitative series are rendered with a solid line, non-quantitative ones with a dashed line.
     boolean[] _quantative;
 
+    protected final Container _container;
+    protected final User _user;
+
+
     public static final BasicStroke LINE = new BasicStroke(2.0f);
     public static final BasicStroke DASH_LINE = new BasicStroke(1.0f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND,
                                                        1.0f, new float[] {3.0f, 3.0f}, 1.0f);
+
+    public ChromatogramDataset(User u, Container c)
+    {
+        _container = c;
+        _user = u;
+    }
+
     public abstract String getChartTitle();
 
     // Start of the peak integration boundary. Shown as a vertical dotted line
@@ -159,10 +181,10 @@ public abstract class ChromatogramDataset
 
     static final class ChartAnnotation
     {
-        private double _retentionTime;
-        private double _intensity;
-        private List<String> _labels;
-        private Color _color;
+        private final double _retentionTime;
+        private final double _intensity;
+        private final List<String> _labels;
+        private final Color _color;
 
         public ChartAnnotation(double retentionTime, double intensity, List<String> labels, Color color)
         {
@@ -293,6 +315,7 @@ public abstract class ChromatogramDataset
 
         public SampleFileDataset(SampleFileChromInfo chromInfo, User user, Container container)
         {
+            super(user, container);
             _chromInfo = chromInfo;
             SampleFile sampleFile = TargetedMSManager.getSampleFile(chromInfo.getSampleFileId(), container);
             Replicate replicate = TargetedMSManager.getReplicate(sampleFile.getReplicateId(), container);
@@ -351,7 +374,7 @@ public abstract class ChromatogramDataset
 
     static class MoleculeDataset extends GeneralMoleculeDataset
     {
-        private MoleculePrecursorColorIndexer _colorIndexer;
+        private final MoleculePrecursorColorIndexer _colorIndexer;
 
         public MoleculeDataset(GeneralMoleculeChromInfo pepChromInfo, boolean syncIntensity, boolean syncRt, User user, Container container)
         {
@@ -384,94 +407,18 @@ public abstract class ChromatogramDataset
         }
     }
 
-    static abstract class GeneralMoleculeDataset extends ChromatogramDataset
+    static abstract class RtRangeDataset extends ChromatogramDataset
     {
-        protected Container _container;
-        protected User _user;
-        protected GeneralMoleculeChromInfo _pepChromInfo;
-        protected final long _generalMoleculeId;
-        protected final long _sampleFileId;
-        private List<ChartAnnotation> _annotations;
-        private double _minPeakRt;
-        private double _maxPeakRt;
+        protected double _minPeakRt;
+        protected double _maxPeakRt;
+        private final List<ChartAnnotation> _annotations = new ArrayList<>();
 
-        private Map<Integer, Color> _seriesColors;
+        /** Create a map of colors to be used for drawing the peaks. */
+        protected final Map<Integer, Color> _seriesColors = new HashMap<>();
 
-        public GeneralMoleculeDataset(GeneralMoleculeChromInfo pepChromInfo, boolean syncIntensity, boolean syncRt, User user, Container container)
+        public RtRangeDataset(User u, Container c)
         {
-            this(pepChromInfo.getGeneralMoleculeId(), pepChromInfo.getSampleFileId(), syncIntensity, syncRt, user, container);
-            _pepChromInfo = pepChromInfo;
-        }
-
-        GeneralMoleculeDataset(long generalMoleculeId, long sampleFileId, boolean syncIntensity, boolean syncRt, User user, Container container)
-        {
-            _generalMoleculeId = generalMoleculeId;
-            _sampleFileId = sampleFileId;
-            _syncIntensity = syncIntensity;
-            _syncRt = syncRt;
-
-            _annotations = new ArrayList<>();
-
-            // Create a map of colors to be used for drawing the peaks.
-            _seriesColors = new HashMap<>();
-
-            _run = TargetedMSManager.getRunForGeneralMolecule(_generalMoleculeId);
-            _user = user;
-            _container = container;
-
-            _fullScanSettings = TargetedMSManager.getTransitionFullScanSettings(_run.getId());
-        }
-
-        abstract String getLabel(PrecursorChromInfo pChromInfo);
-
-        abstract List<PrecursorChromInfoPlus> getPrecursorChromInfosForGeneralMolecule();
-
-        abstract Color getSeriesColor(PrecursorChromInfo pChromInfo, int seriesIndex);
-
-        @Override
-        public void build()
-        {
-            // Get the precursor chrom infos for the peptide/molecule
-            List<PrecursorChromInfoPlus> precursorChromInfoList = getPrecursorChromInfos();
-
-            // Get the retention time range that should be displayed for the chromatogram
-            RtRange chromatogramRtRange = getChromatogramRange(precursorChromInfoList);
-
-            if(_syncIntensity)
-            {
-                // Get the height of the tallest precursor for this peptide/molecule over all replicates
-                // TODO: filter this to currently selected replicates
-                // Note: If we are not storing TransitionChromInfos we will not be able to sync the intensity axis for
-                // all the plots. MaxHeight for a PrecursorChromInfo is the height of the tallest fragment peak, not the
-                // precursor peak which is calculated by summing up the transition peak intensities.
-                _maxDisplayIntensity = PrecursorManager.getMaxPrecursorIntensityEstimate(_generalMoleculeId);
-            }
-
-            _jfreeDataset = new XYSeriesCollection();
-
-            if(precursorChromInfoList != null)
-            {
-                _quantative = new boolean[precursorChromInfoList.size()];
-            }
-
-            for(int i = 0; i < precursorChromInfoList.size(); i++)
-            {
-                PrecursorChromInfoPlus pChromInfo = precursorChromInfoList.get(i);
-
-                Chromatogram chromatogram = pChromInfo.createChromatogram(_run);
-                if (chromatogram != null)
-                {
-                    // Instead of displaying separate peaks for each transition of this precursor,
-                    // we will sum up the intensities and display a single peak for the precursor
-                    PeakInChart peakInChart = addPrecursorAsSeries(_jfreeDataset, chromatogram, pChromInfo,
-                            chromatogramRtRange,
-                            getLabel(pChromInfo),
-                            i);
-                    _maxDatasetIntensity = Math.max(_maxDatasetIntensity, peakInChart.getMaxTraceIntensity());
-
-                    addAnnotation(pChromInfo, peakInChart, i);
-                }
-            }
+            super(u, c);
         }
 
         protected void addAnnotation(PrecursorChromInfo pChromInfo, PeakInChart peakInChart, int index)
@@ -486,23 +433,21 @@ public abstract class ChromatogramDataset
             }
         }
 
-        protected List<PrecursorChromInfoPlus> getPrecursorChromInfos()
+        @Override
+        public List<ChartAnnotation> getChartAnnotations()
         {
-            List<PrecursorChromInfoPlus> precursorChromInfoList = getPrecursorChromInfosForGeneralMolecule();
-
-            List<PrecursorChromInfoPlus> nonOptimizationPeaks = new ArrayList<>();
-            for(PrecursorChromInfoPlus pChromInfo: precursorChromInfoList)
-            {
-                if(!pChromInfo.isOptimizationPeak()) // Ignore optimization peaks
-                {
-                    nonOptimizationPeaks.add(pChromInfo);
-                }
-            }
-            nonOptimizationPeaks.sort(new PrecursorComparator());
-            return nonOptimizationPeaks;
+            return _annotations;
         }
 
-        private RtRange getChromatogramRange(List<PrecursorChromInfoPlus> precursorChromInfoList)
+        protected RtRange summarizeRanges(List<RtRange> ranges)
+        {
+            double min = ranges.stream().min(Comparator.comparingDouble(RtRange::getMinRt)).orElseThrow().getMinRt();
+            double max = ranges.stream().max(Comparator.comparingDouble(RtRange::getMaxRt)).orElseThrow().getMaxRt();
+
+            return new RtRange(min, max);
+        }
+
+        protected RtRange getChromatogramRange(List<PrecursorChromInfoPlus> precursorChromInfoList)
         {
             double minRt = Double.MAX_VALUE;
             double maxRt = 0;
@@ -524,7 +469,7 @@ public abstract class ChromatogramDataset
             if(_syncRt){
                 // Get the min and max retention times of the precursors for this peptide, over all replicates.
                 // TODO: filter this to currently selected replicates
-                RtRange peakRtSummary = TransitionManager.getGeneralMoleculeRtRange(_generalMoleculeId);
+                RtRange peakRtSummary = getRtRangeSummary();
                 displayRange = new RtRange(peakRtSummary.getMinRt(), peakRtSummary.getMaxRt(), true, _syncRt);
             }
 
@@ -536,10 +481,12 @@ public abstract class ChromatogramDataset
             return displayRange;
         }
 
-        private PeakInChart addPrecursorAsSeries(XYSeriesCollection dataset, Chromatogram chromatogram,
-                                                 PrecursorChromInfoPlus pChromInfo,
-                                                 RtRange chromatogramRtRange, String label,
-                                                 int seriesIndex)
+        protected abstract RtRange getRtRangeSummary();
+
+        protected PeakInChart addPrecursorAsSeries(XYSeriesCollection dataset, Chromatogram chromatogram,
+                                                   PrecursorChromInfoPlus pChromInfo,
+                                                   RtRange chromatogramRtRange, String label,
+                                                   int seriesIndex)
         {
             float[] times = chromatogram.getTimes();
 
@@ -589,8 +536,8 @@ public abstract class ChromatogramDataset
             {
                 // If bestMassErrorPpm is not set on the PrecursorChromInfo, try to get it from the quantitative TransitionChromInfos
                 TransitionChromInfoAndQuantitative tci = chromInfoList.stream().filter(TransitionChromInfoAndQuantitative::hasHeightAndIsQuantitative)
-                                                                               .max(Comparator.comparing(TransitionChromInfoAndQuantitative::getHeight))
-                                                                               .orElse(null);
+                        .max(Comparator.comparing(TransitionChromInfoAndQuantitative::getHeight))
+                        .orElse(null);
                 bestMassErrorPpm = tci != null ? tci.getMassErrorPpm() : null;
             }
 
@@ -611,9 +558,106 @@ public abstract class ChromatogramDataset
             }
             dataset.addSeries(series);
 
-            _seriesColors.put(seriesIndex, getSeriesColor(pChromInfo, seriesIndex));
-
             return new PeakInChart(maxPeakIntensity, rtAtPeakApex, maxTraceIntensity, bestMassErrorPpm);
+        }
+
+        abstract Color getSeriesColor(PrecursorChromInfo pChromInfo, int seriesIndex);
+    }
+
+    static abstract class GeneralMoleculeDataset extends RtRangeDataset
+    {
+        protected GeneralMoleculeChromInfo _pepChromInfo;
+        protected final long _generalMoleculeId;
+        protected final long _sampleFileId;
+
+        public GeneralMoleculeDataset(GeneralMoleculeChromInfo pepChromInfo, boolean syncIntensity, boolean syncRt, User user, Container container)
+        {
+            this(pepChromInfo.getGeneralMoleculeId(), pepChromInfo.getSampleFileId(), syncIntensity, syncRt, user, container);
+            _pepChromInfo = pepChromInfo;
+        }
+
+        GeneralMoleculeDataset(long generalMoleculeId, long sampleFileId, boolean syncIntensity, boolean syncRt, User user, Container container)
+        {
+            super(user, container);
+            _generalMoleculeId = generalMoleculeId;
+            _sampleFileId = sampleFileId;
+            _syncIntensity = syncIntensity;
+            _syncRt = syncRt;
+
+            _run = TargetedMSManager.getRunForGeneralMolecule(_generalMoleculeId);
+
+            _fullScanSettings = TargetedMSManager.getTransitionFullScanSettings(_run.getId());
+        }
+
+        @Override
+        protected RtRange getRtRangeSummary()
+        {
+            return TransitionManager.getGeneralMoleculeRtRange(_generalMoleculeId);
+        }
+
+        abstract String getLabel(PrecursorChromInfo pChromInfo);
+
+        abstract List<PrecursorChromInfoPlus> getPrecursorChromInfosForGeneralMolecule();
+
+        @Override
+        public void build()
+        {
+            // Get the precursor chrom infos for the peptide/molecule
+            List<PrecursorChromInfoPlus> precursorChromInfoList = getPrecursorChromInfos();
+
+            // Get the retention time range that should be displayed for the chromatogram
+            RtRange chromatogramRtRange = getChromatogramRange(precursorChromInfoList);
+
+            if(_syncIntensity)
+            {
+                // Get the height of the tallest precursor for this peptide/molecule over all replicates
+                // TODO: filter this to currently selected replicates
+                // Note: If we are not storing TransitionChromInfos we will not be able to sync the intensity axis for
+                // all the plots. MaxHeight for a PrecursorChromInfo is the height of the tallest fragment peak, not the
+                // precursor peak which is calculated by summing up the transition peak intensities.
+                _maxDisplayIntensity = PrecursorManager.getMaxPrecursorIntensityEstimate(_generalMoleculeId);
+            }
+
+            _jfreeDataset = new XYSeriesCollection();
+
+            _quantative = new boolean[precursorChromInfoList.size()];
+
+            for(int i = 0; i < precursorChromInfoList.size(); i++)
+            {
+                PrecursorChromInfoPlus pChromInfo = precursorChromInfoList.get(i);
+
+                Chromatogram chromatogram = pChromInfo.createChromatogram(_run);
+                if (chromatogram != null)
+                {
+                    // Instead of displaying separate peaks for each transition of this precursor,
+                    // we will sum up the intensities and display a single peak for the precursor
+                    PeakInChart peakInChart = addPrecursorAsSeries(_jfreeDataset, chromatogram, pChromInfo,
+                            chromatogramRtRange,
+                            getLabel(pChromInfo),
+                            i);
+
+                    _seriesColors.put(i, getSeriesColor(pChromInfo, i));
+                    _maxDatasetIntensity = Math.max(_maxDatasetIntensity, peakInChart.getMaxTraceIntensity());
+
+                    addAnnotation(pChromInfo, peakInChart, i);
+                }
+            }
+        }
+
+        protected List<PrecursorChromInfoPlus> getPrecursorChromInfos()
+        {
+            List<PrecursorChromInfoPlus> precursorChromInfoList = getPrecursorChromInfosForGeneralMolecule();
+
+            List<PrecursorChromInfoPlus> nonOptimizationPeaks = new ArrayList<>();
+            for(PrecursorChromInfoPlus pChromInfo: precursorChromInfoList)
+            {
+                if(!pChromInfo.isOptimizationPeak()) // Ignore optimization peaks
+                {
+                    nonOptimizationPeaks.add(pChromInfo);
+                }
+            }
+            nonOptimizationPeaks.sort(new PrecursorComparator());
+            return nonOptimizationPeaks;
         }
 
         @Override
@@ -629,15 +673,9 @@ public abstract class ChromatogramDataset
         }
 
         @Override
-        public List<ChartAnnotation> getChartAnnotations()
-        {
-            return _annotations;
-        }
-
-        @Override
         public Color getSeriesColor(int seriesIndex)
         {
-            return  _seriesColors.get(seriesIndex);
+            return _seriesColors.get(seriesIndex);
         }
     }
 
@@ -789,17 +827,14 @@ public abstract class ChromatogramDataset
         protected double _bestTransitionRt;
         protected int _bestTransitionSeriesIndex;
         protected Double _bestTransitionPpm;
-        protected Container _container;
-        protected User _user;
 
         public PrecursorDataset(PrecursorChromInfo pChromInfo, boolean syncIntensity, boolean syncRt, User user, Container container)
         {
+            super(user, container);
             _run = TargetedMSManager.getRunForPrecursor(pChromInfo.getPrecursorId());
             _pChromInfo = pChromInfo;
             _syncRt = syncRt;
             _syncIntensity = syncIntensity;
-            _user = user;
-            _container = container;
 
             _fullScanSettings = TargetedMSManager.getTransitionFullScanSettings(_run.getId());
         }
@@ -911,15 +946,15 @@ public abstract class ChromatogramDataset
             initQuantitativeSeriesArray(tciList);
         }
 
-        void initQuantitativeSeriesArray(List<? extends TransitionChromInfoPlusGeneralTransition> chromInfoList)
+        void initQuantitativeSeriesArray(List<? extends TransitionChromInfoPlusGeneralTransition<?>> chromInfoList)
         {
-            if(chromInfoList == null)
+            if (chromInfoList == null)
             {
                 return;
             }
             _quantative = new boolean[chromInfoList.size()];
             int i = 0;
-            for(TransitionChromInfoPlusGeneralTransition tci: chromInfoList)
+            for(TransitionChromInfoPlusGeneralTransition<?> tci: chromInfoList)
             {
                 _quantative[i++] = tci.getTransition().isQuantitative(_fullScanSettings);
             }
@@ -1397,6 +1432,220 @@ public abstract class ChromatogramDataset
         protected String getSeriesLabel()
         {
             return LabelFactory.transitionLabel(MoleculeTransitionManager.get(_tChromInfo.getTransitionId(), _user, _container));
+        }
+    }
+
+    public static class GroupDataset extends RtRangeDataset
+    {
+        private final PeptideGroup _group;
+        private final SampleFile _sampleFile;
+        private final ViewContext _context;
+
+        private Map<GeneralMolecule, List<PrecursorChromInfoPlus>> _allMolecules;
+
+        public GroupDataset(PeptideGroup group, SampleFile sampleFile, ViewContext context, boolean syncIntensity, boolean syncRt)
+        {
+            super(context.getUser(), context.getContainer());
+            _group = group;
+            _sampleFile = sampleFile;
+            _context = context;
+            _syncIntensity = syncIntensity;
+            _syncRt = syncRt;
+        }
+
+        @Override
+        public String getChartTitle()
+        {
+            return LabelFactory.groupChartTitle(_group, _sampleFile);
+        }
+
+        @Override
+        public Double getPeakStartTime()
+        {
+            return null;
+        }
+
+        @Override
+        public Double getPeakEndTime()
+        {
+            return null;
+        }
+
+        @Override
+        protected RtRange getRtRangeSummary()
+        {
+            List<RtRange> ranges = new ArrayList<>();
+            for (GeneralMolecule generalMolecule : _allMolecules.keySet())
+            {
+                ranges.add(TransitionManager.getGeneralMoleculeRtRange(generalMolecule.getId()));
+            }
+            return summarizeRanges(ranges);
+        }
+
+        @Override
+        Color getSeriesColor(PrecursorChromInfo pChromInfo, int seriesIndex)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Color getSeriesColor(int seriesIndex)
+        {
+            Color result = _seriesColors.get(seriesIndex);
+            if (result == null)
+            {
+                throw new IllegalStateException("No color assigned for " + seriesIndex);
+            }
+            return result;
+        }
+
+        protected List<PrecursorChromInfoPlus> getPrecursorChromInfos()
+        {
+            _allMolecules = new HashMap<>();
+            String peptideSelectionKey = DataRegionSelection.getSelectionKey(TargetedMSSchema.SCHEMA_NAME, TargetedMSSchema.TABLE_PEPTIDE, null, "Peptides");
+            String moleculeSelectionKey = DataRegionSelection.getSelectionKey(TargetedMSSchema.SCHEMA_NAME, TargetedMSSchema.TABLE_MOLECULE, null, "SmallMolecules");
+
+            Set<Long> selectedIds = new HashSet<>();
+            selectedIds.addAll(DataRegionSelection.getSelected(_context, peptideSelectionKey, false).stream().map(Long::parseLong).collect(Collectors.toSet()));
+            selectedIds.addAll(DataRegionSelection.getSelected(_context, moleculeSelectionKey, false).stream().map(Long::parseLong).collect(Collectors.toSet()));
+
+            for (Molecule molecule : MoleculeManager.getMoleculesForGroup(_group.getId()))
+            {
+                _allMolecules.put(molecule, MoleculePrecursorManager.getPrecursorChromInfosForMolecule(molecule.getId(), _sampleFile.getId(), _user, _container));
+            }
+            for (Peptide peptide : PeptideManager.getPeptidesForGroup(_group.getId()))
+            {
+                _allMolecules.put(peptide, PrecursorManager.getPrecursorChromInfosForPeptide(peptide.getId(), _sampleFile.getId(), _user, _container));
+            }
+
+            for (GeneralMolecule generalMolecule : _allMolecules.keySet())
+            {
+                if (selectedIds.contains(generalMolecule.getId()))
+                {
+                    // As soon as we find a single match in the selection filter the molecules based on the selected ids
+                    Map<GeneralMolecule, List<PrecursorChromInfoPlus>> filtered = new HashMap<>();
+                    for (Map.Entry<GeneralMolecule, List<PrecursorChromInfoPlus>> entry : _allMolecules.entrySet())
+                    {
+                        if (selectedIds.contains(entry.getKey().getId()))
+                        {
+                            filtered.put(entry.getKey(), entry.getValue());
+                        }
+                    }
+                    _allMolecules = filtered;
+                    break;
+                }
+            }
+
+            List<PrecursorChromInfoPlus> nonOptimizationPeaks = new ArrayList<>();
+            for(List<PrecursorChromInfoPlus> infos : _allMolecules.values())
+            {
+                for (PrecursorChromInfoPlus info : infos)
+                {
+                    if(!info.isOptimizationPeak()) // Ignore optimization peaks
+                    {
+                        nonOptimizationPeaks.add(info);
+                    }
+                }
+            }
+            nonOptimizationPeaks.sort(new PrecursorComparator());
+            return nonOptimizationPeaks;
+        }
+
+        @Override
+        public void build()
+        {
+            // Get the precursor chrom infos for the peptide/molecule
+            List<PrecursorChromInfoPlus> precursorChromInfoList = getPrecursorChromInfos();
+
+            if(_syncIntensity)
+            {
+                // Get the height of the tallest precursor for this peptide/molecule over all replicates
+                // TODO: filter this to currently selected replicates
+                // Note: If we are not storing TransitionChromInfos we will not be able to sync the intensity axis for
+                // all the plots. MaxHeight for a PrecursorChromInfo is the height of the tallest fragment peak, not the
+                // precursor peak which is calculated by summing up the transition peak intensities.
+                for (GeneralMolecule generalMolecule : _allMolecules.keySet())
+                {
+                    _maxDisplayIntensity = Math.max(_maxDisplayIntensity == null ? 0 : _maxDisplayIntensity.doubleValue(), PrecursorManager.getMaxPrecursorIntensityEstimate(generalMolecule.getId()));
+                }
+            }
+
+            _jfreeDataset = new XYSeriesCollection();
+
+            _quantative = new boolean[precursorChromInfoList.size()];
+
+            List<RtRange> ranges = new ArrayList<>();
+
+            int i = 0;
+            for (Map.Entry<GeneralMolecule, List<PrecursorChromInfoPlus>> entry : _allMolecules.entrySet())
+            {
+                // Get the retention time range that should be displayed for this molecule
+                RtRange chromatogramRtRange = getChromatogramRange(entry.getKey(), entry.getValue());
+                ranges.add(chromatogramRtRange);
+
+                for (PrecursorChromInfoPlus info : entry.getValue())
+                {
+                    Chromatogram chromatogram = info.createChromatogram(_run);
+                    if (chromatogram != null)
+                    {
+                        _seriesColors.put(i, ColorGenerator.getColor(entry.getKey().getTextId(), _seriesColors.values()));
+
+                        // Instead of displaying separate peaks for each transition of this precursor,
+                        // we will sum up the intensities and display a single peak for the precursor
+                        PeakInChart peakInChart = addPrecursorAsSeries(_jfreeDataset, chromatogram, info,
+                                chromatogramRtRange,
+                                getLabel(entry.getKey(), info),
+                                i);
+
+                        _maxDatasetIntensity = Math.max(_maxDatasetIntensity, peakInChart.getMaxTraceIntensity());
+
+                        addAnnotation(info, peakInChart, i);
+                        i++;
+                    }
+                }
+            }
+
+            RtRange fullRange = summarizeRanges(ranges);
+            // Add a little room to the right and left of the full range
+            double padding = (fullRange._maxRt - fullRange._minRt) * 0.1;
+            _minDisplayRt = fullRange.getMinRt() - padding;
+            _maxDisplayRt = fullRange.getMaxRt() + padding;
+        }
+
+        private String getLabel(GeneralMolecule gm, PrecursorChromInfoPlus info)
+        {
+            return gm instanceof Peptide ?
+                LabelFactory.precursorLabel(info.getPrecursorId()) :
+                LabelFactory.moleculePrecursorLabel(info.getPrecursorId(), _user, _container);
+        }
+
+        private RtRange getChromatogramRange(GeneralMolecule generalMolecule, List<PrecursorChromInfoPlus> chromInfos)
+        {
+            List<RtRange> ranges = new ArrayList<>();
+            if (_syncRt)
+            {
+                // Get the minimum and maximum RT for the molecule across replicates
+               ranges.add(TransitionManager.getGeneralMoleculeRtRange(generalMolecule.getId()));
+            }
+            else
+            {
+                for (PrecursorChromInfoPlus info : chromInfos)
+                {
+                    RtRange peakRtSummary = PrecursorManager.getPrecursorPeakRtRange(info);
+                    if (peakRtSummary.isEmpty())
+                    {
+                        // If this precursorChromInfo does not have a minStartTime and maxEndTime AND the startTime and endTime is not set on
+                        // any of its transition peaks, then get the minimum minStartTime and maximum maxEndTime across all precursors of this
+                        // peptide in this replicate so that we can zoom in the general range where we expect to see the peak.
+                        peakRtSummary = TransitionManager.getGeneralMoleculeSampleRtRange(generalMolecule.getId(), info.getSampleFileId());
+                    }
+                    ranges.add(peakRtSummary);
+                }
+            }
+
+            RtRange summary = summarizeRanges(ranges);
+
+            return new RtRange(summary._minRt, summary._maxRt, true, _syncRt);
         }
     }
 }

--- a/src/org/labkey/targetedms/chart/ColorGenerator.java
+++ b/src/org/labkey/targetedms/chart/ColorGenerator.java
@@ -1,0 +1,349 @@
+package org.labkey.targetedms.chart;
+
+import java.awt.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Ported from https://github.com/ProteoWizard/pwiz/blob/master/pwiz_tools/Skyline/Model/ColorGenerator.cs
+ */
+public class ColorGenerator
+{
+    private static final int COLLISION_THRESHOLD = 30;
+
+    /// <summary>
+    /// Generate a color for the given protein.  We try to make colors within a
+    /// protein distinguishable, worrying less about differentiation between colors
+    /// from different proteins.
+    /// </summary>
+    public static java.awt.Color getColor(String peptideName, Collection<Color> siblingColors)
+    {
+        if (peptideName == null)
+            return new Color(170, 170, 170);
+
+        // Get hashed color index for this peptide
+        int index = getColorIndex(peptideName);
+
+        // Check for collision with other peptides in this protein.  A collision happens
+        // when two colors are close enough that they would be hard to distinguish.
+        if (siblingColors.size() < COLORS.size())    // collisions can't be avoided beyond the size of the color array
+        {
+            for (int i = 0; i < COLORS.size(); i++)
+            {
+                var color = COLORS.get(index);
+                boolean collision = false;
+                for (Color existingColor : siblingColors)
+                {
+                    if (Math.abs(color.getRed() - existingColor.getRed()) < COLLISION_THRESHOLD &&
+                            Math.abs(color.getGreen() - existingColor.getGreen()) < COLLISION_THRESHOLD &&
+                            Math.abs(color.getBlue() - existingColor.getBlue()) < COLLISION_THRESHOLD)
+                    {
+                        collision = true;
+                        break;
+                    }
+                }
+                if (!collision)
+                    break;
+
+                // Step to next index value and re-check for collisions.
+                index = (index + 1) % COLORS.size();
+            }
+        }
+
+        return COLORS.get(index);
+    }
+
+    private static int getColorIndex(String peptideName)
+    {
+        // Get hash code for peptide name, then XOR the bytes to make a smaller hash,
+        // then modulo to our color array size.
+        int hash = getCSharpHashCode(peptideName);
+        return ((hash) ^ (hash >> 8) ^ (hash >> 16) ^ (hash >> 24)) % COLORS.size();
+    }
+
+    /**
+     * Ported from https://referencesource.microsoft.com/#mscorlib/system/string.cs
+     */
+    private static int getCSharpHashCode(String peptideName)
+    {
+        int hash1 = 5381;
+        int hash2 = hash1;
+
+        int c;
+        int index = 0;
+        while (index < peptideName.length() && (c = peptideName.charAt(index++)) != 0)
+        {
+            hash1 = ((hash1 << 5) + hash1) ^ c;
+            if (index == peptideName.length())
+                break;
+            c = peptideName.charAt(index++);
+            hash2 = ((hash2 << 5) + hash2) ^ c;
+        }
+
+        return hash1 + (hash2 * 1566083941);
+    }
+
+
+    // These colors were generated using the SkylinePeptideColorGenerator utility.
+    private static final List<Color> COLORS =
+            Collections.unmodifiableList(Arrays.asList(
+                    new Color(85, 106, 104),
+                    new Color(212, 126, 0),
+                    new Color(200, 0, 161),
+                    new Color(0, 194, 255),
+                    new Color(0, 200, 0),
+                    new Color(116, 125, 0),
+                    new Color(163, 166, 255),
+                    new Color(159, 35, 33),
+                    new Color(0, 121, 94),
+                    new Color(142, 68, 147),
+                    new Color(27, 172, 98),
+                    new Color(205, 144, 76),
+                    new Color(196, 110, 138),
+                    new Color(0, 126, 175),
+                    new Color(178, 184, 102),
+                    new Color(237, 140, 255),
+                    new Color(108, 0, 186),
+                    new Color(33, 193, 188),
+                    new Color(0, 92, 0),
+                    new Color(175, 170, 221),
+                    new Color(110, 68, 0),
+                    new Color(0, 108, 188),
+                    new Color(179, 0, 110),
+                    new Color(162, 0, 174),
+                    new Color(0, 216, 151),
+                    new Color(0, 105, 122),
+                    new Color(96, 205, 0),
+                    new Color(0, 122, 0),
+                    new Color(0, 193, 255),
+                    new Color(0, 78, 189),
+                    new Color(51, 81, 0),
+                    new Color(117, 85, 56),
+                    new Color(247, 135, 65),
+                    new Color(251, 130, 236),
+                    new Color(211, 181, 0),
+                    new Color(255, 134, 157),
+                    new Color(0, 198, 210),
+                    new Color(190, 182, 169),
+                    new Color(0, 97, 104),
+                    new Color(255, 79, 255),
+                    new Color(96, 73, 110),
+                    new Color(225, 162, 227),
+                    new Color(0, 99, 0),
+                    new Color(135, 45, 0),
+                    new Color(0, 93, 57),
+                    new Color(110, 164, 1),
+                    new Color(175, 0, 146),
+                    new Color(112, 167, 131),
+                    new Color(249, 109, 191),
+                    new Color(49, 75, 135),
+                    new Color(0, 207, 185),
+                    new Color(128, 61, 0),
+                    new Color(255, 114, 244),
+                    new Color(114, 99, 0),
+                    new Color(0, 182, 227),
+                    new Color(120, 172, 236),
+                    new Color(220, 163, 147),
+                    new Color(0, 192, 75),
+                    new Color(0, 119, 56),
+                    new Color(125, 44, 55),
+                    new Color(147, 23, 109),
+                    new Color(66, 77, 23),
+                    new Color(191, 166, 25),
+                    new Color(168, 115, 148),
+                    new Color(0, 128, 173),
+                    new Color(126, 173, 177),
+                    new Color(195, 89, 213),
+                    new Color(159, 199, 0),
+                    new Color(162, 36, 84),
+                    new Color(134, 61, 172),
+                    new Color(153, 84, 0),
+                    new Color(77, 131, 163),
+                    new Color(247, 149, 135),
+                    new Color(231, 149, 0),
+                    new Color(75, 198, 236),
+                    new Color(137, 67, 0),
+                    new Color(53, 95, 0),
+                    new Color(0, 134, 214),
+                    new Color(173, 181, 0),
+                    new Color(201, 0, 195),
+                    new Color(0, 148, 0),
+                    new Color(174, 139, 223),
+                    new Color(52, 200, 159),
+                    new Color(0, 164, 190),
+                    new Color(243, 152, 203),
+                    new Color(0, 143, 134),
+                    new Color(15, 140, 222),
+                    new Color(17, 116, 30),
+                    new Color(140, 135, 92),
+                    new Color(112, 101, 226),
+                    new Color(90, 73, 0),
+                    new Color(217, 47, 212),
+                    new Color(0, 170, 243),
+                    new Color(0, 100, 123),
+                    new Color(137, 198, 117),
+                    new Color(228, 106, 89),
+                    new Color(87, 68, 68),
+                    new Color(161, 119, 0),
+                    new Color(139, 134, 166),
+                    new Color(103, 167, 255),
+                    new Color(0, 165, 119),
+                    new Color(36, 128, 120),
+                    new Color(0, 139, 136),
+                    new Color(200, 172, 129),
+                    new Color(0, 128, 223),
+                    new Color(225, 77, 136),
+                    new Color(183, 94, 36),
+                    new Color(170, 117, 237),
+                    new Color(220, 27, 164),
+                    new Color(0, 99, 75),
+                    new Color(197, 94, 0),
+                    new Color(99, 68, 135),
+                    new Color(0, 127, 0),
+                    new Color(131, 60, 94),
+                    new Color(102, 62, 0),
+                    new Color(0, 154, 180),
+                    new Color(165, 187, 135),
+                    new Color(0, 100, 162),
+                    new Color(170, 129, 130),
+                    new Color(66, 137, 0),
+                    new Color(207, 174, 203),
+                    new Color(57, 68, 166),
+                    new Color(0, 204, 135),
+                    new Color(173, 58, 219),
+                    new Color(0, 118, 51),
+                    new Color(138, 108, 0),
+                    new Color(196, 78, 133),
+                    new Color(8, 193, 255),
+                    new Color(0, 82, 156),
+                    new Color(168, 99, 92),
+                    new Color(255, 145, 0),
+                    new Color(92, 108, 0),
+                    new Color(240, 40, 205),
+                    new Color(226, 160, 175),
+                    new Color(138, 0, 146),
+                    new Color(124, 132, 193),
+                    new Color(0, 145, 110),
+                    new Color(186, 76, 0),
+                    new Color(0, 149, 0),
+                    new Color(0, 104, 0),
+                    new Color(0, 85, 117),
+                    new Color(255, 121, 255),
+                    new Color(0, 196, 255),
+                    new Color(112, 131, 11),
+                    new Color(41, 169, 187),
+                    new Color(132, 116, 217),
+                    new Color(255, 109, 212),
+                    new Color(87, 122, 96),
+                    new Color(0, 203, 90),
+                    new Color(167, 0, 78),
+                    new Color(101, 144, 80),
+                    new Color(152, 66, 0),
+                    new Color(233, 172, 0),
+                    new Color(204, 89, 177),
+                    new Color(60, 196, 80),
+                    new Color(175, 145, 69),
+                    new Color(201, 97, 101),
+                    new Color(144, 189, 218),
+                    new Color(145, 104, 0),
+                    new Color(0, 98, 95),
+                    new Color(48, 73, 97),
+                    new Color(0, 166, 87),
+                    new Color(0, 89, 0),
+                    new Color(179, 174, 0),
+                    new Color(255, 139, 195),
+                    new Color(35, 105, 0),
+                    new Color(240, 153, 160),
+                    new Color(0, 192, 167),
+                    new Color(0, 212, 251),
+                    new Color(0, 166, 145),
+                    new Color(0, 109, 138),
+                    new Color(209, 157, 0),
+                    new Color(41, 95, 40),
+                    new Color(150, 65, 128),
+                    new Color(166, 123, 189),
+                    new Color(161, 164, 173),
+                    new Color(86, 81, 0),
+                    new Color(0, 109, 171),
+                    new Color(171, 124, 83),
+                    new Color(0, 171, 179),
+                    new Color(212, 78, 98),
+                    new Color(0, 82, 88),
+                    new Color(0, 116, 0),
+                    new Color(169, 107, 0),
+                    new Color(160, 73, 0),
+                    new Color(132, 39, 0),
+                    new Color(215, 150, 250),
+                    new Color(224, 135, 225),
+                    new Color(172, 112, 0),
+                    new Color(0, 132, 166),
+                    new Color(0, 138, 205),
+                    new Color(255, 114, 255),
+                    new Color(255, 125, 230),
+                    new Color(0, 182, 0),
+                    new Color(0, 153, 53),
+                    new Color(71, 162, 55),
+                    new Color(253, 144, 0),
+                    new Color(242, 0, 222),
+                    new Color(54, 116, 189),
+                    new Color(177, 0, 156),
+                    new Color(254, 141, 222),
+                    new Color(138, 34, 47),
+                    new Color(171, 0, 115),
+                    new Color(131, 89, 105),
+                    new Color(0, 121, 106),
+                    new Color(134, 129, 114),
+                    new Color(0, 139, 106),
+                    new Color(148, 31, 0),
+                    new Color(204, 130, 103),
+                    new Color(160, 185, 166),
+                    new Color(179, 91, 0),
+                    new Color(116, 58, 111),
+                    new Color(161, 170, 251),
+                    new Color(0, 133, 146),
+                    new Color(120, 195, 172),
+                    new Color(0, 104, 63),
+                    new Color(255, 89, 255),
+                    new Color(0, 103, 0),
+                    new Color(109, 175, 0),
+                    new Color(150, 142, 0),
+                    new Color(145, 28, 128),
+                    new Color(145, 45, 94),
+                    new Color(0, 105, 0),
+                    new Color(159, 195, 86),
+                    new Color(215, 155, 195),
+                    new Color(221, 135, 52),
+                    new Color(0, 140, 188),
+                    new Color(0, 209, 255),
+                    new Color(112, 57, 42),
+                    new Color(0, 96, 183),
+                    new Color(141, 124, 0),
+                    new Color(231, 117, 149),
+                    new Color(0, 215, 171),
+                    new Color(173, 79, 175),
+                    new Color(0, 154, 98),
+                    new Color(0, 131, 193),
+                    new Color(0, 124, 0),
+                    new Color(0, 161, 253),
+                    new Color(220, 49, 183),
+                    new Color(128, 78, 0),
+                    new Color(37, 114, 227),
+                    new Color(114, 185, 255),
+                    new Color(184, 152, 255),
+                    new Color(186, 7, 175),
+                    new Color(0, 213, 205),
+                    new Color(53, 166, 0),
+                    new Color(138, 0, 171),
+                    new Color(252, 161, 117),
+                    new Color(243, 132, 255),
+                    new Color(85, 92, 133),
+                    new Color(59, 74, 58),
+                    new Color(203, 48, 147),
+                    new Color(179, 146, 0),
+                    new Color(15, 86, 70),
+                    new Color(153, 0, 95),
+                    new Color(176, 68, 15)
+            ));
+}

--- a/src/org/labkey/targetedms/chart/LabelFactory.java
+++ b/src/org/labkey/targetedms/chart/LabelFactory.java
@@ -27,6 +27,7 @@ import org.labkey.targetedms.parser.Molecule;
 import org.labkey.targetedms.parser.MoleculePrecursor;
 import org.labkey.targetedms.parser.MoleculeTransition;
 import org.labkey.targetedms.parser.Peptide;
+import org.labkey.targetedms.parser.PeptideGroup;
 import org.labkey.targetedms.parser.PeptideSettings;
 import org.labkey.targetedms.parser.PrecursorChromInfo;
 import org.labkey.targetedms.parser.Replicate;
@@ -191,21 +192,26 @@ public class LabelFactory
                 molecule.getName();
     }
 
+    public static String groupChartTitle(PeptideGroup group, SampleFile sampleFile)
+    {
+        String label = group.getLabel() == null ? group.getName() : group.getLabel();
+        return generateChromChartTitle(label, sampleFile);
+    }
+
     public static String precursorChromInfoChartTitle(PrecursorChromInfo pChromInfo)
     {
         String label = precursorLabel(pChromInfo.getPrecursorId());
-        return generalPrecursorChromInfoChartTitle(label, pChromInfo);
+        return generateChromChartTitle(label, ReplicateManager.getSampleFile(pChromInfo.getSampleFileId()));
     }
 
     public static String moleculePrecursorChromInfoChartTitle(PrecursorChromInfo pChromInfo, User user, Container container)
     {
         String label = moleculePrecursorLabel(pChromInfo.getPrecursorId(), user, container);
-        return generalPrecursorChromInfoChartTitle(label, pChromInfo);
+        return generateChromChartTitle(label, ReplicateManager.getSampleFile(pChromInfo.getSampleFileId()));
     }
 
-    private static String generalPrecursorChromInfoChartTitle(String precursorLabel, PrecursorChromInfo pChromInfo)
+    private static String generateChromChartTitle(String objectLabel, SampleFile sampleFile)
     {
-        SampleFile sampleFile = ReplicateManager.getSampleFile(pChromInfo.getSampleFileId());
         Replicate replicate = ReplicateManager.getReplicate(sampleFile.getReplicateId());
         TargetedMSRun run = TargetedMSManager.getRun(replicate.getRunId());
 
@@ -221,7 +227,7 @@ public class LabelFactory
             label.append(DateUtil.formatDateTime(run.getContainer(), sampleFile.getAcquiredTime()));
         }
         label.append('\n');
-        label.append(precursorLabel);
+        label.append(objectLabel);
         return label.toString();
     }
 

--- a/src/org/labkey/targetedms/chromlib/ContainerChromatogramLibraryWriter.java
+++ b/src/org/labkey/targetedms/chromlib/ContainerChromatogramLibraryWriter.java
@@ -475,7 +475,7 @@ public class ContainerChromatogramLibraryWriter
     {
         TargetedMSSchema schema = new TargetedMSSchema(_user, _container);
 
-        Collection<Peptide> peptides = PeptideManager.getPeptidesForGroup(pepGroup.getId(), schema);
+        Collection<Peptide> peptides = PeptideManager.getPeptidesForGroup(pepGroup.getId());
         for(Peptide peptide: peptides)
         {
             List<Precursor> precursors = PrecursorManager.getPrecursorsForPeptide(peptide.getId(), schema);

--- a/src/org/labkey/targetedms/model/QCPlotFragment.java
+++ b/src/org/labkey/targetedms/model/QCPlotFragment.java
@@ -1,8 +1,10 @@
 package org.labkey.targetedms.model;
 
+import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import java.awt.*;
 import java.util.List;
 
 /**
@@ -15,6 +17,8 @@ public class QCPlotFragment
     private Double mZ;
     private List<RawMetricDataSet> qcPlotData;
     private List<GuideSetStats> guideSetStats;
+    @Nullable
+    private Color _seriesColor;
 
     public String getSeriesLabel()
     {
@@ -71,6 +75,10 @@ public class QCPlotFragment
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("DataType", getDataType());
         jsonObject.put("SeriesLabel", getSeriesLabel());
+        if (_seriesColor != null)
+        {
+            jsonObject.put("SeriesColor", "#" + Integer.toHexString(_seriesColor.getRGB()).substring(2).toUpperCase());
+        }
         jsonObject.put("mz", getmZ());
 
         JSONArray guideSetArray = new JSONArray();
@@ -131,4 +139,14 @@ public class QCPlotFragment
         return jsonObject;
     }
 
+    public void setSeriesColor(Color seriesColor)
+    {
+        _seriesColor = seriesColor;
+    }
+
+    @Nullable
+    public Color getSeriesColor()
+    {
+        return _seriesColor;
+    }
 }

--- a/src/org/labkey/targetedms/query/ChromatogramDisplayColumnFactory.java
+++ b/src/org/labkey/targetedms/query/ChromatogramDisplayColumnFactory.java
@@ -22,16 +22,18 @@ import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.DisplayColumnFactory;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.query.FieldKey;
+import org.labkey.api.util.GUID;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HttpView;
 import org.labkey.targetedms.TargetedMSController;
-import org.labkey.targetedms.parser.SampleFile;
+import org.labkey.targetedms.view.ChromatogramsDataRegion;
 import org.springframework.web.servlet.mvc.Controller;
 
 import java.io.IOException;
 import java.io.Writer;
 import java.util.Set;
+import java.util.function.Consumer;
 
 /**
  * User: vsharma
@@ -44,6 +46,7 @@ public class ChromatogramDisplayColumnFactory implements DisplayColumnFactory
     private final Type _type;
     private final int _chartWidth;
     private final int _chart_height;
+    private final Consumer<ActionURL> _urlCustomizer;
     private final boolean _syncY;
     private final boolean _syncX;
     private final boolean _splitGraph;
@@ -87,6 +90,14 @@ public class ChromatogramDisplayColumnFactory implements DisplayColumnFactory
                     {
                         return new FieldKey(parentFieldKey, "sample");
                     }
+                },
+        Group(TargetedMSController.GroupChromatogramChartAction.class)
+                {
+                    @Override
+                    public FieldKey getSampleNameFieldKey(FieldKey parentFieldKey)
+                    {
+                        return new FieldKey(parentFieldKey, "Id");
+                    }
                 };
 
         private final Class<? extends Controller> _actionClass;
@@ -106,16 +117,21 @@ public class ChromatogramDisplayColumnFactory implements DisplayColumnFactory
 
     public ChromatogramDisplayColumnFactory(Container container, Type type)
     {
-        this(container, type, CHART_WIDTH, CHART_HEIGHT, false, false, false, false, null, null);
+        this(container, type, CHART_WIDTH, CHART_HEIGHT, null, false, false, false, false, null, null);
     }
 
     public ChromatogramDisplayColumnFactory(Container container, Type type, int chartWidth, int chartHeight)
     {
-        this(container, type, chartWidth, chartHeight, false, false, false, false, null, null);
+        this(container, type, chartWidth, chartHeight, null, false, false, false, false, null, null);
+    }
+
+    public ChromatogramDisplayColumnFactory(Container container, Type type, int chartWidth, int chartHeight, Consumer<ActionURL> urlCustomizer)
+    {
+        this(container, type, chartWidth, chartHeight, urlCustomizer, false, false, false, false, null, null);
     }
 
     public ChromatogramDisplayColumnFactory(Container container, Type type,
-                                            int chartWidth, int chartHeight,
+                                            int chartWidth, int chartHeight, Consumer<ActionURL> urlCustomizer,
                                             boolean syncIntensity, boolean syncRt,
                                             boolean splitGraph, boolean showOptimizationPeaks,
                                             String annotationsFilter, String replicatesFilter)
@@ -124,6 +140,7 @@ public class ChromatogramDisplayColumnFactory implements DisplayColumnFactory
         _type = type;
         _chartWidth = chartWidth;
         _chart_height = chartHeight;
+        _urlCustomizer = urlCustomizer == null ? (x) -> {} : urlCustomizer;
         _syncY = syncIntensity;
         _syncX = syncRt;
         _splitGraph = splitGraph;
@@ -145,6 +162,7 @@ public class ChromatogramDisplayColumnFactory implements DisplayColumnFactory
 
                 ActionURL chromAction = new ActionURL(_type.getActionClass(), _container);
 
+                _urlCustomizer.accept(chromAction);
                 chromAction.addParameter("id", String.valueOf(id));
                 chromAction.addParameter("chartWidth", String.valueOf(_chartWidth));
                 chromAction.addParameter("chartHeight", String.valueOf(_chart_height));
@@ -164,8 +182,18 @@ public class ChromatogramDisplayColumnFactory implements DisplayColumnFactory
 
                 String sampleName = ctx.get(_type.getSampleNameFieldKey(getBoundColumn().getFieldKey().getParent()), String.class);
 
-                String imgLink = "<a name=\"ChromInfo" + id + "\"><img style=\"border: " + (highlight ? "beige" : "white") + " solid 8px; width:" + _chartWidth +"px; height:" + _chart_height + "px\" src=\"" + PageFlowUtil.filter(chromAction.getLocalURIString()) + "\" alt=\"Chromatogram "+ PageFlowUtil.filter(sampleName)+"\"></a>";
-                out.write(imgLink);
+                String domId = GUID.makeGUID();
+                String domLabelId = domId + "-label";
+
+                ChromatogramsDataRegion dataRegion = (ChromatogramsDataRegion)ctx.getCurrentRegion();
+
+                String html = "<a name=\"ChromInfo" + id + "\"></a>";
+                html += "<div alt=\"Chromatogram " + PageFlowUtil.filter(sampleName) + "\" style=\"border: " + (highlight ? "beige" : "white") +
+                        " solid 8px; width:" + (_chartWidth + 16) + "px; height:" + (_chart_height + 50) + "px\" id=\"" + PageFlowUtil.filter(domId) + "\"></div>" +
+                        "<div style=\"text-align: center\" id=\"" + PageFlowUtil.filter(domLabelId) + "\"></div>";
+
+                dataRegion.addSVG(chromAction.getLocalURIString(), domId, domLabelId);
+                out.write(html);
             }
 
             @Override

--- a/src/org/labkey/targetedms/query/ChromatogramDisplayColumnFactory.java
+++ b/src/org/labkey/targetedms/query/ChromatogramDisplayColumnFactory.java
@@ -153,6 +153,19 @@ public class ChromatogramDisplayColumnFactory implements DisplayColumnFactory
     public DisplayColumn createRenderer(ColumnInfo colInfo)
     {
         return new DataColumn(colInfo) {
+
+            @Override
+            public boolean isFilterable()
+            {
+                return false;
+            }
+
+            @Override
+            public boolean isSortable()
+            {
+                return false;
+            }
+
             @Override
             public void renderGridCellContents(RenderContext ctx, Writer out) throws IOException
             {
@@ -189,7 +202,7 @@ public class ChromatogramDisplayColumnFactory implements DisplayColumnFactory
 
                 String html = "<a name=\"ChromInfo" + id + "\"></a>";
                 html += "<div alt=\"Chromatogram " + PageFlowUtil.filter(sampleName) + "\" style=\"border: " + (highlight ? "beige" : "white") +
-                        " solid 8px; width:" + (_chartWidth + 16) + "px; height:" + (_chart_height + 50) + "px\" id=\"" + PageFlowUtil.filter(domId) + "\"></div>" +
+                        " solid 8px; width:" + (_chartWidth + 16) + "px; min-height:" + (_chart_height + 50) + "px\" id=\"" + PageFlowUtil.filter(domId) + "\"></div>" +
                         "<div style=\"text-align: center\" id=\"" + PageFlowUtil.filter(domLabelId) + "\"></div>";
 
                 dataRegion.addSVG(chromAction.getLocalURIString(), domId, domLabelId);

--- a/src/org/labkey/targetedms/query/ChromatogramGridQuerySettings.java
+++ b/src/org/labkey/targetedms/query/ChromatogramGridQuerySettings.java
@@ -31,6 +31,7 @@ public class ChromatogramGridQuerySettings extends QuerySettings
     public ChromatogramGridQuerySettings(ViewContext context, String dataRegionName)
     {
         super(dataRegionName);
+        setMaxRows(10);
         init(context);
 
         setAllowCustomizeView(false);

--- a/src/org/labkey/targetedms/query/ConflictResultsManager.java
+++ b/src/org/labkey/targetedms/query/ConflictResultsManager.java
@@ -24,6 +24,7 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.security.User;
+import org.labkey.api.targetedms.RepresentativeDataState;
 import org.labkey.api.targetedms.TargetedMSService;
 import org.labkey.api.util.Formats;
 import org.labkey.targetedms.TargetedMSManager;
@@ -37,7 +38,6 @@ import org.labkey.targetedms.parser.GeneralTransition;
 import org.labkey.targetedms.parser.Peptide;
 import org.labkey.targetedms.parser.Precursor;
 import org.labkey.targetedms.parser.PrecursorChromInfo;
-import org.labkey.api.targetedms.RepresentativeDataState;
 import org.labkey.targetedms.parser.TransitionChromInfo;
 
 import java.util.ArrayList;
@@ -219,7 +219,7 @@ public class ConflictResultsManager
 
     private static List<BestPrecursorPeptide> getBestPrecursorsForProtein(int proteinId, User user, Container container)
     {
-        Collection<Peptide> peptides = PeptideManager.getPeptidesForGroup(proteinId, new TargetedMSSchema(user, container));
+        Collection<Peptide> peptides = PeptideManager.getPeptidesForGroup(proteinId);
         List<BestPrecursorPeptide> proteinPeptides = new ArrayList<>();
         for(Peptide peptide: peptides)
         {

--- a/src/org/labkey/targetedms/query/GroupChromatogramsTableInfo.java
+++ b/src/org/labkey/targetedms/query/GroupChromatogramsTableInfo.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2012-2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.labkey.targetedms.query;
+
+import org.labkey.api.data.SQLFragment;
+import org.labkey.api.query.FieldKey;
+import org.labkey.api.query.FilteredTable;
+import org.labkey.targetedms.TargetedMSController;
+import org.labkey.targetedms.TargetedMSManager;
+import org.labkey.targetedms.TargetedMSSchema;
+import org.labkey.targetedms.parser.PeptideGroup;
+
+/**
+ * User: vsharma
+ * Date: 4/29/12
+ * Time: 3:31 PM
+ */
+public class GroupChromatogramsTableInfo extends FilteredTable<TargetedMSSchema>
+{
+    private final TargetedMSController.ChromatogramForm _form;
+    private PeptideGroup _group;
+
+    public GroupChromatogramsTableInfo(TargetedMSSchema schema, TargetedMSController.ChromatogramForm form)
+    {
+        super(TargetedMSManager.getTableInfoSampleFile(), schema);
+        _form = form;
+
+        setName(TargetedMSSchema.TABLE_GROUP_CHROM_INFO);
+
+        //wrap all the columns
+        wrapAllColumns(true);
+
+        var col = getMutableColumn("Id");
+        col.setLabel("");
+
+        ChromatogramDisplayColumnFactory colFactory = new ChromatogramDisplayColumnFactory(
+                getContainer(),
+                ChromatogramDisplayColumnFactory.Type.Group,
+                form.getChartWidth(),
+                form.getChartHeight(),
+                (x) -> x.addParameter("groupId", _group.getId()),
+                form.isSyncY(),
+                form.isSyncX(),
+                false,
+                form.isShowOptimizationPeaks(),
+                form.getAnnotationsFilter(),
+                form.getReplicatesFilter());
+        col.setDisplayColumnFactory(colFactory);
+    }
+
+    public void addGroupFilter(PeptideGroup group)
+    {
+        _group = group;
+        SQLFragment runIdSQL = new SQLFragment("ReplicateId IN (SELECT r.Id FROM ");
+        runIdSQL.append(TargetedMSManager.getTableInfoReplicate(), "r");
+        runIdSQL.append(" WHERE r.RunId = ?)");
+        runIdSQL.add(group.getRunId());
+
+        _form.appendReplicateFilters(runIdSQL, "ReplicateId");
+
+        addCondition(runIdSQL, FieldKey.fromParts("ReplicateId"));
+    }
+}

--- a/src/org/labkey/targetedms/query/MoleculeManager.java
+++ b/src/org/labkey/targetedms/query/MoleculeManager.java
@@ -53,9 +53,9 @@ public class MoleculeManager
         sql.append("gm.normalizationmethod, gm.standardtype, gm.concentrationmultiplier, gm.internalstandardconcentration, ");
         sql.append("m.id, m.ionformula, m.customionname, m.massaverage, m.massmonoisotopic ");
         sql.append("FROM targetedms.generalmolecule gm, targetedms.molecule m WHERE ");
-        sql.append("m.id = gm.id AND gm.peptidegroupid=?");
+        sql.append("m.id = gm.id AND gm.peptidegroupid=? ORDER BY gm.Id");
         sql.add(peptideGroupId);
 
-        return new SqlSelector(TargetedMSManager.getSchema(), sql).getCollection(Molecule.class);
+        return new SqlSelector(TargetedMSManager.getSchema(), sql).getArrayList(Molecule.class);
     }
 }

--- a/src/org/labkey/targetedms/query/MoleculePrecursorManager.java
+++ b/src/org/labkey/targetedms/query/MoleculePrecursorManager.java
@@ -23,13 +23,13 @@ import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.security.User;
+import org.labkey.api.targetedms.RepresentativeDataState;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.targetedms.TargetedMSManager;
 import org.labkey.targetedms.TargetedMSSchema;
 import org.labkey.targetedms.model.PrecursorChromInfoLitePlus;
 import org.labkey.targetedms.model.PrecursorChromInfoPlus;
 import org.labkey.targetedms.parser.MoleculePrecursor;
-import org.labkey.api.targetedms.RepresentativeDataState;
 
 import java.util.HashSet;
 import java.util.List;
@@ -199,7 +199,7 @@ public class MoleculePrecursorManager
     }
 
 
-    public static List<PrecursorChromInfoPlus> getPrecursorChromInfosForMolecule(long moleduleId, long sampleFileId, User user, Container container)
+    public static List<PrecursorChromInfoPlus> getPrecursorChromInfosForMolecule(long moleculeId, long sampleFileId, User user, Container container)
     {
         SQLFragment sql = new SQLFragment("SELECT ");
         sql.append("pci.* , pg.Label AS groupName, mol.customIonName, prec.Charge");
@@ -207,7 +207,7 @@ public class MoleculePrecursorManager
         joinTablesForMoleculePrecursorChromInfo(sql, user, container);
         sql.append(" WHERE ");
         sql.append("mol.Id=? ");
-        sql.add(moleduleId);
+        sql.add(moleculeId);
 
         if(sampleFileId != 0)
         {
@@ -216,7 +216,7 @@ public class MoleculePrecursorManager
             sql.add(sampleFileId);
         }
 
-        return  new SqlSelector(TargetedMSManager.getSchema(), sql).getArrayList(PrecursorChromInfoPlus.class);
+        return new SqlSelector(TargetedMSManager.getSchema(), sql).getArrayList(PrecursorChromInfoPlus.class);
     }
 
     private static void joinTablesForMoleculePrecursorChromInfo(SQLFragment sql, User user, Container container)

--- a/src/org/labkey/targetedms/query/PeptideManager.java
+++ b/src/org/labkey/targetedms/query/PeptideManager.java
@@ -15,7 +15,6 @@
 
 package org.labkey.targetedms.query;
 
-import org.jetbrains.annotations.Nullable;
 import org.labkey.api.cache.CacheLoader;
 import org.labkey.api.cache.CacheManager;
 import org.labkey.api.data.Container;
@@ -23,7 +22,6 @@ import org.labkey.api.data.DatabaseCache;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SqlSelector;
 import org.labkey.targetedms.TargetedMSManager;
-import org.labkey.targetedms.TargetedMSSchema;
 import org.labkey.targetedms.parser.GeneralMoleculeChromInfo;
 import org.labkey.targetedms.parser.Peptide;
 
@@ -81,7 +79,7 @@ public class PeptideManager
         return new SqlSelector(TargetedMSManager.getSchema(), sql).getObject(GeneralMoleculeChromInfo.class);
     }
 
-    public static Collection<Peptide> getPeptidesForGroup(long peptideGroupId, TargetedMSSchema schema)
+    public static Collection<Peptide> getPeptidesForGroup(long peptideGroupId)
     {
         SQLFragment sql = new SQLFragment("SELECT gm.id, gm.id, gm.peptidegroupid, gm.rtcalculatorscore, gm.predictedretentiontime, ");
         sql.append("gm.avgmeasuredretentiontime, gm.note, gm.explicitretentiontime, ");

--- a/src/org/labkey/targetedms/query/PeptideManager.java
+++ b/src/org/labkey/targetedms/query/PeptideManager.java
@@ -87,10 +87,10 @@ public class PeptideManager
         sql.append("p.id, p.sequence, p.startindex, p.endindex, p.previousaa, p.nextaa, ");
         sql.append("p.calcneutralmass, p.nummissedcleavages, p.rank, p.decoy, p.peptidemodifiedsequence, ");
         sql.append("gm.standardtype FROM targetedms.generalmolecule gm, targetedms.peptide p WHERE ");
-        sql.append("p.id = gm.id AND gm.peptidegroupid=?");
+        sql.append("p.id = gm.id AND gm.peptidegroupid=? ORDER BY gm.Id");
         sql.add(peptideGroupId);
 
-        return new SqlSelector(TargetedMSManager.getSchema(), sql).getCollection(Peptide.class);
+        return new SqlSelector(TargetedMSManager.getSchema(), sql).getArrayList(Peptide.class);
     }
 
     public static Double getMinRetentionTime(long peptideId)

--- a/src/org/labkey/targetedms/query/PrecursorChromatogramsTableInfo.java
+++ b/src/org/labkey/targetedms/query/PrecursorChromatogramsTableInfo.java
@@ -52,13 +52,9 @@ public class PrecursorChromatogramsTableInfo extends FilteredTable<TargetedMSSch
         peptideCol.setDisplayColumnFactory(colFactory);
     }
 
-    public void setPrecursorId(long precursorId)
+    public void addPrecursorFilter(long precursorId)
     {
         _precursorId = precursorId;
-    }
-
-    public void addPrecursorFilter()
-    {
         addCondition(new SimpleFilter(FieldKey.fromParts("PrecursorId"), _precursorId));
     }
 }

--- a/src/org/labkey/targetedms/view/ChromatogramGridView.java
+++ b/src/org/labkey/targetedms/view/ChromatogramGridView.java
@@ -1,0 +1,16 @@
+package org.labkey.targetedms.view;
+
+import org.labkey.api.view.GridView;
+import org.labkey.api.view.template.ClientDependency;
+import org.springframework.validation.BindException;
+
+public class ChromatogramGridView extends GridView
+{
+    public ChromatogramGridView(ChromatogramsDataRegion dataRegion, BindException errors)
+    {
+        super(dataRegion, errors);
+
+        addClientDependency(ClientDependency.fromPath("/TargetedMS/css/svgChart.css"));
+        addClientDependency(ClientDependency.fromPath("/TargetedMS/js/svgChart.js"));
+    }
+}

--- a/src/org/labkey/targetedms/view/MoleculePrecursorChromatogramsView.java
+++ b/src/org/labkey/targetedms/view/MoleculePrecursorChromatogramsView.java
@@ -16,42 +16,32 @@
 package org.labkey.targetedms.view;
 
 import org.apache.commons.lang3.StringUtils;
-import org.labkey.api.data.ButtonBar;
-import org.labkey.api.data.DataRegion;
-import org.labkey.api.query.QuerySettings;
-import org.labkey.api.view.GridView;
+import org.labkey.api.view.ViewContext;
 import org.labkey.targetedms.TargetedMSController;
 import org.labkey.targetedms.TargetedMSSchema;
 import org.labkey.targetedms.parser.Molecule;
 import org.labkey.targetedms.query.GeneralMoleculePrecursorChromatogramsTableInfo;
-import org.springframework.validation.Errors;
+import org.springframework.validation.BindException;
 
-public class MoleculePrecursorChromatogramsView extends GridView
+import static org.labkey.targetedms.view.ChromatogramsDataRegion.PEPTIDE_PRECURSOR_CHROM_DATA_REGION;
+
+public class MoleculePrecursorChromatogramsView extends ChromatogramGridView
 {
     public MoleculePrecursorChromatogramsView(Molecule molecule, TargetedMSSchema schema,
-                                             TargetedMSController.ChromatogramForm form,
-                                             Errors errors)
+                                              TargetedMSController.ChromatogramForm form,
+                                              BindException errors, ViewContext viewContext)
     {
 
-        super(makeDataRegion(molecule, schema, form), errors);
-        QuerySettings settings = new QuerySettings(getViewContext(), "Molecule and Molecule Precursor chromatograms");
-        settings.setMaxRows(10);
-        getDataRegion().setSettings(settings);
+        super(makeDataRegion(molecule, schema, form, viewContext), errors);
     }
 
-    private static DataRegion makeDataRegion(Molecule molecule, TargetedMSSchema schema,
-                                             TargetedMSController.ChromatogramForm form)
+    private static ChromatogramsDataRegion makeDataRegion(Molecule molecule, TargetedMSSchema schema,
+                                             TargetedMSController.ChromatogramForm form, ViewContext viewContext)
     {
         GeneralMoleculePrecursorChromatogramsTableInfo tableInfo = new GeneralMoleculePrecursorChromatogramsTableInfo(molecule, schema, form);
-        DataRegion dRegion = new DataRegion();
-        dRegion.setTable(tableInfo);
-        dRegion.addColumns(tableInfo, StringUtils.join(tableInfo.getDisplayColumnNames(), ","));
-        dRegion.setShadeAlternatingRows(false);
-        dRegion.setShowPagination(true);
-        dRegion.setShowPaginationCount(true);
-        ButtonBar bar = new ButtonBar();
-        dRegion.setButtonBar(bar);
-
-        return dRegion;
-    }
+        return new ChromatogramsDataRegion(viewContext,
+                tableInfo,
+                PEPTIDE_PRECURSOR_CHROM_DATA_REGION,
+                StringUtils.join(tableInfo.getDisplayColumnNames(), ","));
+        }
 }

--- a/src/org/labkey/targetedms/view/MoleculePrecursorChromatogramsView.java
+++ b/src/org/labkey/targetedms/view/MoleculePrecursorChromatogramsView.java
@@ -23,7 +23,7 @@ import org.labkey.targetedms.parser.Molecule;
 import org.labkey.targetedms.query.GeneralMoleculePrecursorChromatogramsTableInfo;
 import org.springframework.validation.BindException;
 
-import static org.labkey.targetedms.view.ChromatogramsDataRegion.PEPTIDE_PRECURSOR_CHROM_DATA_REGION;
+import static org.labkey.targetedms.view.ChromatogramsDataRegion.MOLECULE_PRECURSOR_CHROM_DATA_REGION;
 
 public class MoleculePrecursorChromatogramsView extends ChromatogramGridView
 {
@@ -41,7 +41,7 @@ public class MoleculePrecursorChromatogramsView extends ChromatogramGridView
         GeneralMoleculePrecursorChromatogramsTableInfo tableInfo = new GeneralMoleculePrecursorChromatogramsTableInfo(molecule, schema, form);
         return new ChromatogramsDataRegion(viewContext,
                 tableInfo,
-                PEPTIDE_PRECURSOR_CHROM_DATA_REGION,
+                MOLECULE_PRECURSOR_CHROM_DATA_REGION,
                 StringUtils.join(tableInfo.getDisplayColumnNames(), ","));
         }
 }

--- a/src/org/labkey/targetedms/view/PeptidePrecursorChromatogramsView.java
+++ b/src/org/labkey/targetedms/view/PeptidePrecursorChromatogramsView.java
@@ -16,47 +16,37 @@
 package org.labkey.targetedms.view;
 
 import org.apache.commons.lang3.StringUtils;
-import org.labkey.api.data.ButtonBar;
-import org.labkey.api.data.DataRegion;
-import org.labkey.api.query.QuerySettings;
-import org.labkey.api.view.GridView;
+import org.labkey.api.view.ViewContext;
 import org.labkey.targetedms.TargetedMSController;
 import org.labkey.targetedms.TargetedMSSchema;
 import org.labkey.targetedms.parser.Peptide;
 import org.labkey.targetedms.query.GeneralMoleculePrecursorChromatogramsTableInfo;
-import org.springframework.validation.Errors;
+import org.springframework.validation.BindException;
+
+import static org.labkey.targetedms.view.ChromatogramsDataRegion.PEPTIDE_PRECURSOR_CHROM_DATA_REGION;
 
 /**
  * User: vsharma
  * Date: 5/7/12
  * Time: 4:17 PM
  */
-public class PeptidePrecursorChromatogramsView extends GridView
+public class PeptidePrecursorChromatogramsView extends ChromatogramGridView
 {
     public PeptidePrecursorChromatogramsView(Peptide peptide, TargetedMSSchema schema,
                                              TargetedMSController.ChromatogramForm form,
-                                             Errors errors)
+                                             BindException errors, ViewContext viewContext)
     {
 
-        super(makeDataRegion(peptide, schema, form), errors);
-        QuerySettings settings = new QuerySettings(getViewContext(), "Peptide and Precursor chromatograms");
-        settings.setMaxRows(10);
-        getDataRegion().setSettings(settings);
+        super(makeDataRegion(peptide, schema, form, viewContext), errors);
     }
 
-    private static DataRegion makeDataRegion(Peptide peptide, TargetedMSSchema schema,
-                                             TargetedMSController.ChromatogramForm form)
+    private static ChromatogramsDataRegion makeDataRegion(Peptide peptide, TargetedMSSchema schema,
+                                             TargetedMSController.ChromatogramForm form, ViewContext viewContext)
     {
         GeneralMoleculePrecursorChromatogramsTableInfo tableInfo = new GeneralMoleculePrecursorChromatogramsTableInfo(peptide, schema, form);
-        DataRegion dRegion = new DataRegion();
-        dRegion.setTable(tableInfo);
-        dRegion.addColumns(tableInfo, StringUtils.join(tableInfo.getDisplayColumnNames(), ","));
-        dRegion.setShadeAlternatingRows(false);
-        dRegion.setShowPagination(true);
-        dRegion.setShowPaginationCount(true);
-        ButtonBar bar = new ButtonBar();
-        dRegion.setButtonBar(bar);
-
-        return dRegion;
+        return new ChromatogramsDataRegion(viewContext,
+                tableInfo,
+                PEPTIDE_PRECURSOR_CHROM_DATA_REGION,
+                StringUtils.join(tableInfo.getDisplayColumnNames(), ","));
     }
 }

--- a/src/org/labkey/targetedms/view/chromatogramsForm.jsp
+++ b/src/org/labkey/targetedms/view/chromatogramsForm.jsp
@@ -149,7 +149,6 @@
                 type: 'table',
                 columns: 3
             }, items: [
-                { xtype: 'hidden', name: 'X-LABKEY-CSRF', value: LABKEY.CSRF },
                 {
                     xtype:'hidden',
                     name: 'id',
@@ -495,7 +494,7 @@
 }(jQuery);
 </script>
 <div id="headContainer">
-    <div onclick="showChart()" style="margin-bottom: 10px;"><img id="showGraphImg" src="<%=getWebappURL("_images/minus.gif")%>"><strong>Display Chart Settings</strong></div>
+    <div onclick="showChart()" style="margin-bottom: 10px;"><img id="showGraphImg" src="<%=getWebappURL("_images/minus.gif")%>"> <strong>Display Chart Settings</strong></div>
     <div id="formContainer" style="float:left; width:550px; padding-bottom: 25px;"></div>
     <div id="allFilters" style="float:left;">
 

--- a/src/org/labkey/targetedms/view/precursorChromatogramsView.jsp
+++ b/src/org/labkey/targetedms/view/precursorChromatogramsView.jsp
@@ -41,9 +41,11 @@
     <tr>
         <%
             String fieldLabel = bean.getPeptideGroup().getSequenceId() != null ? "Protein" : "Group";
+            ActionURL showGroupUrl = new ActionURL(TargetedMSController.ShowProteinAction.class, getContainer());
+            showGroupUrl.addParameter("id", bean.getPeptideGroup().getId());
         %>
         <td class="labkey-form-label"><%=h(fieldLabel)%></td>
-        <td><%= h(bean.getPeptideGroup().getLabel())%></td>
+        <td><a href="<%= h(showGroupUrl)%>"><%= h(bean.getPeptideGroup().getLabel())%></a></td>
     </tr>
     <tr>
         <%

--- a/src/org/labkey/targetedms/view/skylineAuditLogExtraInfoView.jsp
+++ b/src/org/labkey/targetedms/view/skylineAuditLogExtraInfoView.jsp
@@ -5,15 +5,18 @@
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 
 <%
-    JspView<TargetedMSController.SkylineAuditLogExtraInfoBean> me =
-            (JspView<TargetedMSController.SkylineAuditLogExtraInfoBean>) HttpView.currentView();
-    TargetedMSController.SkylineAuditLogExtraInfoBean bean = me.getModelBean();
-    AuditLogEntry entry = bean.getEntry();
+    JspView<AuditLogEntry> me =
+            (JspView<AuditLogEntry>) HttpView.currentView();
+    AuditLogEntry bean = me.getModelBean();
 %>
-<div id="targetedmsAuditLogExtraInfo" >
+    <div id="targetedmsAuditLogExtraInfo" >
+    <% if (bean == null) { %>
+        Unable to find requested audit log entry
+    <% } else { %>
     <table>
-        <tr><td><strong>User Name:</strong> <%= h(entry.getUserName()) %></td><td><span class="fa fa-times">&nbsp;</span></td></tr>
-        <tr><td colspan="2"><strong>Entry Timestamp:</strong> <%=formatDateTime(entry.getCreateTimestamp())%></td></tr>
+        <tr><td><strong>User Name:</strong> <%= h(bean.getUserName()) %></td><td><span class="fa fa-times">&nbsp;</span></td></tr>
+        <tr><td colspan="2"><strong>Entry Timestamp:</strong> <%=formatDateTime(bean.getCreateTimestamp())%></td></tr>
     </table><br/>
-    <pre style="overflow: scroll; max-height: 400px"><%=h(entry.getExtraInfo()) %></pre>
+    <pre style="overflow: scroll; max-height: 400px"><%=h(bean.getExtraInfo()) %></pre>
+    <% } %>
 </div>

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentTest.java
@@ -19,12 +19,12 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.remoteapi.CommandException;
-import org.labkey.remoteapi.query.Filter;
-import org.labkey.remoteapi.query.SelectRowsCommand;
-import org.labkey.remoteapi.query.SelectRowsResponse;
 import org.labkey.remoteapi.Connection;
+import org.labkey.remoteapi.query.Filter;
 import org.labkey.remoteapi.query.Row;
 import org.labkey.remoteapi.query.Rowset;
+import org.labkey.remoteapi.query.SelectRowsCommand;
+import org.labkey.remoteapi.query.SelectRowsResponse;
 import org.labkey.remoteapi.query.Sort;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
@@ -287,15 +287,15 @@ public class TargetedMSExperimentTest extends TargetedMSTest
         //Verify the spectrum shows up correctly.
 
         //Verify we get the expected number of chromatogram graphs.
-        assertElementPresent(Locator.xpath("//img[contains(@src, 'generalMoleculeChromatogramChart.view')]"), 1);
-        assertElementPresent(Locator.xpath("//img[contains(@src, 'precursorChromatogramChart.view')]"), 2);
-        assertElementPresent(Locator.xpath("//img[contains(@alt, 'Chromatogram')]"), 3);
+        assertElementPresent(Locator.xpath("//table[contains(@lk-region-name, 'PeptidePrecursorChromatograms')]"));
+        waitForElements(Locator.xpath("//table[contains(@lk-region-name, 'PeptidePrecursorChromatograms')]//div[contains(@alt, 'Chromatogram silac_1_to_4')]"), 3);
 
         //Click on a precursor icon link.
         clickAndWait(Locator.linkWithHref("precursorAllChromatogramsChart.view?"));
         //Verify expected values in detail view. Verify chromatogram.
         assertTextPresentInThisOrder("Precursor Chromatograms: LTSLNVVAGSDLR", "YAL038W", "672.8777");
-        assertElementPresent(Locator.xpath("//img[contains(@src, 'Chromatogram')]"));
+        assertElementPresent(Locator.xpath("//table[contains(@lk-region-name, 'PrecursorChromatograms')]"));
+        waitForElements(Locator.xpath("//table[contains(@lk-region-name, 'PrecursorChromatograms')]//div[contains(@alt, 'Chromatogram silac_1_to_4')]"), 1);
 
         goBack();
         clickAndWait(Locator.linkContainingText("YAL038W"));
@@ -359,8 +359,12 @@ public class TargetedMSExperimentTest extends TargetedMSTest
         assertElementPresent(Locator.xpath("//tr[td[text()='Avg. RT']][td[normalize-space()='0.9701']]"));
         assertTextPresent("Molecule Precursors");
 
-        assertElementPresent(Locator.xpath("//img[contains(@src, 'generalMoleculeChromatogramChart.view')]"));
-        assertElementPresent(Locator.xpath("//img[contains(@src, 'precursorChromatogramChart.view')]"));
+        // Check the chromatogram plots
+        assertElementPresent(Locator.xpath("//table[contains(@lk-region-name, 'MoleculePrecursorChromatograms')]"));
+        waitForElements(Locator.xpath("//table[contains(@lk-region-name, 'MoleculePrecursorChromatograms')]//div[contains(@alt, 'Chromatogram 13417_02_WAA283_3805_071514')]"), 2);
+        waitForElements(Locator.xpath("//table[contains(@lk-region-name, 'MoleculePrecursorChromatograms')]//div[contains(@alt, 'Chromatogram 13417_03_WAA283_3805_071514')]"), 2);
+        waitForElements(Locator.xpath("//table[contains(@lk-region-name, 'MoleculePrecursorChromatograms')]//div[contains(@alt, 'Chromatogram 13418_02_WAA283_3805_071514')]"), 2);
+        waitForElements(Locator.xpath("//table[contains(@lk-region-name, 'MoleculePrecursorChromatograms')]//div[contains(@alt, 'Chromatogram 13418_03_WAA283_3805_071514')]"), 2);
         ensureComparisonPlots("PC aa C26:0");
 
         //Click on Molecule Precursor Chromatogram link
@@ -373,7 +377,12 @@ public class TargetedMSExperimentTest extends TargetedMSTest
         assertElementPresent(Locator.xpath("//tr[td[text()='Charge']][td[normalize-space()='1']]"));
         assertElementPresent(Locator.xpath("//tr[td[text()='m/z']][td[normalize-space()='650.4755']]"));
 
-        assertElementPresent(Locator.xpath("//img[contains(@src, 'precursorChromatogramChart.view')]"), 4);
+        // Check the chromatogram plots
+        assertElementPresent(Locator.xpath("//table[contains(@lk-region-name, 'PrecursorChromatograms')]"));
+        waitForElements(Locator.xpath("//table[contains(@lk-region-name, 'PrecursorChromatograms')]//div[contains(@alt, 'Chromatogram 13417_02_WAA283_3805_071514')]"), 1);
+        waitForElements(Locator.xpath("//table[contains(@lk-region-name, 'PrecursorChromatograms')]//div[contains(@alt, 'Chromatogram 13417_03_WAA283_3805_071514')]"), 1);
+        waitForElements(Locator.xpath("//table[contains(@lk-region-name, 'PrecursorChromatograms')]//div[contains(@alt, 'Chromatogram 13418_02_WAA283_3805_071514')]"), 1);
+        waitForElements(Locator.xpath("//table[contains(@lk-region-name, 'PrecursorChromatograms')]//div[contains(@alt, 'Chromatogram 13418_03_WAA283_3805_071514')]"), 1);
         ensureComparisonPlots("PC aa C26:0");
 
         //Go back to Document Summary page
@@ -392,8 +401,12 @@ public class TargetedMSExperimentTest extends TargetedMSTest
 
         clickAndWait(Locator.linkContainingText("lysoPC a C14:0").index(0));
         assertTextPresent("Small Molecule Summary");
-        assertElementPresent(Locator.xpath("//img[contains(@src, 'generalMoleculeChromatogramChart.view')]"));
-        assertElementPresent(Locator.xpath("//img[contains(@src, 'precursorChromatogramChart.view')]"));
+        // Check the chromatogram plots
+        assertElementPresent(Locator.xpath("//table[contains(@lk-region-name, 'MoleculePrecursorChromatograms')]"));
+        waitForElements(Locator.xpath("//table[contains(@lk-region-name, 'MoleculePrecursorChromatograms')]//div[contains(@alt, 'Chromatogram 13417_02_WAA283_3805_071514')]"), 2);
+        waitForElements(Locator.xpath("//table[contains(@lk-region-name, 'MoleculePrecursorChromatograms')]//div[contains(@alt, 'Chromatogram 13417_03_WAA283_3805_071514')]"), 2);
+        waitForElements(Locator.xpath("//table[contains(@lk-region-name, 'MoleculePrecursorChromatograms')]//div[contains(@alt, 'Chromatogram 13418_02_WAA283_3805_071514')]"), 2);
+        waitForElements(Locator.xpath("//table[contains(@lk-region-name, 'MoleculePrecursorChromatograms')]//div[contains(@alt, 'Chromatogram 13418_03_WAA283_3805_071514')]"), 2);
         ensureComparisonPlots("lysoPC a C14:0");
         assertElementPresent(Locator.xpath("//a[contains(@href, 'moleculePrecursorAllChromatogramsChart.view')]"));
 
@@ -401,7 +414,12 @@ public class TargetedMSExperimentTest extends TargetedMSTest
 
         clickAndWait(Locator.linkContainingText("lysoPC a C14:0").index(1));
         assertTextPresent("Molecule Precursor Chromatograms");
-        assertElementPresent(Locator.xpath("//img[contains(@src, 'precursorChromatogramChart.view')]"), 4);
+        // Check the chromatogram plots
+        assertElementPresent(Locator.xpath("//table[contains(@lk-region-name, 'PrecursorChromatograms')]"));
+        waitForElements(Locator.xpath("//table[contains(@lk-region-name, 'PrecursorChromatograms')]//div[contains(@alt, 'Chromatogram 13417_02_WAA283_3805_071514')]"), 1);
+        waitForElements(Locator.xpath("//table[contains(@lk-region-name, 'PrecursorChromatograms')]//div[contains(@alt, 'Chromatogram 13417_03_WAA283_3805_071514')]"), 1);
+        waitForElements(Locator.xpath("//table[contains(@lk-region-name, 'PrecursorChromatograms')]//div[contains(@alt, 'Chromatogram 13418_02_WAA283_3805_071514')]"), 1);
+        waitForElements(Locator.xpath("//table[contains(@lk-region-name, 'PrecursorChromatograms')]//div[contains(@alt, 'Chromatogram 13418_03_WAA283_3805_071514')]"), 1);
         ensureComparisonPlots("lysoPC a C14:0");
 
         //Go to Small Molecule Transition List

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSLibraryTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSLibraryTest.java
@@ -211,7 +211,7 @@ public class TargetedMSLibraryTest extends TargetedMSTest
         WebElement width= getDriver().findElement(By.xpath("//input[contains(@id, 'chartWidth-inputEl')]"));
         width.clear();
         width.sendKeys("500");
-        click(Locator.xpath("//a[contains(@class, 'x4-btn x-unselectable x4-box-item x4-toolbar-item x4-btn-default-small x4-noicon x4-btn-noicon x4-btn-default-small-noicon')]"));
+        clickButton("Update",0);
         ensureComparisonPlots("CTCF");
     }
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSMultiplePeptidePlotTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSMultiplePeptidePlotTest.java
@@ -1,0 +1,89 @@
+package org.labkey.test.tests.targetedms;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.Locator;
+import org.labkey.test.categories.Daily;
+import org.labkey.test.components.ext4.ComboBox;
+import org.labkey.test.util.DataRegionTable;
+import org.openqa.selenium.WebElement;
+
+import java.io.File;
+import java.util.List;
+
+@Category({Daily.class})
+@BaseWebDriverTest.ClassTimeout(minutes = 2)
+public class TargetedMSMultiplePeptidePlotTest extends TargetedMSTest
+{
+    @BeforeClass
+    public static void setupProject()
+    {
+        TargetedMSMultiplePeptidePlotTest init = (TargetedMSMultiplePeptidePlotTest) getCurrentTest();
+        init.setupFolder(FolderType.Library);
+    }
+
+    @Override
+    protected String getProjectName()
+    {
+        return "TargetedMS Multiple Peptide Plot Test";
+    }
+
+    @Test
+    public void testMultiplePeptidePlotOnSameChromatogram()
+    {
+        goToProjectHome();
+        importData(SProCoP_FILE);
+
+        goToProjectHome();
+        clickAndWait(Locator.linkWithText(SProCoP_FILE));
+
+        log("Clicking one of the proteins");
+        clickAndWait(Locator.linkWithText("gi|14278146|pdb|1B8E|"));
+
+        log("Verifying the number of plots is same as number of replicates");
+        DataRegionTable table = new DataRegionTable.DataRegionFinder(getDriver()).withName("GroupChromatograms").waitFor();
+        table.clickHeaderMenu("Row Size", "1 per row");
+        table.getPagingWidget().clickShowAll();
+        checker().verifyEquals("Number of plots is not same as number of replicates", 47, table.getDataRowCount());
+
+        log("Verifying the paging controls");
+        table.clickHeaderMenu("Row Size", "4 per row");
+        checker().verifyEquals("Incorrect rows of replicate displayed for 4 per row", 12, table.getDataRowCount());
+
+        table.clickHeaderMenu("Row Size", "10 per row");
+        checker().verifyEquals("Incorrect rows of replicate displayed for 10 per row", 5, table.getDataRowCount());
+
+        log("Verifying Display chart settings");
+        String height = "800";
+        String width = "500";
+        String replicateName = "Q_Exactive_08_09_2013_JGB_32";
+
+        click(Locator.tagWithText("strong", "Display Chart Settings"));
+        setFormElement(Locator.name("chartWidth"), width);
+        setFormElement(Locator.name("chartHeight"), height);
+        new ComboBox.ComboBoxFinder(getDriver()).withInputNamed("replicatesFilter")
+                .findWhenNeeded(getDriver()).setMultiSelect(true).selectComboBoxItem(replicateName);
+        clickButton("Update");
+
+        checker().verifyEquals("Only one graph should have been displayed", 1, table.getDataRowCount());
+        checker().verifyEquals("Incorrect width of the plot", width,
+                Locator.tagWithAttribute("rect", "x", "0").findElement(getDriver()).getAttribute("width"));
+        checker().verifyEquals("Incorrect height of the plot", height,
+                Locator.tagWithAttribute("rect", "x", "0").findElement(getDriver()).getAttribute("height"));
+        checker().verifyTrue("Incorrect replicate", isElementPresent(Locator.tagContainingText("div", replicateName)));
+
+        log("Verifying exporting of PNG and PDF plots");
+        mouseOver(Locator.tagWithAttributeContaining("div", "alt", "Chromatogram"));
+        File pdfFile = doAndWaitForDownload(() -> click(Locator.tagWithClass("i", "fa fa-file-pdf-o")));
+        File pngFile = doAndWaitForDownload(() -> click(Locator.tagWithClass("i", "fa fa-file-image-o")));
+        checker().verifyTrue("Error in exported PDF file", pdfFile.length() != 0);
+        checker().verifyTrue("Error in exported PNG file", pngFile.length() != 0);
+
+        log("Verifying the chromatogram plots for peptides");
+        clickAndWait(Locator.linkWithText("VYVEELKPTPEGDLEILLQK"));
+        List<WebElement> svgs = Locator.tag("svg").findElements(new DataRegionTable("PeptidePrecursorChromatograms", getDriver()));
+        checker().verifyEquals("Incorrect SVG graphs", 20, svgs.size());
+    }
+}

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -713,7 +713,8 @@ public class TargetedMSQCTest extends TargetedMSTest
         if (plotType == CUSUMm || plotType == QCPlotsWebPart.QCPlotType.CUSUMv)
             expectedNumPointsPerSeries *= 2;
 
-        String[] legendItemColors = new String[]{"#66C2A5", "#FC8D62", "#8DA0CB", "#E78AC3", "#A6D854", "#FFD92F", "#E5C494"};
+        // Use the same color assignments that Skyline generates for multi-molecule plots
+        String[] legendItemColors = new String[]{"#755538", "#A1A4AD", "#E2A0AF", "#ED8CFF", "#D19D00", "#70A783", "#00625F"};
 
         PanoramaDashboard qcDashboard = new PanoramaDashboard(this);
         QCPlotsWebPart qcPlotsWebPart = qcDashboard.getQcPlotsWebPart();

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSSkydTextIdTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSSkydTextIdTest.java
@@ -104,7 +104,7 @@ public class TargetedMSSkydTextIdTest extends TargetedMSTest
     private void verifyChromatogramReplicates(List<String> detailHrefs, String...expectedReplicates) throws Exception
     {
         List<Locator> locators = Arrays.stream(expectedReplicates)
-                .map(rep->Locator.xpath("//img[@alt='Chromatogram " + rep + "']"))
+                .map(rep->Locator.xpath("//div[@alt='Chromatogram " + rep + "']"))
                 .collect(Collectors.toList());
         for (String href : detailHrefs)
         {

--- a/webapp/TargetedMS/css/QCSummary.css
+++ b/webapp/TargetedMS/css/QCSummary.css
@@ -54,6 +54,7 @@
 .qc-summary-text {
     padding-top: 5px;
     padding-bottom: 5px;
+    padding-right: 10em;
 }
 
 .sample-file-field-label {

--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -571,7 +571,7 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
             return precursor + ' - ' + this.getMetricPropsById(this.metric).name;
     },
 
-    addEachCombinedPrecusorPlot: function(plotIndex, id, combinePlotData, groupColors, yAxisCount, metricProps, showLogInvalid, legendMargin, plotType, isCUSUMMean) {
+    addEachCombinedPrecursorPlot: function(plotIndex, id, combinePlotData, groupColors, yAxisCount, metricProps, showLogInvalid, legendMargin, plotType, isCUSUMMean) {
         var plotLegendData = this.getCombinedPlotLegendData(metricProps, groupColors, yAxisCount, plotType, isCUSUMMean);
 
         if (plotType !== LABKEY.vis.TrendingLinePlotType.CUSUM) {
@@ -650,7 +650,7 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
         this.attachPlotExportIcons(id, mainTitle + '- All Series', plotIndex, this.getPlotWidth(), this.showInPlotLegends() ? 0 : legendMargin);
     },
 
-    addEachIndividualPrecusorPlot: function(plotIndex, id, precursorIndex, precursorInfo, metricProps, plotType, isCUSUMMean, scope) {
+    addEachIndividualPrecursorPlot: function(plotIndex, id, precursorIndex, precursorInfo, metricProps, plotType, isCUSUMMean, scope) {
         if (this.yAxisScale == 'log' && plotType != LABKEY.vis.TrendingLinePlotType.LeveyJennings && plotType != LABKEY.vis.TrendingLinePlotType.CUSUM)
         {
             Ext4.get(id).update("<span style='font-style: italic;'>Values that are 0 have been replaced with 0.0000001 for log scale plot.</span>");

--- a/webapp/TargetedMS/js/QCPlotHelperWrapper.js
+++ b/webapp/TargetedMS/js/QCPlotHelperWrapper.js
@@ -57,19 +57,19 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperWrapper", {
                 // add a new panel for each plot so we can add the title to the frame
                 if (this.showLJPlot())
                 {
-                    this.addEachIndividualPrecusorPlot(plotIndex, ids[plotIndex++], i, precursorInfo, metricProps, LABKEY.vis.TrendingLinePlotType.LeveyJennings, undefined, me);
+                    this.addEachIndividualPrecursorPlot(plotIndex, ids[plotIndex++], i, precursorInfo, metricProps, LABKEY.vis.TrendingLinePlotType.LeveyJennings, undefined, me);
                 }
                 if (this.showMovingRangePlot())
                 {
-                    this.addEachIndividualPrecusorPlot(plotIndex, ids[plotIndex++], i, precursorInfo, metricProps, LABKEY.vis.TrendingLinePlotType.MovingRange, undefined, me);
+                    this.addEachIndividualPrecursorPlot(plotIndex, ids[plotIndex++], i, precursorInfo, metricProps, LABKEY.vis.TrendingLinePlotType.MovingRange, undefined, me);
                 }
                 if (this.showMeanCUSUMPlot())
                 {
-                    this.addEachIndividualPrecusorPlot(plotIndex, ids[plotIndex++], i, precursorInfo, metricProps, LABKEY.vis.TrendingLinePlotType.CUSUM, true, me);
+                    this.addEachIndividualPrecursorPlot(plotIndex, ids[plotIndex++], i, precursorInfo, metricProps, LABKEY.vis.TrendingLinePlotType.CUSUM, true, me);
                 }
                 if (this.showVariableCUSUMPlot())
                 {
-                    this.addEachIndividualPrecusorPlot(plotIndex, ids[plotIndex], i, precursorInfo, metricProps, LABKEY.vis.TrendingLinePlotType.CUSUM, false, me);
+                    this.addEachIndividualPrecursorPlot(plotIndex, ids[plotIndex], i, precursorInfo, metricProps, LABKEY.vis.TrendingLinePlotType.CUSUM, false, me);
                 }
             }
         }
@@ -150,19 +150,19 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperWrapper", {
 
         if (this.showLJPlot())
         {
-            this.addEachCombinedPrecusorPlot(plotIndex, ids[plotIndex++], combinePlotData, groupColors, yAxisCount, metricProps, showLogInvalid, legendMargin, LABKEY.vis.TrendingLinePlotType.LeveyJennings);
+            this.addEachCombinedPrecursorPlot(plotIndex, ids[plotIndex++], combinePlotData, groupColors, yAxisCount, metricProps, showLogInvalid, legendMargin, LABKEY.vis.TrendingLinePlotType.LeveyJennings);
         }
         if (this.showMovingRangePlot())
         {
-            this.addEachCombinedPrecusorPlot(plotIndex, ids[plotIndex++], combinePlotData, groupColors, yAxisCount, metricProps, showLogInvalid, legendMargin, LABKEY.vis.TrendingLinePlotType.MovingRange);
+            this.addEachCombinedPrecursorPlot(plotIndex, ids[plotIndex++], combinePlotData, groupColors, yAxisCount, metricProps, showLogInvalid, legendMargin, LABKEY.vis.TrendingLinePlotType.MovingRange);
         }
         if (this.showMeanCUSUMPlot())
         {
-            this.addEachCombinedPrecusorPlot(plotIndex, ids[plotIndex++], combinePlotData, groupColors, yAxisCount, metricProps, showLogInvalid, legendMargin, LABKEY.vis.TrendingLinePlotType.CUSUM, true);
+            this.addEachCombinedPrecursorPlot(plotIndex, ids[plotIndex++], combinePlotData, groupColors, yAxisCount, metricProps, showLogInvalid, legendMargin, LABKEY.vis.TrendingLinePlotType.CUSUM, true);
         }
         if (this.showVariableCUSUMPlot())
         {
-            this.addEachCombinedPrecusorPlot(plotIndex, ids[plotIndex], combinePlotData, groupColors, yAxisCount, metricProps, showLogInvalid, legendMargin, LABKEY.vis.TrendingLinePlotType.CUSUM, false);
+            this.addEachCombinedPrecursorPlot(plotIndex, ids[plotIndex], combinePlotData, groupColors, yAxisCount, metricProps, showLogInvalid, legendMargin, LABKEY.vis.TrendingLinePlotType.CUSUM, false);
         }
 
         return true;
@@ -182,21 +182,22 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperWrapper", {
 
     getPlotTypeProperties: function(precursorInfo, plotType, isMean)
     {
-        if (plotType == LABKEY.vis.TrendingLinePlotType.MovingRange)
+        if (plotType === LABKEY.vis.TrendingLinePlotType.MovingRange)
             return this.getMovingRangePlotTypeProperties(precursorInfo);
-        else if (plotType == LABKEY.vis.TrendingLinePlotType.CUSUM)
+        else if (plotType === LABKEY.vis.TrendingLinePlotType.CUSUM)
             return this.getCUSUMPlotTypeProperties(precursorInfo, isMean);
         else
             return this.getLJPlotTypeProperties(precursorInfo);
     },
 
-    getInitFragmentPlotData: function(fragment, dataType, mz)
+    getInitFragmentPlotData: function(fragment, dataType, mz, color)
     {
         var fragmentData = {
             fragment: fragment,
             dataType: dataType,
             data: [],
-            mz: mz
+            mz: mz,
+            color: color
         };
 
         Ext4.apply(fragmentData, this.getInitPlotMinMaxData());
@@ -230,9 +231,10 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperWrapper", {
     {
         var dataType = plotDataRow['DataType'];
         var mz = Ext4.util.Format.number(plotDataRow['mz'], '0.0000');
+        var color = plotDataRow['SeriesColor'];
         if (!this.fragmentPlotData[fragment])
         {
-            this.fragmentPlotData[fragment] = this.getInitFragmentPlotData(fragment, dataType, mz);
+            this.fragmentPlotData[fragment] = this.getInitFragmentPlotData(fragment, dataType, mz, color);
         }
 
         var seriesType = row['SeriesType'] === 2 ? 'series2' : 'series1';

--- a/webapp/TargetedMS/js/QCSummaryPanel.js
+++ b/webapp/TargetedMS/js/QCSummaryPanel.js
@@ -52,9 +52,15 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
                 container.parentOnly = containers.length == 1;
                 if (this.qcPlotPanel.qcIntrumentsArr) {
                     if (this.qcPlotPanel.qcIntrumentsArr.length > 1) {
-                        var msg = 'We recommend that each instrument use its own QC folder.'
-                        container.instrument = ' for multiple instruments - ' + this.qcPlotPanel.qcIntrumentsArr.join(', ') + '. ' + msg;
-
+                        let msg = 'We recommend that each instrument use its own QC folder.';
+                        container.instrument = ' for multiple instruments: ';
+                        let separator = '';
+                        for (let index = 0; index < this.qcPlotPanel.qcIntrumentsArr.length; index++) {
+                            let currentInstrument = this.qcPlotPanel.qcIntrumentsArr[index];
+                            container.instrument += separator + (currentInstrument ? currentInstrument : 'unknown instrument');
+                            separator = ', ';
+                        }
+                        container.instrument += '. ' + msg;
                     }
                     else if (this.qcPlotPanel.qcIntrumentsArr.length === 1 && this.qcPlotPanel.qcIntrumentsArr[0]) {
                         container.instrument = ' for ' + this.qcPlotPanel.qcIntrumentsArr[0];

--- a/webapp/TargetedMS/js/QCSummaryPanel.js
+++ b/webapp/TargetedMS/js/QCSummaryPanel.js
@@ -56,7 +56,7 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
                         container.instrument = ' for multiple instruments - ' + this.qcPlotPanel.qcIntrumentsArr.join(', ') + '. ' + msg;
 
                     }
-                    else if (this.qcPlotPanel.qcIntrumentsArr.length === 1) {
+                    else if (this.qcPlotPanel.qcIntrumentsArr.length === 1 && this.qcPlotPanel.qcIntrumentsArr[0]) {
                         container.instrument = ' for ' + this.qcPlotPanel.qcIntrumentsArr[0];
                     }
                 }

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -1931,7 +1931,16 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     },
 
     getColorRange: function() {
-        return LABKEY.vis.Scale.ColorDiscrete().concat(LABKEY.vis.Scale.DarkColorDiscrete());
+        // Use our default colors
+        const result = LABKEY.vis.Scale.ColorDiscrete().concat(LABKEY.vis.Scale.DarkColorDiscrete());
+
+        // But override them with colors assigned by the server, when available, so that we match Skyline's assignment
+        for (let i = 0; i < this.precursors.length; i++) {
+            if (this.fragmentPlotData[this.precursors[i]].color) {
+                result[i] = this.fragmentPlotData[this.precursors[i]].color;
+            }
+        }
+        return result;
     }
 
 });

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -1936,7 +1936,8 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
 
         // But override them with colors assigned by the server, when available, so that we match Skyline's assignment
         for (let i = 0; i < this.precursors.length; i++) {
-            if (this.fragmentPlotData[this.precursors[i]].color) {
+            // We only get data points for the precursors in the current "page" so double check that it's in the fragmentPlotData object
+            if (this.fragmentPlotData[this.precursors[i]] && this.fragmentPlotData[this.precursors[i]].color) {
                 result[i] = this.fragmentPlotData[this.precursors[i]].color;
             }
         }

--- a/webapp/TargetedMS/js/svgChart.js
+++ b/webapp/TargetedMS/js/svgChart.js
@@ -24,7 +24,7 @@ if (!LABKEY.targetedms.SVGChart) {
 
                     var plotAndTitleHtml = '';
                     if (titleTransformer) {
-                        plotAndTitleHtml += '<div style="text-align: center; word-break: break-word">' +
+                        plotAndTitleHtml += '<div style="text-align: center; white-space: normal; word-break: break-word">' +
                                 LABKEY.Utils.encodeHtml(titleTransformer(parsedResponse.title)).split('\n').join('<br>') +
                                 '</div>';
                     }


### PR DESCRIPTION
#### Rationale
Users want to see all of the peptide or molecules that belong to a grouping at once so that they can compare their peaks against each other, and across replicates

#### Changes
* Introduce per-replicate, multi-peptide/molecule plots to the protein/molecule list details page
* Support selecting/unselecting from peptide/molecule list to narrow what's included in the plot
* Use SVG plots for chromatograms 
* Avoid showing "undefined" in QC summary panel when we don't know anything about the instrument that produced the data
* Steal Skyline code (and implement C# String hash code calculation) for molecule color selection
* Issue 43455: InternalError from org.labkey.targetedms.TargetedMSController.writeChart() when Linux fonts are missing
