### PR TITLE
Remove targetedms tests from 'MS2' suite

### DIFF
--- a/test/src/org/labkey/test/tests/targetedms/ClustergrammerTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/ClustergrammerTest.java
@@ -23,13 +23,12 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.categories.Daily;
-import org.labkey.test.categories.MS2;
 import org.labkey.test.components.targetedms.ClustergrammerDialog;
 import org.labkey.test.components.targetedms.TargetedMSRunsTable;
 
 import java.util.Arrays;
 
-@Category({Daily.class, MS2.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class ClustergrammerTest extends TargetedMSTest
 {

--- a/test/src/org/labkey/test/tests/targetedms/GetDataAPITest.java
+++ b/test/src/org/labkey/test/tests/targetedms/GetDataAPITest.java
@@ -21,7 +21,6 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.categories.Daily;
-import org.labkey.test.categories.MS2;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.WikiHelper;
@@ -29,7 +28,7 @@ import org.labkey.test.util.WikiHelper;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertThat;
 
-@Category({Daily.class, MS2.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class GetDataAPITest extends TargetedMSTest
 {

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSAuditLogTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSAuditLogTest.java
@@ -5,13 +5,12 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.Locator;
 import org.labkey.test.categories.Daily;
-import org.labkey.test.categories.MS2;
 import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.DataRegionTable;
 
 import static org.junit.Assert.assertEquals;
 
-@Category({Daily.class, MS2.class})
+@Category({Daily.class})
 //@BaseWebDriverTest.ClassTimeout(minutes = 25)
 public class TargetedMSAuditLogTest extends TargetedMSTest
 {

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSCalibrationCurveTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSCalibrationCurveTest.java
@@ -32,7 +32,6 @@ import org.labkey.test.Locators;
 import org.labkey.test.SortDirection;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.categories.Daily;
-import org.labkey.test.categories.MS2;
 import org.labkey.test.components.targetedms.CalibrationCurveWebpart;
 import org.labkey.test.pages.targetedms.PKReportPage;
 import org.labkey.test.util.DataRegionTable;
@@ -61,7 +60,7 @@ import static org.junit.Assert.assertTrue;
  * match the values that are in the CSV files in /SampleData/TargetedMS/Quantification/CalibrationScenariosTest.
  * Those data were generated from the Skyline unit test "CalibrationScenariosTest".
  */
-@Category({Daily.class, MS2.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 25)
 public class TargetedMSCalibrationCurveTest extends TargetedMSTest
 {

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSDocumentFormatsTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSDocumentFormatsTest.java
@@ -26,13 +26,12 @@ import org.labkey.remoteapi.query.SelectRowsCommand;
 import org.labkey.remoteapi.query.SelectRowsResponse;
 import org.labkey.remoteapi.query.Sort;
 import org.labkey.test.categories.Daily;
-import org.labkey.test.categories.MS2;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 
-@Category({Daily.class, MS2.class})
+@Category({Daily.class})
 public class TargetedMSDocumentFormatsTest extends TargetedMSTest
 {
     private static final String SAMPLEDATA_FOLDER = "DocumentFormats/";

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentIrtTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentIrtTest.java
@@ -19,11 +19,10 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.categories.Daily;
-import org.labkey.test.categories.MS2;
 
 import static org.junit.Assert.assertEquals;
 
-@Category({Daily.class, MS2.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class TargetedMSExperimentIrtTest extends TargetedMSIrtTest
 {

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentTest.java
@@ -30,7 +30,6 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.categories.Daily;
-import org.labkey.test.categories.MS2;
 import org.labkey.test.components.FilesWebPart;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;
@@ -49,7 +48,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.labkey.test.util.DataRegionTable.DataRegion;
 
-@Category({Daily.class, MS2.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 8)
 public class TargetedMSExperimentTest extends TargetedMSTest
 {

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentalQCLinkTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentalQCLinkTest.java
@@ -8,7 +8,6 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Daily;
-import org.labkey.test.categories.MS2;
 import org.labkey.test.components.CustomizeView;
 import org.labkey.test.components.targetedms.GuideSet;
 import org.labkey.test.components.targetedms.QCPlotsWebPart;
@@ -19,7 +18,7 @@ import org.labkey.test.util.DataRegionTable;
 import java.util.Arrays;
 import java.util.List;
 
-@Category({Daily.class, MS2.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 4)
 public class TargetedMSExperimentalQCLinkTest extends TargetedMSTest
 {

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSGroupComparisonTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSGroupComparisonTest.java
@@ -21,7 +21,6 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.categories.Daily;
-import org.labkey.test.categories.MS2;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.TestLogger;
 import org.openqa.selenium.WebElement;
@@ -43,7 +42,7 @@ import static org.junit.Assert.assertTrue;
  * /SampleData/TargetedMS/Quantification/GroupComparisonScenariosTest.  Those files came from the Skyline unit test
  * "GroupComparisonScenariosTest".
  */
-@Category({Daily.class, MS2.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class TargetedMSGroupComparisonTest extends TargetedMSTest
 {

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSLibraryIrtTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSLibraryIrtTest.java
@@ -20,13 +20,11 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.categories.Daily;
-import org.labkey.test.categories.MS2;
 import org.labkey.test.util.LogMethod;
-import org.openqa.selenium.WebElement;
 
 import static org.junit.Assert.assertEquals;
 
-@Category({Daily.class, MS2.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 10)
 public class TargetedMSLibraryIrtTest extends TargetedMSIrtTest
 {

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSLibraryTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSLibraryTest.java
@@ -20,7 +20,6 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.categories.Daily;
-import org.labkey.test.categories.MS2;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.PipelineStatusTable;
@@ -37,7 +36,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-@Category({Daily.class, MS2.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class TargetedMSLibraryTest extends TargetedMSTest
 {

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSLinkVersionsTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSLinkVersionsTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.categories.Daily;
-import org.labkey.test.categories.MS2;
 import org.labkey.test.components.targetedms.LinkVersionsGrid;
 import org.labkey.test.components.targetedms.TargetedMSRunsTable;
 
@@ -30,7 +29,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
-@Category({Daily.class, MS2.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 25)
 public class TargetedMSLinkVersionsTest extends TargetedMSTest
 {

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSListTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSListTest.java
@@ -24,7 +24,6 @@ import org.labkey.remoteapi.query.SelectRowsCommand;
 import org.labkey.remoteapi.query.SelectRowsResponse;
 import org.labkey.test.Locator;
 import org.labkey.test.categories.Daily;
-import org.labkey.test.categories.MS2;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -37,7 +36,7 @@ import java.util.stream.Collectors;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@Category({Daily.class, MS2.class})
+@Category({Daily.class})
 public class TargetedMSListTest extends TargetedMSTest
 {
     private static final String LIST_SKY_FILE_1 = "ListTest.sky.zip";

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSMAMTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSMAMTest.java
@@ -18,33 +18,13 @@ package org.labkey.test.tests.targetedms;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.remoteapi.CommandException;
-import org.labkey.remoteapi.Connection;
-import org.labkey.remoteapi.query.Filter;
-import org.labkey.remoteapi.query.Row;
-import org.labkey.remoteapi.query.Rowset;
-import org.labkey.remoteapi.query.SelectRowsCommand;
-import org.labkey.remoteapi.query.SelectRowsResponse;
-import org.labkey.remoteapi.query.Sort;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.categories.Daily;
-import org.labkey.test.categories.MS2;
-import org.labkey.test.util.DataRegionTable;
-import org.labkey.test.util.EscapeUtil;
-import org.labkey.test.util.Ext4Helper;
-import org.labkey.test.util.LogMethod;
-import org.openqa.selenium.WebElement;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.labkey.test.util.DataRegionTable.DataRegion;
-
-@Category({Daily.class, MS2.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 8)
 public class TargetedMSMAMTest extends TargetedMSTest
 {

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSMxNReproducibilityReportTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSMxNReproducibilityReportTest.java
@@ -10,7 +10,6 @@ import org.labkey.remoteapi.query.SelectRowsResponse;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.categories.Daily;
-import org.labkey.test.categories.MS2;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.targetedms.ConnectionSource;
 
@@ -23,7 +22,7 @@ import java.sql.SQLException;
 
 import static org.labkey.test.Locator.tag;
 
-@Category({Daily.class, MS2.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 6)
 public class TargetedMSMxNReproducibilityReportTest extends TargetedMSTest
 {

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSPeptideLibraryTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSPeptideLibraryTest.java
@@ -21,7 +21,6 @@ import org.labkey.api.util.Pair;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.categories.Daily;
-import org.labkey.test.categories.MS2;
 import org.labkey.test.components.CustomizeView;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
@@ -35,7 +34,7 @@ import java.util.Set;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@Category({Daily.class, MS2.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class TargetedMSPeptideLibraryTest extends TargetedMSTest
 {

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCGuideSetTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCGuideSetTest.java
@@ -32,7 +32,6 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Daily;
-import org.labkey.test.categories.MS2;
 import org.labkey.test.components.targetedms.GuideSet;
 import org.labkey.test.components.targetedms.GuideSetStats;
 import org.labkey.test.components.targetedms.GuideSetWebPart;
@@ -54,7 +53,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@Category({Daily.class, MS2.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 25)
 public class TargetedMSQCGuideSetTest extends TargetedMSTest
 {

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCSummaryTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCSummaryTest.java
@@ -29,7 +29,6 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.ModulePropertyValue;
 import org.labkey.test.categories.Daily;
-import org.labkey.test.categories.MS2;
 import org.labkey.test.components.targetedms.GuideSet;
 import org.labkey.test.components.targetedms.QCPlotsWebPart;
 import org.labkey.test.components.targetedms.QCSummaryWebPart;
@@ -55,7 +54,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-@Category({Daily.class, MS2.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 12)
 public class TargetedMSQCSummaryTest extends TargetedMSTest
 {

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -26,7 +26,6 @@ import org.labkey.test.Locator;
 import org.labkey.test.SortDirection;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.categories.Daily;
-import org.labkey.test.categories.MS2;
 import org.labkey.test.components.ext4.RadioButton;
 import org.labkey.test.components.html.SiteNavBar;
 import org.labkey.test.components.targetedms.GuideSet;
@@ -61,7 +60,7 @@ import static org.labkey.test.components.targetedms.QCPlotsWebPart.QCPlotType.CU
 import static org.labkey.test.components.targetedms.QCPlotsWebPart.QCPlotType.LeveyJennings;
 import static org.labkey.test.components.targetedms.QCPlotsWebPart.QCPlotType.MovingRange;
 
-@Category({Daily.class, MS2.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 35)
 public class TargetedMSQCTest extends TargetedMSTest
 {

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSSampleFileChromInfoTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSSampleFileChromInfoTest.java
@@ -24,12 +24,11 @@ import org.labkey.remoteapi.query.SelectRowsCommand;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.categories.Daily;
-import org.labkey.test.categories.MS2;
 import org.labkey.test.util.DataRegionTable;
 
 import java.util.Arrays;
 
-@Category({Daily.class, MS2.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 6)
 public class TargetedMSSampleFileChromInfoTest extends TargetedMSTest
 {

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSSkydTextIdTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSSkydTextIdTest.java
@@ -21,7 +21,6 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.categories.Daily;
-import org.labkey.test.categories.MS2;
 import org.openqa.selenium.WebElement;
 
 import java.net.URL;
@@ -29,7 +28,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Category({Daily.class, MS2.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 6)
 public class TargetedMSSkydTextIdTest extends TargetedMSTest
 {

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSSmallMoleculeLibraryTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSSmallMoleculeLibraryTest.java
@@ -20,7 +20,6 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.categories.Daily;
-import org.labkey.test.categories.MS2;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
 
@@ -34,7 +33,7 @@ import java.util.Set;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@Category({Daily.class, MS2.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class TargetedMSSmallMoleculeLibraryTest extends TargetedMSTest
 {

--- a/test/src/org/labkey/test/tests/targetedms/passport/PassportTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/passport/PassportTest.java
@@ -19,15 +19,14 @@ package org.labkey.test.tests.targetedms.passport;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.Locator;
-import org.labkey.test.categories.External;
-import org.labkey.test.categories.MS2;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.util.APIUserHelper;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.UIContainerHelper;
 
 import java.util.List;
 
-@Category({External.class, MS2.class})
+@Category({Daily.class})
 public class PassportTest  extends PassportTestPart
 {
     public PassportTest()


### PR DESCRIPTION
#### Rationale
`PassportTest` used to cover an external module. Now that that module's functionality has been pulled into the targetedms module, the test shouldn't be categorized as "External". Since I'm updating that test, I'm cutting these tests out of the MS2 suite. The MS2 suite on TeamCity is already configured to exclude targetedms test, having these tests in the MS2 suite is pointless.

#### Changes
* Remove targetedms tests from 'MS2' suite
* Remove PassportTest from 'External' suite
