### PR TITLE
Issue 46481: QCMetricEnabled_transitionArea slow on PanoramaWeb

### DIFF
--- a/resources/queries/targetedms/QCMetricEnabled_transitionArea.sql
+++ b/resources/queries/targetedms/QCMetricEnabled_transitionArea.sql
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 -- Approximate the checks in GeneralTransition.isQuantitative()
+-- We need to check both the proteomics and small molecule data. Use two separate EXISTS subqueries so we stop as
+-- soon as we find any data
+SELECT 1 AS E WHERE EXISTS (
 SELECT Id, FragmentType, Quantitative FROM Transition t
     WHERE
         (Quantitative = TRUE) OR (Quantitative IS NULL AND
@@ -27,9 +30,9 @@ SELECT Id, FragmentType, Quantitative FROM Transition t
                                                                                                   WHERE AcquisitionMethod IS NULL OR AcquisitionMethod != 'DDA'
                                                                                                   ))
         )
-
+)
 UNION
-
+SELECT 1 AS E WHERE EXISTS (
 SELECT Id, FragmentType, Quantitative FROM MoleculeTransition t
 WHERE
     (Quantitative = TRUE) OR (Quantitative IS NULL AND
@@ -43,3 +46,4 @@ WHERE
                                                                                                   WHERE AcquisitionMethod IS NULL OR AcquisitionMethod != 'DDA'
                                                                                                   ))
     )
+)


### PR DESCRIPTION
#### Rationale
It's slow to figure out which metrics should be enabled on PanoramaWeb. We're doing an expensive query, QCMetricEnabled_transitionArea, twice

#### Changes
* Optimize query so it can return as soon as it finds either proteomics or small molecule data
* Avoid running queries multiple times