### PR TITLE
Issue 45701: Samples excluded for single metric don't get hidden

### DIFF
--- a/src/org/labkey/targetedms/model/QCPlotFragment.java
+++ b/src/org/labkey/targetedms/model/QCPlotFragment.java
@@ -114,34 +114,32 @@ public class QCPlotFragment
             dataJsonObject.put("SampleFileId", plotData.getSampleFile().getId());
             dataJsonObject.put("PrecursorChromInfoId", plotData.getPrecursorChromInfoId());
             boolean ignoreInQC = plotData.getSampleFile().isIgnoreInQC(plotData.getMetricId());
-            if (ignoreInQC && !showExcluded)
+            if (!ignoreInQC || showExcluded)
             {
                 // Issue 45701: Samples excluded for single metric don't get hidden in QC plots
-                break;
+                if (ignoreInQC)
+                {
+                    // Reduce JSON payload size by only sending value for rows where it's true
+                    dataJsonObject.put("IgnoreInQC", true);
+                }
+                dataJsonObject.put("PrecursorId", plotData.getPrecursorId());
+                dataJsonObject.put("SeriesType", plotData.getMetricSeriesIndex());
+                if (includeMR)
+                {
+                    dataJsonObject.put("MR", plotData.getmR());
+                }
+                if (includeMeanCusum)
+                {
+                    dataJsonObject.put("CUSUMmN", plotData.getCUSUMmN());
+                    dataJsonObject.put("CUSUMmP", plotData.getCUSUMmP());
+                }
+                if (includeVariableCusum)
+                {
+                    dataJsonObject.put("CUSUMvP", plotData.getCUSUMvP());
+                    dataJsonObject.put("CUSUMvN", plotData.getCUSUMvN());
+                }
+                dataJsonArray.put(dataJsonObject);
             }
-
-            if (ignoreInQC)
-            {
-                // Reduce JSON payload size by only sending value for rows where it's true
-                dataJsonObject.put("IgnoreInQC", true);
-            }
-            dataJsonObject.put("PrecursorId", plotData.getPrecursorId());
-            dataJsonObject.put("SeriesType", plotData.getMetricSeriesIndex());
-            if (includeMR)
-            {
-                dataJsonObject.put("MR", plotData.getmR());
-            }
-            if (includeMeanCusum)
-            {
-                dataJsonObject.put("CUSUMmN", plotData.getCUSUMmN());
-                dataJsonObject.put("CUSUMmP", plotData.getCUSUMmP());
-            }
-            if (includeVariableCusum)
-            {
-                dataJsonObject.put("CUSUMvP", plotData.getCUSUMvP());
-                dataJsonObject.put("CUSUMvN", plotData.getCUSUMvN());
-            }
-            dataJsonArray.put(dataJsonObject);
         }
 
         jsonObject.put("data", dataJsonArray);


### PR DESCRIPTION
#### Rationale
My previous fix was too aggressive - it unintentionally stopped as soon as it saw an excluded point, instead of just skipping that one point (could have used continue instead of break).

#### Changes
* Exclude just the excluded point, not everything after it
