### PR TITLE
Issue 45621: Parse and report on crosslinkers as modifications

### DIFF
--- a/api-src/org/labkey/api/targetedms/IModification.java
+++ b/api-src/org/labkey/api/targetedms/IModification.java
@@ -17,6 +17,7 @@ public interface IModification
     Double getMassDiffAvg();
 
     Integer getUnimodId();
+    boolean isCrosslinker();
 
     interface IStructuralModification extends IModification
     {

--- a/resources/queries/targetedms/PTMPercents.query.xml
+++ b/resources/queries/targetedms/PTMPercents.query.xml
@@ -3,7 +3,7 @@
         <tables xmlns="http://labkey.org/data/xml">
             <table tableName="PTMPercents" tableDbType="TABLE">
                 <columns>
-                    <column columnName="Sequence">
+                    <column columnName="PeptideModifiedSequence">
                         <displayColumnFactory>
                             <className>org.labkey.targetedms.query.ModifiedSequenceDisplayColumn$PeptideDisplayColumnFactory</className>
                             <properties>
@@ -11,9 +11,13 @@
                                 <property name="useParens">true</property>
                             </properties>
                         </displayColumnFactory>
+                        <columnTitle>Sequence</columnTitle>
                     </column>
                     <column columnName="PeptideGroupId">
                         <columnTitle>Chain</columnTitle>
+                    </column>
+                    <column columnName="Sequence">
+                        <columnTitle>UnmodifiedSequence</columnTitle>
                     </column>
                 </columns>
             </table>

--- a/resources/queries/targetedms/PTMPercents.sql
+++ b/resources/queries/targetedms/PTMPercents.sql
@@ -3,10 +3,10 @@ SELECT
   StructuralModId AS Modification,
   SUM(ModifiedAreaProportion) AS PercentModified,
   MIN(Id) AS Id @hidden,
-  Sequence,
+  PeptideModifiedSequence,
+  Sequence @hidden,
   PreviousAA @hidden,
   NextAA @hidden,
-  PeptideModifiedSequence @hidden,
   SampleName,
   -- Explicitly cast for SQLServer to avoid trying to add as numeric types
   SUBSTRING(Sequence, IndexAA + 1, 1) || CAST(StartIndex + IndexAA + 1 AS VARCHAR) AS SiteLocation,

--- a/resources/queries/targetedms/PeptideIds.sql
+++ b/resources/queries/targetedms/PeptideIds.sql
@@ -17,9 +17,10 @@ SELECT
    PrecursorId.PeptideId.PeptideGroupId.RunId AS RunId @hidden,
    -- Show the modifications and their locations
    (SELECT GROUP_CONCAT((StructuralModId.Name ||
-                         ' @ ' ||
+                         -- For now omit AA index info for anything but the first crosslinked peptide
+                         CASE WHEN psm.PeptideIndex = 0 THEN (' @ ' ||
                          SUBSTRING(p.Sequence, IndexAA + 1, 1) ||
-                         CAST(IndexAA + p.StartIndex + 1 AS VARCHAR)),
+                         CAST(IndexAA + p.StartIndex + 1 AS VARCHAR)) ELSE '' END),
        (', ' || CHR(10)))
    FROM targetedms.PeptideStructuralModification psm INNER JOIN targetedms.Peptide p ON psm.PeptideId = p.Id WHERE psm.PeptideId = pci.PrecursorId.PeptideId) AS Modification,
    SUM(TotalArea) AS TotalArea

--- a/resources/schemas/dbscripts/postgresql/targetedms-22.005-22.006.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-22.005-22.006.sql
@@ -1,0 +1,7 @@
+ALTER TABLE targetedms.StructuralModification ADD COLUMN CrossLinker BOOLEAN;
+UPDATE targetedms.StructuralModification SET CrossLinker = false;
+ALTER TABLE targetedms.StructuralModification ALTER COLUMN CrossLinker SET NOT NULL;
+
+ALTER TABLE targetedms.PeptideStructuralModification ADD COLUMN PeptideIndex SMALLINT;
+UPDATE targetedms.PeptideStructuralModification SET PeptideIndex = 0;
+ALTER TABLE targetedms.PeptideStructuralModification ALTER COLUMN PeptideIndex SET NOT NULL;

