### PR TITLE
Issue 44557: Optimize queries within Panorama QC folders for faster plot rendering

### DIFF
--- a/resources/queries/targetedms/SampleFileForQC.sql
+++ b/resources/queries/targetedms/SampleFileForQC.sql
@@ -4,6 +4,8 @@ SELECT
     COALESCE(gs.RowId, 0) AS GuideSetId,
     CASE WHEN (sf.AcquiredTime >= gs.TrainingStart AND sf.AcquiredTime <= gs.TrainingEnd) THEN TRUE ELSE FALSE END AS InGuideSetTrainingRange
 FROM SampleFile sf
+    -- Use -1 to signify that an exclusion is for the whole sample (and therefore applies to all metrics)
+    -- See code in SampleFileQCMetadata.java
 LEFT OUTER JOIN (SELECT GROUP_CONCAT(COALESCE(MetricId, -1)) AS ExcludedMetricIds, ReplicateId FROM QCMetricExclusion GROUP BY ReplicateId) e
 ON sf.ReplicateId = e.ReplicateId
 LEFT JOIN GuideSetForOutliers gs

--- a/resources/queries/targetedms/SampleFileForQC.sql
+++ b/resources/queries/targetedms/SampleFileForQC.sql
@@ -1,0 +1,10 @@
+SELECT
+    sf.*,
+    e.ExcludedMetricIds,
+    COALESCE(gs.RowId, 0) AS GuideSetId,
+    CASE WHEN (sf.AcquiredTime >= gs.TrainingStart AND sf.AcquiredTime <= gs.TrainingEnd) THEN TRUE ELSE FALSE END AS InGuideSetTrainingRange
+FROM SampleFile sf
+LEFT OUTER JOIN (SELECT GROUP_CONCAT(COALESCE(MetricId, -1)) AS ExcludedMetricIds, ReplicateId FROM QCMetricExclusion GROUP BY ReplicateId) e
+ON sf.ReplicateId = e.ReplicateId
+LEFT JOIN GuideSetForOutliers gs
+ON ((sf.AcquiredTime >= gs.TrainingStart AND sf.AcquiredTime < gs.ReferenceEnd) OR (sf.AcquiredTime >= gs.TrainingStart AND gs.ReferenceEnd IS NULL))

--- a/src/org/labkey/targetedms/SkylineDocImporter.java
+++ b/src/org/labkey/targetedms/SkylineDocImporter.java
@@ -251,6 +251,9 @@ public class SkylineDocImporter
 
             updateRunStatus(IMPORT_SUCCEEDED, STATUS_SUCCESS);
 
+            // We may have inserted the first set of data for a given metric
+            TargetedMSManager.get().clearCachedEnabledQCMetrics(run.getContainer());
+
             _progressMonitor.complete();
             return TargetedMSManager.getRun(_runId);
         }

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -1292,13 +1292,13 @@ public class TargetedMSController extends SpringActionController
             if (zoomedRange)
             {
                 // filter the stats for targeted range
-                Predicate<RawMetricDataSet> withInDateRange = rawMetricDataSet -> rawMetricDataSet.getAcquiredTime() != null &&
+                Predicate<RawMetricDataSet> withInDateRange = rawMetricDataSet -> rawMetricDataSet.getSampleFile().getAcquiredTime() != null &&
                         (qcStartDate != null &&
-                        (rawMetricDataSet.getAcquiredTime().after(qcStartDate)
-                                || DateUtil.getDateOnly(rawMetricDataSet.getAcquiredTime()).compareTo(qcStartDate) == 0)) &&
+                        (rawMetricDataSet.getSampleFile().getAcquiredTime().after(qcStartDate)
+                                || DateUtil.getDateOnly(rawMetricDataSet.getSampleFile().getAcquiredTime()).compareTo(qcStartDate) == 0)) &&
                         (form.getEndDate() != null &&
-                        (rawMetricDataSet.getAcquiredTime().before(form.getEndDate())
-                                || DateUtil.getDateOnly(rawMetricDataSet.getAcquiredTime()).compareTo(form.getEndDate()) == 0));
+                        (rawMetricDataSet.getSampleFile().getAcquiredTime().before(form.getEndDate())
+                                || DateUtil.getDateOnly(rawMetricDataSet.getSampleFile().getAcquiredTime()).compareTo(form.getEndDate()) == 0));
                 rawMetricDataSets = rawMetricDataSets
                         .stream()
                         .filter(withInDateRange)

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -983,7 +983,7 @@ public class TargetedMSController extends SpringActionController
             List<JSONObject> result = new ArrayList<>();
             for (QCMetricConfiguration configuration : enabledQCMetricConfigurations)
             {
-                   result.add(configuration.toJSON());
+                result.add(configuration.toJSON());
             }
             response.put("configurations", result);
             return response;

--- a/src/org/labkey/targetedms/TargetedMSManager.java
+++ b/src/org/labkey/targetedms/TargetedMSManager.java
@@ -19,17 +19,19 @@ package org.labkey.targetedms;
 import com.google.common.base.Joiner;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.fhcrc.cpas.exp.xml.ExperimentArchiveDocument;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.cache.Cache;
+import org.labkey.api.cache.CacheManager;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DbSchema;
+import org.labkey.api.data.DbSchemaType;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.SQLFragment;
@@ -76,6 +78,7 @@ import org.labkey.api.targetedms.TargetedMSService;
 import org.labkey.api.targetedms.model.SampleFileInfo;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.StringUtilsLabKey;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.UnauthorizedException;
 import org.labkey.api.view.ViewBackgroundInfo;
