### PR TITLE
Issue 46477: QCTrendPlotPanel switch to send guide set range elements to back instead of pulling all points to front

### DIFF
--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -1600,15 +1600,23 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
             }
         }
 
-        // Issue 32277: need to move the data points in front of the guide set range display
+        // Issue 46477: need to move the guide set range display behind the data points
         // so that points can be interacted with (i.e. hover to exclude, see details, etc.)
-        this.bringSvgElementToFront(plot, "a.point");
+        this.sendSvgElementToBack(plot, "rect.training");
     },
 
     bringSvgElementToFront: function(plot, selector) {
         this.getSvgElForPlot(plot).selectAll(selector)
             .each(function() {
                this.parentNode.parentNode.appendChild(this.parentNode);
+            });
+    },
+
+    sendSvgElementToBack: function(plot, selector) {
+        var firstPointLayer = this.getSvgElForPlot(plot).selectAll('g.layer')[0][0];
+        this.getSvgElForPlot(plot).selectAll(selector)
+            .each(function() {
+                this.parentNode.insertBefore(this, firstPointLayer);
             });
     },
 


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46477

With the fix for [32277](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=32277), we fixed the issue in the Panorama QC Plots so that it moved the data points in the plot in front of the guide set range display boxes so that the hover / popup behavior would work as expected. As more data is added to a given folder, this runs into some performance issues moving that many data point elements in the DOM. With this change/fix, we flip that so instead we move the guide set range display boxes behind the data points in the DOM. This should have much better perf since there are far fewer of those elements in each plot.

#### Changes
* QCTrendPlotPanel switch to send guide set range elements to back instead of pulling all points to front
