### PR TITLE
Issue 45138: Adjust FolderXarImporterFactory to support unzipped XARs

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSManager.java
+++ b/src/org/labkey/targetedms/TargetedMSManager.java
@@ -609,7 +609,7 @@ public class TargetedMSManager
             XarSource source = new AbstractFileXarSource("Wrap Targeted MS Run", container, user)
             {
                 @Override
-                public File getLogFile()
+                public Path getLogFilePath()
                 {
                     throw new UnsupportedOperationException();
                 }


### PR DESCRIPTION
#### Rationale
Checking in zipped files (like .xar files) makes it hard to edit and view diffs. We can easily handle importing .xar.xml files in folder archives, even if we always export in the compressed form

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3187

#### Changes
* Check for both .xar and .xar.xml files in folder archives
* Remove deprecated File method variants in favor of Path
