### PR TITLE
Use shared version number for SQLite

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ dependencies
    BuildUtils.addExternalDependency(
            project,
            new ExternalDependency(
-                   "org.xerial:sqlite-jdbc:3.7.2",
+                   "org.xerial:sqlite-jdbc:${sqliteJdbcVersion}",
                    "SQLite JDBC Driver",
                    "bitbucket.org",
                    "https://bitbucket.org/xerial/sqlite-jdbc/wiki/Home",


### PR DESCRIPTION
#### Rationale
We've got a preferred version number for SQLite...

#### Changes
* So use the preferred SQLite version number