### PR TITLE
Issue 43544: ArrayIndexOutOfBoundsException in org.labkey.targetedmsparser.TimeIntensities.interpolate()

### DIFF
--- a/src/org/labkey/targetedms/parser/TimeIntensities.java
+++ b/src/org/labkey/targetedms/parser/TimeIntensities.java
@@ -36,6 +36,10 @@ public class TimeIntensities
     public TimeIntensities interpolate(float[] timesNew)
     {
         float[] intensNew = new float[timesNew.length];
+        if (timesNew.length == 0)
+        {
+            return new TimeIntensities(timesNew, intensNew);
+        }
         int iTime = 0;
         double timeLast = timesNew[0];
         double intenLast = _intensities[0];


### PR DESCRIPTION
Issue 43544: ArrayIndexOutOfBoundsException in org.labkey.targetedmsparser.TimeIntensities.interpolate()