### PR TITLE
Issue 45544: Clicking "View Chromatogram" from Panorama QC plot doesn't page

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -178,6 +178,7 @@ import org.labkey.targetedms.folderImport.QCFolderConstants;
 import org.labkey.targetedms.model.GuideSet;
 import org.labkey.targetedms.model.GuideSetKey;
 import org.labkey.targetedms.model.GuideSetStats;
+import org.labkey.targetedms.model.PrecursorChromInfoLitePlus;
 import org.labkey.targetedms.model.QCMetricConfiguration;
 import org.labkey.targetedms.model.QCPlotFragment;
 import org.labkey.targetedms.model.RawMetricDataSet;
@@ -1893,6 +1894,9 @@ public class TargetedMSController extends SpringActionController
 
             ChromatogramsDataRegion dRegion = new ChromatogramsDataRegion(getViewContext(), tableInfo,
                     ChromatogramsDataRegion.PRECURSOR_CHROM_DATA_REGION);
+
+            pageToSelectedChromatogram(form, dRegion, PrecursorManager.getChromInfosLitePlusForPrecursor(form.getId(), getUser(), getContainer()));
+
             GridView gridView = new ChromatogramGridView(dRegion, errors);
             gridView.setFrame(WebPartView.FrameType.PORTAL);
             gridView.setTitle("Chromatograms");
@@ -1938,6 +1942,40 @@ public class TargetedMSController extends SpringActionController
         }
     }
 
