### PR TITLE
Minor fixes for exception reports without repros

### DIFF
--- a/src/org/labkey/targetedms/PanoramaBadDataException.java
+++ b/src/org/labkey/targetedms/PanoramaBadDataException.java
@@ -28,4 +28,9 @@ public class PanoramaBadDataException extends RuntimeException implements SkipMo
     {
         super(message);
     }
+
+    public PanoramaBadDataException(@NonNls String message, Throwable t)
+    {
+        super(message, t);
+    }
 }

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -2990,12 +2990,17 @@ public class TargetedMSController extends SpringActionController
             validatePeptideGroup(form);
             validatePeptide(form);
             validateMolecule(form);
+
+            if (_molecule == null && _peptide == null && _peptideGrp == null)
+            {
+                throw new NotFoundException();
+            }
         }
 
         @Override
         public void export(SummaryChartForm form, HttpServletResponse response, BindException errors) throws Exception
         {
-            JFreeChart chart = null;
+            JFreeChart chart;
             if (form.isAsProteomics())
             {
                 chart = new ComparisonChartMaker().makePeakAreasChart(
@@ -3009,7 +3014,7 @@ public class TargetedMSController extends SpringActionController
                         form.isLogValues(), getUser(), getContainer()
                 );
             }
-            else if (_molecule != null)
+            else
             {
                 chart = new ComparisonChartMaker().makePeakAreasChart(
                         form.getReplicateId(),

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -2995,7 +2995,7 @@ public class TargetedMSController extends SpringActionController
         @Override
         public void export(SummaryChartForm form, HttpServletResponse response, BindException errors) throws Exception
         {
-            JFreeChart chart;
+            JFreeChart chart = null;
             if (form.isAsProteomics())
             {
                 chart = new ComparisonChartMaker().makePeakAreasChart(
@@ -3009,7 +3009,7 @@ public class TargetedMSController extends SpringActionController
                         form.isLogValues(), getUser(), getContainer()
                 );
             }
-            else
+            else if (_molecule != null)
             {
                 chart = new ComparisonChartMaker().makePeakAreasChart(
                         form.getReplicateId(),

--- a/src/org/labkey/targetedms/chart/ChromatogramDataset.java
+++ b/src/org/labkey/targetedms/chart/ChromatogramDataset.java
@@ -1479,6 +1479,7 @@ public abstract class ChromatogramDataset
             _context = context;
             _syncIntensity = syncIntensity;
             _syncRt = syncRt;
+            _run = TargetedMSManager.getRun(_group.getRunId());
         }
 
         @Override


### PR DESCRIPTION
#### Rationale
We've received some misc exception reports where I don't have a concrete repro but can glean enough from the stack to improve the behavior

#### Changes
* Be sure to fetch a run object when we'll need it later, avoiding an NPE
* Don't report exceptions to mothership for corrupted data files, but give the user better feedback
