### PR TITLE
Fix chromatogram grid rendering

### DIFF
--- a/src/org/labkey/targetedms/view/ChromatogramsDataRegion.java
+++ b/src/org/labkey/targetedms/view/ChromatogramsDataRegion.java
@@ -140,6 +140,12 @@ public class ChromatogramsDataRegion extends DataRegion
     }
 
     @Override
+    protected void renderGridHeaderColumns(RenderContext ctx, Writer out, boolean showRecordSelectors, List<DisplayColumn> renderers)
+    {
+        // No need to render the headers for this specialized grid - they just take space
+    }
+
+    @Override
     protected int renderTableContents(RenderContext ctx, Writer out, boolean showRecordSelectors, List<DisplayColumn> renderers) throws SQLException, IOException
     {
         int rowIndex = 0;

--- a/src/org/labkey/targetedms/view/ChromatogramsDataRegion.java
+++ b/src/org/labkey/targetedms/view/ChromatogramsDataRegion.java
@@ -163,14 +163,12 @@ public class ChromatogramsDataRegion extends DataRegion
                     if (rowClass != null)
                         out.write(" class=\"" + rowClass + "\"");
                     out.write(">");
-                    out.write("<td><table cellpadding=\"0\" cellspacing=\"0\"><tr>");
                 }
                 ctx.setRow(factory.getRowMap(rs));
                 renderTableRow(ctx, out, showRecordSelectors, renderers, rowIndex++);
                 count++;
                 if (count == maxRowSize)
                 {
-                    out.write("</tr></table></td>");
                     out.write("</tr>\n");
                     count = 0;
                 }
@@ -184,7 +182,6 @@ public class ChromatogramsDataRegion extends DataRegion
                 out.write("<td style=\"border:0;\"></td>");
                 count++;
             }
-            out.write("</tr></table>");
             out.write("</tr>\n");
         }
 


### PR DESCRIPTION
#### Rationale
Chromatograms grid in the peptide / molecule details page is displaying all the plots within a nested table in the first column making it appear like the table has extra headers.

#### Related Pull Requests
https://github.com/LabKey/targetedms/pull/598

#### Changes
Removed the nested table so that each plot is rendered in its own column
