### PR TITLE
Issue 44015: Migrate remaining log4j 1.2 usages to 2.x

### DIFF
--- a/src/org/labkey/targetedms/datasource/PsiInstruments.java
+++ b/src/org/labkey/targetedms/datasource/PsiInstruments.java
@@ -15,7 +15,8 @@
  */
 package org.labkey.targetedms.datasource;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.resource.FileResource;
@@ -42,7 +43,7 @@ public class PsiInstruments
 {
     private static Map<String, PsiInstrument> _instruments = new HashMap<>();
 
-    private static final Logger LOG = Logger.getLogger(PsiInstruments.class);
+    private static final Logger LOG = LogManager.getLogger(PsiInstruments.class);
 
     static
     {


### PR DESCRIPTION
#### Rationale
Recent events notwithstanding, we prefer log4j 2.x. Migrate 1.2 usages that were never converted or that snuck in after our big migration.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2899