### PR TITLE
In QC Summary webpart and email notification also show outlier counts by type

### DIFF
--- a/src/org/labkey/panoramapremium/QCNotificationSender.java
+++ b/src/org/labkey/panoramapremium/QCNotificationSender.java
@@ -143,7 +143,19 @@ public class QCNotificationSender implements SkylineDocumentImportListener
         //create separate table for each sample file having outliers
         for (SampleFileInfo sampleFileInfoDetails : samplesToEmail)
         {
-            html.append("<h4>").append(PageFlowUtil.filter(sampleFileInfoDetails.getSampleFile())).append(" - ").append(sampleFileInfoDetails.getLeveyJennings() + sampleFileInfoDetails.getmR() + sampleFileInfoDetails.getCUSUMm() + sampleFileInfoDetails.getCUSUMv()).append(" total outliers</h4>");
+            html.append("<h4>").append(PageFlowUtil.filter(sampleFileInfoDetails.getSampleFile())).append(" - ");
+
+            var totalOutliers = sampleFileInfoDetails.getLeveyJennings() + sampleFileInfoDetails.getmR() + sampleFileInfoDetails.getCUSUMm() + sampleFileInfoDetails.getCUSUMv();
+            if (totalOutliers > 0)
+            {
+                html.append(sampleFileInfoDetails.getLeveyJennings()).append("Levey-Jennings outliers, ");
+                html.append(totalOutliers).append(" total outliers");
+            }
+            else
+            {
+                html.append("no outliers");
+            }
+            html.append("</h4>\n");
             html.append("<p>Acquired ").append(DateUtil.formatDateTime(container, sampleFileInfoDetails.getAcquiredTime())).append("</p>");
             html.append("<table style=\"border: 1px solid #d3d3d3;\"><thead><tr><td style=\"border: 1px solid #d3d3d3;\"></td><td  style=\"border: 1px solid #d3d3d3;\" colspan=\"7\" align=\"center\">Outliers</td></tr>")
                     .append("<tr>")
@@ -182,8 +194,6 @@ public class QCNotificationSender implements SkylineDocumentImportListener
             {
                 emailSubjectAndBody.setRecentOutliers(sampleFileInfoDetails.getLeveyJennings() + sampleFileInfoDetails.getmR() + sampleFileInfoDetails.getCUSUMmN() + sampleFileInfoDetails.getCUSUMmP() + sampleFileInfoDetails.getCUSUMvN() + sampleFileInfoDetails.getCUSUMvP());
             }
-
-            var totalOutliers = sampleFileInfoDetails.getLeveyJennings() + sampleFileInfoDetails.getmR() + sampleFileInfoDetails.getCUSUMmN() + sampleFileInfoDetails.getCUSUMmP() + sampleFileInfoDetails.getCUSUMvN() + sampleFileInfoDetails.getCUSUMvP();
 
             html.append("<tr>")
                     .append("<td style=\"border: 1px solid #d3d3d3;\"><b>Total</b></td>")

--- a/test/src/org/labkey/test/components/targetedms/QCSummaryWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/QCSummaryWebPart.java
@@ -119,7 +119,7 @@ public final class QCSummaryWebPart extends BodyWebPart<QCSummaryWebPart.Element
         static final Locator summaryTile = Locator.tagWithClass("div", "summary-tile");
         static final Locator recentSampleFilesLoading = Locator.tagWithClass("div", "sample-file-details-loading");
         static final Locator recentSampleFile = Locator.css("div.sample-file-item");
-        static final Locator recentSampleFileOutliers = Locator.css("div.sample-file-item-outliers");
+        static final Locator recentSampleFileTotalOutliers = Locator.css("div.sample-file-item-total-outliers");
         static final Locator recentSampleFileAcquired = Locator.css("div.sample-file-item-acquired");
     }
 
@@ -217,7 +217,7 @@ public final class QCSummaryWebPart extends BodyWebPart<QCSummaryWebPart.Element
             if (_recentSampleFileOutliers == null)
             {
                 _recentSampleFileOutliers = new ArrayList<>();
-                _recentSampleFileOutliers.addAll(Locators.recentSampleFileOutliers.findElements(this));
+                _recentSampleFileOutliers.addAll(Locators.recentSampleFileTotalOutliers.findElements(this));
             }
             return _recentSampleFileOutliers;
         }

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -841,7 +841,7 @@ public class TargetedMSQCTest extends TargetedMSTest
 
         // verify initial QC summary outlier info
         verifyQCSummarySampleFileOutliers(sampleFileAcquiredDates[0], "0");
-        verifyQCSummarySampleFileOutliers(sampleFileAcquiredDates[1], "not included in QC");
+        verifyQCSummarySampleFileOutliers(sampleFileAcquiredDates[1], "excluded");
         verifyQCSummarySampleFileOutliers(sampleFileAcquiredDates[2], "0");
 
         // create a guide set and verify updated QC Summary outliers info

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -683,6 +683,9 @@ public class TargetedMSQCTest extends TargetedMSTest
         assertFalse("peptide should not be present", ticAreahoverText.contains("peptide"));
         assertFalse("View Chromatogram link should not be present", ticAreahoverText.contains("VIEW CHROMATOGRAM"));
 
+        // Reload the page to clear the popup
+        refresh();
+
         log("Moving QC Plots Webpart down");
         portalHelper.moveWebPart("QC Plots", PortalHelper.Direction.DOWN);
         portalHelper.exitAdminMode();

