### PR TITLE
Issue 44540: More options for viewing the pipeline log

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -5653,7 +5653,7 @@ public class TargetedMSController extends SpringActionController
 
             if ("skyp".equalsIgnoreCase(form.getView()))
             {
-                String url = data.getWebDavURL(ExpData.PathType.full);
+                String url = data.getWebDavURL(FileContentService.PathType.full);
                 if (url != null)
                 {
                     ByteArrayInputStream inputStream = new ByteArrayInputStream(url.getBytes(StringUtilsLabKey.DEFAULT_CHARSET));

--- a/src/org/labkey/targetedms/query/SampleFileTable.java
+++ b/src/org/labkey/targetedms/query/SampleFileTable.java
@@ -40,6 +40,7 @@ import org.labkey.api.exp.api.ExperimentUrls;
 import org.labkey.api.exp.api.SampleTypeService;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.exp.query.SamplesSchema;
+import org.labkey.api.files.FileContentService;
 import org.labkey.api.query.DefaultQueryUpdateService;
 import org.labkey.api.query.DetailsURL;
 import org.labkey.api.query.ExprColumn;
@@ -328,7 +329,7 @@ public class SampleFileTable extends TargetedMSTable
                         Long dataSize = downloadInfo.getSize();
                         String size = dataSize != null ? FileUtils.byteCountToDisplaySize(dataSize) : "";
                         ExpData expData = downloadInfo.getExpData();
-                        String url = expData.getWebDavURL(ExpData.PathType.full);
+                        String url = expData.getWebDavURL(FileContentService.PathType.full);
                         if(!downloadInfo.isFile())
                         {
                             int idx = url.lastIndexOf('/');


### PR DESCRIPTION
#### Rationale
Very large pipeline job logs cause problems for the detail page's log viewer

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2941

#### Changes
* Centralize WebDav URL generation