### PR TITLE
Issue 44313: Dual-metric QC plots don't respect date filters when showing guide set data

### DIFF
--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -196,30 +196,6 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
 
         }
 
-        if (this.showExpRunRange && this.filterPoints) {
-
-            for (let i = 0; i < plotDataRows.length; i++) {
-                Ext4.Object.each(this.filterPoints[plotDataRows[i].SeriesLabel], function (seriesType, filterPointsData) {
-                    // no need to filter if less than 6 data points are present between reference end of guideset and startdate
-                    if (filterPointsData['filterPointsFirstIndex'] && filterPointsData['filterPointsLastIndex']) {
-                        if (filterPointsData['filterPointsLastIndex'] - filterPointsData['filterPointsFirstIndex'] < 6) {
-                            this.filterQCPoints = false;
-                            // set the startDate field = acquired time of the 1st point of 5 points before the experiment run range
-
-                            this.getStartDateField().setValue(this.formatDate(plotDataRows[i].data[filterPointsData['filterPointsFirstIndex']].AcquiredTime));
-                        }
-                        else { // skip 5 points
-                            filterPointsData['filterPointsLastIndex'] = filterPointsData['filterPointsLastIndex'] - 6;
-                            // set the startDate field = acquired time of the 1st point of 5 points before the experiment run range
-                            // adding 1 as the point is right after filter last index
-                            this.getStartDateField().setValue(this.formatDate(plotDataRows[i].data[filterPointsData['filterPointsLastIndex'] + 1].AcquiredTime));
-                        }
-                    }
-                }, this);
-            }
-
-        }
-
         // Issue 31678: get the full set of dates values from the precursor data and from the annotations
         for (var j = 0; j < this.annotationData.length; j++) {
             allPlotDateValues.push(this.formatDate(new Date(this.annotationData[j].Date), true));
@@ -329,6 +305,30 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
                     }
                 }
             }
+        }
+
+        if (this.showExpRunRange && this.filterPoints) {
+
+            for (let i = 0; i < plotDataRows.length; i++) {
+                Ext4.Object.each(this.filterPoints[plotDataRows[i].SeriesLabel], function (seriesType, filterPointsData) {
+                    // no need to filter if less than 6 data points are present between reference end of guideset and startdate
+                    if (filterPointsData['filterPointsFirstIndex'] && filterPointsData['filterPointsLastIndex']) {
+                        if (filterPointsData['filterPointsLastIndex'] - filterPointsData['filterPointsFirstIndex'] < 6) {
+                            this.filterQCPoints = false;
+                            // set the startDate field = acquired time of the 1st point of 5 points before the experiment run range
+
+                            this.getStartDateField().setValue(this.formatDate(plotDataRows[i].data[filterPointsData['filterPointsFirstIndex']].AcquiredTime));
+                        }
+                        else { // skip 5 points
+                            filterPointsData['filterPointsLastIndex'] = filterPointsData['filterPointsLastIndex'] - 6;
+                            // set the startDate field = acquired time of the 1st point of 5 points before the experiment run range
+                            // adding 1 as the point is right after filter last index
+                            this.getStartDateField().setValue(this.formatDate(plotDataRows[i].data[filterPointsData['filterPointsLastIndex'] + 1].AcquiredTime));
+                        }
+                    }
+                }, this);
+            }
+
         }
 
         this.renderPlots();

