### PR TITLE
Issue 46229: Use time-based ordering to jitter points in Panorama QC plots

### DIFF
--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -660,7 +660,7 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
             mouseOverFnScope: this,
             mouseOutFn: this.plotPointMouseOut,
             mouseOutFnScope: this,
-            position: this.groupedX ? 'jitter' : undefined,
+            position: this.groupedX ? 'sequential' : undefined,
             legendMouseOverFn: this.legendMouseOver,
             legendMouseOverFnScope: this,
             legendMouseOutFn: this.legendMouseOut,
@@ -742,7 +742,7 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
             defaultGuideSets: this.defaultGuideSet,
             mouseOverFn: this.plotPointMouseOver,
             mouseOverFnScope: this,
-            position: this.groupedX ? 'jitter' : undefined,
+            position: this.groupedX ? 'sequential' : undefined,
             disableRangeDisplay: this.isMultiSeries()
         };
 


### PR DESCRIPTION
#### Rationale
In Panorama QC folder plots, you can group data based on acquisition date. However, this randomly jitters the points within the day.  Like we do in the reproducibility plots, it would be better to order them based on their acquisition time. This would make it clearer when a change happens mid-day. 

#### Changes
* Configure to use sequential jittering, grouping by fragment