### PR TITLE
Show better labels for common sample file chromatograms

### DIFF
--- a/resources/schemas/dbscripts/postgresql/targetedms-22.000-22.001.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-22.000-22.001.sql
@@ -1,0 +1,2 @@
+ALTER TABLE targetedms.SampleFileChromInfo
+    ADD COLUMN Flags INT;

--- a/resources/schemas/dbscripts/sqlserver/targetedms-22.000-22.001.sql
+++ b/resources/schemas/dbscripts/sqlserver/targetedms-22.000-22.001.sql
@@ -1,0 +1,2 @@
+ALTER TABLE targetedms.SampleFileChromInfo
+    ADD Flags INT;

--- a/resources/schemas/targetedms.xml
+++ b/resources/schemas/targetedms.xml
@@ -468,6 +468,7 @@
             <column columnName="ChromatogramFormat" />
             <column columnName="ChromatogramOffset" />
             <column columnName="ChromatogramLength" />
+            <column columnName="Flags" />
         </columns>
     </table>
     <table tableDbType="TABLE" tableName="PrecursorChromInfo">

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -181,6 +181,7 @@ import org.labkey.targetedms.model.RawMetricDataSet;
 import org.labkey.targetedms.model.passport.IKeyword;
 import org.labkey.targetedms.outliers.OutlierGenerator;
 import org.labkey.targetedms.parser.CalibrationCurveEntity;
+import org.labkey.targetedms.parser.Chromatogram;
 import org.labkey.targetedms.parser.GeneralMolecule;
 import org.labkey.targetedms.parser.GeneralMoleculeChromInfo;
 import org.labkey.targetedms.parser.Molecule;
@@ -4531,14 +4532,24 @@ public class TargetedMSController extends SpringActionController
 
             List<SampleFileChromInfo> sampleFileChromInfos = TargetedMSManager.getSampleFileChromInfos(_sampleFile);
 
+            SampleFileChromInfoForm imgForm = new SampleFileChromInfoForm();
             for (SampleFileChromInfo sampleFileChromInfo : sampleFileChromInfos)
             {
                 ActionURL chromURL = new ActionURL(SampleFileChromatogramChartAction.class, getContainer());
                 chromURL.addParameter("id", sampleFileChromInfo.getId());
-                SampleFileChromInfoForm imgForm = new SampleFileChromInfoForm();
-                HtmlView chromView = new HtmlView(DOM.IMG(at(src, chromURL.toString(), height, imgForm.getChartHeight(), width, imgForm.getChartWidth())));
+                Chromatogram c = sampleFileChromInfo.createChromatogram(_run);
+                HtmlView chromView;
+                if (c == null)
+                {
+                    chromView = new HtmlView(DOM.DIV("Unable to load chromatogram"));
+                }
+                else
+                {
+                    // Keep as a server-generated image as the trace for long runs can create very large SVGs
+                    chromView = new HtmlView(DOM.IMG(at(src, chromURL.toString(), height, imgForm.getChartHeight(), width, imgForm.getChartWidth())));
+                }
                 chromView.setFrame(WebPartView.FrameType.PORTAL);
-                chromView.setTitle(sampleFileChromInfo.getTextId());
+                chromView.setTitle(sampleFileChromInfo.getTitle());
                 result.addView(chromView);
             }
 

--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -234,7 +234,7 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
     @Override
     public Double getSchemaVersion()
     {
-        return 22.000;
+        return 22.001;
     }
 
     @Override

--- a/src/org/labkey/targetedms/chart/ChromatogramDataset.java
+++ b/src/org/labkey/targetedms/chart/ChromatogramDataset.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.targetedms.chart;
 
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.jfree.chart.ChartColor;
@@ -28,6 +27,7 @@ import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.security.User;
 import org.labkey.api.util.Formats;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ViewContext;
 import org.labkey.targetedms.TargetedMSManager;
 import org.labkey.targetedms.TargetedMSRun;
@@ -82,7 +82,7 @@ import java.util.stream.Collectors;
  */
 public abstract class ChromatogramDataset
 {
-    private static final Logger LOG = LogManager.getLogger(ChromatogramDataset.class);
+    private static final Logger LOG = LogHelper.getLogger(ChromatogramDataset.class, "Builds chromatograms into datasets for plotting");
 
     XYSeriesCollection _jfreeDataset;
     Double _maxDisplayIntensity; // This is set only when we are synchronizing plots on intensity
@@ -870,7 +870,7 @@ public abstract class ChromatogramDataset
         }
 
         @Nullable