--- a/webapp/TargetedMS/js/QCSummaryPanel.js
+++ b/webapp/TargetedMS/js/QCSummaryPanel.js
@@ -296,7 +296,9 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
 
     renderContainerSampleFileStats: function (params) {
         var container = params.container;
-            var html = '<table class="table-condensed labkey-data-region-legacy labkey-show-borders"><thead><tr><td class="labkey-column-header">Replicate Name</td><td class="labkey-column-header">Acquired</td><td class="labkey-column-header">Total outliers</td></tr></thead>';
+            var html = '<table class="table-condensed labkey-data-region-legacy labkey-show-borders">';
+            html += '<thead><tr><td colspan="2"/><td colspan="4" style="text-align: center" class="labkey-column-header">Outliers</td></tr></thead>';
+            html += '<thead><tr><td class="labkey-column-header">Replicate Name</td><td class="labkey-column-header">Acquired</td><td class="labkey-column-header">Levey-Jennings</td><td class="labkey-column-header">Moving Range</td><td class="labkey-column-header">CUSUM</td><td class="labkey-column-header">Total</td></tr></thead>';
             var sampleFiles = params.sampleFiles;
             Ext4.iterate(sampleFiles, function (sampleFile) {
                 // create a new div id for each sampleFile to use for the hover details callout
@@ -308,14 +310,16 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
                 html += '<tr id="' + sampleFile.calloutId + '"><td><div class="sample-file-item">'
                         + '<span class="fa ' + iconCls + '"></span> ' + Ext4.util.Format.htmlEncode(sampleFile.ReplicateName) + '</div></td><td><div class="sample-file-item-acquired">' + Ext4.util.Format.date(sampleFile.AcquiredTime ? new Date(sampleFile.AcquiredTime) : null, LABKEY.extDefaultDateTimeFormat || 'Y-m-d H:i:s') + '</div></td>';
 
-                html += '<td style="text-align: right"><div class="sample-file-item-outliers">';
                 if (sampleFile.IgnoreForAllMetric) {
-                    html += 'not included in QC';
+                    html += '<td colspan="4"><div class="sample-file-item-outliers" style="text-align: center">excluded</div></td>';
                 }
                 else {
-                    html += totalOutliers;
+                    html += '<td style="text-align: right"><div class="sample-file-item-outliers">' + sampleFile.LeveyJennings + "</div></td>"
+                    html += '<td style="text-align: right"><div class="sample-file-item-outliers">' + sampleFile.mR + "</div></td>"
+                    html += '<td style="text-align: right"><div class="sample-file-item-outliers">' + (sampleFile.CUSUMm + sampleFile.CUSUMv) + "</div></td>"
+                    html += '<td style="text-align: right"><div class="sample-file-item-outliers">' + totalOutliers + "</div></td>"
                 }
-                html += '</div></td></tr>';
+                html += '</tr>';
             });
             html += '</table>';
             if (container.fileCount > sampleFiles.length) {

--- a/webapp/TargetedMS/js/QCSummaryPanel.js
+++ b/webapp/TargetedMS/js/QCSummaryPanel.js
@@ -311,13 +311,13 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
                         + '<span class="fa ' + iconCls + '"></span> ' + Ext4.util.Format.htmlEncode(sampleFile.ReplicateName) + '</div></td><td><div class="sample-file-item-acquired">' + Ext4.util.Format.date(sampleFile.AcquiredTime ? new Date(sampleFile.AcquiredTime) : null, LABKEY.extDefaultDateTimeFormat || 'Y-m-d H:i:s') + '</div></td>';
 
                 if (sampleFile.IgnoreForAllMetric) {
-                    html += '<td colspan="4"><div class="sample-file-item-outliers" style="text-align: center">excluded</div></td>';
+                    html += '<td colspan="4"><div class="sample-file-item-total-outliers" style="text-align: center">excluded</div></td>';
                 }
                 else {
-                    html += '<td style="text-align: right"><div class="sample-file-item-outliers">' + sampleFile.LeveyJennings + "</div></td>"
-                    html += '<td style="text-align: right"><div class="sample-file-item-outliers">' + sampleFile.mR + "</div></td>"
-                    html += '<td style="text-align: right"><div class="sample-file-item-outliers">' + (sampleFile.CUSUMm + sampleFile.CUSUMv) + "</div></td>"
-                    html += '<td style="text-align: right"><div class="sample-file-item-outliers">' + totalOutliers + "</div></td>"
+                    html += '<td style="text-align: right"><div class="sample-file-item-lj-outliers">' + sampleFile.LeveyJennings + "</div></td>"
+                    html += '<td style="text-align: right"><div class="sample-file-item-mr-outliers">' + sampleFile.mR + "</div></td>"
+                    html += '<td style="text-align: right"><div class="sample-file-item-cusum-outliers">' + (sampleFile.CUSUMm + sampleFile.CUSUMv) + "</div></td>"
+                    html += '<td style="text-align: right"><div class="sample-file-item-total-outliers">' + totalOutliers + "</div></td>"
                 }
                 html += '</tr>';
             });


### PR DESCRIPTION
#### Rationale
Moving range and CUSUM tend to be noisier outlier types, so it's helpful to see at a glance the outlier counts grouped by their type. Many users may wish to focus (especially initially) on the Levey-Jennings results.

#### Changes
* Show the subtotals of outliers by type, in addition to the grand total, in QC summary and email notifications