--- a/resources/schemas/dbscripts/sqlserver/targetedms-22.005-22.006.sql
+++ b/resources/schemas/dbscripts/sqlserver/targetedms-22.005-22.006.sql
@@ -6,4 +6,4 @@ ALTER TABLE targetedms.StructuralModification ALTER COLUMN CrossLinker BIT NOT N
 ALTER TABLE targetedms.PeptideStructuralModification ADD PeptideIndex SMALLINT;
 GO
 UPDATE targetedms.PeptideStructuralModification SET PeptideIndex = 0;
-ALTER TABLE targetedms.PeptideStructuralModification ALTER COLUMN PeptideIndex NOT NULL;
+ALTER TABLE targetedms.PeptideStructuralModification ALTER COLUMN PeptideIndex SMALLINT NOT NULL;

--- a/resources/schemas/dbscripts/sqlserver/targetedms-22.005-22.006.sql
+++ b/resources/schemas/dbscripts/sqlserver/targetedms-22.005-22.006.sql
@@ -1,0 +1,9 @@
+ALTER TABLE targetedms.StructuralModification ADD CrossLinker BIT;
+GO
+UPDATE targetedms.StructuralModification SET CrossLinker = 0;
+ALTER TABLE targetedms.StructuralModification ALTER COLUMN CrossLinker BIT NOT NULL;
+
+ALTER TABLE targetedms.PeptideStructuralModification ADD PeptideIndex SMALLINT;
+GO
+UPDATE targetedms.PeptideStructuralModification SET PeptideIndex = 0;
+ALTER TABLE targetedms.PeptideStructuralModification ALTER COLUMN PeptideIndex NOT NULL;

--- a/resources/schemas/targetedms.xml
+++ b/resources/schemas/targetedms.xml
@@ -852,6 +852,7 @@
             <column columnName="PeptideId"/>
             <column columnName="StructuralModId"/>
             <column columnName="IndexAA"/>
+            <column columnName="PeptideIndex"/>
             <column columnName="MassDiff"/>
         </columns>
     </table>
@@ -974,12 +975,13 @@
                 <isHidden>true</isHidden>
             </column>
             <column columnName="name"/>
-            <column columnName="aminoacid"/>
+            <column columnName="AminoAcid"/>
             <column columnName="terminus"/>
             <column columnName="formula"/>
-            <column columnName="massdiffmono"/>
-            <column columnName="massdiffavg"/>
-            <column columnName="unimodid"/>
+            <column columnName="MassDiffMono"/>
+            <column columnName="MassDiffAvg"/>
+            <column columnName="UnimodId"/>
+            <column columnName="CrossLinked"/>
         </columns>
     </table>
     <table tableName="structuralmodloss" tableDbType="TABLE">

--- a/resources/schemas/targetedms.xml
+++ b/resources/schemas/targetedms.xml
@@ -981,7 +981,7 @@
             <column columnName="MassDiffMono"/>
             <column columnName="MassDiffAvg"/>
             <column columnName="UnimodId"/>
-            <column columnName="CrossLinked"/>
+            <column columnName="CrossLinker"/>
         </columns>
     </table>
     <table tableName="structuralmodloss" tableDbType="TABLE">

--- a/src/org/labkey/targetedms/SkylineDocImporter.java
+++ b/src/org/labkey/targetedms/SkylineDocImporter.java
@@ -2472,6 +2472,7 @@ public class SkylineDocImporter
         sql.append(getNullableCriteria("massdiffmono", mod.getMassDiffMono()));
         sql.append(getNullableCriteria("massdiffavg", mod.getMassDiffAvg()));
         sql.append(getNullableCriteria("unimodid", mod.getUnimodId()));
+        sql.append(getNullableCriteria("crosslinker", mod.isCrosslinker()));
 
         PeptideSettings.StructuralModification[] structuralModifications = new SqlSelector(TargetedMSManager.getSchema().getScope(), sql).getArray(PeptideSettings.StructuralModification.class);
 

--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -244,7 +244,7 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
     @Override
     public Double getSchemaVersion()
     {
-        return 22.005;
+        return 22.006;
     }
 
     @Override

