### PR TITLE
Handle trailing URL question marks

### DIFF
--- a/test/src/org/labkey/test/tests/panoramapremium/TargetedMSSampleManagerIntegrationTest.java
+++ b/test/src/org/labkey/test/tests/panoramapremium/TargetedMSSampleManagerIntegrationTest.java
@@ -80,7 +80,7 @@ public class TargetedMSSampleManagerIntegrationTest extends TargetedMSPremiumTes
         log("Clicking the replicate column link to verify the navigation");
         clickAndWait(Locator.linkWithText("Q_Exactive_08_09_2013_JGB_02").index(0));
         checker().verifyTrue("Sample link did not navigate to sample manager application",
-                getCurrentRelativeURL().contains(WebTestHelper.buildRelativeUrl("targetedms", getProjectName() + "/" + TargetedMS_SubFolder, "showSampleFile")));
+                getCurrentRelativeURL(false).contains(WebTestHelper.buildRelativeUrl("targetedms", getProjectName() + "/" + TargetedMS_SubFolder, "showSampleFile")));
         goBack();
 
         log("Navigating to SM app");
@@ -88,13 +88,13 @@ public class TargetedMSSampleManagerIntegrationTest extends TargetedMSPremiumTes
         assertElementPresent(Locator.linkWithText(s3));
         clickAndWait(Locator.linkWithText(s1));
         checker().verifyTrue("Sample link did not navigate to sample manager application",
-                getCurrentRelativeURL().contains(WebTestHelper.buildRelativeUrl("sampleManager", getProjectName() + "/" + Sample_Manager_Subfolder, "app")));
+                getCurrentRelativeURL(false).contains(WebTestHelper.buildRelativeUrl("sampleManager", getProjectName() + "/" + Sample_Manager_Subfolder, "app")));
 
         log("Navigating back to labkey server");
         click(Locator.linkWithText("Assays"));
         waitAndClickAndWait(Locator.linkWithText(SProCoP_FILE_ANNOTATED));
         checker().verifyTrue("Did not navigate back to labkey server",
-                getCurrentRelativeURL().contains(WebTestHelper.buildRelativeUrl("targetedms", getProjectName() + "/" + TargetedMS_SubFolder, "showPrecursorList")));
+                getCurrentRelativeURL(false).contains(WebTestHelper.buildRelativeUrl("targetedms", getProjectName() + "/" + TargetedMS_SubFolder, "showPrecursorList")));
 
         log("Disabling the SM to verify the navigation");
         goToProjectHome();
@@ -105,7 +105,7 @@ public class TargetedMSSampleManagerIntegrationTest extends TargetedMSPremiumTes
         waitAndClickAndWait(Locator.linkContainingText("sample files"));
         clickAndWait(Locator.linkWithText(s1));
         checker().verifyTrue("Sample link navigated to sample manager application when disabled at folder level",
-                getCurrentRelativeURL().contains(WebTestHelper.buildRelativeUrl("experiment", getProjectName() + "/" + Sample_Manager_Subfolder, "showMaterial")));
+                getCurrentRelativeURL(false).contains(WebTestHelper.buildRelativeUrl("experiment", getProjectName() + "/" + Sample_Manager_Subfolder, "showMaterial")));
 
     }
 

--- a/test/src/org/labkey/test/tests/targetedms/AbstractQuantificationTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/AbstractQuantificationTest.java
@@ -449,7 +449,7 @@ public class AbstractQuantificationTest extends TargetedMSTest
                 "FROM generalmoleculechrominfo";
         ExecuteSqlCommand sc = new ExecuteSqlCommand("targetedms");
         sc.setSql(query);
