### PR TITLE
Issue 46628: Panorama QC Plot set max number of points to render per series

### DIFF
--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -7,6 +7,7 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
 
     statics: {
         qcPlotTypes : ['Levey-Jennings', 'Moving Range', 'CUSUMm', 'CUSUMv'],
+        maxPointsPerSeries : 300,
     },
 
     showLJPlot: function()
@@ -640,6 +641,12 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
             disableRange = false;
         }
 
+        var maxPointsPerSeries = 0;
+        for (var i = 0; i < this.precursors.length; i++) {
+            maxPointsPerSeries = Math.max(this.fragmentPlotData[this.precursors[i]].data.length, maxPointsPerSeries);
+        }
+        var showDataPoints = maxPointsPerSeries <= LABKEY.targetedms.QCPlotHelperBase.maxPointsPerSeries;
+
         var trendLineProps = {
             disableRangeDisplay: disableRange,
             xTick: this.groupedX ? 'groupedXTick' : 'fullDate',
@@ -655,7 +662,7 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
             pointSize: 2,
             shapeRange: [LABKEY.vis.Scale.Shape()[0] /* circle */, LABKEY.vis.Scale.DataspaceShape()[0] /* open circle */],
             showTrendLine: true,
-            showDataPoints: true,
+            showDataPoints: showDataPoints,
             mouseOverFn: this.plotPointMouseOver,
             mouseOverFnScope: this,
             mouseOutFn: this.plotPointMouseOut,
@@ -663,8 +670,13 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
             position: this.groupedX ? 'sequential' : undefined,
             legendMouseOverFn: this.legendMouseOver,
             legendMouseOverFnScope: this,
-            legendMouseOutFn: this.legendMouseOut,
-            legendMouseOutFnScope: this
+            legendMouseOutFn: this.plotPointMouseOut,
+            legendMouseOutFnScope: this,
+            pathMouseOverFn: this.pathMouseOver,
+            pathMouseOverFnScope: this,
+            pathMouseOutFn: this.plotPointMouseOut,
+            pathMouseOutFnScope: this,
+            hoverTextFn: !showDataPoints ? function() { return 'Narrow the date range to show individual data points.' } : undefined
         };
 
         Ext4.apply(trendLineProps, this.getPlotTypeProperties(combinePlotData, plotType, isCUSUMMean));
@@ -726,6 +738,8 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
                     + "the mean with negative values have been omitted.</span>");
         }
 
+        var showDataPoints = precursorInfo.data.length <= LABKEY.targetedms.QCPlotHelperBase.maxPointsPerSeries;
+
         var trendLineProps = {
             xTick: this.groupedX ? 'groupedXTick' : 'fullDate',
             xTickLabel: 'date',
@@ -737,13 +751,14 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
             pointIdAttr: function(row) { return row['fullDate']; },
             shapeRange: [LABKEY.vis.Scale.Shape()[0] /* circle */, LABKEY.vis.Scale.DataspaceShape()[0] /* open circle */],
             showTrendLine: true,
-            showDataPoints: true,
+            showDataPoints: showDataPoints,
             defaultGuideSetLabel: 'fragment',
             defaultGuideSets: this.defaultGuideSet,
             mouseOverFn: this.plotPointMouseOver,
             mouseOverFnScope: this,
             position: this.groupedX ? 'sequential' : undefined,
-            disableRangeDisplay: this.isMultiSeries()
+            disableRangeDisplay: this.isMultiSeries(),
+            hoverTextFn: !showDataPoints ? function() { return 'Narrow the date range to show individual data points.' } : undefined
         };
 
         // lines are not separated when indices are not present

--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -643,7 +643,9 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
 
         var maxPointsPerSeries = 0;
         for (var i = 0; i < this.precursors.length; i++) {
-            maxPointsPerSeries = Math.max(this.fragmentPlotData[this.precursors[i]].data.length, maxPointsPerSeries);
+            if (this.fragmentPlotData[this.precursors[i]]) {
+                maxPointsPerSeries = Math.max(this.fragmentPlotData[this.precursors[i]].data.length, maxPointsPerSeries);
+            }
         }
         var showDataPoints = maxPointsPerSeries <= LABKEY.targetedms.QCPlotHelperBase.maxPointsPerSeries;
 
@@ -738,7 +740,7 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
                     + "the mean with negative values have been omitted.</span>");
         }
 
-        var showDataPoints = precursorInfo.data.length <= LABKEY.targetedms.QCPlotHelperBase.maxPointsPerSeries;
+        var showDataPoints = precursorInfo.data ? precursorInfo.data.length <= LABKEY.targetedms.QCPlotHelperBase.maxPointsPerSeries : true;
 
         var trendLineProps = {
             xTick: this.groupedX ? 'groupedXTick' : 'fullDate',

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -1257,8 +1257,10 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         }
     },
 
-    legendMouseOut : function(data, item) {
-        this.plotPointMouseOut();
+    pathMouseOver : function(event, pathData, layerSel, path, valueName, config) {
+        if (pathData.group) {
+            this.highlightFragmentSeries(pathData.group);
+        }
     },
 
     plotPointMouseOver : function(event, row, layerSel, point, valueName, plotConfig) {


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46628

When the Panorama QC Trend plots render with a large number of data points per series, the points are too bunched together to really make sense of them or find the right one you are looking for to hover over. In this PR, we set a max of 300 for the trend line plot type in the Panorama scenario so that we don't render individual data points. We also add in hover behavior for the series lines themselves to allow for the series highlighting that is done for hover over legend items and data points themselves.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3825

#### Changes
- max points per series set to 300 and don't render point geom if over that max
- bind mouse events to path line to highlight (similar to point hover and legend hover)
- show hover static hover text when data points are not being rendered
