### PR TITLE
Issue 45649: Add the QCFolderWriter data type to ExperimentExportTask for copying QC folders to Panorama Public

### DIFF
--- a/api-src/org/labkey/api/targetedms/TargetedMSService.java
+++ b/api-src/org/labkey/api/targetedms/TargetedMSService.java
@@ -64,6 +64,7 @@ public interface TargetedMSService
     String CHROM_LIB_FILE_BASE_NAME = "chromlib";
     String CHROM_LIB_FILE_EXT = "clib";
     String PROP_CHROM_LIB_REVISION = "chromLibRevision";
+    String QC_FOLDER_DATA_TYPE = "Panorama QC Folder Settings";
 
     ITargetedMSRun getRun(long runId, Container container);
     @Nullable ITargetedMSRun getRun(long runId, User user);

--- a/src/org/labkey/targetedms/folderImport/QCFolderConstants.java
+++ b/src/org/labkey/targetedms/folderImport/QCFolderConstants.java
@@ -4,7 +4,6 @@ import org.labkey.targetedms.TargetedMSSchema;
 
 public class QCFolderConstants
 {
-    protected static final String QC_FOLDER_DATA_TYPE = "Panorama QC Folder Settings";
     protected static final String QC_FOLDER_DIR = "PanoramaQC";
     public static final String CATEGORY = "TargetedMSLeveyJenningsPlotOptions";
 

--- a/src/org/labkey/targetedms/folderImport/QCFolderImporter.java
+++ b/src/org/labkey/targetedms/folderImport/QCFolderImporter.java
@@ -13,6 +13,7 @@ import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.DuplicateKeyException;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.QueryUpdateServiceException;
+import org.labkey.api.targetedms.TargetedMSService;
 import org.labkey.api.writer.VirtualFile;
 import org.labkey.targetedms.TargetedMSSchema;
 
@@ -27,13 +28,13 @@ public class QCFolderImporter implements FolderImporter
     @Override
     public String getDataType()
     {
-        return QCFolderConstants.QC_FOLDER_DATA_TYPE;
+        return TargetedMSService.QC_FOLDER_DATA_TYPE;
     }
 
     @Override
     public String getDescription()
     {
-        return QCFolderConstants.QC_FOLDER_DATA_TYPE;
+        return TargetedMSService.QC_FOLDER_DATA_TYPE;
     }
 
     @Override

--- a/src/org/labkey/targetedms/folderImport/QCFolderWriterFactory.java
+++ b/src/org/labkey/targetedms/folderImport/QCFolderWriterFactory.java
@@ -23,7 +23,7 @@ public class QCFolderWriterFactory implements FolderWriterFactory
         @Override
         public String getDataType()
         {
-            return QCFolderConstants.QC_FOLDER_DATA_TYPE;
+            return TargetedMSService.QC_FOLDER_DATA_TYPE;
         }
 
         @Override


### PR DESCRIPTION
#### Rationale
We need to enable copying QC folder annotations, guide sets, custom metrics and other settings to Panorama Public.

#### Related Pull Requests
- https://github.com/LabKey/MacCossLabModules/pull/216

#### Changes
Moved the constant QCFolderConstants.QC_FOLDER_DATA_TYPE to TargetedMSService so that it can be accessed in the panoramapublic module. 
