### PR TITLE
Issue 44321: Reproducibility report improvements

### DIFF
--- a/resources/queries/targetedms/PassportMxN.sql
+++ b/resources/queries/targetedms/PassportMxN.sql
@@ -4,7 +4,7 @@ SELECT
     PrecursorId.Id,
     SampleFileId.ReplicateId.Name AS Replicate,
     SampleFileId.AcquiredTime AS AcquiredTime,
-    COALESCE(ifdefined(SampleFileId.ReplicateId.Day), ifdefined(SampleFileId.ReplicateId.SampleGroup)) AS Timepoint,
+    COALESCE(SampleFileId.ReplicateId.BatchName, ifdefined(SampleFileId.ReplicateId.Day), ifdefined(SampleFileId.ReplicateId.SampleGroup)) AS Timepoint,
     ifdefined(SampleFileId.ReplicateId.SampleGroup2) AS Grouping,
     PrecursorId.PeptideId.PeptideGroupId.Label AS ProteinName,
     PrecursorId.PeptideId.PeptideGroupId.SequenceId.SeqId AS seq,

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -1512,6 +1512,7 @@ public class TargetedMSController extends SpringActionController
 
             ChromatogramChartMakerFactory factory = new ChromatogramChartMakerFactory();
             factory.setSyncIntensity(form.isSyncY());
+            factory.setSyncIntensityBasedOnPrecursor(form.isSyncYBasedOnPrecursor());
             factory.setSyncRt(form.isSyncX());
             factory.setSplitGraph(form.isSplitGraph());
             factory.setShowOptimizationPeaks(form.isShowOptimizationPeaks());
