### PR TITLE
Let admins save Panorama QC plot default configurations

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -769,7 +769,7 @@ public class TargetedMSController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class SaveQCPlotSettingsAsDefaultAction extends MutatingApiAction<LeveyJenningsPlotOptions>
+    public static class SaveQCPlotSettingsAsDefaultAction extends MutatingApiAction<LeveyJenningsPlotOptions>
     {
         @Override
         public Object execute(LeveyJenningsPlotOptions form, BindException errors)
@@ -789,8 +789,9 @@ public class TargetedMSController extends SpringActionController
         }
     }
 
-    @RequiresPermission(AdminPermission.class)
-    public class RevertToDefaultQCPlotSettingsAction extends MutatingApiAction<LeveyJenningsPlotOptions>
+    @RequiresLogin
+    @RequiresPermission(ReadPermission.class)
+    public static class RevertToDefaultQCPlotSettingsAction extends MutatingApiAction<LeveyJenningsPlotOptions>
     {
         @Override
         public Object execute(LeveyJenningsPlotOptions form, BindException errors)

--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -17,6 +17,7 @@
 package org.labkey.targetedms;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.poi.ss.formula.functions.Na;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.assay.sample.SampleAssayResultsConfig;
 import org.labkey.api.assay.sample.SampleAssayResultsService;
@@ -42,6 +43,7 @@ import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.protein.ProteinService;
 import org.labkey.api.protein.ProteomicsModule;
 import org.labkey.api.query.QueryView;
+import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.ApplicationAdminPermission;
 import org.labkey.api.settings.AdminConsole;
 import org.labkey.api.targetedms.TargetedMSService;
@@ -50,6 +52,8 @@ import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.BaseWebPartFactory;
 import org.labkey.api.view.JspView;
+import org.labkey.api.view.NavTree;
+import org.labkey.api.view.NavTreeCustomizer;
 import org.labkey.api.view.Portal;
 import org.labkey.api.view.ViewContext;
 import org.labkey.api.view.WebPartFactory;
@@ -75,12 +79,14 @@ import org.labkey.targetedms.view.TransitionPeptideSearchViewProvider;
 import org.labkey.targetedms.view.TransitionProteinSearchViewProvider;
 import org.labkey.targetedms.view.passport.ProteinListView;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import static org.labkey.api.targetedms.TargetedMSService.FOLDER_TYPE_PROP_NAME;
 import static org.labkey.api.targetedms.TargetedMSService.MODULE_NAME;
@@ -506,6 +512,24 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
     {
         addController("targetedms", TargetedMSController.class);
         addController("passport", PassportController.class);
+
+        Portal.registerNavTreeCustomizer("Targeted MS QC Plots", viewContext -> {
+            List<NavTree> result = new ArrayList<>();
+            if (viewContext.hasPermission(AdminPermission.class))
+            {
+                NavTree save = new NavTree("Save as Default View");
+                save.setScript("LABKEY.targetedms.PlotSettingsUtil.saveAsDefault()");
+                result.add(save);
+            }
+            if (!viewContext.getUser().isGuest())
+            {
+                NavTree save = new NavTree("Revert to Default View");
+                save.setScript("LABKEY.targetedms.PlotSettingsUtil.revertToDefault()");
+                result.add(save);
+            }
+
+            return result;
+        });
 
         TargetedMSSchema.register(this);
         SkylineListSchema.register(this);

--- a/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
@@ -207,6 +207,11 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
         elementCache().showExcludedCheckbox.set(check);
     }
 
+    public boolean isShowExcludedPointsChecked()
+    {
+        return elementCache().showExcludedCheckbox.isChecked();
+    }
+
     public void setShowReferenceGuideSet(boolean check)
     {
         elementCache().showReferenceGuideSet.set(check);
@@ -224,6 +229,19 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
     public boolean isShowAllPeptidesInSinglePlotChecked()
     {
         return elementCache().singlePlotCheckbox.isChecked();
+    }
+
+    public QCPlotsWebPart saveAsDefaultView()
+    {
+        clickMenuItem(false ,"Save as Default View");
+        getWrapper().acceptAlert();
+        return this;
+    }
+
+    public QCPlotsWebPart revertToDefaultView()
+    {
+        clickMenuItem("Revert to Default View");
+        return this;
     }
 
     public void applyRange()

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -4,6 +4,32 @@
  * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
  */
 
+if (!LABKEY.targetedms) {
+    LABKEY.targetedms = {};
+}
+
+if (!LABKEY.targetedms.PlotSettingsUtil) {
+    LABKEY.targetedms.PlotSettingsUtil = {
+        saveAsDefault: function () {
+            LABKEY.Ajax.request({
+                method: 'POST',
+                url: LABKEY.ActionURL.buildURL('targetedms', 'saveQCPlotSettingsAsDefault'),
+                success: function() { alert('Defaults saved successfully'); },
+                failure: LABKEY.Utils.getCallbackWrapper(function(error) { alert('Failed to save defaults'); console.log(error); }, this, true)
+            });
+        },
+
+        revertToDefault: function () {
+            LABKEY.Ajax.request({
+                method: 'POST',
+                url: LABKEY.ActionURL.buildURL('targetedms', 'revertToDefaultQCPlotSettings'),
+                success: function() { window.location.reload(); },
+                failure: LABKEY.Utils.getCallbackWrapper(function(error) { alert('Failed to revert to defaults'); console.log(error); }, this, true)
+            });
+        }
+    }
+}
+
 /**
  * Class to create a panel for displaying the R plot for the trending of retention times, peak areas, and other
  * values for the selected graph parameters.


### PR DESCRIPTION
#### Rationale
In preparing to let users submit QC folders to Panorama Public, we want to let admins share their QC plot configuration with other users

#### Changes
* New menu option for admins to save their current view as the default
* New menu option to let everyone revert to the default, whether it's the admin-saved default or the default default