### PR TITLE
Test coverage for Issue 45440

### DIFF
--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -878,26 +878,14 @@ public class TargetedMSQCTest extends TargetedMSTest
         String svgPlotText = qcPlotsWebPart.getSVGPlotText("tiledPlotPanel-2-precursorPlot0");
         assertFalse("Plot with standard deviations option is blank", svgPlotText.isEmpty());
         log("SVG content SD" + svgPlotText);
-        assertTrue("New plot is not as expected for standard deviations (y-axis) values ", svgPlotText.contains("-3\n" +
-                "-2\n" +
-                "-1\n" +
-                "0\n" +
-                "1\n" +
-                "2\n" +
-                "3\n" +
-                "4"));
+        assertTrue("New plot is not as expected for standard deviations (y-axis) values ", svgPlotText.contains("-3-2-101234"));
 
         log("Verifying percent of mean plots");
         qcPlotsWebPart.setScale(QCPlotsWebPart.Scale.PERCENT_OF_MEAN);
         svgPlotText = qcPlotsWebPart.getSVGPlotText("tiledPlotPanel-2-precursorPlot0");
         assertFalse("Plot with percent of mean option is blank", svgPlotText.isEmpty());
         log("SVG for POM " + svgPlotText);
-        assertTrue("New plot is not as expected for percent of mean (y-axis) values", svgPlotText.contains("90\n" +
-                "95\n" +
-                "100\n" +
-                "105\n" +
-                "110\n" +
-                "115"));
+        assertTrue("New plot is not as expected for percent of mean (y-axis) values", svgPlotText.contains("9095100105110115"));
     }
 
     private void verifyQCSummarySampleFileOutliers(String acquiredDate, String outlierInfo)

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -877,6 +877,7 @@ public class TargetedMSQCTest extends TargetedMSTest
         qcPlotsWebPart.setScale(QCPlotsWebPart.Scale.STANDARD_DEVIATIONS);
         String svgPlotText = qcPlotsWebPart.getSVGPlotText("tiledPlotPanel-2-precursorPlot0");
         assertFalse("Plot with standard deviations option is blank", svgPlotText.isEmpty());
