### PR TITLE
Issue 45015: peptide names inside QC plot legends are not displayed correctly

### DIFF
--- a/webapp/TargetedMS/js/QCPlotLegendHelper.js
+++ b/webapp/TargetedMS/js/QCPlotLegendHelper.js
@@ -37,6 +37,11 @@ if (!LABKEY.targetedms.QCPlotLegendHelper) {
         addString: function (name, isSequence) {
             var dict = isSequence ? this.peptidePrefixDictionary : this.customIonPrefixDictionary;
 
+            // For peptides, only look at the sequence
+            if (isSequence) {
+                name = name.substring(0, name.indexOf(' '));
+            }
+
             // Add to dictionary of sequences with this prefix.
             var prefix = this.getPrefix(name);
             var prefixMatches = dict[prefix];
@@ -125,6 +130,8 @@ if (!LABKEY.targetedms.QCPlotLegendHelper) {
                 return '';
 
             if (isPeptide) {
+                // Issue 45015 - include only peptide sequence when abbreviating
+                identifier = identifier.substring(0, identifier.indexOf(' '));
                 identifier = this.stripModifications(identifier);
             }
             else {

--- a/webapp/TargetedMS/js/QCPlotLegendHelper.js
+++ b/webapp/TargetedMS/js/QCPlotLegendHelper.js
@@ -38,7 +38,7 @@ if (!LABKEY.targetedms.QCPlotLegendHelper) {
             var dict = isSequence ? this.peptidePrefixDictionary : this.customIonPrefixDictionary;
 
             // For peptides, only look at the sequence
-            if (isSequence) {
+            if (isSequence && name.indexOf(' ') !== -1) {
                 name = name.substring(0, name.indexOf(' '));
             }
 
@@ -131,7 +131,9 @@ if (!LABKEY.targetedms.QCPlotLegendHelper) {
 
             if (isPeptide) {
                 // Issue 45015 - include only peptide sequence when abbreviating
-                identifier = identifier.substring(0, identifier.indexOf(' '));
+                if (identifier.indexOf(' ') !== -1) {
+                    identifier = identifier.substring(0, identifier.indexOf(' '));
+                }
                 identifier = this.stripModifications(identifier);
             }
             else {


### PR DESCRIPTION
#### Rationale
When abbreviating peptide sequences, we shouldn't be including the mz part of the description as that's tacked on separately

#### Changes
* Trim the charge state and mz when creating unique abbreviations for each peptide sequence