### PR TITLE
Issue 45881: Expand targetedms.PeptideGroup.PreferredName even more

### DIFF
--- a/resources/schemas/dbscripts/postgresql/targetedms-22.007-22.008.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-22.007-22.008.sql
@@ -1,2 +1,2 @@
 -- Accommodate new Skyline protein group features that create very long preferred names
-ALTER TABLE targetedms.PeptideGroup ALTER COLUMN PreferredName TYPE VARCHAR(500);
+ALTER TABLE targetedms.PeptideGroup ALTER COLUMN PreferredName TYPE TEXT;

--- a/resources/schemas/dbscripts/sqlserver/targetedms-22.007-22.008.sql
+++ b/resources/schemas/dbscripts/sqlserver/targetedms-22.007-22.008.sql
@@ -1,2 +1,2 @@
 -- Accommodate new Skyline protein group features that create very long preferred names
-ALTER TABLE targetedms.PeptideGroup ALTER COLUMN PreferredName NVARCHAR(500);
+ALTER TABLE targetedms.PeptideGroup ALTER COLUMN PreferredName NVARCHAR(MAX);

--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -244,7 +244,7 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
     @Override
     public Double getSchemaVersion()
     {
-        return 22.007;
+        return 22.008;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
I previously bumped this column from 50 to 500 characters. That covered the initial test Skyline file which made use of the work-in-progress protein grouping features in Skyline, but isn't enough to cover all uses.

#### Changes
* Why settle for a limited column?