@@ -2217,6 +2218,7 @@ public class TargetedMSController extends SpringActionController
     {
         private long _id;
         private boolean _syncY = false;
+        private boolean _syncYBasedOnPrecursor = false;
         private boolean _syncX = false;
         private boolean _splitGraph = false;
         private boolean _showOptimizationPeaks = false;
@@ -2324,6 +2326,16 @@ public class TargetedMSController extends SpringActionController
         public void setSyncY(boolean syncY)
         {
             _syncY = syncY;
+        }
+
+        public boolean isSyncYBasedOnPrecursor()
+        {
+            return _syncYBasedOnPrecursor;
+        }
+
+        public void setSyncYBasedOnPrecursor(boolean syncYBasedOnPrecursor)
+        {
+            _syncYBasedOnPrecursor = syncYBasedOnPrecursor;
         }
 
         public boolean isSyncX()

--- a/src/org/labkey/targetedms/TargetedMSSchema.java
+++ b/src/org/labkey/targetedms/TargetedMSSchema.java
@@ -992,14 +992,14 @@ public class TargetedMSSchema extends UserSchema
             labelColumn.setURL(result.getDetailsURL(null, null));
             if (proteomics)
             {
-                // Figure out if we have at least 3 replicates marked as QCs, and we have a "Day" annotation column
-                SQLFragment reproducibilitySQL = new SQLFragment("(SELECT CASE WHEN COUNT(*) > 2 THEN COUNT(*) END FROM ");
+                // Figure out if we have at least 3 replicates marked as QCs, and we have a "Day" or "SampleGroup" annotation, or a value for BatchName
+                SQLFragment reproducibilitySQL = new SQLFragment("(SELECT CASE WHEN COUNT(DISTINCT r.Id) > 2 THEN COUNT(DISTINCT r.Id) END FROM ");
                 reproducibilitySQL.append(TargetedMSManager.getTableInfoReplicate(), "r");
-                reproducibilitySQL.append(" INNER JOIN ");
+                reproducibilitySQL.append(" LEFT OUTER JOIN ");
                 reproducibilitySQL.append(TargetedMSManager.getTableInfoReplicateAnnotation(), "ra");
-                reproducibilitySQL.append(" ON ra.ReplicateId = r.Id AND LOWER(ra.Name) = 'day' WHERE r.RunId = ");
+                reproducibilitySQL.append(" ON ra.ReplicateId = r.Id AND (LOWER(ra.Name) = 'day' OR LOWER(ra.Name) = 'samplegroup') WHERE r.RunId = ");
                 reproducibilitySQL.append(ExprColumn.STR_TABLE_ALIAS);
-                reproducibilitySQL.append(".RunId AND (r.SampleType IS NULL OR r.SampleType IN ('qc'))");
+                reproducibilitySQL.append(".RunId AND (r.SampleType IS NULL OR r.SampleType IN ('qc')) AND (ra.ReplicateId IS NOT NULL OR r.BatchName IS NOT NULL)");
                 reproducibilitySQL.append(")");
 
                 // Render a link to the reproducibility report

--- a/src/org/labkey/targetedms/chart/ChromatogramChartMakerFactory.java
+++ b/src/org/labkey/targetedms/chart/ChromatogramChartMakerFactory.java
@@ -41,6 +41,7 @@ public class ChromatogramChartMakerFactory
     private boolean _splitGraph;
     private boolean _showOptimizationPeaks;
     private boolean _legend = true;
+    private boolean _syncIntensityBasedOnPrecursor;
 
     public void setSyncIntensity(boolean syncIntensity)
     {
@@ -87,12 +88,12 @@ public class ChromatogramChartMakerFactory
         }
         else if(!_splitGraph)
         {
-            return new ChromatogramChartMaker().make(new ChromatogramDataset.PrecursorDataset(pChromInfo, _syncIntensity, _syncRt, user, container), _legend);
+            return new ChromatogramChartMaker().make(new ChromatogramDataset.PrecursorDataset(pChromInfo, _syncIntensity, _syncIntensityBasedOnPrecursor, _syncRt, user, container), _legend);
         }
         else
         {
-            ChromatogramDataset.PrecursorDataset precursorIonDataset = new ChromatogramDataset.PrecursorSplitDataset(pChromInfo, _syncIntensity, _syncRt, user, container);
-            ChromatogramDataset.PrecursorDataset productIonDataset = new ChromatogramDataset.ProductSplitDataset(pChromInfo, _syncIntensity, _syncRt, user, container) {
+            ChromatogramDataset.PrecursorDataset precursorIonDataset = new ChromatogramDataset.PrecursorSplitDataset(pChromInfo, _syncIntensity, _syncIntensityBasedOnPrecursor, _syncRt, user, container);
+            ChromatogramDataset.PrecursorDataset productIonDataset = new ChromatogramDataset.ProductSplitDataset(pChromInfo, _syncIntensity, _syncIntensityBasedOnPrecursor, _syncRt, user, container) {
                 @Override
                 int getSeriesOffset()
                 {
@@ -108,11 +109,11 @@ public class ChromatogramChartMakerFactory
     {
         if(!_splitGraph)
         {
-            return new ChromatogramChartMaker().make(new ChromatogramDataset.MoleculePrecursorDataset(pChromInfo, _syncIntensity, _syncRt, user, container));
+            return new ChromatogramChartMaker().make(new ChromatogramDataset.MoleculePrecursorDataset(pChromInfo, _syncIntensity, _syncIntensityBasedOnPrecursor, _syncRt, user, container));
         }
         else
         {
-            ChromatogramDataset.PrecursorDataset precursorIonDataset = new ChromatogramDataset.MoleculePrecursorDataset(pChromInfo, _syncIntensity, _syncRt, user, container)
+            ChromatogramDataset.PrecursorDataset precursorIonDataset = new ChromatogramDataset.MoleculePrecursorDataset(pChromInfo, _syncIntensity, _syncIntensityBasedOnPrecursor, _syncRt, user, container)
             {
                 @Override
                 Transition.Type getTransitionType()
@@ -126,7 +127,7 @@ public class ChromatogramChartMakerFactory
                     return transition.isPrecursorIon();
                 }
             };
-            ChromatogramDataset.PrecursorDataset productIonDataset = new ChromatogramDataset.MoleculePrecursorDataset(pChromInfo, _syncIntensity, _syncRt, user, container) {
+            ChromatogramDataset.PrecursorDataset productIonDataset = new ChromatogramDataset.MoleculePrecursorDataset(pChromInfo, _syncIntensity, _syncIntensityBasedOnPrecursor, _syncRt, user, container) {
 
                 @Override
                 Transition.Type getTransitionType()
@@ -167,5 +168,15 @@ public class ChromatogramChartMakerFactory
     public JFreeChart createGroupChart(PeptideGroup group, SampleFile sampleFile, ViewContext context)
     {
         return new ChromatogramChartMaker().make(new ChromatogramDataset.GroupDataset(group, sampleFile, context, _syncIntensity, _syncRt), false, "Retention Time", "Intensity");
+    }
+
+    public void setSyncIntensityBasedOnPrecursor(boolean syncIntensityBasedOnPrecursor)
+    {
+        _syncIntensityBasedOnPrecursor = syncIntensityBasedOnPrecursor;
+    }
+
+    public boolean getSyncIntensityBasedOnPrecursor()
+    {
+        return _syncIntensityBasedOnPrecursor;
     }
 }

--- a/src/org/labkey/targetedms/query/PrecursorManager.java
+++ b/src/org/labkey/targetedms/query/PrecursorManager.java
@@ -38,6 +38,7 @@ import org.labkey.targetedms.TargetedMSSchema;
 import org.labkey.targetedms.chart.ChromatogramDataset.RtRange;
 import org.labkey.targetedms.model.PrecursorChromInfoLitePlus;
 import org.labkey.targetedms.model.PrecursorChromInfoPlus;
+import org.labkey.targetedms.parser.GeneralPrecursor;
 import org.labkey.targetedms.parser.Precursor;
 import org.labkey.targetedms.parser.PrecursorChromInfo;
 
@@ -544,7 +545,7 @@ public class PrecursorManager
      * This can be used for getting the height of the tallest transition peak for a peptide over all the replicates
      * when we are synchronizing the intensity axis for transition peak chromatograms.
      */
-    public static Double getMaxPrecursorMaxHeight(long generalMoleculeId)
+    public static Double getMaxPrecursorMaxHeight(long generalMoleculeId, @Nullable GeneralPrecursor<?> precursor)
     {
         SQLFragment sql = new SQLFragment("SELECT MAX(pci.maxHeight) FROM ");
         sql.append(TargetedMSManager.getTableInfoPrecursorChromInfo(), "pci");
@@ -554,6 +555,11 @@ public class PrecursorManager
         sql.append(" WHERE");
         sql.append(" gmci.GeneralMoleculeId=?");
         sql.add(generalMoleculeId);
+        if (precursor != null)
+        {
+            sql.append(" AND pci.PrecursorId=?");
+            sql.add(precursor.getId());
+        }
 
         return new SqlSelector(TargetedMSManager.getSchema(), sql).getObject(Double.class);
     }

--- a/src/org/labkey/targetedms/query/TransitionManager.java
+++ b/src/org/labkey/targetedms/query/TransitionManager.java
@@ -29,6 +29,7 @@ import org.labkey.targetedms.TargetedMSManager;
 import org.labkey.targetedms.TargetedMSSchema;
 import org.labkey.targetedms.chart.ChromatogramDataset;
 import org.labkey.targetedms.chart.ChromatogramDataset.RtRange;
+import org.labkey.targetedms.parser.GeneralPrecursor;
 import org.labkey.targetedms.parser.GeneralTransition;
 import org.labkey.targetedms.parser.PrecursorChromInfo;
 import org.labkey.targetedms.parser.Transition;
@@ -118,7 +119,7 @@ public class TransitionManager
                                  .getObject(TransitionChromInfo.class);
     }
 
-    public static Double getMaxTransitionIntensity(long generalMoleculeId, Transition.Type fragmentType)
+    public static Double getMaxTransitionIntensity(long generalMoleculeId, @Nullable GeneralPrecursor<?> precursor, Transition.Type fragmentType)
     {
         SQLFragment sql = new SQLFragment("SELECT MAX(tci.Height) FROM ");
         sql.append(TargetedMSManager.getTableInfoGeneralMoleculeChromInfo(), "gmci");
@@ -149,6 +150,13 @@ public class TransitionManager
         sql.append(" AND ");
         sql.append("gmci.GeneralMoleculeId=?");
         sql.add(generalMoleculeId);
+
+        if (precursor != null)
+        {
+            sql.append(" AND ");
+            sql.append("preci.PrecursorId=?");
+            sql.add(precursor.getId());
+        }
 
         return new SqlSelector(TargetedMSManager.getSchema(), sql).getObject(Double.class);
     }

--- a/src/org/labkey/targetedms/view/passport/MxNReport.jsp
+++ b/src/org/labkey/targetedms/view/passport/MxNReport.jsp
@@ -63,7 +63,8 @@
             <label for="peptideSort">Sort by:&nbsp;</label>
             <select id="peptideSort" name="peptideSort">
                 <option value="intensity">Intensity</option>
-                <option value="sequencelocation">Sequence Location</option>
+                <option value="sequence">Sequence</option>
+                <option value="sequencelocation" id="sequenceLocationPeptideSortOption">Sequence Location</option>
                 <option value="cv">Coefficient of Variation</option>
             </select>
         </td>

--- a/src/org/labkey/targetedms/view/passport/MxNReport.jsp
+++ b/src/org/labkey/targetedms/view/passport/MxNReport.jsp
@@ -86,9 +86,7 @@
         </td>
         <td style="padding-left: 2em">
             Matching precursors:
-            <span id="filteredPeptideCount">
-                <green><%=protein.getPep().size()%></green>/<%=protein.getPep().size()%>
-            </span>
+            <span id="filteredPrecursorCount"></span>/<span id="totalPrecursorCount"></span>
         </td>
     </tr>
     <tr>

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSMxNReproducibilityReportTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSMxNReproducibilityReportTest.java
@@ -91,6 +91,8 @@ public class TargetedMSMxNReproducibilityReportTest extends TargetedMSTest
                         withTimeout(WAIT_FOR_JAVASCRIPT).
                         isDisplayed());
 
+        checker().screenShotIfNewError("calcurve-and-fom");
+
         log("Verifying Calibration Curves link");
         clickTab("Proteins");
         clickAndWait(calibrationCurvesLink());

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSMxNReproducibilityReportTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSMxNReproducibilityReportTest.java
@@ -78,10 +78,10 @@ public class TargetedMSMxNReproducibilityReportTest extends TargetedMSTest
 
         //TODO : More verifications to add for new sample file.
         checker().verifyTrue("Missing calibration curve webpart",
-                isElementPresent(Locator.css("span.labkey-wp-title-text").withText("Calibration Curve")));
+                waitForElement(Locator.css("span.labkey-wp-title-text").withText("Calibration Curve")) != null);
 
         checker().verifyTrue("Missing Figures of Merit  webpart",
-                isElementPresent(Locator.css("span.labkey-wp-title-text").withText("Figures of Merit")));
+                waitForElement(Locator.css("span.labkey-wp-title-text").withText("Figures of Merit")) != null);
 
         log("Verifying Calibration Curves link");
         clickTab("Proteins");

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSMxNReproducibilityReportTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSMxNReproducibilityReportTest.java
@@ -78,10 +78,18 @@ public class TargetedMSMxNReproducibilityReportTest extends TargetedMSTest
 
         //TODO : More verifications to add for new sample file.
         checker().verifyTrue("Missing calibration curve webpart",
-                waitForElement(Locator.css("span.labkey-wp-title-text").withText("Calibration Curve")) != null);
+                Locator.css("span.labkey-wp-title-text").
+                        withText("Calibration Curve").
+                        findWhenNeeded(getDriver()).
+                        withTimeout(WAIT_FOR_JAVASCRIPT).
+                        isDisplayed());
 
         checker().verifyTrue("Missing Figures of Merit  webpart",
-                waitForElement(Locator.css("span.labkey-wp-title-text").withText("Figures of Merit")) != null);
+                Locator.css("span.labkey-wp-title-text").
+                        withText("Figures of Merit").
+                        findWhenNeeded(getDriver()).
+                        withTimeout(WAIT_FOR_JAVASCRIPT).
+                        isDisplayed());
 
         log("Verifying Calibration Curves link");
         clickTab("Proteins");

--- a/webapp/passport/js/MxN/protein.js
+++ b/webapp/passport/js/MxN/protein.js
@@ -28,6 +28,7 @@ protein =
         protein.selectedPrecursor = precursor;
 
         $('#seriesLegend').empty();
+        $('#precursorRadio' + precursorId).prop("checked", true);
 
         const chromParent = $('#chromatograms');
         chromParent.empty();
@@ -75,7 +76,7 @@ protein =
 
         protein.selectedPrecursor.ReplicateInfo.forEach(function(replicate) {
             const parentElement = $('#chrom' + replicate.PrecursorChromInfoId);
-            LABKEY.targetedms.SVGChart.requestAndRenderSVG(chromatogramUrl + "id=" + replicate.PrecursorChromInfoId + "&syncY=true&syncX=false&chartWidth=275&chartHeight=300",
+            LABKEY.targetedms.SVGChart.requestAndRenderSVG(chromatogramUrl + "id=" + replicate.PrecursorChromInfoId + "&syncY=true&syncYBasedOnPrecursor=true&syncX=false&chartWidth=275&chartHeight=300",
                     parentElement[0],
                     $('#seriesLegend')[0],
                     false,
@@ -285,7 +286,8 @@ protein =
                         activePeptides++
                 });
 
-                $("#filteredPeptideCount > green").text(activePeptides);
+                $("#filteredPrecursorCount").text(activePeptides);
+                $("#totalPrecursorCount").text(protein.precursors.length);
             }
 
             // Coalesce updates to the rest of the plot because the slider can rapidly fire many updates
@@ -451,7 +453,7 @@ protein =
 
                 summaryDataTable.push({
                     precursorChromInfoId: row.precursorChromInfoId,
-                    precursorId: precursorId,
+                    precursorId: parseInt(precursorId),
                     sequence: row.sequence,
                     peptideSequence: row.peptideSequence,
                     charge: row.charge,
@@ -490,9 +492,9 @@ protein =
             summaryDataTable.sort(sortFunction);
 
             let tableHTML = '';
-            summaryDataTable.forEach(function(row) {
+            summaryDataTable.forEach(function(row, index) {
                 tableHTML += '<tr' + (row.enabled ? '' : ' style="text-decoration: line-through; background-color: LightGray"') + '>' +
-                        '<td colspan="2"><a href="#chrom' + row.precursorChromInfoId + '" onclick="protein.selectPrecursor(' + row.precursorId + ', true)">' + LABKEY.Utils.encodeHtml(row.sequence) + '</a></td>' +
+                        '<td colspan="2"><input type="radio" ' + (row.precursorId === protein.selectedPrecursor.PrecursorId ? 'checked="true"' : '') + ' name="precursorRadio" id="precursorRadio' + row.precursorId + '" onclick="protein.selectPrecursor(' + row.precursorId + ', true)" /><a href="#chrom' + row.precursorChromInfoId + '" onclick="protein.selectPrecursor(' + row.precursorId + ', true)">' + LABKEY.Utils.encodeHtml(row.sequence) + '</a></td>' +
                         '<td>' + LABKEY.Utils.encodeHtml((row.charge >= 0 ? '+' : '') + row.charge) + '</td>' +
                         '<td style="text-align: right">' + LABKEY.Utils.encodeHtml(row.mz.toFixed(4)) + '</td>' +
                         '<td style="text-align: right">' + (row.StartIndex ? row.StartIndex : '') + '</td>' +


### PR DESCRIPTION
#### Rationale
A few small-ish improvements to the reproducibility report as requested by users with real data

#### Changes
* Use the existing, built-in BatchName field on replicates as an alternative to the "Day" replicate-level annotation.
* Use a radio button on the listing of precursors to make it clearer which is selected and how to toggle among the precursors.
* For the selected precursor, scale the chromatogram plots based on the maximum Y value of just the selected precursor. At the moment, we're scaling them based on the most intense precursor/replicate combination, so for the less abundant precursors you may have very small peaks.
* Offer sort by Sequence
* Don't offer Sequence Location as a sort when we don't have start index/end index info for the peptides (likely because the grouping doesn't have a protein sequence)