### PR TITLE
Improve discoverability of QC folder customization UI

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -644,13 +644,15 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
             fcs.addZiploaderPattern(extBrukerRaw2);
         }
 
+        Portal.registerNavTreeCustomizer("Targeted MS QC Summary", new QCSummaryMenuCustomizer("configureQCGroups", "Configure Included and Excluded Precursors"));
+        Portal.registerNavTreeCustomizer("Targeted MS QC Plots", new QCSummaryMenuCustomizer("configureQCGroups", "Configure Included and Excluded Precursors"));
+
         Portal.registerNavTreeCustomizer("Targeted MS QC Summary", new QCSummaryMenuCustomizer("configureQCMetric", "Configure QC Metrics"));
         Portal.registerNavTreeCustomizer("Targeted MS QC Plots", new QCSummaryMenuCustomizer("configureQCMetric", "Configure QC Metrics"));
 
-        Portal.registerNavTreeCustomizer("Targeted MS QC Summary", new QCSummaryMenuCustomizer("subscribeOutlierNotifications", "Subscribe Outlier Notifications"));
-        Portal.registerNavTreeCustomizer("Targeted MS QC Plots", new QCSummaryMenuCustomizer("subscribeOutlierNotifications", "Subscribe Outlier Notifications"));
+        Portal.registerNavTreeCustomizer("Targeted MS QC Summary", new QCSummaryMenuCustomizer("subscribeOutlierNotifications", "Subscribe to Outlier Notification Emails"));
+        Portal.registerNavTreeCustomizer("Targeted MS QC Plots", new QCSummaryMenuCustomizer("subscribeOutlierNotifications", "Subscribe to Outlier Notification Emails"));
 
-        Portal.registerNavTreeCustomizer("Targeted MS QC Summary", new QCSummaryMenuCustomizer("configureQCGroups", "Include or Exclude Precursors"));
         TargetedMSService.get().registerSkylineDocumentImportListener(QCNotificationSender.get());
     }
 

--- a/test/src/org/labkey/test/tests/panoramapremium/TargetedMSHidePeptidesAndMolecules.java
+++ b/test/src/org/labkey/test/tests/panoramapremium/TargetedMSHidePeptidesAndMolecules.java
@@ -115,7 +115,7 @@ public class TargetedMSHidePeptidesAndMolecules extends TargetedMSTest
     {
         PanoramaDashboard qcDashboard = goToDashboard();
         QCSummaryWebPart qcSummaryWebPart = qcDashboard.getQcSummaryWebPart();
-        qcSummaryWebPart.clickMenuItem("Include or Exclude Precursors");
+        qcSummaryWebPart.clickMenuItem("Configure Included and Excluded Precursors");
         return new DataRegionTable.DataRegionFinder(getDriver()).waitFor();
     }
 }