--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -236,23 +236,27 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
 
         if (this.showExpRunRange && this.filterPoints) {
 
-            Ext4.Object.each(this.filterPoints[label], function (seriesType, filterPointsData) {
-                // no need to filter if less than 6 data points are present between reference end of guideset and startdate
-                let firstIndex = filterPointsData['filterPointsFirstIndex'];
-                let lastIndex = filterPointsData['filterPointsLastIndex'];
-                if (lastIndex - firstIndex < 6) {
-                    this.filterQCPoints = false;
-                    // set the startDate field = acquired time of the 1st point of 5 points before the experiment run range
-                    this.getStartDateField().setValue(this.formatDate(tempData.data[firstIndex].AcquiredTime));
-                }
-                else { // skip 5 points
-                    lastIndex = firstIndex - 6;
-                    // set the startDate field = acquired time of the 1st point of 5 points before the experiment run range
-                    // adding 1 as the point is right after filter last index
-                    this.getStartDateField().setValue(this.formatDate(tempData.data[lastIndex + 1].AcquiredTime));
-                }
+            const scope = this;
+            Ext4.Object.each(this.fragmentPlotData, function(label, fragmentData) {
+                Ext4.Object.each(scope.filterPoints[label], function (seriesType, filterPointsData) {
+                    // no need to filter if less than 6 data points are present between reference end of guideset and startdate
+                    let firstIndex = filterPointsData['filterPointsFirstIndex'];
+                    let lastIndex = filterPointsData['filterPointsLastIndex'];
+                    if (firstIndex && lastIndex) {
+                        if (lastIndex - firstIndex < 6) {
+                            scope.filterQCPoints = false;
+                            // set the startDate field = acquired time of the 1st point of 5 points before the experiment run range
+                            scope.getStartDateField().setValue(scope.formatDate(fragmentData.data[firstIndex].AcquiredTime));
+                        }
+                        else { // skip 5 points
+                            lastIndex = firstIndex - 6;
+                            // set the startDate field = acquired time of the 1st point of 5 points before the experiment run range
+                            // adding 1 as the point is right after filter last index
+                            scope.getStartDateField().setValue(scope.formatDate(fragmentData.data[lastIndex + 1].AcquiredTime));
+                        }
+                    }
+                });
             });
-
 
         }
 

--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -236,27 +236,24 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
 
         if (this.showExpRunRange && this.filterPoints) {
 
-            const scope = this;
             for (let i = 0; i < plotDataRows.length; i++) {
-                Ext4.Object.each(scope.filterPoints[plotDataRows[i].SeriesLabel], function (seriesType, filterPointsData) {
+                Ext4.Object.each(this.filterPoints[plotDataRows[i].SeriesLabel], function (seriesType, filterPointsData) {
                     // no need to filter if less than 6 data points are present between reference end of guideset and startdate
-                    let firstIndex = filterPointsData['filterPointsFirstIndex'];
-                    let lastIndex = filterPointsData['filterPointsLastIndex'];
-                    if (firstIndex && lastIndex) {
-                        if (lastIndex - firstIndex < 6) {
-                            scope.filterQCPoints = false;
+                    if (filterPointsData['filterPointsFirstIndex'] && filterPointsData['filterPointsLastIndex']) {
+                        if (filterPointsData['filterPointsLastIndex'] - filterPointsData['filterPointsFirstIndex'] < 6) {
+                            this.filterQCPoints = false;
                             // set the startDate field = acquired time of the 1st point of 5 points before the experiment run range
 
-                            scope.getStartDateField().setValue(scope.formatDate(plotDataRows[i].data[firstIndex].AcquiredTime));
+                            this.getStartDateField().setValue(this.formatDate(plotDataRows[i].data[filterPointsData['filterPointsFirstIndex']].AcquiredTime));
                         }
                         else { // skip 5 points
-                            lastIndex = lastIndex - 6;
+                            filterPointsData['filterPointsLastIndex'] = filterPointsData['filterPointsLastIndex'] - 6;
                             // set the startDate field = acquired time of the 1st point of 5 points before the experiment run range
                             // adding 1 as the point is right after filter last index
-                            scope.getStartDateField().setValue(scope.formatDate(plotDataRows[i].data[lastIndex + 1].AcquiredTime));
+                            this.getStartDateField().setValue(this.formatDate(plotDataRows[i].data[filterPointsData['filterPointsLastIndex'] + 1].AcquiredTime));
                         }
                     }
-                });
+                }, this);
             }
 
         }

--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -215,6 +215,11 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
                         // for truncating out of range guideset data  find first index of plotDate ending at guideset.trainingEnd
                         if (plotData.GuideSetId == guideSetId && plotData.InGuideSetTrainingRange && guideSetData.TrainingEnd <= this.startDate) {
                             this.filterPoints[fragment][plotData.SeriesType]['filterPointsFirstIndex'] = j + 1;
+                            // ReferenceRangeSeries is used to separate series
+                            this.fragmentPlotData[fragment].data[j]['ReferenceRangeSeries'] = "GuideSet";
+                        }
+                        else {
+                            this.fragmentPlotData[fragment].data[j]['ReferenceRangeSeries'] = "InRange";
                         }
 
                     }, this);
@@ -374,15 +379,6 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
 
                     for (let i = lastIndex; i >= firstIndex; i--) {
                         fragmentData.data.splice(i, 1);
-                    }
-
-                    // ReferenceRangeSeries is used to separate series
-                    for (let i = 0; i < firstIndex; i++) {
-                        fragmentData.data[i]['ReferenceRangeSeries'] = "GuideSet";
-                    }
-
-                    for (let i = firstIndex; i < fragmentData.data.length; i++) {
-                        fragmentData.data[i]['ReferenceRangeSeries'] = "InRange";
                     }
                 });
 

