### PR TITLE
Issue 46531: Add support for z+1 and z+2 ions

### DIFF
--- a/src/org/labkey/targetedms/query/DocTransitionsTableInfo.java
+++ b/src/org/labkey/targetedms/query/DocTransitionsTableInfo.java
@@ -161,6 +161,13 @@ public class DocTransitionsTableInfo extends AbstractGeneralTransitionTableInfo
                     return o == null ? null : o.toString();
                 }
 
+                @Override
+                public Object getExcelCompatibleValue(RenderContext ctx)
+                {
+                    // Return the fragment ion name with extended characters, if any. Example: z• (z+1) and z′ (z+2) ions.
+                    return getValue(ctx, true);
+                }
+
                 @Override @NotNull
                 public HtmlString getFormattedHtml(RenderContext ctx)
                 {


### PR DESCRIPTION
#### Rationale
- Include special characters in fragment ion names when exporting Excel format.

#### Related Pull Requests
https://github.com/LabKey/targetedms/pull/625
