### PR TITLE
Feature Request 45546: Offer to split graphs on precursor details page

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -1894,11 +1894,11 @@ public class TargetedMSController extends SpringActionController
             precursorInfo.setFrame(WebPartView.FrameType.PORTAL);
             precursorInfo.setTitle("Precursor Summary");
 
-            PrecursorChromatogramsTableInfo tableInfo = new PrecursorChromatogramsTableInfo(new TargetedMSSchema(getUser(), getContainer()), form.getChartWidth(), form.getChartHeight());
+            PrecursorChromatogramsTableInfo tableInfo = new PrecursorChromatogramsTableInfo(new TargetedMSSchema(getUser(), getContainer()), form.getChartWidth(), form.getChartHeight(), form.isSplitGraph());
             tableInfo.addPrecursorFilter(precursorId);
 
             ChromatogramsDataRegion dRegion = new ChromatogramsDataRegion(getViewContext(), tableInfo,
-                    ChromatogramsDataRegion.PRECURSOR_CHROM_DATA_REGION);
+                    ChromatogramsDataRegion.PRECURSOR_CHROM_DATA_REGION, form.isSplitGraph());
 
             pageToSelectedChromatogram(form, dRegion, PrecursorManager.getChromInfosLitePlusForPrecursor(form.getId(), getUser(), getContainer()));
 
@@ -2017,11 +2017,11 @@ public class TargetedMSController extends SpringActionController
             precursorInfo.setFrame(WebPartView.FrameType.PORTAL);
             precursorInfo.setTitle("Molecule Precursor Summary");
 
-            PrecursorChromatogramsTableInfo tableInfo = new PrecursorChromatogramsTableInfo(new TargetedMSSchema(getUser(), getContainer()));
+            PrecursorChromatogramsTableInfo tableInfo = new PrecursorChromatogramsTableInfo(new TargetedMSSchema(getUser(), getContainer()), form.getChartWidth(), form.getChartHeight(), form.isSplitGraph());
             tableInfo.addPrecursorFilter(precursorId);
 
             ChromatogramsDataRegion dRegion = new ChromatogramsDataRegion(getViewContext(), tableInfo,
-                    ChromatogramsDataRegion.PRECURSOR_CHROM_DATA_REGION);
+                    ChromatogramsDataRegion.PRECURSOR_CHROM_DATA_REGION, form.isSplitGraph());
 
             pageToSelectedChromatogram(form, dRegion, MoleculePrecursorManager.getChromInfosLitePlusForMoleculePrecursor(form.getId(), getUser(), getContainer()));
 
@@ -2104,7 +2104,7 @@ public class TargetedMSController extends SpringActionController
             tableInfo.addPeptideFilter();
 
             ChromatogramsDataRegion dRegion = new ChromatogramsDataRegion(getViewContext(), tableInfo,
-                    ChromatogramsDataRegion.PEPTIDE_CHROM_DATA_REGION);
+                    ChromatogramsDataRegion.PEPTIDE_CHROM_DATA_REGION, form.isSplitGraph());
             GridView gridView = new GridView(dRegion, errors);
             gridView.setFrame(WebPartView.FrameType.PORTAL);
             gridView.setTitle("Chromatograms");
@@ -2641,14 +2641,14 @@ public class TargetedMSController extends SpringActionController
             // Precursor and transition chromatograms. One row per replicate
             boolean canBeSplitView = PrecursorManager.canBeSplitView(form.getId());
             bean.setCanBeSplitView(canBeSplitView);
-            if(canBeSplitView && !form.isUpdate())
+            if (!canBeSplitView || form.isUpdate())
             {
-                form.setSplitGraph(true);
+                form.setSplitGraph(false);
             }
             boolean showOptPeaksOption = PrecursorManager.hasOptimizationPeaks(form.getId());
             bean.setShowOptPeaksOption(showOptPeaksOption);
 
-            PeptidePrecursorChromatogramsView chromView = new PeptidePrecursorChromatogramsView(peptide, new TargetedMSSchema(getUser(), getContainer()), form, errors, getViewContext());
+            PeptidePrecursorChromatogramsView chromView = new PeptidePrecursorChromatogramsView(peptide, new TargetedMSSchema(getUser(), getContainer()), form, errors, getViewContext(), canBeSplitView);
             JspView<PeptideChromatogramsViewBean> chartForm = new JspView<>("/org/labkey/targetedms/view/chromatogramsForm.jsp", bean);
 
             VBox chromatogramsBox = new VBox();
