### PR TITLE
Issue 44424: Do not allow documents without replicates in library folders, and fix checkbox behavior when resolving conflicts

### DIFF
--- a/resources/queries/targetedms/peptidegroup/FolderProteins.qview.xml
+++ b/resources/queries/targetedms/peptidegroup/FolderProteins.qview.xml
@@ -1,8 +1,10 @@
 <customView xmlns="http://labkey.org/data/xml/queryCustomView" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         label="All Folder Proteins">
     <columns>
-        <column name="RunId/File" />
         <column name="Label" />
+        <column name="Reproducibility" />
+        <column name="CalibrationCurves" />
+        <column name="RunId/File" />
         <column name="Description" />
         <column name="NoteAnnotations" />
         <column name="RepresentativeDataState/Value" />

--- a/resources/queries/targetedms/peptidegroup/LibraryProteins.qview.xml
+++ b/resources/queries/targetedms/peptidegroup/LibraryProteins.qview.xml
@@ -10,7 +10,7 @@
         <column name="RepresentativeDataState" />
     </columns>
     <filters>
-        <filter column="RepresentativeDataState" operator="notin" value="2"/>
+        <filter column="RepresentativeDataState" operator="eq" value="1"/>
     </filters>
     <sorts>
        <sort column="Label" />

--- a/src/org/labkey/targetedms/SkylineDocImporter.java
+++ b/src/org/labkey/targetedms/SkylineDocImporter.java
@@ -351,6 +351,10 @@ public class SkylineDocImporter
             OptimizationInfo optimizationInfo = insertTransitionSettings(parser.getTransitionSettings());
 
             // 2. Replicates and sample files
+            if((_isProteinLibraryDoc || _isPeptideLibraryDoc) && parser.getReplicateCount() == 0)
+            {
+                throw new PipelineJobException("The Skyline document does not have any replicates. Documents imported to a chromatogram library folder must have chromatograms.");
+            }
             ReplicateInfo replicateInfo = insertReplicates(run, parser, optimizationInfo, folderType);
 
             // 3. Peptide settings

--- a/src/org/labkey/targetedms/view/PeptideGroupViewWebPart.java
+++ b/src/org/labkey/targetedms/view/PeptideGroupViewWebPart.java
@@ -19,8 +19,11 @@ import org.labkey.api.query.QueryParam;
 import org.labkey.api.query.QuerySettings;
 import org.labkey.api.query.QueryView;
 import org.labkey.api.query.UserSchema;
+import org.labkey.api.targetedms.TargetedMSService;
 import org.labkey.api.view.ViewContext;
 import org.labkey.targetedms.TargetedMSSchema;
+
+import static org.labkey.api.targetedms.TargetedMSService.FolderType.LibraryProtein;
 
 public class PeptideGroupViewWebPart extends QueryView
 {
@@ -41,7 +44,11 @@ public class PeptideGroupViewWebPart extends QueryView
         QuerySettings settings = schema.getSettings(portalCtx, dataRegionName, TargetedMSSchema.TABLE_PEPTIDE_GROUP);
 
         if (!portalCtx.getRequest().getParameterMap().containsKey(settings.param(QueryParam.viewName)))
-            settings.setViewName("LibraryProteins");
+        {
+            var folderType = TargetedMSService.get().getFolderType(portalCtx.getContainer());
+            var viewName = folderType == LibraryProtein ? "LibraryProteins" : "";
+            settings.setViewName(viewName);
+        }
 
         return settings;
     }

--- a/src/org/labkey/targetedms/view/precursorConflictResolutionView.jsp
+++ b/src/org/labkey/targetedms/view/precursorConflictResolutionView.jsp
@@ -74,18 +74,18 @@ $(document).ready(function () {
         var oldPrecursorCells = table.cells(".oldPrecursor").nodes();
         var newPrecursorCells = table.cells(".newPrecursor").nodes();
         $(newPrecursorCells).removeClass('representative').addClass('representative');
-        $(newPrecursorCells).find(':checkbox').attr('checked', 'checked');
+        $(newPrecursorCells).find(':checkbox').prop('checked', true);
         $(oldPrecursorCells).removeClass('representative');
-        $(oldPrecursorCells).find(':checkbox').removeAttr('checked');
+        $(oldPrecursorCells).find(':checkbox').prop('checked', false);
     });
     $("#selectAllOld").click(function(){
 
         var oldPrecursorCells = table.cells(".oldPrecursor").nodes();
         var newPrecursorCells = table.cells(".newPrecursor").nodes();
         $(oldPrecursorCells).removeClass('representative').addClass('representative');
-        $(oldPrecursorCells).find(':checkbox').attr('checked', 'checked');
+        $(oldPrecursorCells).find(':checkbox').prop('checked', true);
         $(newPrecursorCells).removeClass('representative');
-        $(newPrecursorCells).find(':checkbox').removeAttr('checked');
+        $(newPrecursorCells).find(':checkbox').prop('checked', false);
     });
 
     table = $("#dataTable").DataTable(
@@ -188,13 +188,13 @@ function toggleCheckboxSelection(element)
 
     if(element.is(":checked"))
     {
-        $("."+cls).removeAttr('checked'); // Both old and new precursor checkboxes have the same class. First deselect all.
-        element.prop('checked', 'checked'); // Select the one that triggered this function call.
+        $("input."+cls+":checkbox").prop('checked', false); // Both old and new precursor checkboxes have the same class. First deselect all.
+        element.prop('checked', true); // Select the one that triggered this function call.
     }
     else
     {
-        $("."+cls).prop('checked', 'checked'); // First select all.
-        element.removeAttr('checked');        // Deselect the one that triggered the function call.
+        $("input."+cls+":checkbox").prop('checked', true); // First select all.
+        element.prop('checked', false);       // Deselect the one that triggered the function call.
     }
 }
 

