### PR TITLE
Add a method to get the replicate name for a sample file

### DIFF
--- a/api-src/org/labkey/api/targetedms/ISampleFile.java
+++ b/api-src/org/labkey/api/targetedms/ISampleFile.java
@@ -4,6 +4,8 @@ import java.util.Date;
 
 public interface ISampleFile
 {
+    long getId();
+    long getReplicateId();
     String getFilePath();
     String getSampleName();
     Date getAcquiredTime();

--- a/api-src/org/labkey/api/targetedms/TargetedMSService.java
+++ b/api-src/org/labkey/api/targetedms/TargetedMSService.java
@@ -157,7 +157,7 @@ public interface TargetedMSService
      * @param sampleFileId
      * @param container container that has the Skyline document that the sample file belongs to.
      * @return the replicate name associated with the given sampleFileId. Returns null if a database row with the given
-     * sampleFileId does not exist, or the Skyline document document with the sample file is not in the given container.
+     * sampleFileId does not exist, or if the Skyline document with the sample file is not in the given container.
      */
     @Nullable String getSampleReplicateName(long sampleFileId, Container container);
 }

--- a/api-src/org/labkey/api/targetedms/TargetedMSService.java
+++ b/api-src/org/labkey/api/targetedms/TargetedMSService.java
@@ -151,4 +151,13 @@ public interface TargetedMSService
      */
     @Nullable
     Integer parseChromLibRevision(@NotNull String chromLibFileName);
+
+    /**
+     *
+     * @param sampleFileId
+     * @param container container that has the Skyline document that the sample file belongs to.
+     * @return the replicate name associated with the given sampleFileId. Returns null if a database row with the given
+     * sampleFileId does not exist, or the Skyline document document with the sample file is not in the given container.
+     */
+    @Nullable String getSampleReplicateName(long sampleFileId, Container container);
 }

--- a/src/org/labkey/targetedms/TargetedMSServiceImpl.java
+++ b/src/org/labkey/targetedms/TargetedMSServiceImpl.java
@@ -39,6 +39,7 @@ import org.labkey.api.targetedms.model.SampleFilePath;
 import org.labkey.api.view.ViewBackgroundInfo;
 import org.labkey.targetedms.chromlib.ChromatogramLibraryUtils;
 import org.labkey.targetedms.datasource.MsDataSourceUtil;
+import org.labkey.targetedms.parser.Replicate;
 import org.labkey.targetedms.parser.SampleFile;
 import org.labkey.targetedms.query.LibraryManager;
 import org.labkey.targetedms.query.ModificationManager;
@@ -330,5 +331,12 @@ public class TargetedMSServiceImpl implements TargetedMSService
     public @Nullable Integer parseChromLibRevision(@NotNull String chromLibFileName)
     {
         return ChromatogramLibraryUtils.parseChromLibRevision(chromLibFileName);
+    }
+
+    @Override
+    public @Nullable String getSampleReplicateName(long sampleFileId, Container container)
+    {
+        Replicate replicate = ReplicateManager.getSampleReplicate(sampleFileId, container);
+        return replicate != null ? replicate.getName() : null;
     }
 }

--- a/src/org/labkey/targetedms/query/ReplicateManager.java
+++ b/src/org/labkey/targetedms/query/ReplicateManager.java
@@ -58,6 +58,20 @@ public class ReplicateManager
             .getObject(replicateId, Replicate.class);
     }
 
+    public static Replicate getSampleReplicate(long sampleFileId, Container container)
+    {
+        SQLFragment sqlFragment = new SQLFragment("SELECT rep.* FROM ");
+        sqlFragment.append(TargetedMSManager.getTableInfoSampleFile(), "s");
+        sqlFragment.append(" INNER JOIN ").append(TargetedMSManager.getTableInfoReplicate(), "rep");
+        sqlFragment.append(" ON s.replicateId = rep.Id");
+        sqlFragment.append(" INNER JOIN ").append(TargetedMSManager.getTableInfoRuns(), "r");
+        sqlFragment.append(" ON r.Id = rep.runId");
+        sqlFragment.append(" WHERE s.Id=?").add(sampleFileId);
+        sqlFragment.append(" AND r.Container=?").add(container);
+
+        return new SqlSelector(TargetedMSManager.getSchema(), sqlFragment).getObject(Replicate.class);
+    }
+
     /**
      * @return the distinct list of metric IDs that are set as exclusions for replicates of the supplied name.
      * Null indicates that there was an exclusion for all metrics for the replicate.


### PR DESCRIPTION
#### Rationale
We would like to display the replicate names for sample files in the Panorama Public data validation grid.

