### PR TITLE
Reduce JSON payload size in QC folder API, improve query caching

### DIFF
--- a/api-src/org/labkey/api/targetedms/model/SampleFileInfo.java
+++ b/api-src/org/labkey/api/targetedms/model/SampleFileInfo.java
@@ -20,6 +20,8 @@ public class SampleFileInfo extends OutlierCounts
     /** Use a TreeMap to keep the metrics sorted by name */
     final Map<String, OutlierCounts> byMetric = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
+    private Boolean _inGuideSetTrainingRange;
+
     public SampleFileInfo(long sampleId, Date acquiredTime, String sampleFile, int guideSetId, boolean ignoreForAllMetric, String filePath, Long replicateId)
     {
         this.sampleId = sampleId;
@@ -111,7 +113,20 @@ public class SampleFileInfo extends OutlierCounts
         jsonObject.put("ReplicateId", getReplicateId());
         jsonObject.put("FilePath", getFilePath());
         jsonObject.put("AcquiredTime", getAcquiredTime());
+        jsonObject.put("GuideSetId", getGuideSetId());
+        // Intentionally dereference wrapper object to be sure it's always populated with a true/false value in this codepath
+        jsonObject.put("InGuideSetTrainingRange", _inGuideSetTrainingRange.booleanValue());
 
         return jsonObject;
+    }
+
+    public void setInGuideSetTrainingRange(Boolean inGuideSetTrainingRange)
+    {
+        _inGuideSetTrainingRange = inGuideSetTrainingRange;
+    }
+
+    public boolean getInGuideSetTrainingRange()
+    {
+        return _inGuideSetTrainingRange;
     }
 }

--- a/api-src/org/labkey/api/targetedms/model/SampleFileInfo.java
+++ b/api-src/org/labkey/api/targetedms/model/SampleFileInfo.java
@@ -14,21 +14,20 @@ public class SampleFileInfo extends OutlierCounts
     final String sampleFile;
     final Date acquiredTime;
     final int guideSetId;
-    final boolean ignoreForAllMetric;
     final String filePath;
     final long replicateId;
     /** Use a TreeMap to keep the metrics sorted by name */
     final Map<String, OutlierCounts> byMetric = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
     private Boolean _inGuideSetTrainingRange;
+    private boolean ignoreForAllMetric;
 
-    public SampleFileInfo(long sampleId, Date acquiredTime, String sampleFile, int guideSetId, boolean ignoreForAllMetric, String filePath, Long replicateId)
+    public SampleFileInfo(long sampleId, Date acquiredTime, String sampleFile, int guideSetId, String filePath, Long replicateId)
     {
         this.sampleId = sampleId;
         this.acquiredTime = acquiredTime;
         this.sampleFile = sampleFile;
         this.guideSetId = guideSetId;
-        this.ignoreForAllMetric = ignoreForAllMetric;
         this.filePath = filePath;
         this.replicateId = replicateId;
     }
@@ -51,6 +50,11 @@ public class SampleFileInfo extends OutlierCounts
     public boolean isIgnoreForAllMetric()
     {
         return ignoreForAllMetric;
+    }
+
+    public void setIgnoreForAllMetric(boolean ignoreForAllMetric)
+    {
+        this.ignoreForAllMetric = ignoreForAllMetric;
     }
 
     public long getSampleId()

--- a/resources/queries/targetedms/SampleFileForQC.sql
+++ b/resources/queries/targetedms/SampleFileForQC.sql
@@ -10,3 +10,4 @@ LEFT OUTER JOIN (SELECT GROUP_CONCAT(COALESCE(MetricId, -1)) AS ExcludedMetricId
 ON sf.ReplicateId = e.ReplicateId
 LEFT JOIN GuideSetForOutliers gs
 ON ((sf.AcquiredTime >= gs.TrainingStart AND sf.AcquiredTime < gs.ReferenceEnd) OR (sf.AcquiredTime >= gs.TrainingStart AND gs.ReferenceEnd IS NULL))
+WHERE sf.AcquiredTime IS NOT NULL

--- a/src/org/labkey/targetedms/TargetedMSManager.java
+++ b/src/org/labkey/targetedms/TargetedMSManager.java
@@ -2117,16 +2117,10 @@ public class TargetedMSManager
         return Math.log(value.doubleValue()) / Math.log(2);
     }
 