@@ -4750,7 +4750,7 @@ public class TargetedMSController extends SpringActionController
 
             GroupChromatogramsTableInfo tableInfo = new GroupChromatogramsTableInfo(new TargetedMSSchema(getUser(), getContainer()), form);
             ChromatogramsDataRegion chromatogramRegion = new ChromatogramsDataRegion(getViewContext(), tableInfo,
-                    ChromatogramsDataRegion.GROUP_CHROM_DATA_REGION);
+                    ChromatogramsDataRegion.GROUP_CHROM_DATA_REGION, form.isSplitGraph(), "Id", false);
             chromatogramRegion.setLegendElementId("groupChromatogramLegend");
             tableInfo.addGroupFilter(group);
             ChromatogramGridView chromatogramView = new ChromatogramGridView(chromatogramRegion, errors)

--- a/src/org/labkey/targetedms/query/ChromatogramDisplayColumnFactory.java
+++ b/src/org/labkey/targetedms/query/ChromatogramDisplayColumnFactory.java
@@ -123,9 +123,9 @@ public class ChromatogramDisplayColumnFactory implements DisplayColumnFactory
         this(container, type, CHART_WIDTH, CHART_HEIGHT, null, false, false, false, false, null, null);
     }
 
-    public ChromatogramDisplayColumnFactory(Container container, Type type, int chartWidth, int chartHeight)
+    public ChromatogramDisplayColumnFactory(Container container, Type type, int chartWidth, int chartHeight, boolean splitGraph)
     {
-        this(container, type, chartWidth, chartHeight, null, false, false, false, false, null, null);
+        this(container, type, chartWidth, chartHeight, null, false, false, splitGraph, false, null, null);
     }
 
     public ChromatogramDisplayColumnFactory(Container container, Type type, int chartWidth, int chartHeight, Consumer<ActionURL> urlCustomizer)

--- a/src/org/labkey/targetedms/query/PrecursorChromatogramsTableInfo.java
+++ b/src/org/labkey/targetedms/query/PrecursorChromatogramsTableInfo.java
@@ -30,12 +30,7 @@ public class PrecursorChromatogramsTableInfo extends FilteredTable<TargetedMSSch
 {
     private long _precursorId;
 
-    public PrecursorChromatogramsTableInfo(TargetedMSSchema schema)
-    {
-        this(schema, ChromatogramDisplayColumnFactory.CHART_WIDTH, ChromatogramDisplayColumnFactory.CHART_HEIGHT);
-    }
-
-    public PrecursorChromatogramsTableInfo(TargetedMSSchema schema, int chartWidth, int chartHeight)
+    public PrecursorChromatogramsTableInfo(TargetedMSSchema schema, int chartWidth, int chartHeight, boolean splitGraph)
     {
         super(TargetedMSManager.getTableInfoPrecursorChromInfo(), schema);
 
@@ -48,7 +43,7 @@ public class PrecursorChromatogramsTableInfo extends FilteredTable<TargetedMSSch
         peptideCol.setLabel("");
 
         ChromatogramDisplayColumnFactory colFactory = new ChromatogramDisplayColumnFactory(getContainer(),
-                ChromatogramDisplayColumnFactory.Type.PrecursorSampleLookup, chartWidth, chartHeight);
+                ChromatogramDisplayColumnFactory.Type.PrecursorSampleLookup, chartWidth, chartHeight, splitGraph);
         peptideCol.setDisplayColumnFactory(colFactory);
     }
 

--- a/src/org/labkey/targetedms/view/ChromatogramsDataRegion.java
+++ b/src/org/labkey/targetedms/view/ChromatogramsDataRegion.java
@@ -29,6 +29,7 @@ import org.labkey.api.data.UpdateColumn;
 import org.labkey.api.query.FilteredTable;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.URLHelper;
+import org.labkey.api.view.DisplayElement;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.ViewContext;
 import org.labkey.targetedms.query.ChromatogramGridQuerySettings;
@@ -60,18 +61,27 @@ public class ChromatogramsDataRegion extends DataRegion
     public static final String FRAGMENT_PREFIX = "ChromInfo";
     private final List<String> _listeningDataRegionNames = new ArrayList<>();
     private final JSONArray _svgs = new JSONArray();
+    private final boolean _splitGraph;
 
     private String _legendElementId;
+    private final boolean _canBeSplit;
 
-    public ChromatogramsDataRegion(ViewContext context, FilteredTable<?> tableInfo, String name)
+    public ChromatogramsDataRegion(ViewContext context, FilteredTable<?> tableInfo, String name, boolean splitGraph)
     {
-        this(context, tableInfo, name, "Id");
+        this(context, tableInfo, name, splitGraph, "Id");
     }
 