@@ -121,6 +124,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -131,12 +135,20 @@ public class TargetedMSManager
 {
     private static final TargetedMSManager _instance = new TargetedMSManager();
 
-    private static final Logger _log = LogManager.getLogger(TargetedMSManager.class);
+    private static final Logger _log = LogHelper.getLogger(TargetedMSManager.class, "Panorama utility and DB querying code");
 
     private TargetedMSManager()
     {
         // prevent external construction with a private default constructor
     }
+
+    /**
+     * A very short-lived cache to make it faster to render QC folders. A number of API calls come from the
+     * client rendering the overview, all of which need to know the enabled configs.
+     *
+     * Could switch to a longer-lived cache that's invalidated by changes to the configuration for even more benefit.
+     */
+    private static final Cache<Container, List<QCMetricConfiguration>> _metricCache = CacheManager.getCache(1000, TimeUnit.SECONDS.toMillis(15), "Short-lived QC metric configs");
 
     public static TargetedMSManager get()
     {
@@ -159,7 +171,7 @@ public class TargetedMSManager
 
     public static DbSchema getSchema()
     {
-        return DbSchema.get(TargetedMSSchema.SCHEMA_NAME);
+        return DbSchema.get(TargetedMSSchema.SCHEMA_NAME, DbSchemaType.Module);
     }
 
     public static SqlDialect getSqlDialect()
@@ -592,15 +604,6 @@ public class TargetedMSManager
                 @Override
                 public File getLogFile()
                 {
-                    throw new UnsupportedOperationException();
-                }
-
-                @Override
-                public File getRoot()
-                {
-                    if (!FileUtil.hasCloudScheme(path))
-                        return path.toFile().getParentFile();
-
                     throw new UnsupportedOperationException();
                 }
 
@@ -1281,7 +1284,7 @@ public class TargetedMSManager
     @NotNull
     private static List<String> deleteFileWithLogging(@NotNull Path file, @NotNull List<String> logs)
     {
-        String logMsg = "Deleting " + file.toString();
+        String logMsg = "Deleting " + file;
         logs.add(logMsg);
         _log.info(logMsg);
 
@@ -2105,56 +2108,59 @@ public class TargetedMSManager
 
     public static List<QCMetricConfiguration> getEnabledQCMetricConfigurations(Container container, User user)
     {
-        QuerySchema targetedMSSchema = DefaultSchema.get(user, container).getSchema(TargetedMSSchema.SCHEMA_NAME);
-        if (targetedMSSchema == null)
+        return _metricCache.get(container, null, (p, argument) ->
         {
-            // Module must not be enabled in this folder, so bail out
-            return Collections.emptyList();
-        }
-        TableInfo metricsTable = targetedMSSchema.getTable("qcMetricsConfig", null);
-        List<QCMetricConfiguration> metrics = new TableSelector(metricsTable, new SimpleFilter(FieldKey.fromParts("Enabled"), false, CompareType.NEQ_OR_NULL), new Sort(FieldKey.fromParts("Name"))).getArrayList(QCMetricConfiguration.class);
-        List<QCMetricConfiguration> result = new ArrayList<>();
-        for (QCMetricConfiguration metric : metrics)
-        {
-            if (metric.getEnabled() == null)
+            QuerySchema targetedMSSchema = DefaultSchema.get(user, container).getSchema(TargetedMSSchema.SCHEMA_NAME);
+            if (targetedMSSchema == null)
             {
-                if (metric.getEnabledQueryName() == null || metric.getEnabledSchemaName() == null)
+                // Module must not be enabled in this folder, so bail out
+                return Collections.emptyList();
+            }
+            TableInfo metricsTable = targetedMSSchema.getTable("qcMetricsConfig", null);
+            List<QCMetricConfiguration> metrics = new TableSelector(metricsTable, new SimpleFilter(FieldKey.fromParts("Enabled"), false, CompareType.NEQ_OR_NULL), new Sort(FieldKey.fromParts("Name"))).getArrayList(QCMetricConfiguration.class);
+            List<QCMetricConfiguration> result = new ArrayList<>();
+            for (QCMetricConfiguration metric : metrics)
+            {
+                if (metric.getEnabled() == null)
                 {
-                    // Metrics without a query to define their default enabled status are on by default
-                    result.add(metric);
-                }
-                else
-                {
-                    QuerySchema enabledSchema = TargetedMSSchema.SCHEMA_NAME.equalsIgnoreCase(metric.getEnabledSchemaName()) ? targetedMSSchema : DefaultSchema.get(user, container).getSchema(metric.getEnabledSchemaName());
-                    if (enabledSchema != null)
+                    if (metric.getEnabledQueryName() == null || metric.getEnabledSchemaName() == null)
                     {
-                        TableInfo enabledQuery = enabledSchema.getTable(metric.getEnabledQueryName(), null);
-                        if (enabledQuery != null)
+                        // Metrics without a query to define their default enabled status are on by default
+                        result.add(metric);
+                    }
+                    else
+                    {
+                        QuerySchema enabledSchema = TargetedMSSchema.SCHEMA_NAME.equalsIgnoreCase(metric.getEnabledSchemaName()) ? targetedMSSchema : DefaultSchema.get(user, container).getSchema(metric.getEnabledSchemaName());
+                        if (enabledSchema != null)
                         {
-                            if (new TableSelector(enabledQuery).exists())
+                            TableInfo enabledQuery = enabledSchema.getTable(metric.getEnabledQueryName(), null);
+                            if (enabledQuery != null)
                             {
-                                result.add(metric);
+                                if (new TableSelector(enabledQuery).exists())
+                                {
+                                    result.add(metric);
+                                }
+                            }
+                            else
+                            {
+                                _log.warn("Could not find query " + metric.getEnabledSchemaName() + "." + metric.getEnabledQueryName() + " to determine if metric " + metric.getName() + " should be enabled in container " + container.getPath());
                             }
                         }
                         else
                         {
-                            _log.warn("Could not find query " + metric.getEnabledSchemaName() + "." + metric.getEnabledQueryName() + " to determine if metric " + metric.getName() + " should be enabled in container " + container.getPath());
+                            _log.warn("Could not find schema " + metric.getEnabledSchemaName() + " to determine if metric " + metric.getName() + " should be enabled in container " + container.getPath());
                         }
                     }
-                    else
-                    {
-                        _log.warn("Could not find schema " + metric.getEnabledSchemaName() + " to determine if metric " + metric.getName() + " should be enabled in container " + container.getPath());
-                    }
+                }
+                else
+                {
+                    result.add(metric);
                 }
             }
-            else
-            {
-                result.add(metric);
-            }
-        }
-        // Ensure we get a case-insensitive sort regardless of DB collation
-        Collections.sort(result);
-        return result;
+            // Ensure we get a case-insensitive sort regardless of DB collation
+            Collections.sort(result);
+            return Collections.unmodifiableList(result);
+        });
     }
 
     public List<SampleFileInfo> getSampleFileInfos(Container container, User user, Integer sampleFileLimit)

--- a/src/org/labkey/targetedms/TargetedMSSchema.java
+++ b/src/org/labkey/targetedms/TargetedMSSchema.java
@@ -20,25 +20,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
+import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
-import org.labkey.api.data.AJAXDetailsDisplayColumn;
-import org.labkey.api.data.ColumnInfo;
-import org.labkey.api.data.Container;
-import org.labkey.api.data.ContainerFilter;
-import org.labkey.api.data.ContainerForeignKey;
-import org.labkey.api.data.DataColumn;
-import org.labkey.api.data.DbSchema;
-import org.labkey.api.data.DbSchemaType;
-import org.labkey.api.data.DisplayColumn;
-import org.labkey.api.data.DisplayColumnFactory;
-import org.labkey.api.data.EnumTableInfo;
-import org.labkey.api.data.JdbcType;
-import org.labkey.api.data.RenderContext;
-import org.labkey.api.data.RuntimeSQLException;
-import org.labkey.api.data.SQLFragment;
-import org.labkey.api.data.TableInfo;
-import org.labkey.api.data.UpdateColumn;
-import org.labkey.api.data.WrappedColumn;
+import org.labkey.api.data.*;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.query.ExpRunTable;
 import org.labkey.api.exp.query.ExpSchema;
@@ -221,6 +205,7 @@ public class TargetedMSSchema extends UserSchema
     public static final String SAMPLE_FILE_RUN_PREFIX = "samplefile_run";
 
     private final ExpSchema _expSchema;
+    private Map<String, List<AnnotatedTargetedMSTable.AnnotationSettingForTyping>> _annotations;
 
     static public void register(Module module)
     {
@@ -248,14 +233,9 @@ public class TargetedMSSchema extends UserSchema
 
     private static SQLFragment getJoinToRunsTable(String tableAlias)
     {
-        return getJoinToRunsTable(tableAlias, "RunId");
-    }
-
-    private static SQLFragment getJoinToRunsTable(String tableAlias, String columnName)
-    {
         tableAlias = tableAlias == null ? "" : tableAlias + ".";
         return makeInnerJoin(TargetedMSManager.getTableInfoRuns(),
-                TargetedMSTable.CONTAINER_COL_TABLE_ALIAS, tableAlias + columnName);
+                TargetedMSTable.CONTAINER_COL_TABLE_ALIAS, tableAlias + "RunId");
     }
 
     private static SQLFragment makeInnerJoin(TableInfo table, String alias, String colRight)
@@ -423,7 +403,7 @@ public class TargetedMSSchema extends UserSchema
             {
                 SQLFragment sql = new SQLFragment();
                 sql.append(makeInnerJoin(TargetedMSManager.getTableInfoSkylineAuditLog(), "e", "X.EntryId", "EntryId"));
-                sql.append(getJoinToRunsTable("e", "RunId"));
+                sql.append(getJoinToRunsTable("e"));
                 return sql;
             }
             @Override
@@ -615,6 +595,55 @@ public class TargetedMSSchema extends UserSchema
 
         public abstract SQLFragment getSQL();
         public abstract FieldKey getContainerFieldKey();
+    }
+
+    @NotNull
+    public List<AnnotatedTargetedMSTable.AnnotationSettingForTyping> getAnnotationSettings(String annotationTarget, ContainerFilter containerFilter)
+    {
+        // Cached at the schema level to make them easy to reuse across different tables
+        if (_annotations == null)
+        {
+            _annotations = new CaseInsensitiveHashMap<>();
+            SQLFragment annoSettingsSql = new SQLFragment();
+            TableInfo annotationSettingsTI = TargetedMSManager.getTableInfoAnnotationSettings();
+            // We query for the min and max values to determine both what they're set to, and if they're all the same.
+            // If we have at least one value that's different in the column, the min and max will be different.
+            annoSettingsSql.append("SELECT name," +
+                    "max(Type) maxType, " +
+                    "min(Type) minType, " +
+                    "max(Lookup) maxLookup, " +
+                    "min(Lookup) minLookup, " +
+                    "Targets " +
+                    "  FROM ");
+            annoSettingsSql.append(annotationSettingsTI, " annoSettings ");
+            annoSettingsSql.append(" INNER JOIN ").append(TargetedMSManager.getTableInfoRuns(), " runs ON runs.Id = annoSettings.RunId");
+            annoSettingsSql.append(" WHERE ");
+            annoSettingsSql.append(containerFilter.getSQLFragment(getDbSchema(), new SQLFragment("runs.Container")));
+            // AnnotationSettings table has a "Targets" column that determines which targets
+            // (protein, peptide, precursor, transition, precursor/transition results) an annotation applies to.
+            // Fetch them all at once for efficiency purposes
+            annoSettingsSql.append(" GROUP BY name, Targets");
+
+            new SqlSelector(getDbSchema(), annoSettingsSql).forEach(rs ->
+            {
+                List<AnnotatedTargetedMSTable.AnnotationSettingForTyping> annotationsForTarget =
+                        _annotations.computeIfAbsent(rs.getString("Targets"), x -> new ArrayList<>());
+
+                annotationsForTarget.add(new AnnotatedTargetedMSTable.AnnotationSettingForTyping(
+                        rs.getString("name"),
+                        rs.getString("maxType"),
+                        rs.getString("minType"),
+                        rs.getString("maxLookup"),
+                        rs.getString("minLookup"))
+                );
+            });
+
+            // Do a case-insensitive sort since different DBs have different default collations
+            _annotations.values().forEach(x -> x.sort((a, b) -> a.getName().compareToIgnoreCase(b.getName())));
+        }
+
+        List<AnnotatedTargetedMSTable.AnnotationSettingForTyping> result = _annotations.get(annotationTarget);
+        return result == null ? Collections.emptyList() : Collections.unmodifiableList(result);
     }
 
     public ExpRunTable getTargetedMSRunsTable(ContainerFilter cf)
@@ -1257,7 +1286,7 @@ public class TargetedMSSchema extends UserSchema
         // Tables that have a FK to targetedms.precursor
         if (TABLE_PRECURSOR_CHROM_INFO.equalsIgnoreCase(name))
         {
-            return new PrecursorChromInfoTable(getSchema().getTable(name), this, cf);
+            return new PrecursorChromInfoTable(this, cf);
         }
         if (TABLE_TRANSITION.equalsIgnoreCase(name))
         {

--- a/src/org/labkey/targetedms/model/GuideSet.java
+++ b/src/org/labkey/targetedms/model/GuideSet.java
@@ -113,7 +113,7 @@ public class GuideSet extends Entity
 
         for (RawMetricDataSet dataRow : dataRows)
         {
-            if (dataRow.getGuideSetId() == getRowId())
+            if (dataRow.getSampleFile().getGuideSetId() == getRowId())
             {
                 String metricLabel = OutlierGenerator.get().getMetricLabel(metrics, dataRow);
 

--- a/src/org/labkey/targetedms/model/GuideSetKey.java
+++ b/src/org/labkey/targetedms/model/GuideSetKey.java
@@ -9,6 +9,7 @@ public class GuideSetKey
 
     private final int _guideSetId;
     private final String _seriesLabel;
+    private final int _hashCode;
 
     public GuideSetKey(int metricId, int metricSeriesIndex, int guideSetId, String seriesLabel)
     {
@@ -16,6 +17,7 @@ public class GuideSetKey
         _metricSeriesIndex = metricSeriesIndex;
         _guideSetId = guideSetId;
         _seriesLabel = seriesLabel;
+        _hashCode = Objects.hash(_metricId, _metricSeriesIndex, _guideSetId, _seriesLabel);
     }
 
     public int getMetricId()
@@ -53,7 +55,7 @@ public class GuideSetKey
     @Override
     public int hashCode()
     {
-        return Objects.hash(_metricId, _metricSeriesIndex, _guideSetId, _seriesLabel);
+        return _hashCode;
     }
 
     @Override

--- a/src/org/labkey/targetedms/model/GuideSetStats.java
+++ b/src/org/labkey/targetedms/model/GuideSetStats.java
@@ -98,7 +98,7 @@ public class GuideSetStats
         {
             throw new IllegalStateException("Stats have already been locked");
         }
-        if (!row.getSampleFile().isIgnoreInQC() && null != row.getSampleFile().getAcquiredTime() &&
+        if (!row.getSampleFile().isIgnoreInQC(row.getMetricId()) && null != row.getSampleFile().getAcquiredTime() &&
                 _guideSet.getTrainingStart().compareTo(row.getSampleFile().getAcquiredTime()) <= 0 &&
                 (_guideSet.getTrainingEnd() == null || _guideSet.getTrainingEnd().compareTo(row.getSampleFile().getAcquiredTime()) >= 0))
         {
@@ -140,7 +140,7 @@ public class GuideSetStats
     {
         _locked = true;
 
-        List<RawMetricDataSet> includedTrainingRows = _trainingRows.stream().filter(x -> !x.getSampleFile().isIgnoreInQC()).collect(Collectors.toList());
+        List<RawMetricDataSet> includedTrainingRows = _trainingRows.stream().filter(x -> !x.getSampleFile().isIgnoreInQC(x.getMetricId())).collect(Collectors.toList());
         Double[] trainingValues = getValues(includedTrainingRows, false, false);
 
         _average = Stats.getMean(trainingValues);
@@ -154,7 +154,7 @@ public class GuideSetStats
         allRows.addAll(_trainingRows);
         allRows.addAll(_referenceRows);
 
-        List<RawMetricDataSet> includedRows = allRows.stream().filter(x -> !x.getSampleFile().isIgnoreInQC()).collect(Collectors.toList());
+        List<RawMetricDataSet> includedRows = allRows.stream().filter(x -> !x.getSampleFile().isIgnoreInQC(x.getMetricId())).collect(Collectors.toList());
 
         Double[] metricVals = getValues(includedRows, true, true);
 

--- a/src/org/labkey/targetedms/model/GuideSetStats.java
+++ b/src/org/labkey/targetedms/model/GuideSetStats.java
@@ -98,9 +98,9 @@ public class GuideSetStats
         {
             throw new IllegalStateException("Stats have already been locked");
         }
-        if (!row.isIgnoreInQC() && null != row.getAcquiredTime() &&
-                _guideSet.getTrainingStart().compareTo(row.getAcquiredTime()) <= 0 &&
-                (_guideSet.getTrainingEnd() == null || _guideSet.getTrainingEnd().compareTo(row.getAcquiredTime()) >= 0))
+        if (!row.getSampleFile().isIgnoreInQC() && null != row.getSampleFile().getAcquiredTime() &&
+                _guideSet.getTrainingStart().compareTo(row.getSampleFile().getAcquiredTime()) <= 0 &&
+                (_guideSet.getTrainingEnd() == null || _guideSet.getTrainingEnd().compareTo(row.getSampleFile().getAcquiredTime()) >= 0))
         {
             _trainingRows.add(row);
         }
@@ -140,7 +140,7 @@ public class GuideSetStats
     {
         _locked = true;
 
-        List<RawMetricDataSet> includedTrainingRows = _trainingRows.stream().filter(x -> !x.isIgnoreInQC()).collect(Collectors.toList());
+        List<RawMetricDataSet> includedTrainingRows = _trainingRows.stream().filter(x -> !x.getSampleFile().isIgnoreInQC()).collect(Collectors.toList());
         Double[] trainingValues = getValues(includedTrainingRows, false, false);
 
         _average = Stats.getMean(trainingValues);
@@ -154,7 +154,7 @@ public class GuideSetStats
         allRows.addAll(_trainingRows);
         allRows.addAll(_referenceRows);
 
-        List<RawMetricDataSet> includedRows = allRows.stream().filter(x -> !x.isIgnoreInQC()).collect(Collectors.toList());
+        List<RawMetricDataSet> includedRows = allRows.stream().filter(x -> !x.getSampleFile().isIgnoreInQC()).collect(Collectors.toList());
 
         Double[] metricVals = getValues(includedRows, true, true);
 

--- a/src/org/labkey/targetedms/model/QCPlotFragment.java
+++ b/src/org/labkey/targetedms/model/QCPlotFragment.java
@@ -115,7 +115,7 @@ public class QCPlotFragment
             dataJsonObject.put("PrecursorChromInfoId", plotData.getPrecursorChromInfoId());
             dataJsonObject.put("InGuideSetTrainingRange", plotData.getSampleFile().isInGuideSetTrainingRange());
             dataJsonObject.put("GuideSetId", plotData.getSampleFile().getGuideSetId());
-            dataJsonObject.put("IgnoreInQC", plotData.getSampleFile().isIgnoreInQC());
+            dataJsonObject.put("IgnoreInQC", plotData.getSampleFile().isIgnoreInQC(plotData.getMetricId()));
             dataJsonObject.put("PrecursorId", plotData.getPrecursorId());
             dataJsonObject.put("SeriesType", plotData.getMetricSeriesIndex());
             if (includeMR)

--- a/src/org/labkey/targetedms/model/QCPlotFragment.java
+++ b/src/org/labkey/targetedms/model/QCPlotFragment.java
@@ -111,11 +111,11 @@ public class QCPlotFragment
         {
             JSONObject dataJsonObject = new JSONObject();
             dataJsonObject.put("Value", plotData.getMetricValue());
-            dataJsonObject.put("SampleFileId", plotData.getSampleFileId());
+            dataJsonObject.put("SampleFileId", plotData.getSampleFile().getId());
             dataJsonObject.put("PrecursorChromInfoId", plotData.getPrecursorChromInfoId());
-            dataJsonObject.put("InGuideSetTrainingRange", plotData.isInGuideSetTrainingRange());
-            dataJsonObject.put("GuideSetId", plotData.getGuideSetId());
-            dataJsonObject.put("IgnoreInQC", plotData.isIgnoreInQC());
+            dataJsonObject.put("InGuideSetTrainingRange", plotData.getSampleFile().isInGuideSetTrainingRange());
+            dataJsonObject.put("GuideSetId", plotData.getSampleFile().getGuideSetId());
+            dataJsonObject.put("IgnoreInQC", plotData.getSampleFile().isIgnoreInQC());
             dataJsonObject.put("PrecursorId", plotData.getPrecursorId());
             dataJsonObject.put("SeriesType", plotData.getMetricSeriesIndex());
             if (includeMR)

--- a/src/org/labkey/targetedms/model/RawMetricDataSet.java
+++ b/src/org/labkey/targetedms/model/RawMetricDataSet.java
@@ -71,7 +71,7 @@ public class RawMetricDataSet
         String ionFormula;
         Double massMonoisotopic;
         Double massAverage;
-        String precursorCharge;
+        int precursorCharge;
 
         String seriesLabel;
 
@@ -97,7 +97,7 @@ public class RawMetricDataSet
 
         public void setPrecursorCharge(int precursorCharge)
         {
-            this.precursorCharge = LabelFactory.getChargeLabel(precursorCharge, false);
+            this.precursorCharge = precursorCharge;
         }
 
         public void setModifiedSequence(String modifiedSequence)
@@ -159,11 +159,8 @@ public class RawMetricDataSet
                     }
                 }
 
-                if (null != precursorCharge)
-                {
-                    modifiedSL.append(" ");
-                    modifiedSL.append(precursorCharge);
-                }
+                modifiedSL.append(" ");
+                modifiedSL.append(LabelFactory.getChargeLabel(precursorCharge, false));
 
                 modifiedSL.append(", ");
                 modifiedSL.append(format.format(mz));
@@ -319,35 +316,6 @@ public class RawMetricDataSet
     public void setCUSUMvN(Double d)
     {
         this.cusumVN = d;
-    }
-
-    public String getModifiedSequence()
-    {
-        return _precursor == null ? null : _precursor.modifiedSequence;
-    }
-
-    public String getCustomIonName()
-    {
-        return _precursor == null ? null : _precursor.customIonName;
-    }
-    public String getIonFormula()
-    {
-        return _precursor == null ? null : _precursor.ionFormula;
-    }
-
-    public Double getMassMonoisotopic()
-    {
-        return _precursor == null ? null : _precursor.massMonoisotopic;
-    }
-
-    public Double getMassAverage()
-    {
-        return _precursor == null ? null : _precursor.massAverage;
-    }
-
-    public String getPrecursorCharge()
-    {
-        return _precursor == null ? null : _precursor.precursorCharge;
     }
 
     public boolean isLeveyJenningsOutlier(GuideSetStats stat)

--- a/src/org/labkey/targetedms/model/SampleFileQCMetadata.java
+++ b/src/org/labkey/targetedms/model/SampleFileQCMetadata.java
@@ -1,22 +1,41 @@
 package org.labkey.targetedms.model;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.targetedms.parser.SampleFile;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 public class SampleFileQCMetadata extends SampleFile
 {
-    boolean ignoreInQC;
     boolean inGuideSetTrainingRange;
+    private Set<Integer> _ignoredMetricIds = Collections.emptySet();
 
     @Nullable
-    public boolean isIgnoreInQC()
+    public boolean isIgnoreInQC(int metricId)
     {
-        return ignoreInQC;
+        return _ignoredMetricIds.contains(metricId) || _ignoredMetricIds.contains(-1);
     }
 
-    public void setIgnoreInQC(boolean ignoreInQC)
+    public String getExcludedMetricIds(String ignoredMetricIds)
     {
-        this.ignoreInQC = ignoreInQC;
+        return StringUtils.join(_ignoredMetricIds, ",");
+    }
+
+    public void setExcludedMetricIds(String excludedMetricIds)
+    {
+        if (excludedMetricIds == null)
+        {
+            _ignoredMetricIds = Collections.emptySet();
+        }
+        else
+        {
+            _ignoredMetricIds = Arrays.stream(excludedMetricIds.split(",")).map(Integer::parseInt).collect(Collectors.toSet());
+        }
     }
 
     public boolean isInGuideSetTrainingRange()

--- a/src/org/labkey/targetedms/model/SampleFileQCMetadata.java
+++ b/src/org/labkey/targetedms/model/SampleFileQCMetadata.java
@@ -1,12 +1,10 @@
 package org.labkey.targetedms.model;
 
 import org.apache.commons.lang3.StringUtils;
-import org.jetbrains.annotations.Nullable;
 import org.labkey.targetedms.parser.SampleFile;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -15,7 +13,6 @@ public class SampleFileQCMetadata extends SampleFile
     boolean inGuideSetTrainingRange;
     private Set<Integer> _ignoredMetricIds = Collections.emptySet();
 
-    @Nullable
     public boolean isIgnoreInQC(int metricId)
     {
         // Use -1 to signify that an exclusion is for the whole sample (and therefore applies to all metrics)

--- a/src/org/labkey/targetedms/model/SampleFileQCMetadata.java
+++ b/src/org/labkey/targetedms/model/SampleFileQCMetadata.java
@@ -1,0 +1,31 @@
+package org.labkey.targetedms.model;
+
+import org.jetbrains.annotations.Nullable;
+import org.labkey.targetedms.parser.SampleFile;
+
+public class SampleFileQCMetadata extends SampleFile
+{
+    boolean ignoreInQC;
+    boolean inGuideSetTrainingRange;
+
+    @Nullable
+    public boolean isIgnoreInQC()
+    {
+        return ignoreInQC;
+    }
+
+    public void setIgnoreInQC(boolean ignoreInQC)
+    {
+        this.ignoreInQC = ignoreInQC;
+    }
+
+    public boolean isInGuideSetTrainingRange()
+    {
+        return inGuideSetTrainingRange;
+    }
+
+    public void setInGuideSetTrainingRange(boolean inGuideSetTrainingRange)
+    {
+        this.inGuideSetTrainingRange = inGuideSetTrainingRange;
+    }
+}

--- a/src/org/labkey/targetedms/model/SampleFileQCMetadata.java
+++ b/src/org/labkey/targetedms/model/SampleFileQCMetadata.java
@@ -18,6 +18,9 @@ public class SampleFileQCMetadata extends SampleFile
     @Nullable
     public boolean isIgnoreInQC(int metricId)
     {
+        // Use -1 to signify that an exclusion is for the whole sample (and therefore applies to all metrics)
+        // See GROUP_CONCAT in SampleFileForQC.sql
+
         return _ignoredMetricIds.contains(metricId) || _ignoredMetricIds.contains(-1);
     }
 

--- a/src/org/labkey/targetedms/outliers/OutlierGenerator.java
+++ b/src/org/labkey/targetedms/outliers/OutlierGenerator.java
@@ -325,11 +325,8 @@ public class OutlierGenerator
         {
             while (rs.next())
             {
-                RawMetricDataSet.PrecursorInfo p = new RawMetricDataSet.PrecursorInfo(format);
-                p.setPrecursorId(rs.getLong("Id"));
-                p.setMz(rs.getDouble("MZ"));
+                RawMetricDataSet.PrecursorInfo p = createPrecursor(format, rs, precursors);
                 p.setModifiedSequence(rs.getString("ModifiedSequence"));
-                precursors.put(p.getPrecursorId(), p);
             }
         }
 
@@ -338,17 +335,25 @@ public class OutlierGenerator
         {
             while (rs.next())
             {
-                RawMetricDataSet.PrecursorInfo p = new RawMetricDataSet.PrecursorInfo(format);
-                p.setPrecursorId(rs.getLong("Id"));
-                p.setMz(rs.getDouble("MZ"));
+                RawMetricDataSet.PrecursorInfo p = createPrecursor(format, rs, precursors);
                 p.setCustomIonName(rs.getString("CustomIonName"));
                 p.setIonFormula(rs.getString("IonFormula"));
                 p.setMassMonoisotopic(getDouble(rs, "massMonoisotopic"));
                 p.setMassAverage(getDouble(rs, "massAverage"));
-                precursors.put(p.getPrecursorId(), p);
             }
         }
         return precursors;
+    }
+
+    @NotNull
+    private RawMetricDataSet.PrecursorInfo createPrecursor(DecimalFormat format, ResultSet rs, Map<Long, RawMetricDataSet.PrecursorInfo> precursors) throws SQLException
+    {
+        RawMetricDataSet.PrecursorInfo p = new RawMetricDataSet.PrecursorInfo(format);
+        p.setPrecursorId(rs.getLong("Id"));
+        p.setMz(rs.getDouble("MZ"));
+        p.setPrecursorCharge(rs.getInt("Charge"));
+        precursors.put(p.getPrecursorId(), p);
+        return p;
     }
 
     private Long getLong(ResultSet rs, String columnName) throws SQLException

--- a/src/org/labkey/targetedms/query/PrecursorChromInfoTable.java
+++ b/src/org/labkey/targetedms/query/PrecursorChromInfoTable.java
@@ -19,7 +19,6 @@ import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.SQLFragment;
-import org.labkey.api.data.TableInfo;
 import org.labkey.api.query.DetailsURL;
 import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.FieldKey;
@@ -30,14 +29,9 @@ import org.labkey.targetedms.TargetedMSSchema;
 
 public class PrecursorChromInfoTable extends AnnotatedTargetedMSTable
 {
-    public PrecursorChromInfoTable(final TargetedMSSchema schema, ContainerFilter cf)
+    public PrecursorChromInfoTable(TargetedMSSchema schema, ContainerFilter cf)
     {
-        this(TargetedMSManager.getTableInfoPrecursorChromInfo(), schema, cf);
-    }
-
-    public PrecursorChromInfoTable(TableInfo table, TargetedMSSchema schema, ContainerFilter cf)
-    {
-        super(table, schema, cf, null, new SQLFragment("Container"),
+        super(TargetedMSManager.getTableInfoPrecursorChromInfo(), schema, cf, null, new SQLFragment("Container"),
                 TargetedMSManager.getTableInfoPrecursorChromInfoAnnotation(), "PrecursorChromInfoId", "Precursor Result Annotations", "precursor_result", false);
         var precursorId = getMutableColumn("PrecursorId");
         precursorId.setFk(new TargetedMSForeignKey(getUserSchema(), TargetedMSSchema.TABLE_PRECURSOR, cf));

--- a/src/org/labkey/targetedms/query/QCMetricConfigurationTable.java
+++ b/src/org/labkey/targetedms/query/QCMetricConfigurationTable.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
+import org.labkey.api.data.DbScope;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SqlExecutor;
 import org.labkey.api.data.Table;
@@ -104,6 +105,7 @@ public class QCMetricConfigurationTable extends FilteredTable<TargetedMSSchema>
         {
             var insertedRow = super.insertRow(user, container, row);
             calculateAndInsertTraceValuesForMetric((int) insertedRow.get("Id"), container, user);
+            TargetedMSManager.get().clearCachedEnabledQCMetrics(container);
             return insertedRow;
         }
 
@@ -114,6 +116,7 @@ public class QCMetricConfigurationTable extends FilteredTable<TargetedMSSchema>
             var metricId = (int) updatedRow.get("Id");
             deleteTraceValueForMetric(metricId, container);
             calculateAndInsertTraceValuesForMetric(metricId, container, user);
+            TargetedMSManager.get().clearCachedEnabledQCMetrics(container);
             return updatedRow;
         }
 
@@ -121,6 +124,7 @@ public class QCMetricConfigurationTable extends FilteredTable<TargetedMSSchema>
         protected Map<String, Object> deleteRow(User user, Container container, Map<String, Object> oldRow) throws InvalidKeyException, QueryUpdateServiceException, SQLException
         {
             deleteTraceValueForMetric((Integer) oldRow.get("id"), container);
+            TargetedMSManager.get().clearCachedEnabledQCMetrics(container);
             return super.deleteRow(user, container, oldRow);
         }
 

--- a/src/org/labkey/targetedms/query/QCMetricConfigurationTable.java
+++ b/src/org/labkey/targetedms/query/QCMetricConfigurationTable.java
@@ -104,8 +104,8 @@ public class QCMetricConfigurationTable extends FilteredTable<TargetedMSSchema>
         protected Map<String, Object> insertRow(User user, Container container, Map<String, Object> row) throws DuplicateKeyException, ValidationException, QueryUpdateServiceException, SQLException
         {
             var insertedRow = super.insertRow(user, container, row);
-            calculateAndInsertTraceValuesForMetric((int) insertedRow.get("Id"), container, user);
             TargetedMSManager.get().clearCachedEnabledQCMetrics(container);
+            calculateAndInsertTraceValuesForMetric((int) insertedRow.get("Id"), container, user);
             return insertedRow;
         }
 
@@ -115,16 +115,16 @@ public class QCMetricConfigurationTable extends FilteredTable<TargetedMSSchema>
             var updatedRow = super.updateRow(user, container, row, oldRow);
             var metricId = (int) updatedRow.get("Id");
             deleteTraceValueForMetric(metricId, container);
-            calculateAndInsertTraceValuesForMetric(metricId, container, user);
             TargetedMSManager.get().clearCachedEnabledQCMetrics(container);
+            calculateAndInsertTraceValuesForMetric(metricId, container, user);
             return updatedRow;
         }
 
         @Override
         protected Map<String, Object> deleteRow(User user, Container container, Map<String, Object> oldRow) throws InvalidKeyException, QueryUpdateServiceException, SQLException
         {
-            deleteTraceValueForMetric((Integer) oldRow.get("id"), container);
             TargetedMSManager.get().clearCachedEnabledQCMetrics(container);
+            deleteTraceValueForMetric((Integer) oldRow.get("id"), container);
             return super.deleteRow(user, container, oldRow);
         }
 

--- a/src/org/labkey/targetedms/query/SampleFileTable.java
+++ b/src/org/labkey/targetedms/query/SampleFileTable.java
@@ -161,7 +161,7 @@ public class SampleFileTable extends TargetedMSTable
                 }
             }
             return null;
-        }));
+        }, false));
 
         ActionURL url = new ActionURL(TargetedMSController.ShowSampleFileAction.class, getContainer());
         Map<String, String> urlParams = new HashMap<>();
@@ -221,7 +221,7 @@ public class SampleFileTable extends TargetedMSTable
             aggregates.add(new Aggregate(FieldKey.fromParts("InstrumentId"), Aggregate.BaseType.MAX));
 
             // Also search for values for any replicate annotations being used in this container
-            for (AnnotatedTargetedMSTable.AnnotationSettingForTyping annotation : AnnotatedTargetedMSTable.getAnnotationSettings("replicate", getUserSchema(), ContainerFilter.current(getUserSchema().getContainer())))
+            for (AnnotatedTargetedMSTable.AnnotationSettingForTyping annotation : getUserSchema().getAnnotationSettings("replicate", ContainerFilter.current(getUserSchema().getContainer())))
             {
                 aggregates.add(new Aggregate(FieldKey.fromParts("ReplicateId", annotation.getName()), Aggregate.BaseType.MAX));
             }

--- a/src/org/labkey/targetedms/query/TargetedMSTable.java
+++ b/src/org/labkey/targetedms/query/TargetedMSTable.java
@@ -120,7 +120,7 @@ public class TargetedMSTable extends FilteredTable<TargetedMSSchema>
             sql.append(_joinType != null ? _joinType.getSQL() : "");
 
             sql.append(" WHERE ");
-            sql.append(getContainerFilter().getSQLFragment(getSchema(), _containerSQL, getContainer()));
+            sql.append(getContainerFilter().getSQLFragment(getSchema(), _containerSQL));
 
             if(_containerTableFilter != null)
             {

--- a/src/org/labkey/targetedms/view/chromatogramsForm.jsp
+++ b/src/org/labkey/targetedms/view/chromatogramsForm.jsp
@@ -260,21 +260,21 @@
                     value:'<a style="color:#069; cursor:pointer;" id="clear-annot" onclick="clearAnnotations()">Clear</a>',
                     style:'margin-left:15px;',
                     name: "hideAnnotations"
+                },
+                {
+                    xtype: 'button',
+                    text: 'Update',
+                    handler: function(btn) {
+                        form.getForm().findField("annotationsFilter").setValue(form.getForm().findField("annotationsFilter").getValue().join(","));
+                        form.getForm().findField("replicatesFilter").setValue(form.getForm().findField("replicatesFilter").getValue().join(","));
+                        form.getForm().findField("update").setValue(true);
+                        form.submit({
+                            url: <%=q(bean.getResultsUri())%>,
+                            method: 'GET'
+                        });
+                    }
                 }
             ],