-    public static List<QCMetricConfiguration> getEnabledQCMetricConfigurations(Container container, User user)
+    public static List<QCMetricConfiguration> getEnabledQCMetricConfigurations(TargetedMSSchema targetedMSSchema)
     {
-        return _metricCache.get(container, null, (p, argument) ->
+        return _metricCache.get(targetedMSSchema.getContainer(), null, (c, argument) ->
         {
-            QuerySchema targetedMSSchema = DefaultSchema.get(user, container).getSchema(TargetedMSSchema.SCHEMA_NAME);
-            if (targetedMSSchema == null)
-            {
-                // Module must not be enabled in this folder, so bail out
-                return Collections.emptyList();
-            }
             TableInfo metricsTable = targetedMSSchema.getTable("qcMetricsConfig", null);
             List<QCMetricConfiguration> metrics = new TableSelector(metricsTable, new SimpleFilter(FieldKey.fromParts("Enabled"), false, CompareType.NEQ_OR_NULL), new Sort(FieldKey.fromParts("Name"))).getArrayList(QCMetricConfiguration.class);
             List<QCMetricConfiguration> result = new ArrayList<>();
@@ -2141,7 +2135,7 @@ public class TargetedMSManager
                     }
                     else
                     {
-                        QuerySchema enabledSchema = TargetedMSSchema.SCHEMA_NAME.equalsIgnoreCase(metric.getEnabledSchemaName()) ? targetedMSSchema : DefaultSchema.get(user, container).getSchema(metric.getEnabledSchemaName());
+                        QuerySchema enabledSchema = TargetedMSSchema.SCHEMA_NAME.equalsIgnoreCase(metric.getEnabledSchemaName()) ? targetedMSSchema : targetedMSSchema.getDefaultSchema().getSchema(metric.getEnabledSchemaName());
                         if (enabledSchema != null)
                         {
                             TableInfo enabledQuery = enabledSchema.getTable(metric.getEnabledQueryName(), null);
@@ -2154,12 +2148,12 @@ public class TargetedMSManager
                             }
                             else
                             {
-                                _log.warn("Could not find query " + metric.getEnabledSchemaName() + "." + metric.getEnabledQueryName() + " to determine if metric " + metric.getName() + " should be enabled in container " + container.getPath());
+                                _log.warn("Could not find query " + metric.getEnabledSchemaName() + "." + metric.getEnabledQueryName() + " to determine if metric " + metric.getName() + " should be enabled in container " + c.getPath());
                             }
                         }
                         else
                         {
-                            _log.warn("Could not find schema " + metric.getEnabledSchemaName() + " to determine if metric " + metric.getName() + " should be enabled in container " + container.getPath());
+                            _log.warn("Could not find schema " + metric.getEnabledSchemaName() + " to determine if metric " + metric.getName() + " should be enabled in container " + c.getPath());
                         }
                     }
                 }
@@ -2176,17 +2170,18 @@ public class TargetedMSManager
 
     public List<SampleFileInfo> getSampleFileInfos(Container container, User user, Integer sampleFileLimit)
     {
-        List<QCMetricConfiguration> enabledQCMetricConfigurations = getEnabledQCMetricConfigurations(container, user);
+        TargetedMSSchema schema = new TargetedMSSchema(user, container);
+        List<QCMetricConfiguration> enabledQCMetricConfigurations = getEnabledQCMetricConfigurations(schema);
         if(!enabledQCMetricConfigurations.isEmpty())
         {
             List<GuideSet> guideSets = TargetedMSManager.getGuideSets(container, user);
             Map<Integer, QCMetricConfiguration> metricMap = enabledQCMetricConfigurations.stream().collect(Collectors.toMap(QCMetricConfiguration::getId, Function.identity()));
 
-            List<RawMetricDataSet> rawMetricDataSets = OutlierGenerator.get().getRawMetricDataSets(container, user, enabledQCMetricConfigurations, null, null, Collections.emptyList(), true);
+            List<RawMetricDataSet> rawMetricDataSets = OutlierGenerator.get().getRawMetricDataSets(schema, enabledQCMetricConfigurations, null, null, Collections.emptyList(), true);
 
             Map<GuideSetKey, GuideSetStats> stats = OutlierGenerator.get().getAllProcessedMetricGuideSets(rawMetricDataSets, guideSets.stream().collect(Collectors.toMap(GuideSet::getRowId, Function.identity())));
 
-            return OutlierGenerator.get().getSampleFiles(rawMetricDataSets, stats, metricMap, container, sampleFileLimit);
+            return OutlierGenerator.get().getSampleFiles(rawMetricDataSets, stats, metricMap, schema, sampleFileLimit);
         }
         return Collections.emptyList();
     }
@@ -2584,7 +2579,7 @@ public class TargetedMSManager
 
     public static List<QCMetricConfiguration> getTraceMetricConfigurations(Container container, User user)
     {
-        return getEnabledQCMetricConfigurations(container, user)
+        return getEnabledQCMetricConfigurations(new TargetedMSSchema(user, container))
                 .stream()
                 .filter(qcMetricConfiguration -> qcMetricConfiguration.getTraceName() != null)
                 .collect(Collectors.toList());

--- a/src/org/labkey/targetedms/model/QCPlotFragment.java
+++ b/src/org/labkey/targetedms/model/QCPlotFragment.java
@@ -113,9 +113,12 @@ public class QCPlotFragment
             dataJsonObject.put("Value", plotData.getMetricValue());
             dataJsonObject.put("SampleFileId", plotData.getSampleFile().getId());
             dataJsonObject.put("PrecursorChromInfoId", plotData.getPrecursorChromInfoId());
-            dataJsonObject.put("InGuideSetTrainingRange", plotData.getSampleFile().isInGuideSetTrainingRange());
-            dataJsonObject.put("GuideSetId", plotData.getSampleFile().getGuideSetId());
-            dataJsonObject.put("IgnoreInQC", plotData.getSampleFile().isIgnoreInQC(plotData.getMetricId()));
+            boolean ignoreInQC = plotData.getSampleFile().isIgnoreInQC(plotData.getMetricId());
+            if (ignoreInQC)
+            {
+                // Reduce JSON payload size by only sending value for rows where it's true
+                dataJsonObject.put("IgnoreInQC", true);
+            }
             dataJsonObject.put("PrecursorId", plotData.getPrecursorId());
             dataJsonObject.put("SeriesType", plotData.getMetricSeriesIndex());
             if (includeMR)

--- a/src/org/labkey/targetedms/model/SampleFileQCMetadata.java
+++ b/src/org/labkey/targetedms/model/SampleFileQCMetadata.java
@@ -1,6 +1,7 @@
 package org.labkey.targetedms.model;
 
 import org.apache.commons.lang3.StringUtils;
+import org.labkey.api.targetedms.model.SampleFileInfo;
 import org.labkey.targetedms.parser.SampleFile;
 
 import java.util.Arrays;
@@ -46,5 +47,13 @@ public class SampleFileQCMetadata extends SampleFile
     public void setInGuideSetTrainingRange(boolean inGuideSetTrainingRange)
     {
         this.inGuideSetTrainingRange = inGuideSetTrainingRange;
+    }
+
+    @Override
+    public SampleFileInfo toSampleFileInfo()
+    {
+        SampleFileInfo result = super.toSampleFileInfo();
+        result.setInGuideSetTrainingRange(isInGuideSetTrainingRange());
+        return result;
     }
 }

--- a/src/org/labkey/targetedms/model/SampleFileQCMetadata.java
+++ b/src/org/labkey/targetedms/model/SampleFileQCMetadata.java
@@ -14,12 +14,13 @@ public class SampleFileQCMetadata extends SampleFile
     boolean inGuideSetTrainingRange;
     private Set<Integer> _ignoredMetricIds = Collections.emptySet();
 
+    // Use -1 to signify that an exclusion is for the whole sample (and therefore applies to all metrics)
+    // See GROUP_CONCAT in SampleFileForQC.sql
+    private static final int ALL_METRICS = -1;
+
     public boolean isIgnoreInQC(int metricId)
     {
-        // Use -1 to signify that an exclusion is for the whole sample (and therefore applies to all metrics)
-        // See GROUP_CONCAT in SampleFileForQC.sql
-
-        return _ignoredMetricIds.contains(metricId) || _ignoredMetricIds.contains(-1);
+        return _ignoredMetricIds.contains(metricId) || _ignoredMetricIds.contains(ALL_METRICS);
     }
 
     public String getExcludedMetricIds(String ignoredMetricIds)
@@ -54,6 +55,7 @@ public class SampleFileQCMetadata extends SampleFile
     {
         SampleFileInfo result = super.toSampleFileInfo();
         result.setInGuideSetTrainingRange(isInGuideSetTrainingRange());
+        result.setIgnoreForAllMetric(_ignoredMetricIds.contains(ALL_METRICS));
         return result;
     }
 }

