### PR TITLE
Issue 44682: Run PX data validation as a pipeline job

### DIFF
--- a/api-src/org/labkey/api/targetedms/TargetedMSService.java
+++ b/api-src/org/labkey/api/targetedms/TargetedMSService.java
@@ -27,6 +27,7 @@ import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.services.ServiceRegistry;
 import org.labkey.api.targetedms.model.SampleFileInfo;
+import org.labkey.api.targetedms.model.SampleFilePath;
 import org.labkey.api.view.ViewBackgroundInfo;
 
 import java.nio.file.Path;
@@ -86,11 +87,16 @@ public interface TargetedMSService
     TableInfo getTableInfoGeneralPrecursor();
     TableInfo getTableInfoPrecursor();
     TableInfo getTableInfoMoleculePrecursor();
+    TableInfo getTableInfoPeptideStructuralModification();
+    TableInfo getTableInfoPeptideIsotopeModification();
+    TableInfo getTableInfoInstrument();
 
     List<String> getSampleFilePaths(long runId);
     List<? extends ISampleFile> getSampleFiles(long runId);
     List<? extends IModification.IStructuralModification> getStructuralModificationsUsedInRun(long runId);
     List<? extends IModification.IIsotopeModification> getIsotopeModificationsUsedInRun(long runId);
+    IModification.IStructuralModification getStructuralModification(long id);
+    IModification.IIsotopeModification getIsotopeModification(long id);
 
     @Nullable ISpectrumLibrary getLibrary(long id, @Nullable Container container, User user);
 
@@ -120,11 +126,12 @@ public interface TargetedMSService
     Integer importSkylineDocument(ViewBackgroundInfo info, Path skylinePath) throws XarFormatException, PipelineValidationException;
 
     /**
-     * @param sampleFiles list of sample files for which we should check if data exists
-     * @param container container where we should look for the data
-     * @return list of sample files for which data was found
+     * @param sampleFiles list of sample files for which we should do a path lookup on the server
+     * @param container container where we should look for the files
+     * @param lookupExpData if true, look for a matching row in exp.data before looking on the filesystem
+     * @return List of {@link SampleFilePath} objects encapsulating an ISampleFile and its path on the server.
      */
-    List<? extends ISampleFile> getSampleFilesWithData(List<? extends ISampleFile> sampleFiles, Container container);
+    List<SampleFilePath> getSampleFilePaths(List<? extends ISampleFile> sampleFiles, Container container, boolean lookupExpData);
 
     /**
      * Returns the name of a chromatogram library file according to the naming pattern used for creating

--- a/api-src/org/labkey/api/targetedms/model/SampleFilePath.java
+++ b/api-src/org/labkey/api/targetedms/model/SampleFilePath.java
@@ -1,0 +1,37 @@
+package org.labkey.api.targetedms.model;
+
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.targetedms.ISampleFile;
+
+import java.nio.file.Path;
+
+// Class encapsulating the information for a sample file from a Skyline document, and its path in the "RawFiles" directory
+// in the file root of the container where the Skyline document lives.
+public class SampleFilePath
+{
+    private final ISampleFile _sampleFile;
+    private Path _path;
+
+    public SampleFilePath(ISampleFile sampleFile)
+    {
+        _sampleFile = sampleFile;
+    }
+
+    public ISampleFile getSampleFile()
+    {
+        return _sampleFile;
+    }
+
+    /**
+     * @return the path of the sample file on the server if it exists, null otherwise.
+     */
+    public @Nullable Path getPath()
+    {
+        return _path;
+    }
+
+    public void setPath(Path path)
+    {
+        _path = path;
+    }
+}

--- a/src/org/labkey/targetedms/TargetedMSServiceImpl.java
+++ b/src/org/labkey/targetedms/TargetedMSServiceImpl.java
@@ -35,6 +35,7 @@ import org.labkey.api.targetedms.SkylineDocumentImportListener;
 import org.labkey.api.targetedms.TargetedMSFolderTypeListener;
 import org.labkey.api.targetedms.TargetedMSService;
 import org.labkey.api.targetedms.model.SampleFileInfo;
+import org.labkey.api.targetedms.model.SampleFilePath;
 import org.labkey.api.view.ViewBackgroundInfo;
 import org.labkey.targetedms.chromlib.ChromatogramLibraryUtils;
 import org.labkey.targetedms.datasource.MsDataSourceUtil;
@@ -161,6 +162,23 @@ public class TargetedMSServiceImpl implements TargetedMSService
     }
 
     @Override