-            buttonAlign: 'left',
-            buttons: [{
-                text: 'Update',
-                handler: function(btn) {
-                    form.getForm().findField("annotationsFilter").setValue(form.getForm().findField("annotationsFilter").getValue().join(","));
-                    form.getForm().findField("replicatesFilter").setValue(form.getForm().findField("replicatesFilter").getValue().join(","));
-                    form.getForm().findField("update").setValue(true);
-                    form.submit({
-                    url: <%=q(bean.getResultsUri())%>,
-                        method: 'GET'
-                    });
-                }
-            }]
         });
 
         // This has to happen after form is rendered.

--- a/src/org/labkey/targetedms/view/chromatogramsForm.jsp
+++ b/src/org/labkey/targetedms/view/chromatogramsForm.jsp
@@ -141,6 +141,7 @@
             name: 'chromForm',
             border: false, frame: false,
             width:550,
+            height: 160,
             defaults: {
                 labelWidth: 150,
                 labelHeight: 23,
@@ -468,35 +469,28 @@
         manageFilterListVisibility();
     }
 
-    $(document).ready(function() {
-        if ( $('#formContainer').length) // formContainer must exist inorder for showChart to work.
-        {
-            showChart();
-        }
-    });
-
-    // Handels showing and hiding the form.
+    // Handles showing and hiding the form.
     showChart = function()
     {
-        if($('#showGraphImg').attr('src') === LABKEY.contextPath + "/_images/plus.gif")
+        if($('#showGraphImg').attr('src') === <%= q(getWebappURL("/_images/plus.gif")) %>)
         {
-            $('#showGraphImg').attr('src', LABKEY.contextPath + "/_images/minus.gif");
-            $('#formContainer').show("slow");
-            $('#allFilters').show("slow");
+            $('#showGraphImg').attr('src', <%= q(getWebappURL("/_images/minus.gif")) %>);
+            $('#formContainer').show();
+            $('#allFilters').show();
         }
         else
         {
-            $('#showGraphImg').attr('src', LABKEY.contextPath + "/_images/plus.gif");
-            $('#formContainer').hide("slow");
-            $('#allFilters').hide("slow");
+            $('#showGraphImg').attr('src', <%= q(getWebappURL("/_images/plus.gif")) %>);
+            $('#formContainer').hide();
+            $('#allFilters').hide();
         }
     }
 }(jQuery);
 </script>
 <div id="headContainer">