--- a/src/org/labkey/targetedms/parser/Peptide.java
+++ b/src/org/labkey/targetedms/parser/Peptide.java
@@ -265,6 +265,7 @@ public class Peptide extends GeneralMolecule
     public static final class StructuralModification extends Modification
     {
         private long _structuralModId;
+        private int _peptideIndex = 0;  // Default to a single, non-crosslinked peptide
 
         public long getStructuralModId()
         {
@@ -274,6 +275,16 @@ public class Peptide extends GeneralMolecule
         public void setStructuralModId(long structuralModId)
         {
             _structuralModId = structuralModId;
+        }
+
+        public int getPeptideIndex()
+        {
+            return _peptideIndex;
+        }
+
+        public void setPeptideIndex(int peptideIndex)
+        {
+            _peptideIndex = peptideIndex;
         }
     }
 

--- a/src/org/labkey/targetedms/parser/PeptideSettings.java
+++ b/src/org/labkey/targetedms/parser/PeptideSettings.java
@@ -537,6 +537,8 @@ public class PeptideSettings
         private Double _massDiffMono;
         private Double _massDiffAvg;
         private Integer _unimodId;
+        private boolean _crosslinker;
+
 
         @Override
         public String getName()
@@ -613,6 +615,17 @@ public class PeptideSettings
         public void setUnimodId(Integer unimodId)
         {
             _unimodId = unimodId;
+        }
+
+        @Override
+        public boolean isCrosslinker()
+        {
+            return _crosslinker;
+        }
+
+        public void setCrosslinker(boolean crosslinker)
+        {
+            _crosslinker = crosslinker;
         }
     }
 

--- a/src/org/labkey/targetedms/parser/PeptideSettingsParser.java
+++ b/src/org/labkey/targetedms/parser/PeptideSettingsParser.java
@@ -42,6 +42,7 @@ class PeptideSettingsParser
     private static final String STATIC_MODIFICATIONS = "static_modifications";
     private static final String STATIC_MODIFICATION = "static_modification";
     private static final String POTENTIAL_LOSS = "potential_loss";
+    private static final String CROSSLINKER = "crosslinker";
     private static final String HEAVY_MODIFICATIONS = "heavy_modifications";
     private static final String AMINOACID = "aminoacid";
     private static final String TERMINUS = "terminus";
@@ -187,7 +188,7 @@ class PeptideSettingsParser
 
         // If there is a single internal standard it is written out as an attribute.
         // Otherwise, there is one <internal_standard> element for each standard
-        String inernalStandard = reader.getAttributeValue(null, INTERNAL_STANDARD);
+        String internalStandard = reader.getAttributeValue(null, INTERNAL_STANDARD);
         Set<String> internalStandards = new HashSet<>();
 
         List<PeptideSettings.RunStructuralModification> staticMods = new ArrayList<>();
@@ -195,9 +196,9 @@ class PeptideSettingsParser
         modifications.setStructuralModifications(staticMods);
         modifications.setIsotopeModifications(isotopeMods);
 
-        if(null != inernalStandard)
+        if(null != internalStandard)
         {
-            internalStandards.add(inernalStandard);
+            internalStandards.add(internalStandard);
         }
 
         List<String> isotopeLabelNames  = new ArrayList<>();
@@ -292,6 +293,11 @@ class PeptideSettingsParser
             if (XmlUtil.isEndElement(reader, evtType, STATIC_MODIFICATION))
             {
                 break;
+            }
+
+            if (XmlUtil.isStartElement(reader, evtType, CROSSLINKER))
+            {
+                mod.setCrosslinker(true);
             }
 
             if (XmlUtil.isStartElement(reader, evtType, POTENTIAL_LOSS))

--- a/src/org/labkey/targetedms/query/ConflictResultsManager.java
+++ b/src/org/labkey/targetedms/query/ConflictResultsManager.java
@@ -27,6 +27,7 @@ import org.labkey.api.security.User;
 import org.labkey.api.targetedms.RepresentativeDataState;
 import org.labkey.api.targetedms.TargetedMSService;
 import org.labkey.api.util.Formats;
+import org.labkey.api.util.Pair;
 import org.labkey.targetedms.TargetedMSManager;
 import org.labkey.targetedms.TargetedMSRun;
 import org.labkey.targetedms.TargetedMSSchema;