--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -237,8 +237,8 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
         if (this.showExpRunRange && this.filterPoints) {
 
             const scope = this;
-            Ext4.Object.each(this.fragmentPlotData, function(label, fragmentData) {
-                Ext4.Object.each(scope.filterPoints[label], function (seriesType, filterPointsData) {
+            for (let i = 0; i < plotDataRows.length; i++) {
+                Ext4.Object.each(scope.filterPoints[plotDataRows[i].SeriesLabel], function (seriesType, filterPointsData) {
                     // no need to filter if less than 6 data points are present between reference end of guideset and startdate
                     let firstIndex = filterPointsData['filterPointsFirstIndex'];
                     let lastIndex = filterPointsData['filterPointsLastIndex'];
@@ -246,17 +246,18 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
                         if (lastIndex - firstIndex < 6) {
                             scope.filterQCPoints = false;
                             // set the startDate field = acquired time of the 1st point of 5 points before the experiment run range
-                            scope.getStartDateField().setValue(scope.formatDate(fragmentData.data[firstIndex].AcquiredTime));
+
+                            scope.getStartDateField().setValue(scope.formatDate(plotDataRows[i].data[firstIndex].AcquiredTime));
                         }
                         else { // skip 5 points
-                            lastIndex = firstIndex - 6;
+                            lastIndex = lastIndex - 6;
                             // set the startDate field = acquired time of the 1st point of 5 points before the experiment run range
                             // adding 1 as the point is right after filter last index
-                            scope.getStartDateField().setValue(scope.formatDate(fragmentData.data[lastIndex + 1].AcquiredTime));
+                            scope.getStartDateField().setValue(scope.formatDate(plotDataRows[i].data[lastIndex + 1].AcquiredTime));
                         }
                     }
                 });
-            });
+            }
 
         }
 

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -874,6 +874,9 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                         this.showAllSeriesCheckbox(showAllSeriesCheckBox, showAllSeriesCheckBoxLocation);
 
                         this.setBrushingEnabled(false);
+                        if (this.filterQCPoints) {
+                            this.resetFilterPointsIndices();
+                        }
                         this.displayTrendPlot();
                     }
                 }
@@ -1003,11 +1006,8 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     },
 
     resetFilterPointsIndices: function() {
-        if (this.filterPointsFirstIndex) {
-            this.filterPointsFirstIndex = undefined;
-        }
-        if (this.filterPointsLastIndex) {
-            this.filterPointsLastIndex = undefined;
+        if (this.filterPoints) {
+            this.filterPoints = undefined;
         }
     },
 


### PR DESCRIPTION
#### Rationale
This PR fixes the QC plots when when we're plotting two different metrics at the same time in case of displaying reference guideset with custom date range.