+        log("SVG content SD" + svgPlotText);
         assertTrue("New plot is not as expected for standard deviations (y-axis) values ", svgPlotText.contains("-3\n" +
                 "-2\n" +
                 "-1\n" +
@@ -890,6 +891,7 @@ public class TargetedMSQCTest extends TargetedMSTest
         qcPlotsWebPart.setScale(QCPlotsWebPart.Scale.PERCENT_OF_MEAN);
         svgPlotText = qcPlotsWebPart.getSVGPlotText("tiledPlotPanel-2-precursorPlot0");
         assertFalse("Plot with percent of mean option is blank", svgPlotText.isEmpty());
+        log("SVG for POM " + svgPlotText);
         assertTrue("New plot is not as expected for percent of mean (y-axis) values", svgPlotText.contains("90\n" +
                 "95\n" +
                 "100\n" +

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -877,14 +877,14 @@ public class TargetedMSQCTest extends TargetedMSTest
         qcPlotsWebPart.setScale(QCPlotsWebPart.Scale.STANDARD_DEVIATIONS);
         String svgPlotText = qcPlotsWebPart.getSVGPlotText("tiledPlotPanel-2-precursorPlot0");
         assertFalse("Plot with standard deviations option is blank", svgPlotText.isEmpty());
-        log("SVG content SD" + svgPlotText);
+        //Expected y axis values are -3 -2 -1 0 1 2 3 4
         assertTrue("New plot is not as expected for standard deviations (y-axis) values ", svgPlotText.contains("-3-2-101234"));
 
         log("Verifying percent of mean plots");
         qcPlotsWebPart.setScale(QCPlotsWebPart.Scale.PERCENT_OF_MEAN);
         svgPlotText = qcPlotsWebPart.getSVGPlotText("tiledPlotPanel-2-precursorPlot0");
         assertFalse("Plot with percent of mean option is blank", svgPlotText.isEmpty());
-        log("SVG for POM " + svgPlotText);
+        //Expected y axis values are 90 95 100 105 110 115
         assertTrue("New plot is not as expected for percent of mean (y-axis) values", svgPlotText.contains("9095100105110115"));
     }
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -874,18 +874,28 @@ public class TargetedMSQCTest extends TargetedMSTest
         qcPlotsWebPart.waitForPlots(PRECURSORS.length * 2, true);
 
         log("Verifying standard deviations plots");
-        String initialSVGText = qcPlotsWebPart.getSVGPlotText("tiledPlotPanel-2-precursorPlot0");
         qcPlotsWebPart.setScale(QCPlotsWebPart.Scale.STANDARD_DEVIATIONS);
         String svgPlotText = qcPlotsWebPart.getSVGPlotText("tiledPlotPanel-2-precursorPlot0");
-        assertFalse(svgPlotText.isEmpty());
-        assertFalse(initialSVGText.equals(svgPlotText));
+        assertFalse("Plot with standard deviations option is blank", svgPlotText.isEmpty());
+        assertTrue("New plot is not as expected for standard deviations (y-axis) values ", svgPlotText.contains("-3\n" +
+                "-2\n" +
+                "-1\n" +
+                "0\n" +
+                "1\n" +
+                "2\n" +
+                "3\n" +
+                "4"));
 
         log("Verifying percent of mean plots");
-        initialSVGText = qcPlotsWebPart.getSVGPlotText("tiledPlotPanel-2-precursorPlot0");
         qcPlotsWebPart.setScale(QCPlotsWebPart.Scale.PERCENT_OF_MEAN);
         svgPlotText = qcPlotsWebPart.getSVGPlotText("tiledPlotPanel-2-precursorPlot0");
-        assertFalse(svgPlotText.isEmpty());
-        assertFalse(initialSVGText.equals(svgPlotText));
+        assertFalse("Plot with percent of mean option is blank", svgPlotText.isEmpty());
+        assertTrue("New plot is not as expected for percent of mean (y-axis) values", svgPlotText.contains("90\n" +
+                "95\n" +
+                "100\n" +
+                "105\n" +
+                "110\n" +
+                "115"));
     }
 
     private void verifyQCSummarySampleFileOutliers(String acquiredDate, String outlierInfo)

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -860,6 +860,34 @@ public class TargetedMSQCTest extends TargetedMSTest
         assertEquals("Unexpected number of included data points in plot SVG", 4, excludedPointCount);
     }
 
+    /*
+       Test coverage : Issue 45440: Moving range plot broken when choosing Percent of Mean or Standard Deviation y-axis options
+     */
+    @Test
+    public void testYAxisOptionsMovingRangePlot()
+    {
+        goToProjectHome();
+        PanoramaDashboard qcDashboard = new PanoramaDashboard(this);
+        QCPlotsWebPart qcPlotsWebPart = qcDashboard.getQcPlotsWebPart();
+        log("Enabling Moving range along with Levey-Jennings");
+        qcPlotsWebPart.checkPlotType(MovingRange, true);
+        qcPlotsWebPart.waitForPlots(PRECURSORS.length * 2, true);
+
+        log("Verifying standard deviations plots");
+        String initialSVGText = qcPlotsWebPart.getSVGPlotText("tiledPlotPanel-2-precursorPlot0");
+        qcPlotsWebPart.setScale(QCPlotsWebPart.Scale.STANDARD_DEVIATIONS);
+        String svgPlotText = qcPlotsWebPart.getSVGPlotText("tiledPlotPanel-2-precursorPlot0");
+        assertFalse(svgPlotText.isEmpty());
+        assertFalse(initialSVGText.equals(svgPlotText));
+
+        log("Verifying percent of mean plots");
+        initialSVGText = qcPlotsWebPart.getSVGPlotText("tiledPlotPanel-2-precursorPlot0");
+        qcPlotsWebPart.setScale(QCPlotsWebPart.Scale.PERCENT_OF_MEAN);
+        svgPlotText = qcPlotsWebPart.getSVGPlotText("tiledPlotPanel-2-precursorPlot0");
+        assertFalse(svgPlotText.isEmpty());
+        assertFalse(initialSVGText.equals(svgPlotText));
+    }
+
     private void verifyQCSummarySampleFileOutliers(String acquiredDate, String outlierInfo)
     {
         PanoramaDashboard qcDashboard = new PanoramaDashboard(this);


### PR DESCRIPTION
#### Rationale
Test coverage for Issue 45440: Moving range plot broken when choosing Percent of Mean or Standard Deviation y-axis options

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
Test case TargetedMSQCTest. testYAxisOptionsMovingRangePlot()
