### PR TITLE
Expand peptideGroup.PreferredName column to accommodate protein group Skyline files

### DIFF
--- a/resources/schemas/dbscripts/postgresql/targetedms-22.006-22.007.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-22.006-22.007.sql
@@ -1,0 +1,2 @@
+-- Accommodate new Skyline protein group features that create very long preferred names
+ALTER TABLE targetedms.PeptideGroup ALTER COLUMN PreferredName TYPE VARCHAR(500);

--- a/resources/schemas/dbscripts/sqlserver/targetedms-22.006-22.007.sql
+++ b/resources/schemas/dbscripts/sqlserver/targetedms-22.006-22.007.sql
@@ -1,0 +1,2 @@
+-- Accommodate new Skyline protein group features that create very long preferred names
+ALTER TABLE targetedms.PeptideGroup ALTER COLUMN PreferredName NVARCHAR(500);

--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -244,7 +244,7 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
     @Override
     public Double getSchemaVersion()
     {
-        return 22.006;
+        return 22.007;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Work in progress in Skyline-daily is supporting protein groupings. While the XML schema hasn't been finalized yet, we're getting much longer values for protein preferred names (which contain all of the names in the group now).

#### Changes
* Bump column size to give nominal support for these new files