### PR TITLE
Issue 45183: Add library and isotope dotp metrics

### DIFF
--- a/resources/queries/targetedms/QCMetricEnabled_isotopeDotp.sql
+++ b/resources/queries/targetedms/QCMetricEnabled_isotopeDotp.sql
@@ -1,0 +1,1 @@
+SELECT Id FROM targetedms.PrecursorChromInfo WHERE IsotopeDotp IS NOT NULL

--- a/resources/queries/targetedms/QCMetricEnabled_libraryDotp.sql
+++ b/resources/queries/targetedms/QCMetricEnabled_libraryDotp.sql
@@ -1,0 +1,1 @@
+SELECT Id FROM targetedms.PrecursorChromInfo WHERE LibraryDotp IS NOT NULL

--- a/resources/queries/targetedms/QCMetric_isotopeDotp.sql
+++ b/resources/queries/targetedms/QCMetric_isotopeDotp.sql
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2016-2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+SELECT
+  Id AS PrecursorChromInfoId,
+  SampleFileId AS SampleFileId,
+  IsotopeDotp AS MetricValue
+FROM PrecursorChromInfo

--- a/resources/queries/targetedms/QCMetric_libraryDotp.sql
+++ b/resources/queries/targetedms/QCMetric_libraryDotp.sql
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2016-2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+SELECT
+  Id AS PrecursorChromInfoId,
+  SampleFileId AS SampleFileId,
+  LibraryDotp AS MetricValue
+FROM PrecursorChromInfo

--- a/resources/schemas/dbscripts/postgresql/targetedms-22.003-22.004.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-22.003-22.004.sql
@@ -1,0 +1,7 @@
+WITH rootIdentity as (select EntityId as theIdentity FROM core.Containers WHERE Parent is null)
+INSERT INTO targetedms.QCMetricConfiguration (Container, Name, Series1Label, Series1SchemaName, Series1QueryName, PrecursorScoped, EnabledQueryName, EnabledSchemaName) VALUES
+    ((select theIdentity from rootIdentity), 'Library dotp', 'Library dotp', 'targetedms', 'QCMetric_libraryDotp', true, 'QCMetricEnabled_libraryDotp', 'targetedms');
+
+WITH rootIdentity as (select EntityId as theIdentity FROM core.Containers WHERE Parent is null)
+INSERT INTO targetedms.QCMetricConfiguration (Container, Name, Series1Label, Series1SchemaName, Series1QueryName, PrecursorScoped, EnabledQueryName, EnabledSchemaName) VALUES
+    ((select theIdentity from rootIdentity), 'Isotope dotp', 'Isotope dotp', 'targetedms', 'QCMetric_isotopeDotp', true, 'QCMetricEnabled_isotopeDotp', 'targetedms');

--- a/resources/schemas/dbscripts/sqlserver/targetedms-22.003-22.004.sql
+++ b/resources/schemas/dbscripts/sqlserver/targetedms-22.003-22.004.sql
@@ -1,0 +1,8 @@
+declare @rootIdentity ENTITYID;
+select @rootIdentity = [EntityId] FROM [core].[Containers] WHERE Parent is null
+
+INSERT INTO targetedms.QCMetricConfiguration (Container, Name, Series1Label, Series1SchemaName, Series1QueryName, PrecursorScoped, EnabledQueryName, EnabledSchemaName) VALUES
+    (@rootIdentity, 'Library dotp', 'Library dotp', 'targetedms', 'QCMetric_libraryDotp', 1, 'QCMetricEnabled_libraryDotp', 'targetedms');
+
+INSERT INTO targetedms.QCMetricConfiguration (Container, Name, Series1Label, Series1SchemaName, Series1QueryName, PrecursorScoped, EnabledQueryName, EnabledSchemaName) VALUES
+    (@rootIdentity, 'Isotope dotp', 'Isotope dotp', 'targetedms', 'QCMetric_isotopeDotp', 1, 'QCMetricEnabled_isotopeDotp', 'targetedms');

--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -240,7 +240,7 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
     @Override
     public Double getSchemaVersion()
     {
-        return 22.003;
+        return 22.004;
     }
 
     @Override

--- a/test/src/org/labkey/test/components/targetedms/ParetoPlotsWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/ParetoPlotsWebPart.java
@@ -44,9 +44,11 @@ public class ParetoPlotsWebPart extends BodyWebPart<ParetoPlotsWebPart.ElementCa
         TPAREARATIO("Transition/Precursor Area Ratio"),
         PAREA("Precursor Area"),
         TAREA("Transition Area"),
-        MASSACCURACY("Mass Accuracy");
+        MASSACCURACY("Mass Accuracy"),
+        ISOTOPE_DOTP("Isotope dotp"),
+        LIBRARY_DOTP("Library dotp");
 
-        private String _text;
+        private final String _text;
 
         MetricTypeTicks(String text)
         {
@@ -81,8 +83,8 @@ public class ParetoPlotsWebPart extends BodyWebPart<ParetoPlotsWebPart.ElementCa
         CUSUMm("Mean CUSUM", "_CUSUMm"),
         CUSUMv("Variability CUSUM", "_CUSUMv");
 
-        private String _label;
-        private String _suffix;
+        private final String _label;
+        private final String _suffix;
 
         ParetoPlotType(String text, String idSuffix)
         {

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCGuideSetTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCGuideSetTest.java
@@ -254,7 +254,9 @@ public class TargetedMSQCGuideSetTest extends TargetedMSTest
         assertEquals("Wrong number of non-conformers for MA", 21, paretoPlotsWebPart.getPlotBarHeight(guideSetId, plotType, 4));
         assertEquals("Wrong number of non-conformers for RT", 17, paretoPlotsWebPart.getPlotBarHeight(guideSetId, plotType, 5));
         assertEquals("Wrong number of non-conformers for FWHM", 12, paretoPlotsWebPart.getPlotBarHeight(guideSetId, plotType, 6));
-        assertEquals("Wrong number of non-conformers for T/P Ratio", 4, paretoPlotsWebPart.getPlotBarHeight(guideSetId, plotType, 7));
+        assertEquals("Wrong number of non-conformers for Isotope dotp", 5, paretoPlotsWebPart.getPlotBarHeight(guideSetId, plotType, 7));
+        assertEquals("Wrong number of non-conformers for area ratio", 4, paretoPlotsWebPart.getPlotBarHeight(guideSetId, plotType, 8));
+        assertEquals("Wrong number of non-conformers for TIC area", 2, paretoPlotsWebPart.getPlotBarHeight(guideSetId, plotType, 9));
         verifyTicksOnPlots(paretoPlotsWebPart, guideSetId, plotType);
         verifyNavigationToPanoramaDashboard(guideSetId, QCPlotsWebPart.QCPlotType.MovingRange, 0, QCPlotsWebPart.MetricType.TOTAL_PEAK, true);
 


### PR DESCRIPTION
#### Rationale
Comparing dotp values against expected isotope distributions and library spectra is a valuable way to assess data quality

#### Changes
* Add new Isotope and Library dotp metrics, which auto-hide when data isn't available