### PR TITLE
Increase timeout for TargetedMSQCTest

### DIFF
--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -41,6 +41,7 @@ import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.LogMethod;
+import org.labkey.test.util.LoggedParam;
 import org.labkey.test.util.PipelineStatusTable;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.targetedms.QCHelper;
@@ -466,7 +467,8 @@ public class TargetedMSQCTest extends TargetedMSTest
         qcPlotsWebPart.resetInitialQCPlotFields();
     }
 
-    private void testEachMultiSeriesQCPlot(QCPlotsWebPart.QCPlotType plotType)
+    @LogMethod
+    private void testEachMultiSeriesQCPlot(@LoggedParam QCPlotsWebPart.QCPlotType plotType)
     {
         log("Test plot type " + plotType.getLongLabel());
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -61,7 +61,7 @@ import static org.labkey.test.components.targetedms.QCPlotsWebPart.QCPlotType.Le
 import static org.labkey.test.components.targetedms.QCPlotsWebPart.QCPlotType.MovingRange;
 
 @Category({Daily.class, MS2.class})
-@BaseWebDriverTest.ClassTimeout(minutes = 28)
+@BaseWebDriverTest.ClassTimeout(minutes = 35)
 public class TargetedMSQCTest extends TargetedMSTest
 {
     private static final String[] PRECURSORS = {


### PR DESCRIPTION
#### Rationale
[The total runtime for TargetedMSQCTest](https://teamcity.labkey.org/test/2672876845889446132?currentProjectId=LabkeyTrunk_DailySuites) had been consistently around 25 minutes before September then dipped to 20 minutes on October 4th then graduallly increased to 28 minutes for the past couple of weeks. Now, it occasionally exceeds the current 30 minute timeout.
There were several targetedms changes around the time the test sped up {[1](https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailySuites_DailyEPostgres/1556200?buildTab=changes), [2](https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailySuites_DailyEPostgres/1557962?buildTab=changes), [3](https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailySuites_DailyEPostgres/1559934?buildTab=changes)} but no clear explanation for it or the subsequent slowdown.

For now, I'm just going to increase the timeout to clean up TeamCity test results a bit.

#### Changes
* Increase the timeout of `TargetedMSQCTest`