@@ -200,14 +201,15 @@ public class ConflictResultsManager
 
     private static String getPeptideModifiedSequence(Peptide peptide)
     {
-        Map<Integer, Double> structuralModMap = ModificationManager.getPeptideStructuralModsMap(peptide.getId());
+        Map<Pair<Integer, Integer>, Double> structuralModMap = ModificationManager.getPeptideStructuralModsMap(peptide.getId());
         StringBuilder modifiedSequence = new StringBuilder();
 
         String sequence = peptide.getSequence();
         for(int i = 0; i < sequence.length(); i++)
         {
             modifiedSequence.append(sequence.charAt(i));
-            Double massDiff = structuralModMap.get(i);
+            // This is only used for very old Skyline documents predating support for crosslinking, so always use 0 as the peptideIndex
+            Double massDiff = structuralModMap.get(Pair.of(0, i));
             if(massDiff != null)
             {
                 String sign = massDiff > 0 ? "+" : "";

--- a/src/org/labkey/targetedms/query/SampleFileTable.java
+++ b/src/org/labkey/targetedms/query/SampleFileTable.java
@@ -131,7 +131,9 @@ public class SampleFileTable extends TargetedMSTable
         // Note - keep this COALESCE in sync with the LazyForeignKey SQL below
         SQLFragment sampleIdentifierSQL = new SQLFragment("COALESCE(");
         sampleIdentifierSQL.append(p.first);
-        sampleIdentifierSQL.append(", CASE WHEN LENGTH(");
+        sampleIdentifierSQL.append(", CASE WHEN ");
+        sampleIdentifierSQL.append(getSqlDialect().getVarcharLengthFunction());
+        sampleIdentifierSQL.append("(");
         sampleIdentifierSQL.append(ExprColumn.STR_TABLE_ALIAS);
         sampleIdentifierSQL.append(".SampleId) > 2 THEN ");
         sampleIdentifierSQL.append(ExprColumn.STR_TABLE_ALIAS);

--- a/src/org/labkey/targetedms/query/SampleFileTable.java
+++ b/src/org/labkey/targetedms/query/SampleFileTable.java
@@ -131,9 +131,11 @@ public class SampleFileTable extends TargetedMSTable
         // Note - keep this COALESCE in sync with the LazyForeignKey SQL below
         SQLFragment sampleIdentifierSQL = new SQLFragment("COALESCE(");
         sampleIdentifierSQL.append(p.first);
-        sampleIdentifierSQL.append(", ");
+        sampleIdentifierSQL.append(", CASE WHEN LENGTH(");
         sampleIdentifierSQL.append(ExprColumn.STR_TABLE_ALIAS);
-        sampleIdentifierSQL.append(".SampleId, ");
+        sampleIdentifierSQL.append(".SampleId) > 2 THEN ");
+        sampleIdentifierSQL.append(ExprColumn.STR_TABLE_ALIAS);
+        sampleIdentifierSQL.append(".SampleId END, ");
         sampleIdentifierSQL.append(ExprColumn.STR_TABLE_ALIAS);
         sampleIdentifierSQL.append(".SampleName)");
 

--- a/src/org/labkey/targetedms/view/CrossLinkedPeptideInfo.java
+++ b/src/org/labkey/targetedms/view/CrossLinkedPeptideInfo.java
@@ -179,6 +179,11 @@ public class CrossLinkedPeptideInfo
             }
             return null;
         }
+
+        public int getPeptidIndex()
+        {
+            return _index;
+        }
     }
 
     public static class TestCase

--- a/src/org/labkey/targetedms/view/CrossLinkedPeptideInfo.java
+++ b/src/org/labkey/targetedms/view/CrossLinkedPeptideInfo.java
@@ -180,7 +180,7 @@ public class CrossLinkedPeptideInfo
             return null;
         }
 
-        public int getPeptidIndex()
+        public int getPeptideIndex()
         {
             return _index;
         }

--- a/src/org/labkey/targetedms/view/ModifiedPeptideHtmlMaker.java
+++ b/src/org/labkey/targetedms/view/ModifiedPeptideHtmlMaker.java
@@ -179,7 +179,7 @@ public class ModifiedPeptideHtmlMaker
                     }
                 }
             }
-            renderSequence(extraSequence, filterModIndices(strModIndices, extraSequence.getPeptidIndex()), isotopeModIndices, result, labelModColor, useParens, previousAA, nextAA);
+            renderSequence(extraSequence, filterModIndices(strModIndices, extraSequence.getPeptideIndex()), isotopeModIndices, result, labelModColor, useParens, previousAA, nextAA);
         }
 
         result.append("</div>");


### PR DESCRIPTION
#### Rationale
While we can get most of the crosslinking info we need from the modified peptide sequence, to know the name of the crosslinking modification we need to parse it from the Skyline document and store it

#### Changes
* Schema changes to store crosslink modification info
* Parse info from .sky file and insert into DB
* Render full crosslinked peptide in PTM report
* Highlight only the the modified amino acids in crosslinked peptides