-    <div onclick="showChart()" style="margin-bottom: 10px;"><img id="showGraphImg" src="<%=getWebappURL("_images/minus.gif")%>"> <strong>Display Chart Settings</strong></div>
-    <div id="formContainer" style="float:left; width:550px; padding-bottom: 25px;"></div>
-    <div id="allFilters" style="float:left;">
+    <div onclick="showChart()" style="margin-bottom: 10px;"><img id="showGraphImg" src="<%=getWebappURL("_images/plus.gif")%>"> <strong>Display Chart Settings</strong></div>
+    <div id="formContainer" style="float:left; width:550px; height: 160px; padding-bottom: 25px; display: none;"></div>
+    <div id="allFilters" style="float:left; display: none;">
 
         <div style="float:left;" class="chrom_title_box" id="reptitle" >
             <h3 class="title">Replicate Filters</h3>

--- a/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
@@ -367,7 +367,7 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
 
     public String getExperimentRangeRectTitle()
     {
-        return elementCache().experimentRangeRect.findElement(getDriver()).getText();
+        return elementCache().experimentRangeRect.waitForElement(getDriver(), WAIT_FOR_JAVASCRIPT).getText();
     }
 
     public int getGuideSetErrorBarPathCount(String cls)

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentalQCLinkTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentalQCLinkTest.java
@@ -148,8 +148,10 @@ public class TargetedMSExperimentalQCLinkTest extends TargetedMSTest
         qcDashboard = new PanoramaDashboard(this);
         qcPlotsWebPart = qcDashboard.getQcPlotsWebPart();
 
