### PR TITLE
Issue 45903: Report Skyline document downloads to Google Analytics 4

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -5779,12 +5779,12 @@ public class TargetedMSController extends SpringActionController
             // Tell the browser to wait 400ms before going to the download.  This is to ensure
             // that the GA tracking request goes through. Some browsers will interrupt the tracking
             // request if the download opens on the same page.
-            String timeout = "setTimeout(function(){location.href=that.href;},400);return false;";
+            String timeout = "that=this; setTimeout(function(){location.href=that.href;},400);return false;";
 
             // Wrap in try/catch as a hacky way to not care which GA variants are active
 
             // Universal Analytics - remove after conversion to GA4 is complete
-            onClickScript = "try {that=this; _gaq.push(['_trackEvent', 'SkyDocDownload', " + PageFlowUtil.qh(run.getContainer().getPath()) + ", " + PageFlowUtil.qh(run.getFileName()) + "]); } catch (err) {}";
+            onClickScript = "try {_gaq.push(['_trackEvent', 'SkyDocDownload', " + PageFlowUtil.qh(run.getContainer().getPath()) + ", " + PageFlowUtil.qh(run.getFileName()) + "]); } catch (err) {}";
             // GA4 variant
             onClickScript += "try {gtag('event', 'SkyDocDownload', {path: " + PageFlowUtil.qh(run.getContainer().getPath()) + ", fileName: " + PageFlowUtil.qh(run.getFileName()) + "}); } catch(err) {}";
 

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -5781,7 +5781,14 @@ public class TargetedMSController extends SpringActionController
             // request if the download opens on the same page.
             String timeout = "setTimeout(function(){location.href=that.href;},400);return false;";
 
-            onClickScript = "if(_gaq) {that=this; _gaq.push(['_trackEvent', 'SkyDocDownload', '" + run.getContainer().getPath() + "', '" + run.getFileName() + "']); " + timeout + "}";
+            // Wrap in try/catch as a hacky way to not care which GA variants are active
+
+            // Universal Analytics - remove after conversion to GA4 is complete
+            onClickScript = "try {that=this; _gaq.push(['_trackEvent', 'SkyDocDownload', " + PageFlowUtil.qh(run.getContainer().getPath()) + ", " + PageFlowUtil.qh(run.getFileName()) + "]); } catch (err) {}";
+            // GA4 variant
+            onClickScript += "try {gtag('event', 'SkyDocDownload', {path: " + PageFlowUtil.qh(run.getContainer().getPath()) + ", fileName: " + PageFlowUtil.qh(run.getFileName()) + "}); } catch(err) {}";
+
+            onClickScript += timeout;
         }
 
         String documentSize = getDocumentSize(run);


### PR DESCRIPTION
#### Rationale
We have a couple of places where our generated HTML is submitting special events to Google Analytics. We're switching to GA4 as Google has deprecated the old style.

#### Changes
* Co-submit to Universal Analytics and GA4