### PR TITLE
Issue 44713: Disconnect on table name in metadata for targetedms.RunRepresentativeDataState

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSSchema.java
+++ b/src/org/labkey/targetedms/TargetedMSSchema.java
@@ -939,15 +939,18 @@ public class TargetedMSSchema extends UserSchema
             return result;
         }
 
-        if (TABLE_REPRESENTATIVE_DATA_STATE_RUN.equalsIgnoreCase(name))
+        // Issue 44713: Disconnect on table name in metadata for targetedms.RepresentativeDataState_Run/RunRepresentativeDataState
+        if (TABLE_REPRESENTATIVE_DATA_STATE_RUN.equalsIgnoreCase(name) || RunRepresentativeDataState.class.getSimpleName().equalsIgnoreCase(name))
         {
-            return new EnumTableInfo<>(
+            EnumTableInfo result = new EnumTableInfo<>(
                     RunRepresentativeDataState.class,
                     this,
                     RunRepresentativeDataState::getLabel,
                     true,
                     "Possible states a run might be in for resolving representative data after upload"
                     );
+            result.setName(TABLE_REPRESENTATIVE_DATA_STATE_RUN);
+            return result;
         }
         if (TABLE_REPRESENTATIVE_DATA_STATE.equalsIgnoreCase(name))
         {


### PR DESCRIPTION
#### Rationale
Sometimes this table thinks its name is RunRepresentativeDataState and other times RepresentativeDataState_Run

#### Changes
* Standardize on RepresentativeDataState_Run but still resolve it when asked for RunRepresentativeDataState