+    public TableInfo getTableInfoPeptideStructuralModification()
+    {
+        return TargetedMSManager.getTableInfoPeptideStructuralModification();
+    }
+    @Override
+    public TableInfo getTableInfoPeptideIsotopeModification()
+    {
+        return TargetedMSManager.getTableInfoPeptideIsotopeModification();
+    }
+
+    @Override
+    public TableInfo getTableInfoInstrument()
+    {
+        return TargetedMSManager.getTableInfoInstrument();
+    }
+
+    @Override
     public List<String> getSampleFilePaths(long runId)
     {
         return ReplicateManager.getSampleFilePaths(runId);
@@ -182,6 +200,18 @@ public class TargetedMSServiceImpl implements TargetedMSService
     public List<? extends IModification.IIsotopeModification> getIsotopeModificationsUsedInRun(long runId)
     {
         return ModificationManager.getIsotopeModificationsUsedInRun(runId);
+    }
+
+    @Override
+    public IModification.IStructuralModification getStructuralModification(long id)
+    {
+        return ModificationManager.getStructuralModification(id);
+    }
+
+    @Override
+    public IModification.IIsotopeModification getIsotopeModification(long id)
+    {
+        return ModificationManager.getIsotopeModification(id);
     }
 
     @Override
@@ -285,9 +315,9 @@ public class TargetedMSServiceImpl implements TargetedMSService
     }
 
     @Override
-    public List<? extends ISampleFile> getSampleFilesWithData(List<? extends ISampleFile> sampleFiles, Container container)
+    public List<SampleFilePath> getSampleFilePaths(List<? extends ISampleFile> sampleFiles, Container container, boolean lookupExpData)
     {
-        return MsDataSourceUtil.getInstance().getSampleFilesWithData(sampleFiles, container);
+        return MsDataSourceUtil.getInstance().getSampleFilePaths(sampleFiles, container, lookupExpData);
     }
 
     @Override

--- a/src/org/labkey/targetedms/datasource/MsDataSourceTypes.java
+++ b/src/org/labkey/targetedms/datasource/MsDataSourceTypes.java
@@ -117,13 +117,13 @@ public class MsDataSourceTypes
         }
     };
 
-    private static MsDataSource[] sourceTypes = new MsDataSource[]{
+    private static final MsDataSource[] sourceTypes = new MsDataSource[]{
             THERMO, SCIEX, SHIMADZU, // File-based
             WATERS, AGILENT, BRUKER, // Directory-based
             CONVERTED_DATA_SOURCE}; // mzML, mzXML etc.
 
 
-    private static Map<String, List<MsDataSource>> EXTENSION_SOURCE_MAP = new HashMap<>();
+    private static final Map<String, List<MsDataSource>> EXTENSION_SOURCE_MAP = new HashMap<>();
     static
     {
         for (MsDataSource s : sourceTypes)
@@ -141,6 +141,7 @@ public class MsDataSourceTypes
         // Can return more than one data source type. For example, Bruker and Waters both have .d extension;
         // Thermo and Waters both have .raw extension
         var sources = EXTENSION_SOURCE_MAP.get(extension(name));
+        if (sources == null) sources = EXTENSION_SOURCE_MAP.get(extension(name, 2)); // .wiff.scan file, for example
         return sources != null ? sources : Collections.emptyList();
     }
 
@@ -151,14 +152,11 @@ public class MsDataSourceTypes
 
     private static String extension(String name)
     {
-        if(name != null)
-        {
-            int idx = name.lastIndexOf('.');
-            if(idx != -1)
-            {
-                return name.substring(idx).toLowerCase();
-            }
-        }
-        return "";
+        return extension(name, 1);
+    }
+
+    private static String extension(String name, int dots)
+    {
+        return name.substring(FileUtil.getBaseName(name, dots).length()).toLowerCase();
     }
 }

--- a/src/org/labkey/targetedms/query/ModificationManager.java
+++ b/src/org/labkey/targetedms/query/ModificationManager.java
@@ -15,8 +15,6 @@
 
 package org.labkey.targetedms.query;
 
-import org.jetbrains.annotations.Nullable;
-import org.labkey.api.cache.CacheLoader;
 import org.labkey.api.cache.CacheManager;
 import org.labkey.api.data.DatabaseCache;
 import org.labkey.api.data.SQLFragment;
@@ -26,6 +24,7 @@ import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.query.FieldKey;
+import org.labkey.api.targetedms.IModification;
 import org.labkey.api.util.Pair;
 import org.labkey.targetedms.TargetedMSManager;
 import org.labkey.targetedms.parser.Peptide;
@@ -54,6 +53,18 @@ public class ModificationManager
     private static PeptideIsotopeModIndexes _peptideIsotopeModIndexes = new PeptideIsotopeModIndexes();
 
     private ModificationManager() {}
+
+    public static IModification.IStructuralModification getStructuralModification(long id)
+    {
+        // This table does not contain rows scoped to a container so we don't need a container filter
+        return new TableSelector(TargetedMSManager.getTableInfoStructuralModification()).getObject(id, PeptideSettings.StructuralModification.class);
+    }
+
+    public static IModification.IIsotopeModification getIsotopeModification(long id)
+    {
+        // This table does not contain rows scoped to a container so we don't need a container filter
+        return new TableSelector(TargetedMSManager.getTableInfoIsotopeModification()).getObject(id, PeptideSettings.IsotopeModification.class);
+    }
 
     /**
      * @param peptideId


### PR DESCRIPTION
#### Rationale
Updates to the TargetedMS API to support work for Issue 44682: Run PX data validation as a pipeline job

#### Related Pull Requests
* https://github.com/LabKey/MacCossLabModules/pull/175

#### Changes
- Return file paths for Skyline document sample files if they were uploaded to the server
- Added methods to get structural and isotope modifications by database id
- Recognize .wiff.scan file as a data source type