-        SelectRowsResponse resp = sc.execute(createDefaultConnection(true), getProjectName() + "/" + scenario);
+        SelectRowsResponse resp = sc.execute(createDefaultConnection(), getProjectName() + "/" + scenario);
         List<Map<String, Object>> expectedRows = readScenarioCsv(scenario, "PeptideResultQuantification");
         for (Map<String, Object> expectedRow : expectedRows)
         {

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSCalibrationCurveTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSCalibrationCurveTest.java
@@ -268,7 +268,7 @@ public class TargetedMSCalibrationCurveTest extends AbstractQuantificationTest
 
     private void setSampleFileReplicate(long sampleFileId, long replicateId) throws IOException, CommandException
     {
-        Connection connection = createDefaultConnection(true);
+        Connection connection = createDefaultConnection();
         List<Map<String, Object>> sampleFileRows = Arrays.asList(
                 Maps.of("id", sampleFileId,
                         "replicateId", replicateId

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSDocumentFormatsTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSDocumentFormatsTest.java
@@ -139,7 +139,7 @@ public class TargetedMSDocumentFormatsTest extends TargetedMSTest
 
     private void validateCrossLinked(String file, int countWithAnyIon, String modifiedPeptide, String ion, double precursorMz, double... transitionMz) throws IOException, CommandException
     {
-        Connection cn = createDefaultConnection(false);
+        Connection cn = createDefaultConnection();
 
         Filter fileFilter = new Filter("PrecursorId/PeptideId/PeptideGroupId/RunId/Name", file, Filter.Operator.EQUAL);
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentTest.java
@@ -92,7 +92,7 @@ public class TargetedMSExperimentTest extends TargetedMSTest
     @LogMethod
     protected void verifyAttributeGroupIdCalcs() throws IOException, CommandException
     {
-        Connection cn = createDefaultConnection(false);
+        Connection cn = createDefaultConnection();
         // Query for small molecule data
         SelectRowsCommand smallMoleculeCommand = new SelectRowsCommand("targetedms", "generalmoleculechrominfo");
         smallMoleculeCommand.setRequiredVersion(9.1);
@@ -132,7 +132,7 @@ public class TargetedMSExperimentTest extends TargetedMSTest
         cmd.setRequiredVersion(9.1);
         cmd.setColumns(Arrays.asList("ReplicateId/Name", "FilePath", "AcquiredTime", "InstrumentId", "InstrumentSerialNumber", "SampleId"));
         cmd.addFilter("InstrumentSerialNumber", "6147F", Filter.Operator.EQUAL);
-        SelectRowsResponse response = cmd.execute(createDefaultConnection(false), getCurrentContainerPath());
+        SelectRowsResponse response = cmd.execute(createDefaultConnection(), getCurrentContainerPath());
 
         assertEquals("Matching row count", 1, response.getRowset().getSize());
         assertEquals("Matching FilePath", "E:\\skydata\\20110215_MikeB\\S_1.RAW?centroid_ms1=true", response.getRowset().iterator().next().getValue("FilePath"));
@@ -651,7 +651,7 @@ public class TargetedMSExperimentTest extends TargetedMSTest
     @NotNull
     private Rowset getPeptideAreaRatiosResults(String documentName) throws IOException, CommandException
     {
-        Connection conn = createDefaultConnection(false);
+        Connection conn = createDefaultConnection();
         SelectRowsCommand cmd = new SelectRowsCommand("targetedms", "peptidearearatio");
         cmd.setRequiredVersion(9.1);
         cmd.setSorts(List.of(new Sort("PeptideChrominfoId/SampleFileId/ReplicateId"),

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentTest.java
@@ -289,7 +289,7 @@ public class TargetedMSExperimentTest extends TargetedMSTest
         waitForElements(Locator.xpath("//table[contains(@lk-region-name, 'PeptidePrecursorChromatograms')]//div[contains(@alt, 'Chromatogram silac_1_to_4')]"), 3);
 
         //Click on a precursor icon link.
-        clickAndWait(Locator.linkWithHref("precursorAllChromatogramsChart.view?"));
+        clickAndWait(Locator.linkWithHref("precursorAllChromatogramsChart.view"));
         //Verify expected values in detail view. Verify chromatogram.
         assertTextPresentInThisOrder("Precursor Chromatograms: LTSLNVVAGSDLR", "YAL038W", "672.8777");
         assertElementPresent(Locator.xpath("//table[contains(@lk-region-name, 'PrecursorChromatograms')]"));

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSListTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSListTest.java
@@ -67,7 +67,7 @@ public class TargetedMSListTest extends TargetedMSTest
 
         SelectRowsCommand rowsCommand = new SelectRowsCommand("targetedmslists", samplesName.get());
         rowsCommand.setRequiredVersion(9.1);
-        SelectRowsResponse rowsResponse = rowsCommand.execute(createDefaultConnection(false), getCurrentContainerPath());
+        SelectRowsResponse rowsResponse = rowsCommand.execute(createDefaultConnection(), getCurrentContainerPath());
         assertEquals("Wrong number of rows in 'Samples'", 5, rowsResponse.getRows().size());
 
         Set<String> sampleNames = new HashSet<>();
@@ -93,7 +93,7 @@ public class TargetedMSListTest extends TargetedMSTest
         // Check that the targetedms.replicate table has the expected rows and points to the right lookup values
         SelectRowsCommand replicateRowsCommand = new SelectRowsCommand("targetedms", "replicate");
         replicateRowsCommand.setRequiredVersion(9.1);
-        SelectRowsResponse replicateRowsResponse = replicateRowsCommand.execute(createDefaultConnection(false), getCurrentContainerPath());
+        SelectRowsResponse replicateRowsResponse = replicateRowsCommand.execute(createDefaultConnection(), getCurrentContainerPath());
         assertEquals("Wrong number of replicate rows", replicateRowCount, replicateRowsResponse.getRowCount().intValue());
         Set<String> replicateSampleLookupValues = new HashSet<>();
         replicateRowsResponse.getRowset().forEach((r) -> replicateSampleLookupValues.add((String)r.getDisplayValue("Sample")));
@@ -101,11 +101,11 @@ public class TargetedMSListTest extends TargetedMSTest
 
         // Check the contents of the unioned "Samples" lookup query
         SelectRowsCommand sampleRowsUnionedCommand = new SelectRowsCommand("targetedmslists", "All_Samples");
-        assertEquals("Wrong number of unioned sample list rows", sampleUnionRowCount, sampleRowsUnionedCommand.execute(createDefaultConnection(false), getCurrentContainerPath()).getRowCount().intValue());
+        assertEquals("Wrong number of unioned sample list rows", sampleUnionRowCount, sampleRowsUnionedCommand.execute(createDefaultConnection(), getCurrentContainerPath()).getRowCount().intValue());
 
         // Check the schema to make sure it's exposing the expected single-list and unioned-list queries
         GetQueriesCommand command = new GetQueriesCommand("targetedmslists");
-        GetQueriesResponse queriesResponse = command.execute(createDefaultConnection(false), getCurrentContainerPath());
+        GetQueriesResponse queriesResponse = command.execute(createDefaultConnection(), getCurrentContainerPath());
         assertEquals("Wrong number of queries", listQueryCount, queriesResponse.getQueryNames().size());
         Set<String> trimmedNames = queriesResponse.getQueryNames().stream().filter((s) -> !s.startsWith("All_")).map((s) -> s.substring(s.indexOf("_") + 1)).collect(Collectors.toSet());
         assertTrue("Missing 'DocumentProperties'", trimmedNames.contains("DocumentProperties"));

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCSummaryTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCSummaryTest.java
@@ -381,7 +381,7 @@ public class TargetedMSQCSummaryTest extends TargetedMSTest
 
     private String doAutoQCPing(@Nullable String subFolder)
     {
-        Connection cn = createDefaultConnection(true);
+        Connection cn = createDefaultConnection();
         AutoQCPing aqcp = new AutoQCPing();
         CommandResponse cr;
         String folderPath = getProjectName();

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSSampleFileChromInfoTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSSampleFileChromInfoTest.java
@@ -73,7 +73,7 @@ public class TargetedMSSampleFileChromInfoTest extends TargetedMSTest
 
 
 
-        Connection cn = createDefaultConnection(false);
+        Connection cn = createDefaultConnection();
         SelectRowsCommand cmd = new SelectRowsCommand("targetedms", "samplefilechrominfo");
         cmd.setRequiredVersion(9.1);
         cmd.setColumns(Arrays.asList("SampleFileId", "StartTime", "EndTime", "TextId", "NumPoints", "UncompressedSize", "ChromatogramFormat", "ChromatogramOffset", "ChromatogramLength", "SampleFileId/ReplicateId"));


### PR DESCRIPTION
#### Rationale
Many tests and helpers are very sensitive to the presence or absence of trailling '?'s on URLs (or "?#" for app URLs). Now that `URLBuilder` checks the `EXPERIMENTAL_NO_QUESTION_MARK_URL` flag when building URLs, numerous tests are getting confused.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/1210

#### Changes
* Handle trailing URL question marks
* Clean up some deprecated method usage
