### PR TITLE
QC plot layout improvements: tooltip truncation, redundant titles, etc

### DIFF
--- a/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
@@ -742,11 +742,11 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
 
     public enum QCPlotExclusionState
     {
-        Include("Include in QC"),
-        ExcludeMetric("Exclude sample from QC for this metric"),
-        ExcludeAll("Exclude sample from QC for all metrics");
+        Include("Include"),
+        ExcludeMetric("Exclude replicate for this metric"),
+        ExcludeAll("Exclude replicate for all metrics");
 
-        private String _label;
+        private final String _label;
 
         QCPlotExclusionState(String label)
         {

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCSummaryTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCSummaryTest.java
@@ -255,8 +255,8 @@ public class TargetedMSQCSummaryTest extends TargetedMSTest
         refresh();
         waitForElements(Locator.tagWithClass("div", "sample-file-item"), 6);
 
-        validateAutoQCStatus(MAIN_SUMMARY, Arrays.asList("qc-correct", "fa-check-circle"), "Was pinged recently on " + mainFolderLastPingDate);
-        validateAutoQCStatus(SUB_FOLDER02, Arrays.asList("qc-correct", "fa-check-circle"), "Was pinged recently on " + subfolder2LastPingDate);
+        validateAutoQCStatus(MAIN_SUMMARY, Arrays.asList("qc-correct", "fa-check-circle"), "AutoQC pinged recently on " + mainFolderLastPingDate);
+        validateAutoQCStatus(SUB_FOLDER02, Arrays.asList("qc-correct", "fa-check-circle"), "AutoQC pinged recently on " + subfolder2LastPingDate);
 
 
         log("Now wait for ping limit to occur.");
@@ -266,8 +266,8 @@ public class TargetedMSQCSummaryTest extends TargetedMSTest
         refresh();
 
         log("Validate the ping timeout icons for the main folder and sub-folder 2.");
-        validateAutoQCStatus(MAIN_SUMMARY, Arrays.asList("qc-error", "fa-circle"), "Was pinged on " + mainFolderLastPingDate);
-        validateAutoQCStatus(SUB_FOLDER02, Arrays.asList("qc-error", "fa-circle"), "Was pinged on " + subfolder2LastPingDate);
+        validateAutoQCStatus(MAIN_SUMMARY, Arrays.asList("qc-error", "fa-circle"), "AutoQC last pinged on " + mainFolderLastPingDate);
+        validateAutoQCStatus(SUB_FOLDER02, Arrays.asList("qc-error", "fa-circle"), "AutoQC last pinged on " + subfolder2LastPingDate);
 
         log("Subfolder 1 should still think it's never been pinged");
         validateAutoQCStatus(SUB_FOLDER01, Arrays.asList("qc-none", "fa-circle-o"), "AutoQC has never pinged this folder");

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCSummaryTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCSummaryTest.java
@@ -236,13 +236,13 @@ public class TargetedMSQCSummaryTest extends TargetedMSTest
         tempStringList02.add(Arrays.asList("Q_Exactive_08_23_2013_JGB_37", "Acquired: 2013-08-26 04:27"));
         validateSampleFile(0, tempStringList01, tempStringList02);
 
-        validateAutoQCStatus(MAIN_SUMMARY, Arrays.asList("qc-none", "fa-circle-o"), "Has never been pinged");
+        validateAutoQCStatus(MAIN_SUMMARY, Arrays.asList("qc-none", "fa-circle-o"), "AutoQC has never pinged this folder");
 
         log("Now validate the icon for the sub-folder 1.");
-        validateAutoQCStatus(SUB_FOLDER01, Arrays.asList("qc-none", "fa-circle-o"), "Has never been pinged");
+        validateAutoQCStatus(SUB_FOLDER01, Arrays.asList("qc-none", "fa-circle-o"), "AutoQC has never pinged this folder");
 
         log("Now validate the icon for the sub-folder 2.");
-        validateAutoQCStatus(SUB_FOLDER02, Arrays.asList("qc-none", "fa-circle-o"), "Has never been pinged");
+        validateAutoQCStatus(SUB_FOLDER02, Arrays.asList("qc-none", "fa-circle-o"), "AutoQC has never pinged this folder");
 
         log("Ping to simulate AutoQC checking in.");
         //http://localhost:8080/labkey/TargetedMSQCSummaryTest%20Project/QC%20Subfolder%202/targetedms-autoqcping.view
@@ -270,7 +270,7 @@ public class TargetedMSQCSummaryTest extends TargetedMSTest
         validateAutoQCStatus(SUB_FOLDER02, Arrays.asList("qc-error", "fa-circle"), "Was pinged on " + subfolder2LastPingDate);
 
         log("Subfolder 1 should still think it's never been pinged");
-        validateAutoQCStatus(SUB_FOLDER01, Arrays.asList("qc-none", "fa-circle-o"), "Has never been pinged");
+        validateAutoQCStatus(SUB_FOLDER01, Arrays.asList("qc-none", "fa-circle-o"), "AutoQC has never pinged this folder");
 
 
         log("Validate that a guide set updates the file info as expected.");

--- a/webapp/TargetedMS/css/qcTrendPlotReport.css
+++ b/webapp/TargetedMS/css/qcTrendPlotReport.css
@@ -72,8 +72,8 @@
 }
 
 .qc-hover-field .x4-form-item-label {
-    margin-top: 2px;
     font-weight: bold;
+    font-size: 12px;
 }
 
 .qc-paging-prev, .qc-paging-next {

--- a/webapp/TargetedMS/js/BaseQCPlotPanel.js
+++ b/webapp/TargetedMS/js/BaseQCPlotPanel.js
@@ -133,15 +133,10 @@ Ext4.define('LABKEY.targetedms.BaseQCPlotPanel', {
     {
         var leftPositionPx = (( (!this.largePlot && this.plotTypes && this.plotTypes.length > 1) ? plotIndex % 2 : 0) * plotWidth) + (indexFromLeft * 30) + 60,
             exportIconDivId = divId + iconCls,
-            html = '<div id="' + exportIconDivId + '" class="export-icon" style="left: ' + leftPositionPx + 'px;">'
+            html = '<div id="' + exportIconDivId + '" class="export-icon" title="' + Ext4.util.Format.htmlEncode(tooltip) + '" style="left: ' + leftPositionPx + 'px;">'
                     + '<i class="fa ' + iconCls + '"></i></div>';
 
         Ext4.get(divId).insertHtml('afterBegin', html);
-
-        Ext4.create('Ext.tip.ToolTip', {
-            target: exportIconDivId,
-            html: tooltip
-        });
 
         Ext4.get(exportIconDivId).on('click', callbackFn, this);
     },

--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -598,19 +598,24 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
     getYScaleLabel: function(plotType, conversion, label) {
         var yScaleLabel;
 
+        var conversionLabel = null;
+
         if (plotType !== LABKEY.vis.TrendingLinePlotType.MovingRange && plotType !== LABKEY.vis.TrendingLinePlotType.LeveyJennings) {
             yScaleLabel = 'Sum of Deviations'
         }
-        else if (conversion && label !== "Transition Area") {
+        else if (conversion) {
             var options = this.getYAxisOptions();
             for (var i = 0; i < options.data.length; i++) {
                 if (options.data[i][0] === conversion)
-                    yScaleLabel = options.data[i][1];
+                    conversionLabel = options.data[i][1];
             }
         }
 
         if (!yScaleLabel) {
             yScaleLabel = label;
+            if (conversionLabel) {
+                yScaleLabel += ' (' + conversionLabel + ')';
+            }
         }
         return yScaleLabel;
     },
@@ -636,7 +641,6 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
         else if (this.yAxisScale === 'standardDeviation' && plotType === LABKEY.vis.TrendingLinePlotType.LeveyJennings) {
             disableRange = false;
         }
-        var scope = this;
 
         var trendLineProps = {
             disableRangeDisplay: disableRange,
@@ -676,13 +680,14 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
                 },
                 subtitle: {
                     value: this.getSubtitle("All Series", plotType, trendLineProps.valueConversion),
+                    visibility: 'hidden',  // Set as hidden so it doesn't clutter the web UI. It'll get set to visible during export, where it's useful context.
                     color: '#555555'
                 },
                 yLeft: {
                     value: this.getYScaleLabel(plotType, trendLineProps.valueConversion, metricProps.yAxisLabel1)
                 },
                 yRight: {
-                    value: this.isMultiSeries() ? metricProps.yAxisLabel2 : undefined,
+                    value: this.isMultiSeries() ? this.getYScaleLabel(plotType, trendLineProps.valueConversion, metricProps.yAxisLabel2) : undefined,
                     visibility: this.isMultiSeries() ? undefined : 'hidden'
                 }
             },
@@ -779,6 +784,7 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
                 },
                 subtitle: {
                     value: this.getSubtitle(this.precursors[precursorIndex], plotType, trendLineProps.valueConversion),
+                    visibility: 'hidden',  // Set as hidden so it doesn't clutter the web UI. It'll get set to visible during export, where it's useful context.
                     color: '#555555'
                 },
                 yLeft: {
@@ -787,7 +793,7 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
                     position: leftMarginOffset > 0 ? leftMarginOffset - 15 : undefined
                 },
                 yRight: {
-                    value: this.isMultiSeries() ? metricProps.yAxisLabel2 : undefined,
+                    value: this.isMultiSeries() ? this.getYScaleLabel(plotType, trendLineProps.valueConversion, metricProps.yAxisLabel2) : undefined,
                     visibility: this.isMultiSeries() ? undefined : 'hidden',
                     color: this.isMultiSeries() ? this.getColorRange()[1] : undefined
                 }

--- a/webapp/TargetedMS/js/QCPlotHoverPanel.js
+++ b/webapp/TargetedMS/js/QCPlotHoverPanel.js
@@ -75,26 +75,25 @@ Ext4.define('LABKEY.targetedms.QCPlotHoverPanel', {
             this.add(this.getPlotPointDetailField('Group', 'CUSUMmN' == this.valueName || 'CUSUMvN' == this.valueName ? 'CUSUM-' : 'CUSUM+'));
         }
 
-        if(this.metricProps.precursorScoped)
-            this.add(this.getPlotPointDetailField('m/z', this.pointData['mz']));
-        this.add(this.getPlotPointDetailField('Replicate', this.pointData['ReplicateName']));
-        this.add(this.getPlotPointDetailField('Acquired', this.pointData['fullDate']));
         if (this.pointData.conversion && this.pointData.rawValue !== undefined && this.valueName.indexOf("CUSUM") === -1) {
             if (this.pointData.conversion === 'percentDeviation') {
-                this.add(this.getPlotPointDetailField('Value', this.formatMetricValue(this.pointData.rawValue)));
-                this.add(this.getPlotPointDetailField('Percent of Mean', (this.valueName ? this.pointData[this.valueName] : this.pointData['value']) + '%'))
+                this.add(this.getPlotPointDetailField('Value', LABKEY.targetedms.PlotSettingsUtil.formatNumeric(this.pointData.rawValue)));
+                this.add(this.getPlotPointDetailField('% of Mean', (this.valueName ? this.pointData[this.valueName] : this.pointData['value']) + '%'))
             }
             else if (this.pointData.conversion === 'standardDeviation') {
-                this.add(this.getPlotPointDetailField('Value', this.formatMetricValue(this.pointData.rawValue)));
-                this.add(this.getPlotPointDetailField('Standard Deviations', this.valueName ? this.pointData[this.valueName] : this.pointData['value']))
+                this.add(this.getPlotPointDetailField('Value', LABKEY.targetedms.PlotSettingsUtil.formatNumeric(this.pointData.rawValue)));
+                this.add(this.getPlotPointDetailField('Std Devs', this.valueName ? this.pointData[this.valueName] : this.pointData['value']))
             }
             else {
-                this.add(this.getPlotPointDetailField('Value', this.formatMetricValue(this.valueName ? this.pointData[this.valueName] : this.pointData['value'])));
+                this.add(this.getPlotPointDetailField('Value', LABKEY.targetedms.PlotSettingsUtil.formatNumeric(this.valueName ? this.pointData[this.valueName] : this.pointData['value'])));
             }
         }
         else {
-            this.add(this.getPlotPointDetailField('Value', this.formatMetricValue(this.valueName ? this.pointData[this.valueName] : this.pointData['value'])));
+            this.add(this.getPlotPointDetailField('Value', LABKEY.targetedms.PlotSettingsUtil.formatNumeric(this.valueName ? this.pointData[this.valueName] : this.pointData['value'])));
         }
+
+        this.add(this.getPlotPointDetailField('Replicate', this.pointData['ReplicateName']));
+        this.add(this.getPlotPointDetailField('Acquired', this.pointData['fullDate']));
         this.add(this.getPlotPointDetailField('File Path', this.pointData['FilePath'].replace(/\\/g, '\\<wbr>').replace(/\//g, '\/<wbr>').replace(/_/g, '_<wbr>')));
 
         if (this.canEdit) {
@@ -105,25 +104,6 @@ Ext4.define('LABKEY.targetedms.QCPlotHoverPanel', {
         }
 
         this.add(Ext4.create('Ext.Component', { html: this.getPlotPointClickLinks() }));
-    },
-
-    formatMetricValue: function(value) {
-        if (Ext4.isNumeric(value)) {
-            if (value > 1000) {
-                return Ext4.util.Format.number(value, '0,000');
-            }
-            if (value > 100) {
-                return Ext4.util.Format.number(value, '0.#');
-            }
-            if (value > 10) {
-                return Ext4.util.Format.number(value, '0.##');
-            }
-            if (value > 1) {
-                return Ext4.util.Format.number(value, '0.###');
-            }
-            return Ext4.util.Format.number(value, '0.####');
-        }
-        return value;
     },
 
     getPlotPointDetailField : function(label, value, includeCls) {
@@ -145,7 +125,7 @@ Ext4.define('LABKEY.targetedms.QCPlotHoverPanel', {
                 items: [this.getPlotPointExclusionRadioGroup()],
                 dockedItems: [{
                     xtype: 'toolbar',
-                    dock: 'bottom',
+                    dock: 'right',
                     ui: 'footer',
                     padding: '0 0 10px 0',
                     items: ['->', this.getPlotPointExclusionSaveBtn()]
@@ -255,17 +235,17 @@ Ext4.define('LABKEY.targetedms.QCPlotHoverPanel', {
                 width: 450,
                 columns: 1,
                 items: [{
-                    boxLabel: 'Include in QC', name: 'status',
+                    boxLabel: 'Include', name: 'status',
                     inputValue: this.STATE.INCLUDE,
-                    checked: this.originalStatus == this.STATE.INCLUDE
+                    checked: this.originalStatus === this.STATE.INCLUDE
                 },{
-                    boxLabel: 'Exclude sample from QC for this metric', name: 'status',
+                    boxLabel: 'Exclude replicate for this metric', name: 'status',
                     inputValue: this.STATE.EXCLUDE_METRIC,
-                    checked: this.originalStatus == this.STATE.EXCLUDE_METRIC
+                    checked: this.originalStatus === this.STATE.EXCLUDE_METRIC
                 },{
-                    boxLabel: 'Exclude sample from QC for all metrics', name: 'status',
+                    boxLabel: 'Exclude replicate for all metrics', name: 'status',
                     inputValue: this.STATE.EXCLUDE_ALL,
-                    checked: this.originalStatus == this.STATE.EXCLUDE_ALL
+                    checked: this.originalStatus === this.STATE.EXCLUDE_ALL
                 }],
                 listeners: {
                     scope: this,

--- a/webapp/TargetedMS/js/QCSummaryPanel.js
+++ b/webapp/TargetedMS/js/QCSummaryPanel.js
@@ -142,7 +142,7 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
                     '<div class="qc-summary-text">No sample files imported</div>',
                     '<div class="auto-qc-ping" id="{autoQcCalloutId}">AutoQC <span class="{autoQCPing:this.getAutoQCPingClass}"></span></div>',
                 '<tpl elseif="docCount == 0 && parentOnly">',
-                    '<div class="qc-summary-text">No data found.</div>',
+                    '<div class="qc-summary-text">No data found.</div><div>&nbsp;</div>' + this.getAutoQCSetupInfo(),
                 '<tpl elseif="docCount &gt; 0">',
                     '<div class="qc-summary-text">',
                         '<a href="{path:this.getSampleFileLink}">{fileCount} sample file{fileCount:this.pluralize}</a> ' +
@@ -180,6 +180,15 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
         );
     },
 
+    getAutoQCSetupInfo: function() {
+        return '<div><a href="https://panoramaweb.org/home/wiki-page.view?name=autoqc_loader" target="_blank" rel="noopener noreferrer">AutoQC</a>' +
+                ' can automically analyze and import system suitability data into this folder using a Skyline template document.</div><br/>' +
+                '<div>After installing AutoQC, create a configuration for this folder. Within its Panorama setting tab, ' +
+                'check the Publish to Panorama checkbox. Use <strong>' + LABKEY.Utils.encodeHtml(LABKEY.ActionURL.getBaseURL()) +
+                '</strong> as the URL and <strong>' + LABKEY.Utils.encodeHtml(LABKEY.ActionURL.getContainer()) + '</strong>' +
+                ' as the folder path.</div>'
+    },
+
     showAutoQCMessage : function(divId, autoQC, hasChildren) {
         var divEl = Ext4.get(divId),
             content = '';
@@ -188,17 +197,15 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
             return;
 
         if (autoQC == null) {
-            content = 'Has never been pinged';
+            content = 'AutoQC has never pinged this folder';
         }
         else
         {
             var modifiedFormatted = Ext4.util.Format.date(new Date(autoQC.modified), LABKEY.extDefaultDateTimeFormat || 'Y-m-d H:i:s');
-            content = autoQC.isRecent ? 'Was pinged recently on ' + modifiedFormatted : 'Was pinged on ' + modifiedFormatted;
+            content = autoQC.isRecent ? 'AutoQC pinged recently on ' + modifiedFormatted : 'AutoQC last pinged on ' + modifiedFormatted;
         }
 
-        content = '<div>' + content + '</div><br/><div>To point AutoQC at this folder, go to configuration\'s Panorama setting tab. ' +
-                'Check the Publish to Panorama checkbox. Use <strong>' + LABKEY.Utils.encodeHtml(LABKEY.ActionURL.getBaseURL()) +
-                '</strong> as the URL and <strong>' + LABKEY.Utils.encodeHtml(LABKEY.ActionURL.getContainer()) + '</strong> as the folder.</div>'
+        content = '<div>' + content + '</div><br/>' + this.getAutoQCSetupInfo();
 
         // add mouse listeners to the div element for when to show the AutoQC message
         divEl.on('mouseover', function() {

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -26,6 +26,16 @@ if (!LABKEY.targetedms.PlotSettingsUtil) {
                 success: function() { window.location.reload(); },
                 failure: LABKEY.Utils.getCallbackWrapper(function(error) { alert('Failed to revert to defaults'); console.log(error); }, this, true)
             });
+        },
+
+        formatNumeric: function(val) {
+            if (LABKEY.vis.isValid(val)) {
+                if (val > 100000 || val < -100000) {
+                    return val.toExponential(3);
+                }
+                return parseFloat(val.toFixed(3));
+            }
+            return "N/A";
         }
     }
 }
@@ -1548,9 +1558,9 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                     expDataArr.push(pointsData[i].value);
                 }
 
-                var expMean = me.formatNumeric(LABKEY.vis.Stat.getMean(expDataArr));
-                var expStdDev = me.formatNumeric(LABKEY.vis.Stat.getStdDev(expDataArr));
-                var expPercentCV = me.formatNumeric((expStdDev / expMean) * 100);
+                var expMean = LABKEY.targetedms.PlotSettingsUtil.formatNumeric(LABKEY.vis.Stat.getMean(expDataArr));
+                var expStdDev = LABKEY.targetedms.PlotSettingsUtil.formatNumeric(LABKEY.vis.Stat.getStdDev(expDataArr));
+                var expPercentCV = LABKEY.targetedms.PlotSettingsUtil.formatNumeric((expStdDev / expMean) * 100);
 
                 var expRangeData = [];
                 expRangeData.push({
@@ -1596,9 +1606,9 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                     mean, stdDev, percentCV;
 
                 if (showGuideSetStats) {
-                    mean = me.formatNumeric(seriesGuideSetInfo.Mean);
-                    stdDev = me.formatNumeric(seriesGuideSetInfo.StdDev);
-                    percentCV = me.formatNumeric((stdDev / mean) * 100);
+                    mean = LABKEY.targetedms.PlotSettingsUtil.formatNumeric(seriesGuideSetInfo.Mean);
+                    stdDev = LABKEY.targetedms.PlotSettingsUtil.formatNumeric(seriesGuideSetInfo.StdDev);
+                    percentCV = LABKEY.targetedms.PlotSettingsUtil.formatNumeric((stdDev / mean) * 100);
                 }
 
                 return "Guide Set ID: " + Ext4.String.htmlEncode(d.GuideSetId) + ","
@@ -1707,16 +1717,6 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         else {
             return d;
         }
-    },
-
-    formatNumeric: function(val) {
-        if (LABKEY.vis.isValid(val)) {
-            if (val > 100000 || val < -100000) {
-                return val.toExponential(3);
-            }
-            return parseFloat(val.toFixed(3));
-        }
-        return "N/A";
     },
 
     getReportConfig: function() {


### PR DESCRIPTION
#### Rationale
Issue 45204: Help users know the right AutoQC settings

We can improve the labels in Panorama QC plots and associated tooltips to reduce redundancy and increase accuracy

#### Changes
* Don't show plot subtitles that are redundant with web part headers, but do show them in exports
* Fix truncation on "Export to PNG" button
* Give users guidance on setting up AutoQC when they have an empty QC folder
* Don't lose the primary y-axis label when we're showing percent of mean, etc
* No need to show mz twice in the tooltip
* Improve formatting of values and layout in tulip