### PR TITLE
Issue 45620: Modification index is zero-based for Peptide Map report

### DIFF
--- a/resources/queries/targetedms/PeptideIds.sql
+++ b/resources/queries/targetedms/PeptideIds.sql
@@ -19,7 +19,7 @@ SELECT
    (SELECT GROUP_CONCAT((StructuralModId.Name ||
                          ' @ ' ||
                          SUBSTRING(p.Sequence, IndexAA + 1, 1) ||
-                         CAST(IndexAA + p.StartIndex AS VARCHAR)),
+                         CAST(IndexAA + p.StartIndex + 1 AS VARCHAR)),
        (', ' || CHR(10)))
    FROM targetedms.PeptideStructuralModification psm INNER JOIN targetedms.Peptide p ON psm.PeptideId = p.Id WHERE psm.PeptideId = pci.PrecursorId.PeptideId) AS Modification,
    SUM(TotalArea) AS TotalArea

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSMAMTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSMAMTest.java
@@ -61,7 +61,7 @@ public class TargetedMSMAMTest extends TargetedMSTest
         assertTextPresentInThisOrder("NU205", "NU205", "1433Z");
         assertTextPresentInThisOrder("70-84", "325-333", "28-41");
         assertTextPresentInThisOrder("(K)ASTEGVAIQGQQGTR(L)", "(K)AQYEDIANR(S)", "(K)SVTEQGAELSNEER(N)");
-        assertTextPresentInThisOrder("Carbamidomethyl Cysteine @ C156", "Carbamidomethyl Cysteine @ C245", "Carbamidomethyl Cysteine @ C94");
+        assertTextPresentInThisOrder("Carbamidomethyl Cysteine @ C157", "Carbamidomethyl Cysteine @ C245", "Carbamidomethyl Cysteine @ C94");
     }
 
     @Test

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSMAMTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSMAMTest.java
@@ -61,7 +61,7 @@ public class TargetedMSMAMTest extends TargetedMSTest
         assertTextPresentInThisOrder("NU205", "NU205", "1433Z");
         assertTextPresentInThisOrder("70-84", "325-333", "28-41");
         assertTextPresentInThisOrder("(K)ASTEGVAIQGQQGTR(L)", "(K)AQYEDIANR(S)", "(K)SVTEQGAELSNEER(N)");
-        assertTextPresentInThisOrder("Carbamidomethyl Cysteine @ C156", "Carbamidomethyl Cysteine @ C244", "Carbamidomethyl Cysteine @ C93");
+        assertTextPresentInThisOrder("Carbamidomethyl Cysteine @ C156", "Carbamidomethyl Cysteine @ C245", "Carbamidomethyl Cysteine @ C94");
     }
 
     @Test


### PR DESCRIPTION
#### Rationale
Panorama and Skyline have agreed to always show users a one-based index for peptide locations and amino acid offsets. However, the Peptide Map is still showing a zero-based modification index.

#### Changes
* Add one to be one-based