### PR TITLE
Issue 45525: File handles are not closed when searching for Skyline document sample files

### DIFF
--- a/src/org/labkey/targetedms/datasource/MsDataSourceUtil.java
+++ b/src/org/labkey/targetedms/datasource/MsDataSourceUtil.java
@@ -43,6 +43,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.labkey.api.files.FileContentService.UPLOADED_FILE;
@@ -296,10 +297,10 @@ public class MsDataSourceUtil
     }
 
     private Path getDataPath(String fileName, MsDataSource sourceType, Path rawFilesDir)
+    {
+        try (Stream<Path> list = Files.walk(rawFilesDir).filter(p -> isSourceMatch(p, fileName, sourceType)))
         {
-        try
-        {
-            return Files.walk(rawFilesDir).filter(p -> isSourceMatch(p, fileName, sourceType)).findFirst().orElse(null);
+            return list.findFirst().orElse(null);
         }
         catch (IOException e)
         {


### PR DESCRIPTION
#### Changes
`Files.walk` should be called in a try-with-resources block
