### PR TITLE
Automation test for Issue 44507

### DIFF
--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSAuditLogTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSAuditLogTest.java
@@ -49,7 +49,6 @@ public class TargetedMSAuditLogTest extends TargetedMSTest
                 auditLog.getDataAsText(0, "MessageText"));
         assertEquals("End message is incorrect", "Managed results",
                 auditLog.getDataAsText(8, "MessageText"));
-
     }
 
     /*
@@ -66,7 +65,12 @@ public class TargetedMSAuditLogTest extends TargetedMSTest
 
         log("Verifying logs are imported correctly in " + FOLDER_2);
         DataRegionTable auditLog = getAuditLogs(FOLDER_2);
-        assertEquals("Invalid number of audit logs", 9, auditLog.getDataRowCount());
+        assertEquals("Invalid number of audit logs in " + FOLDER_2, 9, auditLog.getDataRowCount());
+
+        log("Verifying logs are not affected in first folder after importing in second folder");
+        auditLog = getAuditLogs(getProjectName());
+        assertEquals("Invalid number of audit logs in " + getProjectName(), 9, auditLog.getDataRowCount());
+
 
         log("Deleting " + FOLDER_2);
         APIContainerHelper apiContainerHelper = new APIContainerHelper(this);

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSAuditLogTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSAuditLogTest.java
@@ -3,15 +3,16 @@ package org.labkey.test.tests.targetedms;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.categories.Daily;
-import org.labkey.test.util.ApiPermissionsHelper;
+import org.labkey.test.util.APIContainerHelper;
 import org.labkey.test.util.DataRegionTable;
 
 import static org.junit.Assert.assertEquals;
 
 @Category({Daily.class})
-//@BaseWebDriverTest.ClassTimeout(minutes = 25)
+@BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class TargetedMSAuditLogTest extends TargetedMSTest
 {
     protected static final String AuditTrail_FILE = "AuditTrail.sky.zip";
@@ -33,7 +34,6 @@ public class TargetedMSAuditLogTest extends TargetedMSTest
     {
         setupFolder(FolderType.QC);
         _userHelper.createUser(USER);
-        new ApiPermissionsHelper(this).setUserPermissions(USER, "Reader");
         importData(AuditTrail_FILE);
     }
 
@@ -41,13 +41,7 @@ public class TargetedMSAuditLogTest extends TargetedMSTest
     public void testAuditLogImported()
     {
         log("Start of test");
-        goToProjectHome();
-        clickTab("Runs");
-        clickAndWait(Locator.linkContainingText(AuditTrail_FILE));
-
-        log("Navigating to the audit log");
-        clickAndWait(Locator.tagWithAttribute("a", "data-original-title", "Skyline Audit Log"));
-        DataRegionTable auditLog = new DataRegionTable("SkylineAuditLog", getDriver());
+        DataRegionTable auditLog = getAuditLogs(getProjectName());
 
         log("Verifying the imported logs");
         assertEquals("Invalid number of audit logs", 9, auditLog.getDataRowCount());
@@ -56,5 +50,41 @@ public class TargetedMSAuditLogTest extends TargetedMSTest
         assertEquals("End message is incorrect", "Managed results",
                 auditLog.getDataAsText(8, "MessageText"));
 
+    }
+
+    /*
+        Test coverage for Issue 44507: Importing the same Skyline document in multiple containers associates the audit log solely with the last import
+     */
+    @Test
+    public void testAuditLogInTwoDifferentFolders()
+    {
+        log("Creating folder and importing same SKY file");
+        goToProjectHome();
+        String FOLDER_2 = "Folder 2 with same audit logs";
+        setUpFolder(FOLDER_2, FolderType.QC);
+        importData(AuditTrail_FILE);
+
+        log("Verifying logs are imported correctly in " + FOLDER_2);
+        DataRegionTable auditLog = getAuditLogs(FOLDER_2);
+        assertEquals("Invalid number of audit logs", 9, auditLog.getDataRowCount());
+
+        log("Deleting " + FOLDER_2);
+        APIContainerHelper apiContainerHelper = new APIContainerHelper(this);
+        apiContainerHelper.deleteProject(FOLDER_2, false);
+
+        log("Verifying the logs are present in first folder");
+        auditLog = getAuditLogs(getProjectName());
+        assertEquals("Invalid number of audit logs", 9, auditLog.getDataRowCount());
+    }
+
+    private DataRegionTable getAuditLogs(String projectName)
+    {
+        goToProjectHome(projectName);
+        clickTab("Runs");
+        clickAndWait(Locator.linkContainingText(AuditTrail_FILE));
+
+        log("Navigating to the audit log");
+        clickAndWait(Locator.tagWithAttribute("a", "data-original-title", "Skyline Audit Log"));
+        return new DataRegionTable("SkylineAuditLog", getDriver());
     }
 }


### PR DESCRIPTION
#### Rationale
Automation test Issue 44507: Importing the same Skyline document in multiple containers associates the audit log solely with the last import

1. Import into container A, verify you can see the log there.
2. Import into container B. Verify you can see the log in both A and B.
3. Delete from A. Verify you can see the log in B.
4. Celebrate!

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
New test case : TargetedMSAuditLogTest .testAuditLogInTwoDifferentFolders() 