+
         checker().verifyEquals("Incorrect expRange information", expRange, qcPlotsWebPart.getExperimentRangeRectTitle());
         checker().verifyEquals("Incorrect guideSet information", guideSetTitle, qcPlotsWebPart.getGuideSetTrainingRectTitle(2));
+        checker().screenShotIfNewError("InitialRangeFiltering");
 
         String testStartDate = "2013-08-19";
         String testEndDate = "2013-08-27";

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSMultiplePeptidePlotTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSMultiplePeptidePlotTest.java
@@ -67,6 +67,7 @@ public class TargetedMSMultiplePeptidePlotTest extends TargetedMSTest
         setFormElement(shortWait().until(ExpectedConditions.visibilityOfElementLocated(Locator.name("chartHeight"))), height);
         new ComboBox.ComboBoxFinder(getDriver()).withInputNamed("replicatesFilter")
                 .findWhenNeeded(getDriver()).setMultiSelect(true).selectComboBoxItem(replicateName);
+
         clickButton("Update");
 
         checker().verifyEquals("Only one graph should have been displayed", 1, table.getDataRowCount());

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSMxNReproducibilityReportTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSMxNReproducibilityReportTest.java
@@ -151,7 +151,8 @@ public class TargetedMSMxNReproducibilityReportTest extends TargetedMSTest
         clickAndWait(Locator.linkWithText("Show Details"));
 
         log("Verifying only 3 samples for displayed");
