### PR TITLE
Issue 46066: Display one row per replicate in the Peptide / Molecule chromatograms grid

### DIFF
--- a/src/org/labkey/targetedms/query/ChromatogramGridQuerySettings.java
+++ b/src/org/labkey/targetedms/query/ChromatogramGridQuerySettings.java
@@ -26,12 +26,16 @@ import org.labkey.api.view.ViewContext;
  */
 public class ChromatogramGridQuerySettings extends QuerySettings
 {
-    private int _maxRowSize = 2;
+    private int _maxRowSize;
 
-    public ChromatogramGridQuerySettings(ViewContext context, String dataRegionName)
+    public ChromatogramGridQuerySettings(ViewContext context, String dataRegionName, boolean replicateChromatogramsGrouped)
     {
         super(dataRegionName);
         setMaxRows(10);
+        // On the peptide / molecule details page all the chromatograms from a replicate are displayed together. These are
+        // the total precursor ion chromatogram and the fragment ion chromatograms from all the peptide / molecule precursors
+        // In this case we set the default row size to 1 so that each row displays the chromatograms from a single replicate.
+        _maxRowSize = replicateChromatogramsGrouped ? 1 : 2;
         init(context);
 
         setAllowCustomizeView(false);

--- a/src/org/labkey/targetedms/view/MoleculePrecursorChromatogramsView.java
+++ b/src/org/labkey/targetedms/view/MoleculePrecursorChromatogramsView.java
@@ -44,7 +44,8 @@ public class MoleculePrecursorChromatogramsView extends ChromatogramGridView
                 MOLECULE_PRECURSOR_CHROM_DATA_REGION,
                 form.isSplitGraph(),
                 canBeSplit,
-                StringUtils.join(tableInfo.getDisplayColumnNames(), ",")
+                StringUtils.join(tableInfo.getDisplayColumnNames(), ","),
+                true // All chromatograms from a replicate are displayed together in a row.
             );
         }
 }

--- a/src/org/labkey/targetedms/view/PeptidePrecursorChromatogramsView.java
+++ b/src/org/labkey/targetedms/view/PeptidePrecursorChromatogramsView.java
@@ -49,6 +49,8 @@ public class PeptidePrecursorChromatogramsView extends ChromatogramGridView
                 PEPTIDE_PRECURSOR_CHROM_DATA_REGION,
                 form.isSplitGraph(),
                 canBeSplit,
-                StringUtils.join(tableInfo.getDisplayColumnNames(), ","));
+                StringUtils.join(tableInfo.getDisplayColumnNames(), ","),
+                true // All chromatograms from a replicate are displayed together in a row.
+                );
     }
 }

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSMultiplePeptidePlotTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSMultiplePeptidePlotTest.java
@@ -86,11 +86,18 @@ public class TargetedMSMultiplePeptidePlotTest extends TargetedMSTest
 
         log("Verifying the chromatogram plots for peptides");
         clickAndWait(Locator.linkWithText("VYVEELKPTPEGDLEILLQK"));
-        int expectedGraphCount = 20;
         table = new DataRegionTable("PeptidePrecursorChromatograms", getDriver());
+        // There are 47 replicates. In the default view we expect a row for each of the first 10 replicates
+        checker().verifyEquals("Expected one row each for the first 10 replicates", 10, table.getDataRowCount());
+        // Each row should have two chromatogram charts from a replicate - the total precursor chromatogram and the fragment ion chromatogram for the precursor
+        int expectedGraphCount = 20;
         waitForElementToDisappear(Locator.tagWithAttributeContaining("div", "alt", "Chromatogram Q_Exactive")
                 .withText("Loading..."), WebDriverWrapper.WAIT_FOR_PAGE);
         List<WebElement> svgs = Locator.tag("svg").findElements(table);
         checker().withScreenshot("SVGCount").verifyEquals("Incorrect SVG graphs", expectedGraphCount, svgs.size());
+        // Change the row size to 2 replicates per row
+        table.clickHeaderMenu("Row Size", "2 replicates per row");
+        // Each row will have chromatograms from two replicates. We expect 5 rows since we are displaying the first 10 replicates.
+        checker().verifyEquals("Incorrect row count after changing row size to 2 replicates per row", 5, table.getDataRowCount());
     }
 }


### PR DESCRIPTION
#### Rationale
In the chromatograms grid on the peptide / molecule details page, multiple plots from a single replicate are displayed together. These are plots for the total precursor ion chromatogram and the fragment ion chromatograms for each precursor of the peptide / molecule.  In the default view, the grid displays chromatograms from 2 replicates.  We would like to change it so that each row has chromatograms only from a single replicate. 

#### Changes
- Set the default row size for the peptide / molecule chromatograms grid to 1 replicate per row
- Change the "Row Size" menu item to say "X replicates per row" instead of "X per row"
