### PR TITLE
Expose new columns on Peptide table to show mod info

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSSchema.java
+++ b/src/org/labkey/targetedms/TargetedMSSchema.java
@@ -1061,8 +1061,8 @@ public class TargetedMSSchema extends UserSchema
                                                                   ContainerJoinType.RunFK,
                                                                   TargetedMSManager.getTableInfoPeptideGroupAnnotation(),
                                                                   "PeptideGroupId",
-                                                                  proteomics ? "Protein Annotations" : "Molecule List Annotations",
-                                                                  "protein", false) // This may change as more small molecule work is done in Skyline.
+                                                                  proteomics ? COL_PROTEIN : COL_LIST,
+                                                                  "protein")
             {
                 @Override
                 protected Class<? extends Controller> getDetailsActionClass()
@@ -1170,19 +1170,6 @@ public class TargetedMSSchema extends UserSchema
             result.getMutableColumnOrThrow("RepresentativeDataState").setFk(QueryForeignKey.from(this, cf).to(TargetedMSSchema.TABLE_REPRESENTATIVE_DATA_STATE, "RowId", null));
             result.getMutableColumnOrThrow("RepresentativeDataState").setHidden(true);
 
-            // Create a WrappedColumn for Note & Annotations
-            WrappedColumn noteAnnotation = new WrappedColumn(result.getColumn("Annotations"), "NoteAnnotations");
-            noteAnnotation.setDisplayColumnFactory(AnnotationUIDisplayColumn::new);
-            if (proteomics)
-            {
-                noteAnnotation.setLabel(TargetedMSSchema.COL_PROTEIN + " Note/Annotations");
-            }
-            else
-            {
-                noteAnnotation.setLabel(TargetedMSSchema.COL_LIST + " Note/Annotations");
-            }
-            result.addColumn(noteAnnotation);
-
             SQLFragment libPrecursorCountSQL;
             if (TargetedMSManager.isLibraryFolder(getContainer()))
             {
@@ -1210,7 +1197,7 @@ public class TargetedMSSchema extends UserSchema
 
         if (TABLE_REPLICATE.equalsIgnoreCase(name))
         {
-            return new AnnotatedTargetedMSTable(getSchema().getTable(name), this, cf, ContainerJoinType.RunFK, TargetedMSManager.getTableInfoReplicateAnnotation(), "ReplicateId", "Replicate Annotations", "replicate", false);
+            return new AnnotatedTargetedMSTable(getSchema().getTable(name), this, cf, ContainerJoinType.RunFK, TargetedMSManager.getTableInfoReplicateAnnotation(), "ReplicateId", "Replicate", "replicate");
         }
 
         // Tables that have a FK to targetedms.Runs
@@ -1393,7 +1380,7 @@ public class TargetedMSSchema extends UserSchema
         if (TABLE_TRANSITION_CHROM_INFO.equalsIgnoreCase(name))
         {
             TargetedMSTable result = new AnnotatedTargetedMSTable(getSchema().getTable(name), this, cf, ContainerJoinType.SampleFileFK,
-                    TargetedMSManager.getTableInfoTransitionChromInfoAnnotation(), "TransitionChromInfoId", "Transition Result Annotations", "transition_result", false);
+                    TargetedMSManager.getTableInfoTransitionChromInfoAnnotation(), "TransitionChromInfoId", "Transition Result", "transition_result");
             TargetedMSSchema targetedMSSchema = this;
 
             var transitionId = result.getMutableColumnOrThrow("TransitionId");

--- a/src/org/labkey/targetedms/query/AbstractGeneralMoleculeTableInfo.java
+++ b/src/org/labkey/targetedms/query/AbstractGeneralMoleculeTableInfo.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.targetedms.query;
 
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.SQLFragment;
@@ -31,7 +32,7 @@ import org.labkey.api.targetedms.RepresentativeDataState;
 
 public abstract class AbstractGeneralMoleculeTableInfo extends JoinedTargetedMSTable
 {
-    public AbstractGeneralMoleculeTableInfo(TargetedMSSchema schema, TableInfo tableInfo, ContainerFilter cf, String annotationColumnName, boolean omitAnnotations)
+    public AbstractGeneralMoleculeTableInfo(TargetedMSSchema schema, TableInfo tableInfo, ContainerFilter cf, @Nullable String annotationLabelPrefix)
     {
         super(TargetedMSManager.getTableInfoGeneralMolecule(),
                 tableInfo,
@@ -39,8 +40,9 @@ public abstract class AbstractGeneralMoleculeTableInfo extends JoinedTargetedMST
                 cf,
                 TargetedMSSchema.ContainerJoinType.PeptideGroupFK,
                 TargetedMSManager.getTableInfoGeneralMoleculeAnnotation(),
-                "GeneralMoleculeId", annotationColumnName,
-                "peptide", omitAnnotations); // This may change as more small molecule work is done in Skyline.
+                "GeneralMoleculeId",
+                annotationLabelPrefix,
+                "peptide"); // This may change as more small molecule work is done in Skyline.
 
         // use the description and title column from the specialized TableInfo
         setDescription(tableInfo.getDescription());

--- a/src/org/labkey/targetedms/query/AbstractGeneralPrecursorTableInfo.java
+++ b/src/org/labkey/targetedms/query/AbstractGeneralPrecursorTableInfo.java
@@ -20,13 +20,11 @@ import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.TableInfo;
-import org.labkey.api.data.WrappedColumn;
 import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.LookupForeignKey;
 import org.labkey.targetedms.TargetedMSManager;
 import org.labkey.targetedms.TargetedMSSchema;
-import org.labkey.targetedms.view.AnnotationUIDisplayColumn;
 
 /**
  * User: binalpatel
@@ -40,14 +38,14 @@ public class AbstractGeneralPrecursorTableInfo extends JoinedTargetedMSTable
         super(TargetedMSManager.getTableInfoGeneralPrecursor(), tableInfo, schema, cf,
         TargetedMSSchema.ContainerJoinType.GeneralMoleculeFK,
         TargetedMSManager.getTableInfoPrecursorAnnotation(),
-        "PrecursorId", "Precursor Annotations", "precursor", omitAnnotations);
+        "PrecursorId", omitAnnotations ? null : "Precursor", "precursor");
 
         setName(tableName);
         // use the description and title column from the specialized TableInfo
         setDescription(tableInfo.getDescription());
         setTitleColumn(tableInfo.getTitleColumn());
 
-        getMutableColumn("RepresentativeDataState").setFk(new LookupForeignKey()
+        getMutableColumnOrThrow("RepresentativeDataState").setFk(new LookupForeignKey()
         {
             @Override
             public TableInfo getLookupTableInfo()
@@ -63,15 +61,6 @@ public class AbstractGeneralPrecursorTableInfo extends JoinedTargetedMSTable
         transitionCountSQL.append(".Id)");
         ExprColumn transitionCountCol = new ExprColumn(this, "TransitionCount", transitionCountSQL, JdbcType.INTEGER);
         addColumn(transitionCountCol);
-
-        if (!omitAnnotations)
-        {
-            // Create a WrappedColumn for Note & Annotations
-            WrappedColumn noteAnnotation = new WrappedColumn(getColumn("Annotations"), "NoteAnnotations");
-            noteAnnotation.setDisplayColumnFactory(colInfo -> new AnnotationUIDisplayColumn(colInfo));
-            noteAnnotation.setLabel("Precursor Note/Annotations");
-            addColumn(noteAnnotation);
-        }
     }
 
     public void setRunId(long runId)

--- a/src/org/labkey/targetedms/query/AbstractGeneralTransitionTableInfo.java
+++ b/src/org/labkey/targetedms/query/AbstractGeneralTransitionTableInfo.java
@@ -33,7 +33,7 @@ public class AbstractGeneralTransitionTableInfo extends JoinedTargetedMSTable
     {
         super(TargetedMSManager.getTableInfoGeneralTransition(), tableInfo,
                 schema, cf, TargetedMSSchema.ContainerJoinType.GeneralPrecursorFK,
-                TargetedMSManager.getTableInfoTransitionAnnotation(), "TransitionId", "Annotations", "transition", omitAnnotations);
+                TargetedMSManager.getTableInfoTransitionAnnotation(), "TransitionId", omitAnnotations ? null : "Transition", "transition");
     }
 
     public void setRunId(long runId)

--- a/src/org/labkey/targetedms/query/DocTransitionsTableInfo.java
+++ b/src/org/labkey/targetedms/query/DocTransitionsTableInfo.java
@@ -18,12 +18,10 @@ package org.labkey.targetedms.query;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.SQLFragment;
-import org.labkey.api.data.WrappedColumn;
 import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.FieldKey;
 import org.labkey.targetedms.TargetedMSManager;
 import org.labkey.targetedms.TargetedMSSchema;
-import org.labkey.targetedms.view.AnnotationUIDisplayColumn;
 
 import java.util.ArrayList;
 
@@ -44,7 +42,7 @@ public class DocTransitionsTableInfo extends AbstractGeneralTransitionTableInfo
 
         setDescription(TargetedMSManager.getTableInfoTransition().getDescription());
 
-        var precursorCol = getMutableColumn("GeneralPrecursorId");
+        var precursorCol = getMutableColumnOrThrow("GeneralPrecursorId");
         precursorCol.setFk(new TargetedMSForeignKey(getUserSchema(), TargetedMSSchema.TABLE_PRECURSOR, cf));
         precursorCol.setHidden(true);
 
@@ -103,14 +101,5 @@ public class DocTransitionsTableInfo extends AbstractGeneralTransitionTableInfo
         visibleColumns.add(FieldKey.fromParts("Charge"));
 
         setDefaultVisibleColumns(visibleColumns);
-
-        if (!omitAnnotations)
-        {
-            // Create a WrappedColumn for Note & Annotations
-            WrappedColumn noteAnnotation = new WrappedColumn(getColumn("Annotations"), "NoteAnnotations");
-            noteAnnotation.setDisplayColumnFactory(colInfo -> new AnnotationUIDisplayColumn(colInfo));
-            noteAnnotation.setLabel("Transition Note/Annotations");
-            addColumn(noteAnnotation);
-        }
     }
 }

--- a/src/org/labkey/targetedms/query/JoinedTargetedMSTable.java
+++ b/src/org/labkey/targetedms/query/JoinedTargetedMSTable.java
@@ -16,6 +16,7 @@
 package org.labkey.targetedms.query;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.SQLFragment;
@@ -41,9 +42,9 @@ public class JoinedTargetedMSTable extends AnnotatedTargetedMSTable
 {
     private final TableInfo _specializedTable;
 
-    public JoinedTargetedMSTable(TableInfo generalTable, TableInfo specializedTable, TargetedMSSchema schema, ContainerFilter cf, TargetedMSSchema.ContainerJoinType joinType, TableInfo annotationTableInfo, String annotationFKName, String columnName, String annotationTarget, boolean omitAnnotations)
+    public JoinedTargetedMSTable(TableInfo generalTable, TableInfo specializedTable, TargetedMSSchema schema, ContainerFilter cf, TargetedMSSchema.ContainerJoinType joinType, TableInfo annotationTableInfo, String annotationFKName, @Nullable String annotationLabelPrefix, String annotationTarget)
     {
-        super(generalTable, schema, cf, joinType, annotationTableInfo, annotationFKName, columnName, annotationTarget, omitAnnotations);
+        super(generalTable, schema, cf, joinType, annotationTableInfo, annotationFKName, annotationLabelPrefix, annotationTarget);
 
         _specializedTable = specializedTable;
         setName(_specializedTable.getName());

--- a/src/org/labkey/targetedms/query/MoleculeTransitionsTableInfo.java
+++ b/src/org/labkey/targetedms/query/MoleculeTransitionsTableInfo.java
@@ -77,14 +77,5 @@ public class MoleculeTransitionsTableInfo extends AbstractGeneralTransitionTable
         visibleColumns.add(FieldKey.fromParts("Mz"));
         visibleColumns.add(FieldKey.fromParts("Charge"));
         setDefaultVisibleColumns(visibleColumns);
-
-        if (!omitAnnotations)
-        {
-            // Create a WrappedColumn for Note & Annotations
-            WrappedColumn noteAnnotation = new WrappedColumn(getColumn("Annotations"), "NoteAnnotations");
-            noteAnnotation.setDisplayColumnFactory(colInfo -> new AnnotationUIDisplayColumn(colInfo));
-            noteAnnotation.setLabel("Molecule Transition Note/Annotations");
-            addColumn(noteAnnotation);
-        }
     }
 }

--- a/src/org/labkey/targetedms/query/PrecursorChromInfoTable.java
+++ b/src/org/labkey/targetedms/query/PrecursorChromInfoTable.java
@@ -32,7 +32,7 @@ public class PrecursorChromInfoTable extends AnnotatedTargetedMSTable
     public PrecursorChromInfoTable(TargetedMSSchema schema, ContainerFilter cf)
     {
         super(TargetedMSManager.getTableInfoPrecursorChromInfo(), schema, cf, null, new SQLFragment("Container"),
-                TargetedMSManager.getTableInfoPrecursorChromInfoAnnotation(), "PrecursorChromInfoId", "Precursor Result Annotations", "precursor_result", false);
+                TargetedMSManager.getTableInfoPrecursorChromInfoAnnotation(), "PrecursorChromInfoId", "Precursor Result", "precursor_result");
         var precursorId = getMutableColumn("PrecursorId");
         precursorId.setFk(new TargetedMSForeignKey(getUserSchema(), TargetedMSSchema.TABLE_PRECURSOR, cf));
 

--- a/src/org/labkey/targetedms/query/PrecursorTableInfo.java
+++ b/src/org/labkey/targetedms/query/PrecursorTableInfo.java
@@ -15,12 +15,9 @@
  */
 package org.labkey.targetedms.query;
 
-import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.ContainerFilter;
-import org.labkey.api.data.DisplayColumn;
-import org.labkey.api.data.DisplayColumnFactory;
 import org.labkey.api.data.TableInfo;
-import org.labkey.api.data.WrappedColumn;
+import org.labkey.api.data.WrappedColumnInfo;
 import org.labkey.api.query.FieldKey;
 import org.labkey.targetedms.TargetedMSController;
 import org.labkey.targetedms.TargetedMSManager;
@@ -46,7 +43,7 @@ public class PrecursorTableInfo extends AbstractGeneralPrecursorTableInfo
     {
         super(tableInfo, tableName, schema, cf, omitAnnotations);
 
-        var generalMoleculeId = getMutableColumn("GeneralMoleculeId");
+        var generalMoleculeId = getMutableColumnOrThrow("GeneralMoleculeId");
         generalMoleculeId.setFk(new TargetedMSForeignKey(_userSchema, TargetedMSSchema.TABLE_PEPTIDE, cf));
         generalMoleculeId.setHidden(true);
 
@@ -54,19 +51,11 @@ public class PrecursorTableInfo extends AbstractGeneralPrecursorTableInfo
         peptideId.setFk(new TargetedMSForeignKey(_userSchema, TargetedMSSchema.TABLE_PEPTIDE, cf));
         addColumn(peptideId);
 
-        getMutableColumn("IsotopeLabelId").setFk(new TargetedMSForeignKey(getUserSchema(), TargetedMSSchema.TABLE_ISOTOPE_LABEL, cf));
+        getMutableColumnOrThrow("IsotopeLabelId").setFk(new TargetedMSForeignKey(getUserSchema(), TargetedMSSchema.TABLE_ISOTOPE_LABEL, cf));
 
-        WrappedColumn modSeqCol = new WrappedColumn(getColumn("ModifiedSequence"), ModifiedSequenceDisplayColumn.PRECURSOR_COLUMN_NAME);
-        modSeqCol.setLabel("Precursor");
+        var modSeqCol = WrappedColumnInfo.wrapAsCopy(this, FieldKey.fromParts(ModifiedSequenceDisplayColumn.PRECURSOR_COLUMN_NAME), getColumn("ModifiedSequence"), "Precursor", null);
         modSeqCol.setDescription("Modified precursor sequence");
-        modSeqCol.setDisplayColumnFactory( new DisplayColumnFactory()
-        {
-            @Override
-            public DisplayColumn createRenderer(ColumnInfo colInfo)
-            {
-                return new ModifiedSequenceDisplayColumn.PrecursorCol(colInfo);
-            }
-        });
+        modSeqCol.setDisplayColumnFactory(ModifiedSequenceDisplayColumn.PrecursorCol::new);
         modSeqCol.setURL(getDetailsURL(null, null));
         addColumn(modSeqCol);
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCGuideSetTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCGuideSetTest.java
@@ -356,6 +356,7 @@ public class TargetedMSQCGuideSetTest extends TargetedMSTest
         expected.add("Day: 1\nSampleIdentifier: AnnotatedSample1");
         expected.add("1");
         expected.add("AnnotatedSample1");
+        expected.add("Day: 1\nSampleIdentifier: AnnotatedSample1");
         assertEquals("Wrong data in first row", expected, strings);
     }
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCGuideSetTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCGuideSetTest.java
@@ -356,7 +356,7 @@ public class TargetedMSQCGuideSetTest extends TargetedMSTest
         expected.add("Day: 1\nSampleIdentifier: AnnotatedSample1");
         expected.add("1");
         expected.add("AnnotatedSample1");
-        expected.add("Day: 1\nSampleIdentifier: AnnotatedSample1");
+        expected.add("Day: 1\n    SampleIdentifier: AnnotatedSample1");
         assertEquals("Wrong data in first row", expected, strings);
     }
 


### PR DESCRIPTION
#### Rationale
Panorama currently shows modified peptide info inline in the sequence, including mass differences, but doesn't easily reveal the name of the modification. Users have asked to see the structural modification names, and it makes sense to also offer the isotope mod info too.

#### Changes
* Add multi-value lookups to targetedms.Peptide: StructuralModifications and IsotopeModifications
* Consolidate and simplify annotation/note display across tables