-        private GeneralPrecursor getPrecursor()
+        private GeneralPrecursor<?> getPrecursor()
         {
             getGeneralMoleculeId();
             return _precursor;
@@ -1654,13 +1654,6 @@ public abstract class ChromatogramDataset
             double padding = (fullRange._maxRt - fullRange._minRt) * 0.1;
             _minDisplayRt = fullRange.getMinRt() - padding;
             _maxDisplayRt = fullRange.getMaxRt() + padding;
-        }
-
-        private String getLabel(GeneralMolecule gm, PrecursorChromInfoPlus info)
-        {
-            return gm instanceof Peptide ?
-                LabelFactory.precursorLabel(info.getPrecursorId()) :
-                LabelFactory.moleculePrecursorLabel(info.getPrecursorId(), _user, _container);
         }
 
         private RtRange getChromatogramRange(GeneralMolecule generalMolecule, List<PrecursorChromInfoPlus> chromInfos)

--- a/src/org/labkey/targetedms/chart/ChromatogramDataset.java
+++ b/src/org/labkey/targetedms/chart/ChromatogramDataset.java
@@ -329,7 +329,7 @@ public abstract class ChromatogramDataset
         @Override
         public String getChartTitle()
         {
-            return _chromInfo.getTextId() == null ? "Unknown trace" : _chromInfo.getTextId();
+            return _chromInfo.getTitle();
         }
 
         @Override