+    /**
+     * If the client's requested we show a particular chromatogram figure out which page of plots it's on
+     * and send a redirect to get there. See issue 45544.
+     */
+    private void pageToSelectedChromatogram(ChromatogramForm form, ChromatogramsDataRegion dRegion, List<PrecursorChromInfoLitePlus> chromInfos)
+    {
+        if (form.getChromInfoId() != null)
+        {
+            // We're looking to show a particular chromatogram
+            int index = 0;
+
+            // Figure out which page of plots it's on
+            for (PrecursorChromInfoLitePlus chromInfo : chromInfos)
+            {
+                if (chromInfo.getId() == form.getChromInfoId())
+                {
+                    int perPage = dRegion.getSettings().getMaxRows();
+                    ActionURL redirectURL = getViewContext().getActionURL().clone();
+                    // Swap the URL parameter, so we can highlight it and not need to recalculate the index
+                    redirectURL.deleteParameter("chromInfoId");
+                    redirectURL.addParameter(ChromatogramsDataRegion.HIGHLIGHTED_CHROMATOGRAM_PARAMETER_NAME, form.getChromInfoId());
+                    if (index > perPage)
+                    {
+                        redirectURL.addParameter(dRegion.getName() + ".offset", ((index / perPage) * perPage));
+                    }
+                    redirectURL.setFragment(ChromatogramsDataRegion.FRAGMENT_PREFIX + form.getChromInfoId());
+                    throw new RedirectException(redirectURL);
+                }
+                index++;
+            }
+        }
+        // No match found so no need to redirect
+    }
+
     @RequiresPermission(ReadPermission.class)
     public class MoleculePrecursorAllChromatogramsChartAction extends SimpleViewAction<ChromatogramForm>
     {
@@ -1979,6 +2017,9 @@ public class TargetedMSController extends SpringActionController
 
             ChromatogramsDataRegion dRegion = new ChromatogramsDataRegion(getViewContext(), tableInfo,
                     ChromatogramsDataRegion.PRECURSOR_CHROM_DATA_REGION);
+
+            pageToSelectedChromatogram(form, dRegion, MoleculePrecursorManager.getChromInfosLitePlusForMoleculePrecursor(form.getId(), getUser(), getContainer()));
+
             GridView gridView = new GridView(dRegion, errors);
             gridView.setFrame(WebPartView.FrameType.PORTAL);
             gridView.setTitle("Chromatograms");
@@ -2336,6 +2377,8 @@ public class TargetedMSController extends SpringActionController
         private String _annotationsFilter;
         private String _replicatesFilter;
         private boolean _update;
+        private Long _chromInfoId;
+        private Long _highlightChromInfoId;
 
         public ChromatogramForm()
         {
@@ -2361,6 +2404,16 @@ public class TargetedMSController extends SpringActionController
         public void setReplicatesFilter(String replicatesFilter)
         {
             _replicatesFilter = replicatesFilter;
+        }
+
+        public Long getChromInfoId()
+        {
+            return _chromInfoId;
+        }
+
+        public void setChromInfoId(Long chromInfoId)
+        {
+            _chromInfoId = chromInfoId;
         }
 
         @NotNull

--- a/src/org/labkey/targetedms/query/ChromatogramDisplayColumnFactory.java
+++ b/src/org/labkey/targetedms/query/ChromatogramDisplayColumnFactory.java
@@ -35,6 +35,9 @@ import java.io.Writer;
 import java.util.Set;
 import java.util.function.Consumer;
 
+import static org.labkey.targetedms.view.ChromatogramsDataRegion.FRAGMENT_PREFIX;
+import static org.labkey.targetedms.view.ChromatogramsDataRegion.HIGHLIGHTED_CHROMATOGRAM_PARAMETER_NAME;
+
 /**
  * User: vsharma
  * Date: 5/3/12
@@ -190,7 +193,7 @@ public class ChromatogramDisplayColumnFactory implements DisplayColumnFactory
                 boolean highlight = false;
                 if (HttpView.hasCurrentView())
                 {
-                    highlight = String.valueOf(id).equals(HttpView.currentRequest().getParameter("chromInfoId"));
+                    highlight = String.valueOf(id).equals(HttpView.currentRequest().getParameter(HIGHLIGHTED_CHROMATOGRAM_PARAMETER_NAME));
                 }
 
                 String sampleName = ctx.get(_type.getSampleNameFieldKey(getBoundColumn().getFieldKey().getParent()), String.class);
@@ -200,7 +203,7 @@ public class ChromatogramDisplayColumnFactory implements DisplayColumnFactory
 
                 ChromatogramsDataRegion dataRegion = (ChromatogramsDataRegion)ctx.getCurrentRegion();
 
-                String html = "<a name=\"ChromInfo" + id + "\"></a>";
+                String html = "<a name=\"" + FRAGMENT_PREFIX + id + "\"></a>";
                 html += "<div alt=\"Chromatogram " + PageFlowUtil.filter(sampleName) + "\" style=\"border: " + (highlight ? "beige" : "white") +
                         " solid 8px; width:" + (_chartWidth + 16) + "px; min-height:" + (_chart_height + 50) + "px\" id=\"" + PageFlowUtil.filter(domId) + "\"></div>" +
                         "<div style=\"text-align: center\" id=\"" + PageFlowUtil.filter(domLabelId) + "\"></div>";

--- a/src/org/labkey/targetedms/query/MoleculePrecursorManager.java
+++ b/src/org/labkey/targetedms/query/MoleculePrecursorManager.java
@@ -134,6 +134,9 @@ public class MoleculePrecursorManager
             sql.add(sampleFileId);
         }
 
+        // Apply a deterministic ordering, related to properly scrolling for issue 45544
+        sql.append(" ORDER BY pci.Id");
+
         return  new SqlSelector(TargetedMSManager.getSchema(), sql).getArrayList(PrecursorChromInfoLitePlus.class);
     }
 

--- a/src/org/labkey/targetedms/query/PrecursorManager.java
+++ b/src/org/labkey/targetedms/query/PrecursorManager.java
@@ -367,6 +367,9 @@ public class PrecursorManager
             sql.add(sampleFileId);
         }
 
+        // Apply a deterministic ordering, related to properly scrolling for issue 45544
+        sql.append(" ORDER BY pci.Id");
+
         return  new SqlSelector(TargetedMSManager.getSchema(), sql).getArrayList(PrecursorChromInfoLitePlus.class);
     }
 

--- a/src/org/labkey/targetedms/view/ChromatogramsDataRegion.java
+++ b/src/org/labkey/targetedms/view/ChromatogramsDataRegion.java
@@ -56,6 +56,8 @@ public class ChromatogramsDataRegion extends DataRegion
     public static final String PEPTIDE_PRECURSOR_CHROM_DATA_REGION = "PeptidePrecursorChromatograms";
     public static final String MOLECULE_PRECURSOR_CHROM_DATA_REGION = "MoleculePrecursorChromatograms";
 
+    public static final String HIGHLIGHTED_CHROMATOGRAM_PARAMETER_NAME = "highlightChromInfoId";
+    public static final String FRAGMENT_PREFIX = "ChromInfo";
     private final List<String> _listeningDataRegionNames = new ArrayList<>();
     private final JSONArray _svgs = new JSONArray();
 


### PR DESCRIPTION
#### Rationale
We want to take users directly to the chromatogram they clicked to see instead of making them scroll to it

#### Changes
* Figure out which page of plots the desired chromatogram is on
* Redirect to the desired offset and retain fragment info to automatically scroll to the right plot
