### PR TITLE
Promote QueryViewProvider to main API

### DIFF
--- a/src/org/labkey/targetedms/view/TransitionPeptideSearchViewProvider.java
+++ b/src/org/labkey/targetedms/view/TransitionPeptideSearchViewProvider.java
@@ -26,6 +26,7 @@ import org.labkey.api.protein.ProteinService;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QuerySettings;
 import org.labkey.api.query.QueryView;
+import org.labkey.api.query.QueryViewProvider;
 import org.labkey.api.targetedms.TargetedMSService;
 import org.labkey.api.view.ViewContext;
 import org.labkey.targetedms.TargetedMSModule;
@@ -41,7 +42,7 @@ import java.util.List;
 * User: jeckels
 * Date: May 10, 2012
 */
-public class TransitionPeptideSearchViewProvider implements ProteinService.QueryViewProvider<ProteinService.PeptideSearchForm>
+public class TransitionPeptideSearchViewProvider implements QueryViewProvider<ProteinService.PeptideSearchForm>
 {
     @Override
     public String getDataRegionName()

--- a/src/org/labkey/targetedms/view/TransitionProteinSearchViewProvider.java
+++ b/src/org/labkey/targetedms/view/TransitionProteinSearchViewProvider.java
@@ -28,6 +28,7 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.FilteredTable;
 import org.labkey.api.query.QuerySettings;
 import org.labkey.api.query.QueryView;
+import org.labkey.api.query.QueryViewProvider;
 import org.labkey.api.targetedms.TargetedMSService;
 import org.labkey.api.view.ViewContext;
 import org.labkey.targetedms.TargetedMSModule;
@@ -44,7 +45,7 @@ import java.util.List;
 * User: jeckels
 * Date: May 10, 2012
 */
-public class TransitionProteinSearchViewProvider implements ProteinService.QueryViewProvider<ProteinService.ProteinSearchForm>
+public class TransitionProteinSearchViewProvider implements QueryViewProvider<ProteinService.ProteinSearchForm>
 {
     @Override
     public String getDataRegionName()


### PR DESCRIPTION
#### Rationale
* Other modules want to support registration of query views

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2861

#### Changes
* Move QueryViewProvider from MS2Service to core API