--- a/src/org/labkey/targetedms/parser/SampleFileChromInfo.java
+++ b/src/org/labkey/targetedms/parser/SampleFileChromInfo.java
@@ -18,6 +18,9 @@ package org.labkey.targetedms.parser;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.targetedms.TargetedMSRun;
+import org.labkey.targetedms.parser.skyd.ChromGroupHeaderInfo;
+
+import java.util.EnumSet;
 
 /**
  * User: vsharma
@@ -29,6 +32,9 @@ public class SampleFileChromInfo extends AbstractChromInfo
     private Float _startTime;
     private Float _endTime;
     private String _textId;
+
+    private String _title;
+    private Integer _flags;
 
     public SampleFileChromInfo()
     {
@@ -92,5 +98,51 @@ public class SampleFileChromInfo extends AbstractChromInfo
     public void setTextId(String textId)
     {
         _textId = textId;
+    }
+
+    public String getTitle()
+    {
+        if (_title == null)
+        {
+            if (_textId != null)
+            {
+                _title = _textId;
+            }
+            else
+            {
+                // We didn't start capturing these flags at import time until 22.3
+                if (_flags != null)
+                {
+                    EnumSet<ChromGroupHeaderInfo.FlagValues> flagValues = ChromGroupHeaderInfo.getFlagValues(_flags);
+                    if (flagValues.contains(ChromGroupHeaderInfo.FlagValues.extracted_base_peak))
+                    {
+                        _title = "Base Peak Chromatogram";
+                    }
+                    else if (flagValues.contains(ChromGroupHeaderInfo.FlagValues.extracted_qc_trace))
+                    {
+                        _title = "QC Trace";
+                    }
+                    else
+                    {
+                        _title = "Total Ion Chromatogram";
+                    }
+                }
+                else
+                {
+                    _title = "Unknown trace";
+                }
+            }
+        }
+        return _title;
+    }
+
+    public void setFlags(Integer flags)
+    {
+        _flags = flags;
+    }
+
+    public Integer getFlags()
+    {
+        return _flags;
     }
 }

--- a/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
+++ b/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
@@ -3061,6 +3061,7 @@ public class SkylineDocumentParser implements AutoCloseable
                     info.setChromatogramLength(chromatogram.getCompressedSize());
                     info.setNumPoints(chromatogram.getNumPoints());
                     info.setUncompressedSize(chromatogram.getUncompressedSize());
+                    info.setFlags(Short.toUnsignedInt(chromatogram.getFlagBits()));
 
                     result.add(info);
                 }

--- a/src/org/labkey/targetedms/parser/skyd/CacheFormat.java
+++ b/src/org/labkey/targetedms/parser/skyd/CacheFormat.java
@@ -82,7 +82,7 @@ public class CacheFormat {
 
     public StructSerializer<CachedFileHeaderStruct> cachedFileSerializer()
     {
-        return new StructSerializer<CachedFileHeaderStruct>(CachedFileHeaderStruct.class,
+        return new StructSerializer<>(CachedFileHeaderStruct.class,
                 CachedFileHeaderStruct.getStructSize(CacheFormatVersion.CURRENT),
                 _cachedFileSize)
         {
@@ -95,7 +95,7 @@ public class CacheFormat {
     }
 
     public StructSerializer<ChromGroupHeaderInfo> chromGroupHeaderInfoSerializer() {
-        return new StructSerializer<ChromGroupHeaderInfo>(ChromGroupHeaderInfo.class, ChromGroupHeaderInfo.getStructSize(CacheFormatVersion.CURRENT), _chromGroupHeaderSize)
+        return new StructSerializer<>(ChromGroupHeaderInfo.class, ChromGroupHeaderInfo.getStructSize(CacheFormatVersion.CURRENT), _chromGroupHeaderSize)
         {
             @Override
             public ChromGroupHeaderInfo fromByteArray(byte[] bytes)
@@ -105,18 +105,18 @@ public class CacheFormat {
         };
     }
     public StructSerializer<ChromTransition> chromTransitionSerializer() {
-        return new StructSerializer<ChromTransition>(ChromTransition.class, ChromTransition.getStructSize(CacheFormatVersion.CURRENT), _chromTransitionSize)
+        return new StructSerializer<>(ChromTransition.class, ChromTransition.getStructSize(CacheFormatVersion.CURRENT), _chromTransitionSize)
+        {
+            @Override
+            public ChromTransition fromByteArray(byte[] bytes)
             {
-                @Override
-                public ChromTransition fromByteArray(byte[] bytes)
-                {
-                    return new ChromTransition(_formatVersion, new LittleEndianByteArrayInputStream(bytes));
-                }
-            };
+                return new ChromTransition(_formatVersion, new LittleEndianByteArrayInputStream(bytes));
+            }
+        };
     }
 
     public StructSerializer<ChromPeak> chromPeakSerializer() {
-        return new StructSerializer<ChromPeak>(ChromPeak.class, ChromPeak.getStructSize(CacheFormatVersion.CURRENT), _chromPeakSize)
+        return new StructSerializer<>(ChromPeak.class, ChromPeak.getStructSize(CacheFormatVersion.CURRENT), _chromPeakSize)
         {
             @Override
             public ChromPeak fromByteArray(byte[] bytes)

--- a/src/org/labkey/targetedms/parser/skyd/ChromGroupHeaderInfo.java
+++ b/src/org/labkey/targetedms/parser/skyd/ChromGroupHeaderInfo.java
@@ -121,7 +121,16 @@ public class ChromGroupHeaderInfo
     }
 
     public EnumSet<FlagValues> getFlagValues() {
-        return EnumFlagValues.enumSetFromFlagValues(FlagValues.class, Short.toUnsignedLong(flagBits));
+        return getFlagValues(Short.toUnsignedLong(flagBits));
+    }
+
+    public static EnumSet<FlagValues> getFlagValues(long bits) {
+        return EnumFlagValues.enumSetFromFlagValues(FlagValues.class, bits);
+    }
+
+    public short getFlagBits()
+    {
+        return flagBits;
     }
 
     public enum FlagValues
@@ -133,7 +142,13 @@ public class ChromGroupHeaderInfo
         has_sim_scan_ids,
         has_frag_scan_ids,
         polarity_negative,
-        raw_chromatograms
+        raw_chromatograms,
+        // Three bits for ion mobility info
+        ion_mobility_type_1,
+        ion_mobility_type_2,
+        ion_mobility_type_3,
+        dda_acquisition_method,
+        extracted_qc_trace
     }
 
     public static int getStructSize(CacheFormatVersion cacheFormatVersion) {


### PR DESCRIPTION
#### Rationale
Commonly used sample file-scoped chromatograms like the Total Ion Chromatogram aren't stored in the .skyd file with a title. Instead, we can look at the flags to determine their types.

Note that we won't have the flags available for previously imported data.

#### Changes
* Add column to store the flags
* Parse and store at import time
* Use the flags to label the chromatogram