--- a/src/org/labkey/targetedms/outliers/OutlierGenerator.java
+++ b/src/org/labkey/targetedms/outliers/OutlierGenerator.java
@@ -236,11 +236,10 @@ public class OutlierGenerator
         }
     }
 
-    public List<RawMetricDataSet> getRawMetricDataSets(Container container, User user, List<QCMetricConfiguration> configurations, Date startDate, Date endDate, List<AnnotationGroup> annotationGroups, boolean showExcluded)
+    public List<RawMetricDataSet> getRawMetricDataSets(TargetedMSSchema schema, List<QCMetricConfiguration> configurations, Date startDate, Date endDate, List<AnnotationGroup> annotationGroups, boolean showExcluded)
     {
         List<RawMetricDataSet> result = new ArrayList<>();
 
-        TargetedMSSchema schema = new TargetedMSSchema(user, container);
         TableInfo sampleFileForQC = schema.getTable("SampleFileForQC");
         List<SampleFileQCMetadata> sfs = new TableSelector(sampleFileForQC).getArrayList(SampleFileQCMetadata.class);
 
@@ -389,9 +388,12 @@ public class OutlierGenerator
 
     /**
      * @param metrics id to QC metric  */
-    public List<SampleFileInfo> getSampleFiles(List<RawMetricDataSet> dataRows, Map<GuideSetKey, GuideSetStats> allStats, Map<Integer, QCMetricConfiguration> metrics, Container container, Integer limit)
+    public List<SampleFileInfo> getSampleFiles(List<RawMetricDataSet> dataRows, Map<GuideSetKey, GuideSetStats> allStats, Map<Integer, QCMetricConfiguration> metrics, TargetedMSSchema schema, Integer limit)
     {
-        List<SampleFileInfo> result = TargetedMSManager.getSampleFiles(container, new SQLFragment("sf.AcquiredTime IS NOT NULL")).stream().map(SampleFile::toSampleFileInfo).collect(Collectors.toList());
+        TableInfo sampleFileForQC = schema.getTable("SampleFileForQC");
+        List<SampleFileQCMetadata> sfs = new TableSelector(sampleFileForQC).getArrayList(SampleFileQCMetadata.class);
+
+        List<SampleFileInfo> result = sfs.stream().map(SampleFile::toSampleFileInfo).collect(Collectors.toList());
         Map<Long, SampleFileInfo> sampleFiles = result.stream().collect(Collectors.toMap(SampleFileInfo::getSampleId, Function.identity(), (a, b) -> a));
 
         for (RawMetricDataSet dataRow : dataRows)

--- a/src/org/labkey/targetedms/parser/SampleFile.java
+++ b/src/org/labkey/targetedms/parser/SampleFile.java
@@ -51,7 +51,6 @@ public class SampleFile extends SkylineEntity implements ISampleFile
 
     // Calculated values loaded via TargetedMSManager.getSampleFiles()
     private Integer _guideSetId;
-    private boolean _ignoreForAllMetric;
 
     private List<Instrument> _instrumentInfoList;
 
@@ -206,19 +205,9 @@ public class SampleFile extends SkylineEntity implements ISampleFile
         _guideSetId = guideSetId;
     }
 
-    public boolean isIgnoreForAllMetric()
-    {
-        return _ignoreForAllMetric;
-    }
-
-    public void setIgnoreForAllMetric(boolean ignoreForAllMetric)
-    {
-        _ignoreForAllMetric = ignoreForAllMetric;
-    }
-
     public SampleFileInfo toSampleFileInfo()
     {
-        return new SampleFileInfo(getId(), getAcquiredTime(), getSampleName(), _guideSetId, _ignoreForAllMetric, getFilePath(), getReplicateId());
+        return new SampleFileInfo(getId(), getAcquiredTime(), getSampleName(), _guideSetId, getFilePath(), getReplicateId());
     }
 
     @Override

--- a/src/org/labkey/targetedms/query/QCMetricConfigurationTable.java
+++ b/src/org/labkey/targetedms/query/QCMetricConfigurationTable.java
@@ -16,16 +16,13 @@
 package org.labkey.targetedms.query;
 
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
-import org.labkey.api.data.DbScope;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SqlExecutor;
 import org.labkey.api.data.Table;
 import org.labkey.api.data.TableInfo;
-import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.DefaultQueryUpdateService;
 import org.labkey.api.query.DuplicateKeyException;
 import org.labkey.api.query.FilteredTable;
@@ -41,7 +38,6 @@ import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.targetedms.TargetedMSManager;
 import org.labkey.targetedms.TargetedMSRun;
 import org.labkey.targetedms.TargetedMSSchema;
-import org.labkey.targetedms.model.QCMetricConfiguration;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -95,9 +91,12 @@ public class QCMetricConfigurationTable extends FilteredTable<TargetedMSSchema>
 
     public static class QCMetricConfigurationTableUpdateService extends DefaultQueryUpdateService
     {
-        protected QCMetricConfigurationTableUpdateService(TableInfo queryTable, TableInfo realTable)
+        private final QCMetricConfigurationTable _queryTable;
+
+        protected QCMetricConfigurationTableUpdateService(QCMetricConfigurationTable queryTable, TableInfo realTable)
         {
             super(queryTable, realTable);
+            _queryTable = queryTable;
         }
 
         @Override
@@ -143,7 +142,7 @@ public class QCMetricConfigurationTable extends FilteredTable<TargetedMSSchema>
         private void calculateAndInsertTraceValuesForMetric(int metricId, Container container, User user)
         {
             var qcMetricConfigurations = TargetedMSManager
-                    .getEnabledQCMetricConfigurations(container, user)
+                    .getEnabledQCMetricConfigurations(_queryTable.getUserSchema())
                     .stream()
                     .filter(qcMetricConfiguration -> qcMetricConfiguration.getId() == metricId)
                     .collect(Collectors.toList());

--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -130,15 +130,18 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
 
         LABKEY.Ajax.request({
             url: LABKEY.ActionURL.buildURL('targetedms', 'GetQCPlotsData.api'),
-            success: this.processPlotData,
+            success: function(response) {
+                this.lastParsedResponse = JSON.parse(response.responseText);
+                this.processPlotData();
+            },
             failure: LABKEY.Utils.getCallbackWrapper(this.failureHandler),
             scope: this,
             jsonData: plotsConfig
         });
     },
 
-    processPlotData: function(response) {
-        var parsed = JSON.parse(response.responseText);
+    processPlotData: function() {
+        var parsed = this.lastParsedResponse;
         var plotDataRows = parsed.plotDataRows;
         var metricProps = parsed.metricProps;
         var sampleFiles = parsed.sampleFiles;
@@ -158,19 +161,26 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
             this.processRawGuideSetData(plotDataRows);
         }
 
+        let sampleFilesById = {};
+        Ext4.iterate(sampleFiles, function (sampleFile) {
+            sampleFilesById[sampleFile['SampleId']] = sampleFile;
+        }, this);
+
+
         var tempData; // temp variable to store data for setting the date
         for (var i = this.pagingStartIndex; i < this.pagingEndIndex; i++) {
             var plotDataRow = plotDataRows[i];
             tempData = plotDataRow;
             var fragment = plotDataRow.SeriesLabel;
             Ext4.iterate(plotDataRow.data, function (plotData) {
-                Ext4.iterate(sampleFiles, function (sampleFile) {
-                    if (plotData['SampleFileId'] === sampleFile['SampleId']) {
-                        plotData['FilePath'] = sampleFile['FilePath'];
-                        plotData['ReplicateId'] = sampleFile['ReplicateId'];
-                        plotData['AcquiredTime'] = sampleFile['AcquiredTime'];
-                    }
-                }, this);
+
+                // Flatten the sample file data into each row
+                let sampleFile = sampleFilesById[plotData['SampleFileId']];
+                plotData['FilePath'] = sampleFile['FilePath'];
+                plotData['ReplicateId'] = sampleFile['ReplicateId'];
+                plotData['AcquiredTime'] = sampleFile['AcquiredTime'];
+                plotData['GuideSetId'] = sampleFile['GuideSetId'];
+                plotData['InGuideSetTrainingRange'] = sampleFile['InGuideSetTrainingRange'];
 
                 var data = this.processPlotDataRow(plotData, plotDataRow, fragment, metricProps);
                 this.fragmentPlotData[fragment].data.push(data);

--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -142,6 +142,9 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
 
     processPlotData: function() {
         var parsed = this.lastParsedResponse;
+        if (!parsed)
+            return;
+
         var plotDataRows = parsed.plotDataRows;
         var metricProps = parsed.metricProps;
         var sampleFiles = parsed.sampleFiles;

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -702,7 +702,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
 
                         // call processPlotData instead of renderPlots so that we recalculate min y-axis scale for log
                         this.setLoadingMsg();
-                        this.getPlotsData();
+                        this.processPlotData();
                     }
                 }
             });
@@ -970,7 +970,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
 
                         this.setBrushingEnabled(false);
                         this.setLoadingMsg();
-                        this.getAnnotationData();
+                        this.processPlotData();
                     }
                 }
             });


### PR DESCRIPTION
#### Rationale
We want QC folders to be faster

#### Changes
* Reduce JSON payload by not sending booleans that are false 99% of the time. Only send when true
* Pull more sample level metadata into the sample file section and out of the individual data rows
* Avoid round-tripping again for QC plot customizations that don't impact the data needed
* Reuse schema object to let us cache more tables and queries