### PR TITLE
Issue 44257: IllegalStateException in PrecursorDataset.buildJFreedataset()

### DIFF
--- a/src/org/labkey/targetedms/chart/ChromatogramDataset.java
+++ b/src/org/labkey/targetedms/chart/ChromatogramDataset.java
@@ -329,7 +329,7 @@ public abstract class ChromatogramDataset
         @Override
         public String getChartTitle()
         {
-            return _chromInfo.getTextId() == null ? "Unknown trace" : _chromInfo.getTextId();
+            return _chromInfo.getTitle();
         }
 
         @Override
@@ -940,14 +940,10 @@ public abstract class ChromatogramDataset
             if (tciList.isEmpty() && _pChromInfo.getTransitionChromatogramIndicesList() != null)
             {
                 List<Transition> transitions = TransitionManager.getTransitionsForPrecursor(_precursor.getId(), _user, _container);
-                if (transitions.size() != _pChromInfo.getTransitionChromatogramIndicesList().size())
-                {
-                    throw new IllegalStateException("Mismatch in transitions and indices lengths: " + transitions.size() + " vs " + _pChromInfo.getTransitionChromatogramIndicesList().size());
-                }
                 int index = 0;
                 for (Transition transition : transitions)
                 {
-                    if (include(transition))
+                    if (include(transition) && index < _pChromInfo.getTransitionChromatogramIndicesList().size())
                     {
                         tciList.add(new TransChromInfoPlusTransition(_pChromInfo.makeDummyTransitionChromInfo(index), transition));
                     }

--- a/src/org/labkey/targetedms/chart/ChromatogramDataset.java
+++ b/src/org/labkey/targetedms/chart/ChromatogramDataset.java
@@ -329,7 +329,7 @@ public abstract class ChromatogramDataset
         @Override
         public String getChartTitle()
         {
-            return _chromInfo.getTitle();
+            return _chromInfo.getTextId() == null ? "Unknown trace" : _chromInfo.getTextId();
         }
 
         @Override

--- a/src/org/labkey/targetedms/query/TransitionManager.java
+++ b/src/org/labkey/targetedms/query/TransitionManager.java
@@ -178,11 +178,7 @@ public class TransitionManager
 
         if (pci.getTransitionChromatogramIndicesList() != null)
         {
-            if (transitions.size() != pci.getTransitionChromatogramIndicesList().size())
-            {
-                throw new IllegalStateException("Mismatch in transitions and indices lengths: " + transitions.size() + " vs " + pci.getTransitionChromatogramIndicesList().size());
-            }
-            for (int i = 0; i < pci.getTransitionChromatogramIndicesList().size(); i++)
+            for (int i = 0; i < pci.getTransitionChromatogramIndicesList().size() && i < transitions.size(); i++)
             {
                 // Transition list is sorted by the 'Id' column so should be in the same order as the chromatogram indices list
                 GeneralTransition transition = transitions.get(i);
@@ -198,7 +194,7 @@ public class TransitionManager
                 GeneralTransition transition = transitionMap.get(tci.getTransitionId());
                 if(transition == null)
                 {
-                    throw new IllegalStateException("Cannot find transtion for TransitionChromInfo. TransitionId is: " + tci.getTransitionId());
+                    throw new IllegalStateException("Cannot find transition for TransitionChromInfo. TransitionId is: " + tci.getTransitionId());
                 }
                 result.add(new TransitionChromInfoAndQuantitative(tci, transition.isQuantitative(fullScanSettings)));
             }


### PR DESCRIPTION
#### Rationale
We're being too picky about matching the length of the lists. We can match Skyline's plotting by only showing the ones that align

#### Changes
* Don't reject based on list lengths, filter out those that don't align