### PR TITLE
Issue 45701: Samples excluded for single metric don't get hidden in QC plots

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -1388,7 +1388,7 @@ public class TargetedMSController extends SpringActionController
             response.put("sampleFiles", sampleFiles.stream().map(SampleFileInfo::toQCPlotJSON).collect(Collectors.toList()));
             response.put("plotDataRows", qcPlotFragments
                     .stream()
-                    .map(qcPlotFragment -> qcPlotFragment.toJSON(form.isIncludeLJ(), form.isIncludeMR(), form.isIncludeMeanCusum(), form.isIncludeVariableCusum()))
+                    .map(qcPlotFragment -> qcPlotFragment.toJSON(form.isIncludeLJ(), form.isIncludeMR(), form.isIncludeMeanCusum(), form.isIncludeVariableCusum(), form.isShowExcluded()))
                     .collect(Collectors.toList()));
             response.put("metricProps", metricMap.get(passedMetricId).toJSON());
             response.put("filterQCPoints", filterQCPoints);

--- a/src/org/labkey/targetedms/model/QCPlotFragment.java
+++ b/src/org/labkey/targetedms/model/QCPlotFragment.java
@@ -70,7 +70,7 @@ public class QCPlotFragment
         this.guideSetStats = guideSetStats;
     }
 
-    public JSONObject toJSON(boolean includeLJ, boolean includeMR, boolean includeMeanCusum, boolean includeVariableCusum)
+    public JSONObject toJSON(boolean includeLJ, boolean includeMR, boolean includeMeanCusum, boolean includeVariableCusum, boolean showExcluded)
     {
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("DataType", getDataType());
@@ -114,6 +114,12 @@ public class QCPlotFragment
             dataJsonObject.put("SampleFileId", plotData.getSampleFile().getId());
             dataJsonObject.put("PrecursorChromInfoId", plotData.getPrecursorChromInfoId());
             boolean ignoreInQC = plotData.getSampleFile().isIgnoreInQC(plotData.getMetricId());
+            if (ignoreInQC && !showExcluded)
+            {
+                // Issue 45701: Samples excluded for single metric don't get hidden in QC plots
+                break;
+            }
+
             if (ignoreInQC)
             {
                 // Reduce JSON payload size by only sending value for rows where it's true


### PR DESCRIPTION
#### Rationale
We should hide replicates hidden for individual and all metrics in QC plots unless you opt-in to seeing them. Right now we're only hiding the "all metric" exclusions.

#### Changes
* Filter the excluded data points before returning JSON to the client