### PR TITLE
Wait for chart settings form to be visible

### DIFF
--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSMultiplePeptidePlotTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSMultiplePeptidePlotTest.java
@@ -7,10 +7,10 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.categories.Daily;
-import org.labkey.test.categories.Data;
 import org.labkey.test.components.ext4.ComboBox;
 import org.labkey.test.util.DataRegionTable;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.io.File;
 import java.util.List;
@@ -63,8 +63,8 @@ public class TargetedMSMultiplePeptidePlotTest extends TargetedMSTest
         String replicateName = "Q_Exactive_08_09_2013_JGB_32";
 
         click(Locator.tagWithText("strong", "Display Chart Settings"));
-        setFormElement(Locator.name("chartWidth"), width);
-        setFormElement(Locator.name("chartHeight"), height);
+        setFormElement(shortWait().until(ExpectedConditions.visibilityOfElementLocated(Locator.name("chartWidth"))), width);
+        setFormElement(shortWait().until(ExpectedConditions.visibilityOfElementLocated(Locator.name("chartHeight"))), height);
         new ComboBox.ComboBoxFinder(getDriver()).withInputNamed("replicatesFilter")
                 .findWhenNeeded(getDriver()).setMultiSelect(true).selectComboBoxItem(replicateName);
         clickButton("Update");


### PR DESCRIPTION
#### Rationale
Wait for form elements to be visible. Should fix intermittent TeamCity failures like:
```
org.openqa.selenium.ElementNotInteractableException: Element <input id="textfield-1012-inputEl" class="x4-form-field x4-form-text" name="chartWidth" type="text"> could not be scrolled into view
  [...]
  at app//org.labkey.test.WebDriverWrapper.setInput(WebDriverWrapper.java:3288)
  at app//org.labkey.test.WebDriverWrapper.setFormElement(WebDriverWrapper.java:3276)
  at app//org.labkey.test.WebDriverWrapper.setFormElement_aroundBody96(WebDriverWrapper.java:3250)
  at app//org.labkey.test.WebDriverWrapper.setFormElement_aroundBody97$advice(WebDriverWrapper.java:40)
  at app//org.labkey.test.WebDriverWrapper.setFormElement(WebDriverWrapper.java:1)
  at app//org.labkey.test.tests.targetedms.TargetedMSMultiplePeptidePlotTest.testMultiplePeptidePlotOnSameChromatogram(TargetedMSMultiplePeptidePlotTest.java:66)
```

#### Changes
* Wait for chart settings form to be visible