-    public ChromatogramsDataRegion(ViewContext context, FilteredTable<?> tableInfo, String name, String columns)
+    public ChromatogramsDataRegion(ViewContext context, FilteredTable<?> tableInfo, String name, boolean splitGraph, String columns)
+    {
+        this(context, tableInfo, name, splitGraph, columns, true);
+    }
+
+    public ChromatogramsDataRegion(ViewContext context, FilteredTable<?> tableInfo, String name, boolean splitGraph, String columns, boolean canBeSplit)
     {
         setTable(tableInfo);
         addColumns(tableInfo, columns);
+        _splitGraph = splitGraph;
+        _canBeSplit = canBeSplit;
 
         ChromatogramGridQuerySettings settings = new ChromatogramGridQuerySettings(context, name);
         setSettings(settings);
@@ -85,7 +95,23 @@ public class ChromatogramsDataRegion extends DataRegion
     {
         ButtonBar bar = new ButtonBar();
         bar.add(createRowSizeMenuButton());
+        if (_canBeSplit)
+        {
+            bar.add(createSplitGraphButton());
+        }
         setButtonBar(bar);
+    }
+
+    private MenuButton createSplitGraphButton()
+    {
+        MenuButton graphMenu = new MenuButton("Graph Type", getName() + ".Menu.GraphType");
+
+        URLHelper target = getSettings().getSortFilterURL();
+
+        graphMenu.addMenuItem("Split", target.clone().replaceParameter("splitGraph", "true"), null, _splitGraph);
+        graphMenu.addMenuItem("Combined", target.clone().replaceParameter("splitGraph", "false"), null, !_splitGraph);
+
+        return graphMenu;
     }
 
     @Override

--- a/src/org/labkey/targetedms/view/MoleculePrecursorChromatogramsView.java
+++ b/src/org/labkey/targetedms/view/MoleculePrecursorChromatogramsView.java
@@ -42,6 +42,7 @@ public class MoleculePrecursorChromatogramsView extends ChromatogramGridView
         return new ChromatogramsDataRegion(viewContext,
                 tableInfo,
                 MOLECULE_PRECURSOR_CHROM_DATA_REGION,
+                form.isSplitGraph(),
                 StringUtils.join(tableInfo.getDisplayColumnNames(), ","));
         }
 }

--- a/src/org/labkey/targetedms/view/PeptidePrecursorChromatogramsView.java
+++ b/src/org/labkey/targetedms/view/PeptidePrecursorChromatogramsView.java
@@ -34,19 +34,21 @@ public class PeptidePrecursorChromatogramsView extends ChromatogramGridView
 {
     public PeptidePrecursorChromatogramsView(Peptide peptide, TargetedMSSchema schema,
                                              TargetedMSController.ChromatogramForm form,
-                                             BindException errors, ViewContext viewContext)
+                                             BindException errors, ViewContext viewContext, boolean canBeSplit)
     {
 
-        super(makeDataRegion(peptide, schema, form, viewContext), errors);
+        super(makeDataRegion(peptide, schema, form, viewContext, canBeSplit), errors);
     }
 
     private static ChromatogramsDataRegion makeDataRegion(Peptide peptide, TargetedMSSchema schema,
-                                             TargetedMSController.ChromatogramForm form, ViewContext viewContext)
+                                             TargetedMSController.ChromatogramForm form, ViewContext viewContext, boolean canBeSplit)
     {
         GeneralMoleculePrecursorChromatogramsTableInfo tableInfo = new GeneralMoleculePrecursorChromatogramsTableInfo(peptide, schema, form);
-        return new ChromatogramsDataRegion(viewContext,
+        ChromatogramsDataRegion result = new ChromatogramsDataRegion(viewContext,
                 tableInfo,
                 PEPTIDE_PRECURSOR_CHROM_DATA_REGION,
-                StringUtils.join(tableInfo.getDisplayColumnNames(), ","));
+                form.isSplitGraph(),
+                StringUtils.join(tableInfo.getDisplayColumnNames(), ","), canBeSplit);
+        return result;
     }
 }


### PR DESCRIPTION
#### Rationale
On our peptide details page we show a plot for all of the precursors of the peptide and then separate plots for each precursor. This is helpful because they may have wildly different intensities, so one can dwarf the other on the plot. 

Now we will do same on the precursor details page.

#### Changes
* New menu item on the chromatogram grid to toggle between split and combined views
* Hide menu item where it doesn't make sense 

<img width="877" alt="Screen Shot 2022-06-24 at 6 18 27 PM" src="https://user-images.githubusercontent.com/5114642/175752847-16d89c17-3901-4792-96a7-2838c7a9db78.png">
