### PR TITLE
Issue 45440: Moving range plot broken with y-axis options and L-J plots

### DIFF
--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -160,7 +160,7 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
         if (this.showLJPlot()) {
             this.processLJGuideSetData(plotDataRows);
         }
-        else if (this.showMovingRangePlot() || this.showMeanCUSUMPlot() || this.showVariableCUSUMPlot()) {
+        if (this.showMovingRangePlot() || this.showMeanCUSUMPlot() || this.showVariableCUSUMPlot()) {
             this.processRawGuideSetData(plotDataRows);
         }
 
@@ -612,7 +612,7 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
         if (!yScaleLabel) {
             yScaleLabel = label;
             if (conversionLabel) {
-                yScaleLabel += ' (' + conversionLabel + ')';
+                yScaleLabel = yScaleLabel ? (yScaleLabel + ' (' + conversionLabel + ')') : conversionLabel;
             }
         }
         return yScaleLabel;


### PR DESCRIPTION
#### Rationale
The moving range plots show a straight line at 0 or 100 with some combination of options.

#### Changes
* Initialize for moving-range plots when needed, whether we're showing Levey-Jennings or not.
* Avoid showing 'undefined' for plot y-axis labels