### PR TITLE
Feature Request 44776: Panorama QC settings export based on current user

### DIFF
--- a/src/org/labkey/targetedms/folderImport/PanoramaQCSettings.java
+++ b/src/org/labkey/targetedms/folderImport/PanoramaQCSettings.java
@@ -252,24 +252,30 @@ public enum PanoramaQCSettings
                     //-Show Reference Guide Set - checkbox value
                     //-Show Excluded Precursors– checkbox value
 
-                    Map<String, String> plotSettings = PropertyManager.getProperties(user, container, QCFolderConstants.CATEGORY);
+                    // Get the saved defaults for the container
+                    Map<String, String> plotSettings = PropertyManager.getProperties(container, QCFolderConstants.CATEGORY);
 
-                    try (PrintWriter out = vf.getPrintWriter(QCFolderConstants.QC_PLOT_SETTINGS_PROPS_FILE_NAME)) {
-
-                        Properties prop = new Properties();
-                        for (String name : plotSettings.keySet())
+                    // Don't bother saving if there aren't any default settings
+                    if (!plotSettings.isEmpty())
+                    {
+                        try (PrintWriter out = vf.getPrintWriter(QCFolderConstants.QC_PLOT_SETTINGS_PROPS_FILE_NAME))
                         {
-                            if (name.equalsIgnoreCase("metric"))
+
+                            Properties prop = new Properties();
+                            for (String name : plotSettings.keySet())
                             {
-                                String metricValue = getMetricNameFromRowId(user, container, Integer.valueOf(plotSettings.get(name)));
-                                prop.put(name, metricValue);
+                                if (name.equalsIgnoreCase("metric"))
+                                {
+                                    String metricValue = getMetricNameFromRowId(user, container, Integer.valueOf(plotSettings.get(name)));
+                                    prop.put(name, metricValue);
+                                }
+                                else
+                                {
+                                    prop.put(name, plotSettings.get(name));
+                                }
                             }
-                            else
-                            {
-                                prop.put(name, plotSettings.get(name));
-                            }
+                            prop.store(out, null);
                         }
-                        prop.store(out, null);
                     }
                 }
 


### PR DESCRIPTION
#### Rationale
When exporting a Panorama QC folder, we want to round-trip the QC plot settings. But we're exporting the current user's settings instead of the shared defaults

#### Changes
* Default settings aren't scoped to a user, so don't fetch settings based on the user