--- a/src/org/labkey/targetedms/view/proteinConflictResolutionView.jsp
+++ b/src/org/labkey/targetedms/view/proteinConflictResolutionView.jsp
@@ -72,18 +72,18 @@ $(document).ready(function () {
         var oldProteinCells = table.cells(".oldProtein").nodes();
         var newProteinCells = table.cells(".newProtein").nodes();
         $(newProteinCells).removeClass('representative').addClass('representative');
-        $(newProteinCells).find(':checkbox').attr('checked', 'checked');
+        $(newProteinCells).find(':checkbox').prop('checked', true);
         $(oldProteinCells).removeClass('representative');
-        $(oldProteinCells).find(':checkbox').removeAttr('checked');
+        $(oldProteinCells).find(':checkbox').prop('checked', false);
     });
     $("#selectAllOld").click(function(){
 
         var oldProteinCells = table.cells(".oldProtein").nodes();
         var newProteinCells = table.cells(".newProtein").nodes();
         $(oldProteinCells).removeClass('representative').addClass('representative');
-        $(oldProteinCells).find(':checkbox').attr('checked', 'checked');
+        $(oldProteinCells).find(':checkbox').prop('checked', true);
         $(newProteinCells).removeClass('representative');
-        $(newProteinCells).find(':checkbox').removeAttr('checked');
+        $(newProteinCells).find(':checkbox').prop('checked', false);
     });
 
     table = $("#dataTable").DataTable(
@@ -178,19 +178,19 @@ function loadProteinDetails(tr, newProteinId, oldProteinId, response, request) {
 function toggleCheckboxSelection(element)
 {
     var cls = element.attr('class').split(' ')[0]; // get the first class name
-    //console.log(cls);
+    // console.log(cls);
 
     $("td."+cls).toggleClass("representative");
 
     if(element.is(":checked"))
     {
-        $("."+cls).removeAttr('checked'); // Both old and new protein checkboxes have the same class. First deselect all.
-        element.prop('checked', 'checked'); // Select the one that triggered this function call.
+        $("input."+cls+":checkbox").prop('checked', false); // Both old and new protein checkboxes have the same class. First deselect all.
+        element.prop('checked', true); // Select the one that triggered this function call.
     }
     else
     {
-        $("."+cls).prop('checked', 'checked'); // First select all.
-        element.removeAttr('checked');        // Deselect the one that triggered the function call.
+        $("input."+cls+":checkbox").prop('checked', true); // First select all.
+        element.prop('checked', false);        // Deselect the one that triggered the function call.
     }
 }
 
@@ -199,9 +199,9 @@ function toggleCheckboxSelection(element)
         var selectedIds = [];
         table.rows().every(function(){
             var selected = $(this.nodes()).find("input:checked").val();
-            //console.log(selected);
             selectedIds.push(selected);
         });
+        // console.log("Selected: " + selectedIds);
         $("#conflictTableForm #selectedInputValues").val(selectedIds);
         $("#conflictTableForm").submit();
     }

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSMxNReproducibilityReportTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSMxNReproducibilityReportTest.java
@@ -116,9 +116,8 @@ public class TargetedMSMxNReproducibilityReportTest extends TargetedMSTest
 
         // Go to the view via the schema browser to make sure it's not giving the link to the reproducibility report
         goToSchemaBrowser();
-        DataRegionTable table = viewQueryData("targetedms", "PeptideGroup");
-        table.goToView("Library Proteins");
-        table = new DataRegionTable("query", this);
+        viewQueryData("targetedms", "PeptideGroup");
+        DataRegionTable table = new DataRegionTable("query", this);
         table.setFilter("Label", "Equals", "gi|171455|gb|AAA88712.1|");
 
         assertElementNotPresent("Shouldn't have reproducibility report link", reproducibilityReportLink());
@@ -139,7 +138,9 @@ public class TargetedMSMxNReproducibilityReportTest extends TargetedMSTest
         checker().verifyFalse("Reproducibility report link should not be present", isElementPresent(reproducibilityReportLink()));
         checker().verifyTrue("Calibration curve icon should be present", isElementPresent(calibrationCurvesLink()));
 
-        clickAndWait(calibrationCurvesLink().index(2));
+        DataRegionTable table = new DataRegionTable("PeptideGroup", this);
+        table.setFilter("Label", "Equals", "TG|1578-1589|z2");
+        clickAndWait(calibrationCurvesLink());
 
         log("Verifying the FOM values");
         waitForElement(Locator.css("span.labkey-wp-title-text").withText("Figures of Merit"));


### PR DESCRIPTION
#### Changes
- Importing Skyline documents with no replicates fails with an error in a library folder
- Fixed checkbox behavior in conflict resolution view
- Fixed "Library Proteins" query view to display current library proteins
- Updated TargetedMSLibraryTest