--- a/test/src/org/labkey/test/tests/panoramapremium/TargetedMSQCFolderImportExport.java
+++ b/test/src/org/labkey/test/tests/panoramapremium/TargetedMSQCFolderImportExport.java
@@ -154,7 +154,7 @@ public class TargetedMSQCFolderImportExport extends TargetedMSPremiumTest
     {
         goToProjectHome(projectName);
         QCSummaryWebPart qcSummaryWebPart = goToDashboard().getQcSummaryWebPart();
-        qcSummaryWebPart.clickMenuItem("Include or Exclude Precursors");
+        qcSummaryWebPart.clickMenuItem("Configure Included and Excluded Precursors");
         DataRegionTable table = new DataRegionTable.DataRegionFinder(getDriver()).waitFor();
         table.checkCheckbox(rowNum);
         table.clickHeaderButton("Mark As Excluded");

--- a/test/src/org/labkey/test/tests/panoramapremium/TargetedMSQCPremiumTest.java
+++ b/test/src/org/labkey/test/tests/panoramapremium/TargetedMSQCPremiumTest.java
@@ -114,8 +114,8 @@ public class TargetedMSQCPremiumTest extends TargetedMSPremiumTest
         PanoramaDashboard qcDashboard = goToDashboard();
         QCSummaryWebPart qcSummary = qcDashboard.getQcSummaryWebPart();
 
-        log("Clicking the outliew notification link");
-        qcSummary.clickMenuItem("Subscribe Outlier Notifications");
+        log("Clicking the outlier notification link");
+        qcSummary.clickMenuItem("Subscribe to Outlier Notification Emails");
         waitForElement(Locator.radioButtonByName("subscriptionType").index(1));
         checkRadioButton(Locator.radioButtonByName("subscriptionType").index(1));
         setFormElement(Locator.name("outlierCount"), "1");

--- a/webapp/TargetedMS/css/QCSummary.css
+++ b/webapp/TargetedMS/css/QCSummary.css
@@ -29,9 +29,15 @@
 .auto-qc-ping {
     color: #222222;
     position: absolute;
-    top: 5px;
-    right: 5px;
-    cursor: pointer
+    top: 0;
+    right: 0;
+    cursor: help;
+}
+.email-notifications {
+    color: #222222;
+    position: absolute;
+    top: 1.8em;
+    right: 0;
 }
 .qc-none {
     color: grey;

--- a/webapp/TargetedMS/js/QCSummaryPanel.js
+++ b/webapp/TargetedMS/js/QCSummaryPanel.js
@@ -143,13 +143,24 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
                     '<div class="auto-qc-ping" id="{autoQcCalloutId}">AutoQC <span class="{autoQCPing:this.getAutoQCPingClass}"></span></div>',
                 '<tpl elseif="docCount == 0 && parentOnly">',
                     '<div class="qc-summary-text">No data found.</div><div>&nbsp;</div>' + this.getAutoQCSetupInfo(),
+                '<tpl elseif="docCount &gt; 0 && LABKEY.user.isAdmin">',
+                    '<div class="qc-summary-text">',
+                        '<a href="{path:this.getSampleFileLink}">{fileCount} sample file{fileCount:this.pluralize}</a> ' +
+                            'tracking <a href="{path:this.getPrecursorConfigLink}">{precursorCount} precursor{precursorCount:this.pluralize}</a> ' +
+                            'with <a href="{path:this.getMetricConfigLink}">{metricCount} metric{metricCount:this.pluralize}</a> {instrument}',
+                    '</div>',
                 '<tpl elseif="docCount &gt; 0">',
                     '<div class="qc-summary-text">',
                         '<a href="{path:this.getSampleFileLink}">{fileCount} sample file{fileCount:this.pluralize}</a> ' +
-                            'tracking {precursorCount} precursor{precursorCount:this.pluralize} with {metricCount} metric{metricCount:this.pluralize} {instrument}',
+                        'tracking {precursorCount} precursor{precursorCount:this.pluralize} with {metricCount} metric{metricCount:this.pluralize} {instrument}',
                     '</div>',
+                '</tpl>',
+                '<tpl if="docCount &gt; 0">',
                     '<div class="item-text sample-file-details sample-file-details-loading" id="qc-summary-samplefiles-{id}">Loading...</div>',
                     '<div class="auto-qc-ping" id="{autoQcCalloutId}">AutoQC <span class="{autoQCPing:this.getAutoQCPingClass}"></span></div>',
+                '</tpl>',
+                '<tpl if="!LABKEY.user.isGuest">',
+                    '<div class="email-notifications" id="{autoQcCalloutId}"><a href="{path:this.getEmailNotificationLink}">Notifications <span class="fa fa-envelope"></span></a></div>',
                 '</tpl>',
             '</tpl>',
             {
@@ -165,6 +176,18 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
                 {
                     return LABKEY.ActionURL.buildURL('query', 'executeQuery', path,
                             {schemaName: 'targetedms', 'query.queryName': 'SampleFile'});
+                },
+                getMetricConfigLink: function (path)
+                {
+                    return LABKEY.ActionURL.buildURL('targetedms', 'configureQCMetric', path);
+                },
+                getPrecursorConfigLink: function (path)
+                {
+                    return LABKEY.ActionURL.buildURL('targetedms', 'configureQCGroups', path);
+                },
+                getEmailNotificationLink: function (path)
+                {
+                    return LABKEY.ActionURL.buildURL('targetedms', 'subscribeOutlierNotifications', path);
                 },
                 getFullHistoryLink: function (path)
                 {


### PR DESCRIPTION
#### Rationale
There are nice options to customize Panorama QC folders but many users aren't finding them

#### Changes
* Add links in QC Summary web part
** Precursor and metric enable/disable UI for admins
** Email notifications for non-guests
* Make context menus consistently named and available on both the QC Summary and QC plot web parts