-        checker().verifyEquals("More then 3 samples displayed",
+        waitForText("Blank+IS__VIFonly");
+        checker().verifyEquals("More than 3 samples displayed",
                 "Blank+IS__VIFonly\n" + "Blank+IS__VIFonly (2)\n" + "Cal 1_0_20 ng_mL_VIFonly\n" + "and 22 more",
                 Locator.tagWithId("div", "fom-sampleList").findElement(getDriver()).getText());
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -73,13 +73,13 @@ public class TargetedMSQCTest extends TargetedMSTest
             "VLVLDTDYK",
             "VYVEELKPTPEGDLEILLQK"};
     private static final String[] PRECURSOR_TITLES = {
-            "ATEEQLK +2, 409.7163",
-            "FFVAPFPEVFGK +2, 692.8686",
-            "GASIVEDK +2, 409.7163",
-            "LVNELTEFAK +2, 582.3190",
-            "VLDALDSIK +2, 487.2819",
-            "VLVLDTDYK +2, 533.2950",
-            "VYVEELKPTPEGDLEILLQK +2, 1,157.1330"};
+            "ATEEQLK ++, 409.7163",
+            "FFVAPFPEVFGK ++, 692.8686",
+            "GASIVEDK ++, 409.7163",
+            "LVNELTEFAK ++, 582.3190",
+            "VLDALDSIK ++, 487.2819",
+            "VLVLDTDYK ++, 533.2950",
+            "VYVEELKPTPEGDLEILLQK ++, 1,157.1330"};
 
     private static final String QCREPLICATE_1 = "25fmol_Pepmix_spike_SRM_1601_01";
     private static final String QCREPLICATE_2 = "25fmol_Pepmix_spike_SRM_1601_02";
@@ -529,8 +529,8 @@ public class TargetedMSQCTest extends TargetedMSTest
     public void testDocsWithOverlappingSampleFiles()
     {
         List<String> precursors = new ArrayList<>();
-        precursors.add("AGGSSEPVTGLADK +2, 644.8226");
-        precursors.add("VEATFGVDESANK +2, 683.8279");
+        precursors.add("AGGSSEPVTGLADK ++, 644.8226");
+        precursors.add("VEATFGVDESANK ++, 683.8279");
         Collections.sort(precursors);
 
         String subFolderName = "OverlappingSampleFiles";


### PR DESCRIPTION
#### Rationale
Fast pages are good. QC folders in Panorama are slower than we want, and there are some platform changes to help improve the SQL we run and how we process the data in Java.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2960

#### Changes
* Optimize SQL generation for QC metrics
* Pull redundant data (precursor and sample file info) out of the main metric query to improve SQL and Java perf (and memory footprint)
* Don't use reflection-based ResultSet->Java object mapping, instead pull directly from the ResultSet and use setters
* Misc minor code cleanup
* Cache annotation and QC metric configuration info for very short-term use