### PR TITLE
Issue 45712: Importing second Skyline doc with > 100 audit records on SQLServer fails

### DIFF
--- a/src/org/labkey/targetedms/SkylineAuditLogManager.java
+++ b/src/org/labkey/targetedms/SkylineAuditLogManager.java
@@ -340,7 +340,14 @@ public class SkylineAuditLogManager
                 .append(" )\n")
                 .append(" SELECT DISTINCT t.*, r.VersionId FROM tree t \n")
                 .append(" LEFT JOIN ").append(TargetedMSManager.getTableInfoSkylineRunAuditLogEntry(), "r").append(" ON t.Id = r.AuditLogEntryId \n")
-                .append(" ORDER BY treedepth");
+                .append(" ORDER BY treedepth\n");
+
+        if (TargetedMSManager.getSqlDialect().isSqlServer())
+        {
+            // Issue 45712: SQLServer defaults to a limit of 100 recursion steps. Import verification will prevent
+            // loops so don't set a limit
+            treeQuery.append("option (maxrecursion 0)");
+        }
 
         BaseSelector.ResultSetHandler<Map<String, AuditLogTree>> resultSetHandler = (rs, conn) -> {
             Map<String, AuditLogTree> result = new HashMap<>(10);


### PR DESCRIPTION
#### Rationale
In 22.3 we changed to use a CTE to chain together audit records efficiently, but SQLServer defaults to limiting recursion at 100 items!

#### Changes
* Tell SQLServer it's OK to keep going
