### PR TITLE
Issue 44765: Increase CacheFormatVersion to 15

### DIFF
--- a/src/org/labkey/targetedms/parser/skyd/CacheFormatVersion.java
+++ b/src/org/labkey/targetedms/parser/skyd/CacheFormatVersion.java
@@ -34,6 +34,7 @@ public enum CacheFormatVersion
     Twelve,// Adds structure sizes to CacheHeaderStruct
     Thirteen, // Adds total ion current to CachedFileHeaderStruct
     Fourteen, // Adds sample id to CachedFileHeaderStruct
+    Fifteen, // Add import time to CachedFileHeaderStruct
     UnknownFutureVersion;
     public static CacheFormatVersion fromInteger(int i) {
         if (i <= Zero.ordinal()) {
@@ -44,5 +45,5 @@ public enum CacheFormatVersion
         }
         return values()[i];
     }
-    public static final CacheFormatVersion CURRENT = Fourteen;
+    public static final CacheFormatVersion CURRENT = Fifteen;
 }

--- a/src/org/labkey/targetedms/parser/skyd/CachedFileHeaderStruct.java
+++ b/src/org/labkey/targetedms/parser/skyd/CachedFileHeaderStruct.java
@@ -42,6 +42,8 @@ public class CachedFileHeaderStruct
     float ticArea;
     int lenSampleId;
     int lenSerialNumber;
+    // Version 15 file header addition
+    long importTime;
 
     public CachedFileHeaderStruct(LittleEndianInput dataInputStream)
     {
@@ -57,9 +59,13 @@ public class CachedFileHeaderStruct
         ticArea = Float.intBitsToFloat(dataInputStream.readInt());
         lenSampleId = dataInputStream.readInt();
         lenSerialNumber = dataInputStream.readInt();
+        importTime = dataInputStream.readLong();
     }
 
     public static int getStructSize(CacheFormatVersion formatVersion) {
+        if (formatVersion.compareTo(CacheFormatVersion.Fifteen) >= 0) {
+            return 68;
+        }
         if (formatVersion.compareTo(CacheFormatVersion.Fourteen) >= 0) {
             return 60;
         }

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSMxNReproducibilityReportTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSMxNReproducibilityReportTest.java
@@ -151,9 +151,7 @@ public class TargetedMSMxNReproducibilityReportTest extends TargetedMSTest
         clickAndWait(Locator.linkWithText("Show Details"));
 
         log("Verifying only 3 samples for displayed");
-        checker().verifyEquals("More then 3 samples displayed",
-                "Blank+IS__VIFonly\n" + "Blank+IS__VIFonly (2)\n" + "Cal 1_0_20 ng_mL_VIFonly\n" + "and 22 more",
-                Locator.tagWithId("div", "fom-sampleList").findElement(getDriver()).getText());
+        waitForElementText(Locator.tagWithId("div", "fom-sampleList"), "Blank+IS__VIFonly\n" + "Blank+IS__VIFonly (2)\n" + "Cal 1_0_20 ng_mL_VIFonly\n" + "and 22 more");
 
         log("Verifying the downloaded file");
         File exportedExcel = clickAndWaitForDownload(Locator.linkWithId("targetedms-fom-export"));


### PR DESCRIPTION
#### Rationale
The current supported CacheFormatVersion in the targetedms module is 14. Skyline now supports version 15. The only new information added to version 15 is the "Import Time" which is the time the chromatograms were extracted. This can be ignored by Panorama so we can bump up the supported CacheFormatVersion to 15.


