### PR TITLE
Improve labels and rendering on QC precursor exclusion

### DIFF
--- a/resources/queries/targetedms/QCGroupingPrecursorMolecules.query.xml
+++ b/resources/queries/targetedms/QCGroupingPrecursorMolecules.query.xml
@@ -3,9 +3,12 @@
         <tables xmlns="http://labkey.org/data/xml">
             <table tableName="QCGroupingPrecursorMolecules" tableDbType="NOT_IN_DB">
                 <columns>
-                    <column columnName="Id">
+                    <column columnName="PrecursorId">
                         <isHidden>true</isHidden>
                         <isKeyField>true</isKeyField> <!--this is needed for the 'requiresSelection' to work in buttonBarOptions -->
+                    </column>
+                    <column columnName="Label">
+                        <columnTitle>Molecule List</columnTitle>
                     </column>
                 </columns>
             </table>

--- a/resources/queries/targetedms/QCGroupingPrecursorMolecules.sql
+++ b/resources/queries/targetedms/QCGroupingPrecursorMolecules.sql
@@ -1,7 +1,7 @@
 -- This query for Molecules displays under QC Summary menu 'Include or Exclude Peptides/Molecules'
 
 SELECT
-    mp.Id,
+    mp.Id AS PrecursorId,
     mp.Label,
     mp.customIonName,
     mp.ionFormula,

--- a/resources/queries/targetedms/QCGroupingPrecursorPeptides.query.xml
+++ b/resources/queries/targetedms/QCGroupingPrecursorPeptides.query.xml
@@ -3,9 +3,16 @@
         <tables xmlns="http://labkey.org/data/xml">
             <table tableName="QCGroupingPrecursorPeptides" tableDbType="NOT_IN_DB">
                 <columns>
-                    <column columnName="Id">
+                    <column columnName="PrecursorId">
                         <isHidden>true</isHidden>
                         <isKeyField>true</isKeyField> <!--this is needed for the 'requiresSelection' to work in buttonBarOptions -->
+                    </column>
+                    <!-- This is the PeptideGroupId, named to be compatible with the DisplayColumn that's rendering it -->
+                    <column columnName="Id">
+                        <isHidden>true</isHidden>
+                    </column>
+                    <column columnName="Label">
+                        <columnTitle>Protein</columnTitle>
                     </column>
                 </columns>
             </table>

--- a/resources/queries/targetedms/QCGroupingPrecursorPeptides.sql
+++ b/resources/queries/targetedms/QCGroupingPrecursorPeptides.sql
@@ -1,9 +1,10 @@
 -- This query for Precursor Peptides displays under QC Summary menu 'Include or Exclude Peptides/Molecules'
 
 SELECT
-precPep.Id,
-precPep.modifiedSequence,
+precPep.Id AS PrecursorId,
+precPep.PeptideGroupId AS Id,
 precPep.Label,
+precPep.modifiedSequence,
 precPep.charge,
 precPep.mz,
 precPep.neutralMass,
@@ -14,6 +15,7 @@ FROM
         min(prec.Id) AS Id,
         prec.modifiedSequence AS modifiedSequence,
         prec.GeneralMoleculeId.PeptideGroupId.Label AS Label,
+        prec.GeneralMoleculeId.PeptideGroupId AS PeptideGroupId,
         prec.charge AS charge,
         prec.mz AS mz,
         prec.neutralMass AS neutralMass,
@@ -24,6 +26,7 @@ FROM
         GROUP BY
             prec.modifiedSequence,
             prec.GeneralMoleculeId.PeptideGroupId.Label,
+            prec.GeneralMoleculeId.PeptideGroupId,
             prec.charge,
             prec.mz,
             prec.neutralMass,


### PR DESCRIPTION
#### Rationale
The protein tooltip is broken in the include/exclude precursor UI, and the columns labels aren't clear and consistent

#### Changes
* Adjust column names in query to align with protein display column renderer
* Use "Molecule List" and "Protein" instead of "Label" as grid header
* Show the grouping column first in both sections