### PR TITLE
 FR 44763 Access mean and CV of any metric cross last N runs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,9 @@ dependencies
    BuildUtils.addLabKeyDependency(project: project, config: "jspImplementation", depProjectPath: BuildUtils.getCommonAssayModuleProjectPath(project.gradle, "ms2"), depProjectConfig: "apiJarFile")
    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getCommonAssayModuleProjectPath(project.gradle, "ms2"), depProjectConfig: "published", depExtension: "module")
    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "experiment"), depProjectConfig: "published", depExtension: "module")
-   
+
+   compileOnly "org.projectlombok:lombok:${lombokVersion}"
+   annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 }
 
 sourceSets {

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -1279,7 +1279,7 @@ public class TargetedMSController extends SpringActionController
             // always query for the full range
             List<RawMetricDataSet> rawMetricDataSets = generator.getRawMetricDataSets(schema, qcMetricConfigurations, qcFolderStartDate, qcFolderEndDate, form.getSelectedAnnotations(), form.isShowExcluded(), form.isShowExcludedPrecursors());
             Map<GuideSetKey, GuideSetStats> stats;
-            if (form.includeTrailingCVPlot || form.includeTrailingMeanPlot)
+            if ((form.includeTrailingCVPlot || form.includeTrailingMeanPlot) && form.trailingRuns > 2)
             {
                 stats = generator.getAllProcessedMetricGuideSets(rawMetricDataSets, guideSets.stream().collect(Collectors.toMap(GuideSet::getRowId, Function.identity())), form.trailingRuns);
             }

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -1408,7 +1408,7 @@ public class TargetedMSController extends SpringActionController
             Map<GuideSetKey, GuideSetStats> stats;
             if ((form.includeTrailingCVPlot || form.includeTrailingMeanPlot) && form._trailingRuns > 2)
             {
-                stats = generator.getAllProcessedMetricGuideSets(rawMetricDataSets, guideSets.stream().collect(Collectors.toMap(GuideSet::getRowId, Function.identity())), form._trailingRuns, form._startDate, form._endDate);
+                stats = generator.getAllProcessedMetricGuideSets(rawMetricDataSets, guideSets.stream().collect(Collectors.toMap(GuideSet::getRowId, Function.identity())), form._trailingRuns);
             }
             else
             {

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -1281,7 +1281,7 @@ public class TargetedMSController extends SpringActionController
             Map<GuideSetKey, GuideSetStats> stats;
             if ((form.includeTrailingCVPlot || form.includeTrailingMeanPlot) && form.trailingRuns > 2)
             {
-                stats = generator.getAllProcessedMetricGuideSets(rawMetricDataSets, guideSets.stream().collect(Collectors.toMap(GuideSet::getRowId, Function.identity())), form.trailingRuns);
+                stats = generator.getAllProcessedMetricGuideSets(rawMetricDataSets, guideSets.stream().collect(Collectors.toMap(GuideSet::getRowId, Function.identity())), form.trailingRuns, form._startDate, form._endDate);
             }
             else
             {

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -18,6 +18,7 @@ package org.labkey.targetedms;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.keypoint.PngEncoder;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.batik.dom.GenericDOMImplementation;
@@ -1191,7 +1192,7 @@ public class TargetedMSController extends SpringActionController
         @Getter @Setter  private boolean showExcluded;
         @Getter @Setter private boolean showReferenceGS;
         @Getter @Setter private boolean showExcludedPrecursors;
-        @Getter @Setter private int trailingRuns;
+        @Getter @Setter @Builder.Default private int trailingRuns = 10;
         @Getter @Setter private boolean includeTrailingMeanPlot;
         @Getter @Setter private boolean includeTrailingCVPlot;
 

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -1192,7 +1192,7 @@ public class TargetedMSController extends SpringActionController
         @Getter @Setter  private boolean showExcluded;
         @Getter @Setter private boolean showReferenceGS;
         @Getter @Setter private boolean showExcludedPrecursors;
-        @Getter @Setter @Builder.Default private int trailingRuns = 10;
+        @Getter @Setter private int trailingRuns = 10;
         @Getter @Setter private boolean includeTrailingMeanPlot;
         @Getter @Setter private boolean includeTrailingCVPlot;
 

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -18,9 +18,6 @@ package org.labkey.targetedms;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.keypoint.PngEncoder;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
 import org.apache.batik.dom.GenericDOMImplementation;
 import org.apache.batik.svggen.SVGGeneratorContext;
 import org.apache.batik.svggen.SVGGraphics2D;
@@ -816,7 +813,7 @@ public class TargetedMSController extends SpringActionController
         private List<String> _plotTypes;
         private Boolean _largePlot;
         public List<String> _selectedAnnotations;
-        @Getter @Setter private Integer trailingRuns;
+        private Integer _trailingRuns;
 
         public Map<String, String> getAsMapOfStrings()
         {
@@ -841,8 +838,8 @@ public class TargetedMSController extends SpringActionController
                 valueMap.put("largePlot", Boolean.toString(_largePlot));
             if(_selectedAnnotations != null)
                 valueMap.put("selectedAnnotations", getSelectedAnnotationsString());
-            if (trailingRuns != null)
-                valueMap.put("trailingRuns", Integer.toString(trailingRuns));
+            if (_trailingRuns != null)
+                valueMap.put("trailingRuns", Integer.toString(_trailingRuns));
             // note: start and end date handled separately since they can be null and we want to persist that
             return valueMap;
         }
@@ -935,6 +932,16 @@ public class TargetedMSController extends SpringActionController
         public String getSelectedAnnotationsString()
         {
             return StringUtils.join(_selectedAnnotations, ",");
+        }
+
+        public Integer getTrailingRuns()
+        {
+            return _trailingRuns;
+        }
+
+        public void setTrailingRuns(Integer trailingRuns)
+        {
+            _trailingRuns = trailingRuns;
         }
     }
 
@@ -1181,20 +1188,70 @@ public class TargetedMSController extends SpringActionController
 
     public static class QCPlotsDataForm
     {
-        @Getter @Setter private int metricId;
-        @Getter @Setter private boolean includeLJ;
-        @Getter @Setter private boolean includeMR;
-        @Getter @Setter private boolean includeMeanCusum;
-        @Getter @Setter private boolean includeVariableCusum;
+        private int _metricId;
+        private boolean _includeLJ;
+        private boolean _includeMR;
+        private boolean _includeMeanCusum;
+        private boolean _includeVariableCusum;
         private Date _startDate;
         private Date _endDate;
-        @Getter @Setter private List<OutlierGenerator.AnnotationGroup> selectedAnnotations = Collections.emptyList();
-        @Getter @Setter  private boolean showExcluded;
-        @Getter @Setter private boolean showReferenceGS;
-        @Getter @Setter private boolean showExcludedPrecursors;
-        @Getter @Setter private int trailingRuns = 10;
-        @Getter @Setter private boolean includeTrailingMeanPlot;
-        @Getter @Setter private boolean includeTrailingCVPlot;
+        private List<OutlierGenerator.AnnotationGroup> _selectedAnnotations = Collections.emptyList();
+        private boolean _showExcluded;
+        private boolean _showReferenceGS;
+        private boolean _showExcludedPrecursors;
+        private int _trailingRuns = 10;
+        private boolean includeTrailingMeanPlot;
+        private boolean includeTrailingCVPlot;
+
+        public int getMetricId()
+        {
+            return _metricId;
+        }
+
+        public void setMetricId(int metricId)
+        {
+            this._metricId = metricId;
+        }
+
+        public boolean isIncludeLJ()
+        {
+            return _includeLJ;
+        }
+
+        public void setIncludeLJ(boolean includeLJ)
+        {
+            this._includeLJ = includeLJ;
+        }
+
+        public boolean isIncludeMR()
+        {
+            return _includeMR;
+        }
+
+        public void setIncludeMR(boolean includeMR)
+        {
+            this._includeMR = includeMR;
+        }
+
+        public boolean isIncludeMeanCusum()
+        {
+            return _includeMeanCusum;
+        }
+
+        public void setIncludeMeanCusum(boolean includeMeanCusum)
+        {
+            this._includeMeanCusum = includeMeanCusum;
+        }
+
+        public boolean isIncludeVariableCusum()
+        {
+            return _includeVariableCusum;
+        }
+
+        public void setIncludeVariableCusum(boolean includeVariableCusum)
+        {
+            this._includeVariableCusum = includeVariableCusum;
+        }
 
         public Date getStartDate()
         {
@@ -1214,6 +1271,76 @@ public class TargetedMSController extends SpringActionController
         public void setEndDate(java.sql.Date endDate)
         {
             _endDate = endDate;
+        }
+
+        public List<OutlierGenerator.AnnotationGroup> getSelectedAnnotations()
+        {
+            return _selectedAnnotations;
+        }
+
+        public void setSelectedAnnotations(List<OutlierGenerator.AnnotationGroup> selectedAnnotations)
+        {
+            _selectedAnnotations = selectedAnnotations;
+        }
+
+        public boolean isShowExcluded()
+        {
+            return _showExcluded;
+        }
+
+        public void setShowExcluded(boolean showExcluded)
+        {
+            _showExcluded = showExcluded;
+        }
+
+        public boolean isShowReferenceGS()
+        {
+            return _showReferenceGS;
+        }
+
+        public void setShowReferenceGS(boolean showReferenceGS)
+        {
+            _showReferenceGS = showReferenceGS;
+        }
+
+        public boolean isShowExcludedPrecursors()
+        {
+            return _showExcludedPrecursors;
+        }
+
+        public void setShowExcludedPrecursors(boolean showExcludedPrecursors)
+        {
+            _showExcludedPrecursors = showExcludedPrecursors;
+        }
+
+        public int getTrailingRuns()
+        {
+            return _trailingRuns;
+        }
+
+        public void setTrailingRuns(int trailingRuns)
+        {
+            _trailingRuns = trailingRuns;
+        }
+
+        public boolean isIncludeTrailingMeanPlot()
+        {
+            return includeTrailingMeanPlot;
+        }
+
+        public void setIncludeTrailingMeanPlot(boolean includeTrailingMeanPlot)
+        {
+            this.includeTrailingMeanPlot = includeTrailingMeanPlot;
+        }
+
+        public boolean isIncludeTrailingCVPlot()
+        {
+            return includeTrailingCVPlot;
+        }
+
+        public void setIncludeTrailingCVPlot(boolean includeTrailingCVPlot)
+        {
+            this.includeTrailingCVPlot = includeTrailingCVPlot;
         }
     }
 
@@ -1279,9 +1406,9 @@ public class TargetedMSController extends SpringActionController
             // always query for the full range
             List<RawMetricDataSet> rawMetricDataSets = generator.getRawMetricDataSets(schema, qcMetricConfigurations, qcFolderStartDate, qcFolderEndDate, form.getSelectedAnnotations(), form.isShowExcluded(), form.isShowExcludedPrecursors());
             Map<GuideSetKey, GuideSetStats> stats;
-            if ((form.includeTrailingCVPlot || form.includeTrailingMeanPlot) && form.trailingRuns > 2)
+            if ((form.includeTrailingCVPlot || form.includeTrailingMeanPlot) && form._trailingRuns > 2)
             {
-                stats = generator.getAllProcessedMetricGuideSets(rawMetricDataSets, guideSets.stream().collect(Collectors.toMap(GuideSet::getRowId, Function.identity())), form.trailingRuns, form._startDate, form._endDate);
+                stats = generator.getAllProcessedMetricGuideSets(rawMetricDataSets, guideSets.stream().collect(Collectors.toMap(GuideSet::getRowId, Function.identity())), form._trailingRuns, form._startDate, form._endDate);
             }
             else
             {

--- a/src/org/labkey/targetedms/model/GuideSet.java
+++ b/src/org/labkey/targetedms/model/GuideSet.java
@@ -15,6 +15,8 @@
  */
 package org.labkey.targetedms.model;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.json.old.JSONObject;
 import org.labkey.api.data.Entity;
 import org.labkey.api.targetedms.model.OutlierCounts;
@@ -31,73 +33,12 @@ import java.util.Map;
  */
 public class GuideSet extends Entity
 {
-    private int _rowId;
-
-    private String _comment;
-    private Date _trainingStart;
-    private Date _trainingEnd;
-    private Date _referenceEnd;
-    private boolean _isDefault;
-
-    public int getRowId()
-    {
-        return _rowId;
-    }
-
-    public void setRowId(int rowId)
-    {
-        _rowId = rowId;
-    }
-
-    public String getComment()
-    {
-        return _comment;
-    }
-
-    public void setComment(String comment)
-    {
-        _comment = comment;
-    }
-
-    public Date getTrainingStart()
-    {
-        return _trainingStart;
-    }
-
-    public void setTrainingStart(Date trainingStart)
-    {
-        _trainingStart = trainingStart;
-    }
-
-    public Date getTrainingEnd()
-    {
-        return _trainingEnd;
-    }
-
-    public void setTrainingEnd(Date trainingEnd)
-    {
-        _trainingEnd = trainingEnd;
-    }
-
-    public Date getReferenceEnd()
-    {
-        return _referenceEnd;
-    }
-
-    public void setReferenceEnd(Date referenceEnd)
-    {
-        _referenceEnd = referenceEnd;
-    }
-
-    public boolean isDefault()
-    {
-        return _isDefault;
-    }
-
-    public void setIsDefault(boolean isDefault)
-    {
-        _isDefault = isDefault;
-    }
+    @Getter @Setter private int rowId;
+    @Getter @Setter private String comment;
+    @Getter @Setter private Date trainingStart;
+    @Getter @Setter private Date trainingEnd;
+    @Getter @Setter private Date referenceEnd;
+    @Getter @Setter private boolean isDefault;
 
     public JSONObject toJSON(List<RawMetricDataSet> dataRows, Map<Integer, QCMetricConfiguration> metrics, Map<GuideSetKey, GuideSetStats> stats)
     {

--- a/src/org/labkey/targetedms/model/GuideSet.java
+++ b/src/org/labkey/targetedms/model/GuideSet.java
@@ -15,8 +15,6 @@
  */
 package org.labkey.targetedms.model;
 
-import lombok.Getter;
-import lombok.Setter;
 import org.json.old.JSONObject;
 import org.labkey.api.data.Entity;
 import org.labkey.api.targetedms.model.OutlierCounts;
@@ -33,12 +31,73 @@ import java.util.Map;
  */
 public class GuideSet extends Entity
 {
-    @Getter @Setter private int rowId;
-    @Getter @Setter private String comment;
-    @Getter @Setter private Date trainingStart;
-    @Getter @Setter private Date trainingEnd;
-    @Getter @Setter private Date referenceEnd;
-    @Getter @Setter private boolean isDefault;
+    private int _rowId;
+
+    private String _comment;
+    private Date _trainingStart;
+    private Date _trainingEnd;
+    private Date _referenceEnd;
+    private boolean _isDefault;
+
+    public int getRowId()
+    {
+        return _rowId;
+    }
+
+    public void setRowId(int rowId)
+    {
+        _rowId = rowId;
+    }
+
+    public String getComment()
+    {
+        return _comment;
+    }
+
+    public void setComment(String comment)
+    {
+        _comment = comment;
+    }
+
+    public Date getTrainingStart()
+    {
+        return _trainingStart;
+    }
+
+    public void setTrainingStart(Date trainingStart)
+    {
+        _trainingStart = trainingStart;
+    }
+
+    public Date getTrainingEnd()
+    {
+        return _trainingEnd;
+    }
+
+    public void setTrainingEnd(Date trainingEnd)
+    {
+        _trainingEnd = trainingEnd;
+    }
+
+    public Date getReferenceEnd()
+    {
+        return _referenceEnd;
+    }
+
+    public void setReferenceEnd(Date referenceEnd)
+    {
+        _referenceEnd = referenceEnd;
+    }
+
+    public boolean isDefault()
+    {
+        return _isDefault;
+    }
+
+    public void setIsDefault(boolean isDefault)
+    {
+        _isDefault = isDefault;
+    }
 
     public JSONObject toJSON(List<RawMetricDataSet> dataRows, Map<Integer, QCMetricConfiguration> metrics, Map<GuideSetKey, GuideSetStats> stats)
     {

--- a/src/org/labkey/targetedms/model/GuideSetStats.java
+++ b/src/org/labkey/targetedms/model/GuideSetStats.java
@@ -197,22 +197,19 @@ public class GuideSetStats
         int j = 0; // index to traverse trailingMeans and trailingCVs array
         if (null != trailingRuns)
         {
-            for (int i = trailingRuns; i < includedRows.size(); i++)
+            for (int i = trailingRuns-1; i < includedRows.size(); i++)
             {
                 RawMetricDataSet row = includedRows.get(i);
-                RawMetricDataSet trailingStartRow = includedRows.get(i-trailingRuns);
-                RawMetricDataSet trailingEndRow = includedRows.get(i-1);
+                RawMetricDataSet trailingStartRow = includedRows.get(j);
                 if (trailingMeans != null && trailingMeans.length > 0 && j < trailingMeans.length)
                 {
                     row.setTrailingMean(trailingMeans[j]);
                     row.setTrailingStart(trailingStartRow.getSampleFile().getAcquiredTime());
-                    row.setTrailingEnd(trailingEndRow.getSampleFile().getAcquiredTime());
                 }
                 if (trailingCVs != null && trailingCVs.length > 0 && j < trailingCVs.length)
                 {
                     row.setTrailingCV(trailingCVs[j]);
                     row.setTrailingStart(trailingStartRow.getSampleFile().getAcquiredTime());
-                    row.setTrailingEnd(trailingEndRow.getSampleFile().getAcquiredTime());
                 }
                 j++;
             }

--- a/src/org/labkey/targetedms/model/GuideSetStats.java
+++ b/src/org/labkey/targetedms/model/GuideSetStats.java
@@ -163,8 +163,7 @@ public class GuideSetStats
         Double[] trailingMeans = null;
         Double[] trailingCVs = null;
 
-        // when guideset is present, pass metricVals from start of the guideset
-        if (trailingRuns != null && _guideSet.getRowId() != 0)
+        if (trailingRuns != null)
         {
             trailingMeans = Stats.getTrailingMeans(metricVals, trailingRuns);
             trailingCVs = Stats.getTrailingCVs(metricVals, trailingRuns);

--- a/src/org/labkey/targetedms/model/GuideSetStats.java
+++ b/src/org/labkey/targetedms/model/GuideSetStats.java
@@ -190,13 +190,23 @@ public class GuideSetStats
                 row.setCUSUMvP(positiveCUSUMv[i]);
                 row.setCUSUMvN(negativeCUSUMv[i]);
             }
-            if (trailingMeans != null && trailingMeans.length > 0 && i < trailingMeans.length)
+        }
+        // start trailingCVs and trailingMeans from number of trailingRuns after the beginning
+        int j = 0; // index to traverse trailingMeans and trailingCVs array
+        if (null != trailingRuns)
+        {
+            for (int i = trailingRuns; i < includedRows.size(); i++)
             {
-                row.setTrailingMean(trailingMeans[i]);
-            }
-            if (trailingCVs != null && trailingCVs.length > 0 && i < trailingCVs.length)
-            {
-                row.setTrailingCV(trailingCVs[i]);
+                j++;
+                RawMetricDataSet row = includedRows.get(i);
+                if (trailingMeans.length > 0 && j < trailingMeans.length)
+                {
+                    row.setTrailingMean(trailingMeans[j]);
+                }
+                if (trailingCVs.length > 0 && j < trailingCVs.length)
+                {
+                    row.setTrailingCV(trailingCVs[j]);
+                }
             }
         }
     }

--- a/src/org/labkey/targetedms/model/GuideSetStats.java
+++ b/src/org/labkey/targetedms/model/GuideSetStats.java
@@ -136,7 +136,7 @@ public class GuideSetStats
         return result.toArray(new Double[0]);
     }
 
-    public void calculateStats()
+    public void calculateStats(Integer trailingRuns)
     {
         _locked = true;
 
@@ -160,6 +160,15 @@ public class GuideSetStats
 
         Double[] mRs = Stats.getMovingRanges(metricVals, false, null);
 
+        Double[] trailingMeans = null;
+        Double[] trailingCVs = null;
+
+        if (trailingRuns != null)
+        {
+            trailingMeans = Stats.getTrailingMeans(metricVals, trailingRuns);
+            trailingCVs = Stats.getTrailingCVs(metricVals, trailingRuns);
+        }
+
         double[] positiveCUSUMm = Stats.getCUSUMS(metricVals, false, false, false, null);
         double[] negativeCUSUMm = Stats.getCUSUMS(metricVals, true, false, false, null);
 
@@ -180,6 +189,14 @@ public class GuideSetStats
                 row.setCUSUMmN(negativeCUSUMm[i]);
                 row.setCUSUMvP(positiveCUSUMv[i]);
                 row.setCUSUMvN(negativeCUSUMv[i]);
+            }
+            if (trailingMeans != null && trailingMeans.length > 0 && i < trailingMeans.length)
+            {
+                row.setTrailingMean(trailingMeans[i]);
+            }
+            if (trailingCVs != null && trailingCVs.length > 0 && i < trailingCVs.length)
+            {
+                row.setTrailingCV(trailingCVs[i]);
             }
         }
     }

--- a/src/org/labkey/targetedms/model/GuideSetStats.java
+++ b/src/org/labkey/targetedms/model/GuideSetStats.java
@@ -197,7 +197,6 @@ public class GuideSetStats
         {
             for (int i = trailingRuns; i < includedRows.size(); i++)
             {
-                j++;
                 RawMetricDataSet row = includedRows.get(i);
                 if (trailingMeans != null && trailingMeans.length > 0 && j < trailingMeans.length)
                 {
@@ -207,6 +206,7 @@ public class GuideSetStats
                 {
                     row.setTrailingCV(trailingCVs[j]);
                 }
+                j++;
             }
         }
     }

--- a/src/org/labkey/targetedms/model/GuideSetStats.java
+++ b/src/org/labkey/targetedms/model/GuideSetStats.java
@@ -15,9 +15,11 @@
  */
 package org.labkey.targetedms.model;
 
+import org.labkey.api.util.DateUtil;
 import org.labkey.api.visualization.Stats;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -43,6 +45,7 @@ public class GuideSetStats
     private double _movingRangeStdDev;
 
     private boolean _locked = false;
+    private int _trailingBeginIndex = 0;
 
     public GuideSetStats(GuideSetKey key, GuideSet guideSet)
     {
@@ -110,6 +113,39 @@ public class GuideSetStats
         }
     }
 
+    private Double[] getValuesForTrailing(List<RawMetricDataSet> rows, Date qcFolderStartDate, Date qcFolderEndDate)
+    {
+        List<Double> result = new ArrayList<>();
+        int beginInd = 0;
+        for (RawMetricDataSet row : rows)
+        {
+            if ((row.getSampleFile().getAcquiredTime().after(qcFolderStartDate)
+                    || DateUtil.getDateOnly(row.getSampleFile().getAcquiredTime()).compareTo(qcFolderStartDate) == 0) &&
+            (row.getSampleFile().getAcquiredTime().before(qcFolderEndDate)
+                            || DateUtil.getDateOnly(row.getSampleFile().getAcquiredTime()).compareTo(qcFolderEndDate) == 0))
+            {
+                Double value = row.getMetricValue();
+                if (value == null)
+                {
+                    result.add(0.0d);
+                }
+                else
+                {
+                    result.add((double) Math.round(value * 10000.0d) / 10000.0d);
+                }
+                if (_trailingBeginIndex == 0)
+                {
+                    _trailingBeginIndex = beginInd;
+                }
+            }
+            else
+            {
+                beginInd++;
+            }
+        }
+        return result.toArray(new Double[0]);
+    }
+
     private Double[] getValues(List<RawMetricDataSet> rows, boolean transformNullsToZero, boolean roundValues)
     {
         List<Double> result = new ArrayList<>();
@@ -136,7 +172,7 @@ public class GuideSetStats
         return result.toArray(new Double[0]);
     }
 
-    public void calculateStats(Integer trailingRuns)
+    public void calculateStats(Integer trailingRuns, Date qcFolderStartDate, Date qcFolderEndDate)
     {
         _locked = true;
 
@@ -165,8 +201,9 @@ public class GuideSetStats
 
         if (trailingRuns != null)
         {
-            trailingMeans = Stats.getTrailingMeans(metricVals, trailingRuns);
-            trailingCVs = Stats.getTrailingCVs(metricVals, trailingRuns);
+            var trailingVals = getValuesForTrailing(includedRows, qcFolderStartDate, qcFolderEndDate);
+            trailingMeans = Stats.getTrailingMeans(trailingVals, trailingRuns);
+            trailingCVs = Stats.getTrailingCVs(trailingVals, trailingRuns);
         }
 
         double[] positiveCUSUMm = Stats.getCUSUMS(metricVals, false, false, false, null);
@@ -195,7 +232,7 @@ public class GuideSetStats
         int j = 0; // index to traverse trailingMeans and trailingCVs array
         if (null != trailingRuns)
         {
-            for (int i = trailingRuns; i < includedRows.size(); i++)
+            for (int i = _trailingBeginIndex + trailingRuns; i < includedRows.size(); i++)
             {
                 RawMetricDataSet row = includedRows.get(i);
                 if (trailingMeans != null && trailingMeans.length > 0 && j < trailingMeans.length)

--- a/src/org/labkey/targetedms/model/GuideSetStats.java
+++ b/src/org/labkey/targetedms/model/GuideSetStats.java
@@ -163,7 +163,8 @@ public class GuideSetStats
         Double[] trailingMeans = null;
         Double[] trailingCVs = null;
 
-        if (trailingRuns != null)
+        // when guideset is present, pass metricVals from start of the guideset
+        if (trailingRuns != null && _guideSet.getRowId() != 0)
         {
             trailingMeans = Stats.getTrailingMeans(metricVals, trailingRuns);
             trailingCVs = Stats.getTrailingCVs(metricVals, trailingRuns);
@@ -199,11 +200,11 @@ public class GuideSetStats
             {
                 j++;
                 RawMetricDataSet row = includedRows.get(i);
-                if (trailingMeans.length > 0 && j < trailingMeans.length)
+                if (trailingMeans != null && trailingMeans.length > 0 && j < trailingMeans.length)
                 {
                     row.setTrailingMean(trailingMeans[j]);
                 }
-                if (trailingCVs.length > 0 && j < trailingCVs.length)
+                if (trailingCVs != null && trailingCVs.length > 0 && j < trailingCVs.length)
                 {
                     row.setTrailingCV(trailingCVs[j]);
                 }

--- a/src/org/labkey/targetedms/model/QCPlotFragment.java
+++ b/src/org/labkey/targetedms/model/QCPlotFragment.java
@@ -146,6 +146,11 @@ public class QCPlotFragment
                 {
                     dataJsonObject.put("TrailingCV", plotData.getTrailingCV());
                 }
+                if (includeTrailingMean || includeTrailingCV)
+                {
+                    dataJsonObject.put("TrailingStartDate", plotData.getTrailingStart());
+                    dataJsonObject.put("TrailingEndDate", plotData.getTrailingEnd());
+                }
                 dataJsonArray.put(dataJsonObject);
             }
         }

--- a/src/org/labkey/targetedms/model/QCPlotFragment.java
+++ b/src/org/labkey/targetedms/model/QCPlotFragment.java
@@ -149,7 +149,6 @@ public class QCPlotFragment
                 if (includeTrailingMean || includeTrailingCV)
                 {
                     dataJsonObject.put("TrailingStartDate", plotData.getTrailingStart());
-                    dataJsonObject.put("TrailingEndDate", plotData.getTrailingEnd());
                 }
                 dataJsonArray.put(dataJsonObject);
             }

--- a/src/org/labkey/targetedms/model/QCPlotFragment.java
+++ b/src/org/labkey/targetedms/model/QCPlotFragment.java
@@ -70,7 +70,7 @@ public class QCPlotFragment
         this.guideSetStats = guideSetStats;
     }
 
-    public JSONObject toJSON(boolean includeLJ, boolean includeMR, boolean includeMeanCusum, boolean includeVariableCusum, boolean showExcluded)
+    public JSONObject toJSON(boolean includeLJ, boolean includeMR, boolean includeMeanCusum, boolean includeVariableCusum, boolean showExcluded, boolean includeTrailingMean, boolean includeTrailingCV)
     {
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("DataType", getDataType());
@@ -137,6 +137,14 @@ public class QCPlotFragment
                 {
                     dataJsonObject.put("CUSUMvP", plotData.getCUSUMvP());
                     dataJsonObject.put("CUSUMvN", plotData.getCUSUMvN());
+                }
+                if (includeTrailingMean)
+                {
+                    dataJsonObject.put("TrailingMean", plotData.getTrailingMean());
+                }
+                if (includeTrailingCV)
+                {
+                    dataJsonObject.put("TrailingCV", plotData.getTrailingCV());
                 }
                 dataJsonArray.put(dataJsonObject);
             }

--- a/src/org/labkey/targetedms/model/RawMetricDataSet.java
+++ b/src/org/labkey/targetedms/model/RawMetricDataSet.java
@@ -15,6 +15,8 @@
  */
 package org.labkey.targetedms.model;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.targetedms.model.OutlierCounts;
@@ -27,10 +29,10 @@ public class RawMetricDataSet
 {
     private final SampleFileQCMetadata _sampleFile;
 
-    String seriesLabel;
-    Double metricValue;
-    int metricId;
-    int metricSeriesIndex;
+    @Setter String seriesLabel;
+    @Setter Double metricValue;
+    @Getter @Setter int metricId;
+    @Getter @Setter int metricSeriesIndex;
 
     Long precursorChromInfoId;
 
@@ -39,6 +41,8 @@ public class RawMetricDataSet
     Double cusumMN;
     Double cusumVP;
     Double cusumVN;
+    @Getter @Setter Double trailingMean;
+    @Getter @Setter Double trailingCV;
 
     PrecursorInfo _precursor;
 
@@ -190,40 +194,10 @@ public class RawMetricDataSet
         return "";
     }
 
-    public void setSeriesLabel(String seriesLabel)
-    {
-        this.seriesLabel = seriesLabel;
-    }
-
     @Nullable
     public Double getMetricValue()
     {
         return metricValue;
-    }
-
-    public void setMetricValue(Double metricValue)
-    {
-        this.metricValue = metricValue;
-    }
-
-    public int getMetricId()
-    {
-        return metricId;
-    }
-
-    public void setMetricId(int metricId)
-    {
-        this.metricId = metricId;
-    }
-
-    public int getMetricSeriesIndex()
-    {
-        return metricSeriesIndex;
-    }
-
-    public void setMetricSeriesIndex(int metricSeriesIndex)
-    {
-        this.metricSeriesIndex = metricSeriesIndex;
     }
 
     public GuideSetKey getGuideSetKey()

--- a/src/org/labkey/targetedms/model/RawMetricDataSet.java
+++ b/src/org/labkey/targetedms/model/RawMetricDataSet.java
@@ -43,7 +43,6 @@ public class RawMetricDataSet
     Double trailingMean;
     Double trailingCV;
     Date trailingStart;
-    Date trailingEnd;
     PrecursorInfo _precursor;
 
     private GuideSetKey _guideSetKey;
@@ -424,13 +423,4 @@ public class RawMetricDataSet
         this.trailingStart = trailingStart;
     }
 
-    public Date getTrailingEnd()
-    {
-        return trailingEnd;
-    }
-
-    public void setTrailingEnd(Date trailingEnd)
-    {
-        this.trailingEnd = trailingEnd;
-    }
 }

--- a/src/org/labkey/targetedms/model/RawMetricDataSet.java
+++ b/src/org/labkey/targetedms/model/RawMetricDataSet.java
@@ -15,8 +15,6 @@
  */
 package org.labkey.targetedms.model;
 
-import lombok.Getter;
-import lombok.Setter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.targetedms.model.OutlierCounts;
@@ -24,15 +22,16 @@ import org.labkey.api.visualization.Stats;
 import org.labkey.targetedms.chart.LabelFactory;
 
 import java.text.DecimalFormat;
+import java.util.Date;
 
 public class RawMetricDataSet
 {
     private final SampleFileQCMetadata _sampleFile;
 
-    @Setter String seriesLabel;
-    @Setter Double metricValue;
-    @Getter @Setter int metricId;
-    @Getter @Setter int metricSeriesIndex;
+    String seriesLabel;
+    Double metricValue;
+    int metricId;
+    int metricSeriesIndex;
 
     Long precursorChromInfoId;
 
@@ -41,9 +40,10 @@ public class RawMetricDataSet
     Double cusumMN;
     Double cusumVP;
     Double cusumVN;
-    @Getter @Setter Double trailingMean;
-    @Getter @Setter Double trailingCV;
-
+    Double trailingMean;
+    Double trailingCV;
+    Date trailingStart;
+    Date trailingEnd;
     PrecursorInfo _precursor;
 
     private GuideSetKey _guideSetKey;
@@ -194,10 +194,40 @@ public class RawMetricDataSet
         return "";
     }
 
+    public void setSeriesLabel(String seriesLabel)
+    {
+        this.seriesLabel = seriesLabel;
+    }
+
     @Nullable
     public Double getMetricValue()
     {
         return metricValue;
+    }
+
+    public void setMetricValue(Double metricValue)
+    {
+        this.metricValue = metricValue;
+    }
+
+    public int getMetricId()
+    {
+        return metricId;
+    }
+
+    public void setMetricId(int metricId)
+    {
+        this.metricId = metricId;
+    }
+
+    public int getMetricSeriesIndex()
+    {
+        return metricSeriesIndex;
+    }
+
+    public void setMetricSeriesIndex(int metricSeriesIndex)
+    {
+        this.metricSeriesIndex = metricSeriesIndex;
     }
 
     public GuideSetKey getGuideSetKey()
@@ -362,5 +392,45 @@ public class RawMetricDataSet
         {
             counts.setCUSUMvN(counts.getCUSUMvN() + 1);
         }
+    }
+
+    public Double getTrailingMean()
+    {
+        return trailingMean;
+    }
+
+    public void setTrailingMean(Double trailingMean)
+    {
+        this.trailingMean = trailingMean;
+    }
+
+    public Double getTrailingCV()
+    {
+        return trailingCV;
+    }
+
+    public void setTrailingCV(Double trailingCV)
+    {
+        this.trailingCV = trailingCV;
+    }
+
+    public Date getTrailingStart()
+    {
+        return trailingStart;
+    }
+
+    public void setTrailingStart(Date trailingStart)
+    {
+        this.trailingStart = trailingStart;
+    }
+
+    public Date getTrailingEnd()
+    {
+        return trailingEnd;
+    }
+
+    public void setTrailingEnd(Date trailingEnd)
+    {
+        this.trailingEnd = trailingEnd;
     }
 }

--- a/src/org/labkey/targetedms/outliers/OutlierGenerator.java
+++ b/src/org/labkey/targetedms/outliers/OutlierGenerator.java
@@ -419,7 +419,12 @@ public class OutlierGenerator
      * Calculate guide set stats for Levey-Jennings and moving range comparisons.
      * @param guideSets id to GuideSet
      */
+
     public Map<GuideSetKey, GuideSetStats> getAllProcessedMetricGuideSets(List<RawMetricDataSet> rawMetricData, Map<Integer, GuideSet> guideSets)
+    {
+        return getAllProcessedMetricGuideSets(rawMetricData, guideSets, null);
+    }
+    public Map<GuideSetKey, GuideSetStats> getAllProcessedMetricGuideSets(List<RawMetricDataSet> rawMetricData, Map<Integer, GuideSet> guideSets, Integer trailingRuns)
     {
         Map<GuideSetKey, GuideSetStats> result = new HashMap<>();
 
@@ -430,7 +435,7 @@ public class OutlierGenerator
             stats.addRow(row);
         }
 
-        result.values().forEach(GuideSetStats::calculateStats);
+        result.values().forEach(g -> g.calculateStats(trailingRuns));
         return result;
     }
 

--- a/src/org/labkey/targetedms/outliers/OutlierGenerator.java
+++ b/src/org/labkey/targetedms/outliers/OutlierGenerator.java
@@ -423,9 +423,9 @@ public class OutlierGenerator
 
     public Map<GuideSetKey, GuideSetStats> getAllProcessedMetricGuideSets(List<RawMetricDataSet> rawMetricData, Map<Integer, GuideSet> guideSets)
     {
-        return getAllProcessedMetricGuideSets(rawMetricData, guideSets, null, null, null);
+        return getAllProcessedMetricGuideSets(rawMetricData, guideSets, null);
     }
-    public Map<GuideSetKey, GuideSetStats> getAllProcessedMetricGuideSets(List<RawMetricDataSet> rawMetricData, Map<Integer, GuideSet> guideSets, @Nullable Integer trailingRuns, @Nullable Date qcFolderStartDate, @Nullable Date qcFolderEndDate)
+    public Map<GuideSetKey, GuideSetStats> getAllProcessedMetricGuideSets(List<RawMetricDataSet> rawMetricData, Map<Integer, GuideSet> guideSets, @Nullable Integer trailingRuns)
     {
         Map<GuideSetKey, GuideSetStats> result = new HashMap<>();
 
@@ -436,7 +436,7 @@ public class OutlierGenerator
             stats.addRow(row);
         }
 
-        result.values().forEach(g -> g.calculateStats(trailingRuns, qcFolderStartDate, qcFolderEndDate));
+        result.values().forEach(g -> g.calculateStats(trailingRuns));
         return result;
     }
 

--- a/src/org/labkey/targetedms/outliers/OutlierGenerator.java
+++ b/src/org/labkey/targetedms/outliers/OutlierGenerator.java
@@ -17,6 +17,7 @@ package org.labkey.targetedms.outliers;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.RuntimeSQLException;
 import org.labkey.api.data.SQLFragment;
@@ -422,9 +423,9 @@ public class OutlierGenerator
 
     public Map<GuideSetKey, GuideSetStats> getAllProcessedMetricGuideSets(List<RawMetricDataSet> rawMetricData, Map<Integer, GuideSet> guideSets)
     {
-        return getAllProcessedMetricGuideSets(rawMetricData, guideSets, null);
+        return getAllProcessedMetricGuideSets(rawMetricData, guideSets, null, null, null);
     }
-    public Map<GuideSetKey, GuideSetStats> getAllProcessedMetricGuideSets(List<RawMetricDataSet> rawMetricData, Map<Integer, GuideSet> guideSets, Integer trailingRuns)
+    public Map<GuideSetKey, GuideSetStats> getAllProcessedMetricGuideSets(List<RawMetricDataSet> rawMetricData, Map<Integer, GuideSet> guideSets, @Nullable Integer trailingRuns, @Nullable Date qcFolderStartDate, @Nullable Date qcFolderEndDate)
     {
         Map<GuideSetKey, GuideSetStats> result = new HashMap<>();
 
@@ -435,7 +436,7 @@ public class OutlierGenerator
             stats.addRow(row);
         }
 
-        result.values().forEach(g -> g.calculateStats(trailingRuns));
+        result.values().forEach(g -> g.calculateStats(trailingRuns, qcFolderStartDate, qcFolderEndDate));
         return result;
     }
 

--- a/src/org/labkey/targetedms/view/qcTrendPlotReport.jsp
+++ b/src/org/labkey/targetedms/view/qcTrendPlotReport.jsp
@@ -45,7 +45,7 @@
         dependencies.add("targetedms/js/BaseQCPlotPanel.js");
         dependencies.add("targetedms/js/QCTrendPlotPanel.js");
         dependencies.add("targetedms/js/QCPlotHoverPanel.js");
-        dependencies.add("ux/CheckCombo/CheckCombo.js");
+        dependencies.add("targetedms/js/PlotTypeCheckCombo.js");
     }
 %>
 <%
@@ -99,6 +99,42 @@
                 maxAcquiredTime: data.rows[0]['MaxAcquiredTime'] ? new Date(data.rows[0]['MaxAcquiredTime']) : null,
                 runs: data.rows[0]['runs']
             });
+        }
+
+        function createPlotTypeTooltip(tgt, plotType) {
+            let calloutMgr = hopscotch.getCalloutManager();
+            calloutMgr.removeAllCallouts();
+            calloutMgr.createCallout({
+                id: Ext4.id(),
+                target: tgt,
+                placement: 'top',
+                width: 300,
+                xOffset: -250,
+                arrowOffset: 270,
+                showCloseButton: false,
+                title: plotType.trim() + ' Plot Type',
+                content: this.getPlotTypeHelpTooltip(plotType.trim())
+            }, this);
+        }
+
+        function destroyPlotTypeTooltip() {
+            hopscotch.getCalloutManager().removeAllCallouts();
+        }
+
+        function  getPlotTypeHelpTooltip(plotTypeName) {
+            if (plotTypeName === 'Levey-Jennings')
+                return LABKEY.targetedms.LeveyJenningsPlotHelper.tooltips['Levey-Jennings'];
+            else if (plotTypeName === 'Moving Range')
+                return LABKEY.targetedms.MovingRangePlotHelper.tooltips['Moving Range'];
+            else if (plotTypeName === 'CUSUMm')
+                return LABKEY.targetedms.CUSUMPlotHelper.tooltips['CUSUMm'];
+            else if (plotTypeName === 'CUSUMv')
+                return LABKEY.targetedms.CUSUMPlotHelper.tooltips['CUSUMv'];
+            else if (plotTypeName === 'Trailing Mean')
+                return LABKEY.targetedms.TrailingMeanPlotHelper.tooltips['Trailing Mean'];
+            else if (plotTypeName === 'Trailing CV')
+                return LABKEY.targetedms.TrailingCVPlotHelper.tooltips['Trailing CV'];
+            return '';
         }
 
         Ext4.onReady(init);

--- a/src/org/labkey/targetedms/view/qcTrendPlotReport.jsp
+++ b/src/org/labkey/targetedms/view/qcTrendPlotReport.jsp
@@ -37,12 +37,15 @@
         dependencies.add("targetedms/js/QCPlotHelperBase.js");
         dependencies.add("targetedms/js/QCPlotLegendHelper.js");
         dependencies.add("targetedms/js/LeveyJenningsPlotHelper.js");
+        dependencies.add("targetedms/js/TrailingMeanPlotHelper.js");
+        dependencies.add("targetedms/js/TrailingCVPlotHelper.js");
         dependencies.add("targetedms/js/CUSUMPlotHelper.js");
         dependencies.add("targetedms/js/MovingRangePlotHelper.js");
         dependencies.add("targetedms/js/QCPlotHelperWrapper.js");
         dependencies.add("targetedms/js/BaseQCPlotPanel.js");
         dependencies.add("targetedms/js/QCTrendPlotPanel.js");
         dependencies.add("targetedms/js/QCPlotHoverPanel.js");
+        dependencies.add("ux/CheckCombo/CheckCombo.js");
     }
 %>
 <%
@@ -69,7 +72,7 @@
 
             LABKEY.Query.executeSql({
                 schemaName: 'targetedms',
-                sql: 'SELECT MIN(AcquiredTime) AS MinAcquiredTime, MAX(AcquiredTime) AS MaxAcquiredTime FROM SampleFile',
+                sql: 'SELECT MIN(AcquiredTime) AS MinAcquiredTime, MAX(AcquiredTime) AS MaxAcquiredTime, count(*) AS runs FROM SampleFile',
                 success: function(data) {
                     if (data.rows.length === 0 || !data.rows[0]['MinAcquiredTime']) {
                         Ext4.get(plotPanelId).update("No data found. Please upload runs using the Data Pipeline or directly from Skyline.");
@@ -93,7 +96,8 @@
                 plotDivId: plotPanelId,
                 plotPaginationDivId: plotPaginationPanelId,
                 minAcquiredTime: data.rows[0]['MinAcquiredTime'] ? new Date(data.rows[0]['MinAcquiredTime']) : null,
-                maxAcquiredTime: data.rows[0]['MaxAcquiredTime'] ? new Date(data.rows[0]['MaxAcquiredTime']) : null
+                maxAcquiredTime: data.rows[0]['MaxAcquiredTime'] ? new Date(data.rows[0]['MaxAcquiredTime']) : null,
+                runs: data.rows[0]['runs']
             });
         }
 

--- a/test/src/org/labkey/test/components/targetedms/QCPlot.java
+++ b/test/src/org/labkey/test/components/targetedms/QCPlot.java
@@ -29,18 +29,21 @@ import java.util.regex.Pattern;
 
 public class QCPlot
 {
-    WebElement plot;
+    final WebElement plot;
     String precursor;
     Map<String, QCHelper.AnnotationType> annotationTypes;
 
     QCPlot(WebElement plot)
     {
         this.plot = plot;
-        this.precursor = elements().precursor.findElement(plot).getText().trim();
     }
 
     public String getPrecursor()
     {
+        if (precursor == null)
+        {
+            precursor = elements().precursor.findElement(plot).getText().trim();
+        }
         return precursor;
     }
 

--- a/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
@@ -38,6 +38,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
@@ -266,10 +267,11 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
     {
         if (plotCount > 0)
         {
+            Supplier<String> messageSupplier = () -> "Waiting for " + plotCount + " plots. Found: " + elementCache().findPlots().size();
             if (exact)
-                WebDriverWrapper.waitFor(() -> elementCache().findPlots().size() == plotCount, WebDriverWrapper.WAIT_FOR_PAGE);
+                WebDriverWrapper.waitFor(() -> elementCache().findPlots().size() == plotCount, messageSupplier, WebDriverWrapper.WAIT_FOR_PAGE);
             else
-                WebDriverWrapper.waitFor(() -> elementCache().findPlots().size() >= plotCount, WebDriverWrapper.WAIT_FOR_PAGE);
+                WebDriverWrapper.waitFor(() -> elementCache().findPlots().size() >= plotCount, messageSupplier, WebDriverWrapper.WAIT_FOR_PAGE);
         }
         else
         {
@@ -818,9 +820,16 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
         Locator.XPathLocator hopscotchBubble = Locator.byClass("hopscotch-bubble-container");
         Locator.XPathLocator hopscotchBubbleClose = Locator.byClass("hopscotch-bubble-close");
 
-        List<WebElement> findPlots()
+        List<WebElement> findPlotPanels()
         {
             return Locator.css("table.qc-plot-wp").waitForElements(plotPanel, 20000);
+        }
+
+        List<WebElement> findPlots()
+        {
+            List<WebElement> plots = new ArrayList<>();
+            findPlotPanels().forEach(panel -> plots.addAll(Locator.css(".chart-render-div").findElements(panel)));
+            return plots;
         }
 
         List<WebElement> noRecords()

--- a/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
@@ -16,7 +16,6 @@
 package org.labkey.test.components.targetedms;
 
 import org.apache.commons.collections4.SetUtils;
-import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.Locators;
 import org.labkey.test.WebDriverWrapper;
@@ -268,10 +267,7 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
 
     public void applyRange()
     {
-        WebElement panelChild = Locator.css("svg").findElement(elementCache().plotPanel); // The panel itself doesn't become stale, but its children do
-        getWrapper().clickButton("Apply", 0);
-        getWrapper().shortWait().until(ExpectedConditions.stalenessOf(panelChild));
-        getWrapper()._ext4Helper.waitForMaskToDisappear(BaseWebDriverTest.WAIT_FOR_PAGE);
+        doAndWaitForUpdate(() -> elementCache().applyRangeButton.click());
     }
 
     public void waitForPlots(Integer plotCount)
@@ -781,6 +777,7 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
     {
         WebElement startDate = Locator.css("#start-date-field input").findWhenNeeded(this);
         WebElement endDate = Locator.css("#end-date-field input").findWhenNeeded(this);
+        WebElement applyRangeButton = Ext4Helper.Locators.ext4Button("Apply").findWhenNeeded(this);
         Locator.XPathLocator scaleCombo = Locator.id("scale-combo-box");
         Locator.XPathLocator dateRangeCombo = Locator.id("daterange-combo-box");
         Locator.XPathLocator metricTypeCombo = Locator.id("metric-type-field");

--- a/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
@@ -820,17 +820,17 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
         Locator.XPathLocator hopscotchBubble = Locator.byClass("hopscotch-bubble-container");
         Locator.XPathLocator hopscotchBubbleClose = Locator.byClass("hopscotch-bubble-close");
 
-        List<WebElement> findPlotPanels()
+        List<WebElement> findPlots()
         {
             return Locator.css("table.qc-plot-wp").waitForElements(plotPanel, 20000);
         }
 
-        List<WebElement> findPlots()
-        {
-            List<WebElement> plots = new ArrayList<>();
-            findPlotPanels().forEach(panel -> plots.addAll(Locator.css(".chart-render-div").findElements(panel)));
-            return plots;
-        }
+//        List<WebElement> findPlots()
+//        {
+//            List<WebElement> plots = new ArrayList<>();
+//            findPlotPanels().forEach(panel -> plots.addAll(Locator.css(".chart-render-div").findElements(panel)));
+//            return plots;
+//        }
 
         List<WebElement> noRecords()
         {

--- a/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
@@ -23,7 +23,6 @@ import org.labkey.test.components.BodyWebPart;
 import org.labkey.test.components.ext4.Checkbox;
 import org.labkey.test.components.ext4.ComboBox;
 import org.labkey.test.components.ext4.Window;
-import org.labkey.test.selenium.LazyWebElement;
 import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
@@ -626,7 +625,7 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
         PERCENT_OF_MEAN("Percent of Mean"),
         STANDARD_DEVIATIONS("Standard Deviations");
 
-        private String _text;
+        private final String _text;
 
         Scale(String text)
         {
@@ -760,7 +759,7 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
         IRTCORRELATION("iRT Correlation"),
         TICAREA("TIC Area");
 
-        private String _text;
+        private final String _text;
 
         MetricType(String text)
         {
@@ -781,10 +780,10 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
         }
     }
 
-    public class Elements extends BodyWebPart.ElementCache
+    public class Elements extends BodyWebPart<?>.ElementCache
     {
-        WebElement startDate = new LazyWebElement(Locator.css("#start-date-field input"), this);
-        WebElement endDate = new LazyWebElement(Locator.css("#end-date-field input"), this);
+        WebElement startDate = Locator.css("#start-date-field input").findWhenNeeded(this);
+        WebElement endDate = Locator.css("#end-date-field input").findWhenNeeded(this);
         Locator.XPathLocator scaleCombo = Locator.id("scale-combo-box");
         Locator.XPathLocator dateRangeCombo = Locator.id("daterange-combo-box");
         Locator.XPathLocator metricTypeCombo = Locator.id("metric-type-field");
@@ -803,8 +802,8 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
                 .findWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT));
 
 
-        WebElement plotPanel = new LazyWebElement(Locator.css("div.tiledPlotPanel"), this);
-        WebElement paginationPanel = new LazyWebElement(Locator.css("div.plotPaginationHeaderPanel"), this);
+        WebElement plotPanel = Locator.css("div.tiledPlotPanel").findWhenNeeded(this);
+        WebElement paginationPanel = Locator.css("div.plotPaginationHeaderPanel").findWhenNeeded(this);
         Locator extFormDisplay = Locator.css("div.x4-form-display-field");
         Locator.CssLocator guideSetTrainingRect = Locator.css("svg rect.training");
         Locator.CssLocator experimentRangeRect = Locator.css("svg rect.expRange");

--- a/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
@@ -177,7 +177,9 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
     public Set<QCPlotType> getCurrentQCPlotTypes()
     {
         WebElement typeInput = Locator.tag("input").waitForElement(elementCache().qcPlotTypeCombo, 1000);
-        return Arrays.stream(typeInput.getDomProperty("value").split(", ?")).map(QCPlotType::getEnum).collect(Collectors.toSet());
+        return Arrays.stream(typeInput.getDomProperty("value").split(", ?"))
+                .filter(s -> !s.isEmpty())
+                .map(QCPlotType::getEnum).collect(Collectors.toSet());
     }
 
     public void setGroupXAxisValuesByDate(boolean check)

--- a/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
@@ -675,20 +675,22 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
 
     public enum QCPlotType
     {
-        LeveyJennings("Levey-Jennings", ""),
-        MovingRange("Moving Range", "_mR"),
-        CUSUMm("CUSUMm", "_CUSUMm"),
-        CUSUMv("CUSUMv", "_CUSUMv"),
-        TrailingCV("Trailing CV", ""),
-        TrailingMean("Trailing Mean", "");
+        LeveyJennings("Levey-Jennings", "", true),
+        MovingRange("Moving Range", "_mR", true),
+        CUSUMm("CUSUMm", "_CUSUMm", true),
+        CUSUMv("CUSUMv", "_CUSUMv", true),
+        TrailingCV("Trailing CV", "", false),
+        TrailingMean("Trailing Mean", "", false);
 
         private final String _label;
         private final String _idSuffix;
+        private final boolean _standardPointCount;
 
-        QCPlotType(String label, String idSuffix)
+        QCPlotType(String label, String idSuffix, boolean standardPointCount)
         {
             _label = label;
             _idSuffix = idSuffix;
+            _standardPointCount = standardPointCount;
         }
 
         public String getLabel()
@@ -699,6 +701,11 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
         public String getIdSuffix()
         {
             return _idSuffix;
+        }
+
+        public boolean isStandardPointCount()
+        {
+            return _standardPointCount;
         }
 
         @Override

--- a/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
@@ -144,15 +144,18 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
     public void setQCPlotTypes(@LoggedParam QCPlotType... qcPlotTypes)
     {
         Set<QCPlotType> currentQCPlotTypes = getCurrentQCPlotTypes();
-        SetUtils.disjunction(Set.of(qcPlotTypes), currentQCPlotTypes)
-                .forEach(this::toggleQCPlotType);
+        toggleQCPlotTypes(SetUtils.disjunction(Set.of(qcPlotTypes), currentQCPlotTypes));
     }
 
-    public void toggleQCPlotType(QCPlotType qcPlotType)
+    private void toggleQCPlotTypes(Set<QCPlotType> plotTypes)
     {
-        dismissTooltip();
+        if (!plotTypes.isEmpty())
+        {
+            dismissTooltip();
 
-        doAndWaitForUpdate(() -> elementCache().qcPlotTypeCombo.selectComboBoxItem(qcPlotType.getLabel()));
+            String[] typeLabels = plotTypes.stream().map(QCPlotType::getLabel).toArray(String[]::new);
+            elementCache().qcPlotTypeCombo.toggleComboBoxItems(typeLabels);
+        }
     }
 
     public List<String> getMetricTypeOptions()
@@ -554,7 +557,7 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
     {
         if (!isPlotTypeSelected(plotType))
         {
-            toggleQCPlotType(plotType);
+            toggleQCPlotTypes(Set.of(plotType));
         }
     }
 
@@ -789,7 +792,7 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
         Locator.XPathLocator metricTypeCombo = Locator.id("metric-type-field");
 
         ComboBox qcPlotTypeCombo = new ComboBox.ComboBoxFinder(getDriver()).withIdPrefix("qc-plot-type-with-y-options")
-                .findWhenNeeded(this).setMatcher(Ext4Helper.TextMatchTechnique.CONTAINS);
+                .findWhenNeeded(this).setMatcher(Ext4Helper.TextMatchTechnique.CONTAINS).setMultiSelect(true);
         Checkbox groupedXCheckbox = new Checkbox(Locator.css("#grouped-x-field input")
                 .findWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT));
         Checkbox singlePlotCheckbox = new Checkbox(Locator.css("#peptides-single-plot input")
@@ -823,13 +826,6 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
         {
             return Locator.css("table.qc-plot-wp").waitForElements(plotPanel, 20000);
         }
-
-//        List<WebElement> findPlots()
-//        {
-//            List<WebElement> plots = new ArrayList<>();
-//            findPlotPanels().forEach(panel -> plots.addAll(Locator.css(".chart-render-div").findElements(panel)));
-//            return plots;
-//        }
 
         List<WebElement> noRecords()
         {

--- a/test/src/org/labkey/test/pages/targetedms/PanoramaDashboard.java
+++ b/test/src/org/labkey/test/pages/targetedms/PanoramaDashboard.java
@@ -30,16 +30,13 @@ public class PanoramaDashboard extends PortalBodyPanel
     public QCPlotsWebPart getQcPlotsWebPart()
     {
         getQcSummaryWebPart(); // Wait for page layout to stabilize. Prevents errant tooltips.
-        return new QCPlotsWebPart(getDriver());
+        QCPlotsWebPart qcPlotsWebPart = new QCPlotsWebPart(getDriver());
+        qcPlotsWebPart.waitForReady();
+        return qcPlotsWebPart;
     }
 
     public QCSummaryWebPart getQcSummaryWebPart()
     {
         return new QCSummaryWebPart(getDriver());
-    }
-
-    public QCSummaryWebPart getQcSummaryWebPart(int index)
-    {
-        return new QCSummaryWebPart(getDriver(), index);
     }
 }

--- a/test/src/org/labkey/test/tests/panoramapremium/TargetedMSHidePeptidesAndMolecules.java
+++ b/test/src/org/labkey/test/tests/panoramapremium/TargetedMSHidePeptidesAndMolecules.java
@@ -73,7 +73,7 @@ public class TargetedMSHidePeptidesAndMolecules extends TargetedMSTest
         checker().verifyEquals("Incorrect number of plots displayed when excluded ", 1, qcPlotsWebPart.getPlots().size());
 
         qcPlotsWebPart.setShowExcludedPrecursors(true);
-        qcPlotsWebPart.waitForPlots(2, true);
+        qcPlotsWebPart.waitForPlots(2);
         checker().verifyEquals("Incorrect number of plots after show excluded precursor is checked ", 2, qcPlotsWebPart.getPlots().size());
 
         log("Verifying Inclusion");

--- a/test/src/org/labkey/test/tests/panoramapremium/TargetedMSIsotopologueTest.java
+++ b/test/src/org/labkey/test/tests/panoramapremium/TargetedMSIsotopologueTest.java
@@ -10,8 +10,6 @@ import org.labkey.test.components.ext4.Window;
 import org.labkey.test.components.targetedms.QCPlotsWebPart;
 import org.labkey.test.pages.targetedms.PanoramaDashboard;
 
-import java.util.Arrays;
-
 import static org.junit.Assert.assertTrue;
 
 @Category({})
@@ -53,7 +51,7 @@ public class TargetedMSIsotopologueTest extends TargetedMSPremiumTest
         PanoramaDashboard qcDashboard = goToDashboard();
         QCPlotsWebPart qcPlotsWebPart = qcDashboard.getQcPlotsWebPart();
 
-        qcPlotsWebPart.setShowAllPeptidesInSinglePlot(true, null);
+        qcPlotsWebPart.setShowAllPeptidesInSinglePlot(true);
 
         log("Verifying if all the metrics are present");
         assertTrue("Accuracy metric is not present", verifyMetricIsPresent(qcPlotsWebPart, "Isotopologue Accuracy"));

--- a/test/src/org/labkey/test/tests/panoramapremium/TargetedMSQCPremiumTest.java
+++ b/test/src/org/labkey/test/tests/panoramapremium/TargetedMSQCPremiumTest.java
@@ -255,7 +255,7 @@ public class TargetedMSQCPremiumTest extends TargetedMSPremiumTest
         PanoramaDashboard panoramaDashboard = new PanoramaDashboard(this);
         QCPlotsWebPart qcPlotsWebPart = panoramaDashboard.getQcPlotsWebPart();
         qcPlotsWebPart.setMetricType(QCPlotsWebPart.MetricType.TOTAL_PEAK);
-        qcPlotsWebPart.checkPlotType(CUSUMm, true);
+        qcPlotsWebPart.checkPlotType(CUSUMm);
         qcPlotsWebPart.setShowExcludedPoints(true);
         qcPlotsWebPart.saveAsDefaultView();
 

--- a/test/src/org/labkey/test/tests/panoramapremium/TargetedMSQCPremiumTest.java
+++ b/test/src/org/labkey/test/tests/panoramapremium/TargetedMSQCPremiumTest.java
@@ -223,7 +223,7 @@ public class TargetedMSQCPremiumTest extends TargetedMSPremiumTest
         PanoramaDashboard dashboard = new PanoramaDashboard(this);
         QCPlotsWebPart qcPlotsWebPart = dashboard.getQcPlotsWebPart();
         _ext4Helper.selectComboBoxItem(Locator.id("metric-type-field"), metricName);
-        qcPlotsWebPart.waitForPlots(1, true);
+        qcPlotsWebPart.waitForPlots(1);
         String pressurePlotSVGText = qcPlotsWebPart.getSVGPlotText("precursorPlot0");
         assertFalse("Pressure trace plot is not present", pressurePlotSVGText.isEmpty());
         assertTrue("Y axis label is not correct or present", pressurePlotSVGText.contains(yAxisLabel));

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCGuideSetTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCGuideSetTest.java
@@ -523,7 +523,6 @@ public class TargetedMSQCGuideSetTest extends TargetedMSTest
 
             PanoramaDashboard qcDashboard = new PanoramaDashboard(this);
             qcDashboard.getQcPlotsWebPart().createGuideSet(guideSet, expectErrorMsg);
-            qcDashboard.getQcPlotsWebPart().waitForPlots();
         }
         else
         {

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCGuideSetTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCGuideSetTest.java
@@ -201,7 +201,7 @@ public class TargetedMSQCGuideSetTest extends TargetedMSTest
         verifyGuideSetRelatedElementsForPlots(qcPlotsWebPart, 4, shapeCounts, 20);
         qcPlotsWebPart.setShowAllPeptidesInSinglePlot(true, 1);
         assertEquals("Unexpected number of training range rects visible", 4, qcPlotsWebPart.getGuideSetTrainingRectCount());
-        qcPlotsWebPart.setShowAllPeptidesInSinglePlot(false, null);
+        qcPlotsWebPart.setShowAllPeptidesInSinglePlot(false);
         qcPlotsWebPart.setGroupXAxisValuesByDate(false);
 
         // filter plot by start/end date to check reference points without training points in view

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -225,7 +225,6 @@ public class TargetedMSQCTest extends TargetedMSTest
         goToProjectHome();
         PanoramaDashboard qcDashboard = new PanoramaDashboard(this);
         QCPlotsWebPart qcPlotsWebPart = qcDashboard.getQcPlotsWebPart();
-        qcPlotsWebPart.waitForPlots(2, false);
         scrollIntoView(Locator.tagWithText("span","FFVAPFPEVFGK ++, 692.8686"));
         mouseOver(qcPlotsWebPart.getPointByAcquiredDate(date));
         waitForElement(qcPlotsWebPart.getBubble());
@@ -302,7 +301,7 @@ public class TargetedMSQCTest extends TargetedMSTest
 
         // test that plot0_plotType_1 (CUSUMm) does not change from linear
         qcPlotsWebPart.checkPlotType(CUSUMm);
-        qcPlotsWebPart.waitForPlots(2, true);
+        qcPlotsWebPart.waitForPlots(2);
         initialSVGText = qcPlotsWebPart.getSVGPlotText("precursorPlot0_plotType_1");
         qcPlotsWebPart.setScale(QCPlotsWebPart.Scale.LOG);
         assertTrue(initialSVGText.equals(qcPlotsWebPart.getSVGPlotText("precursorPlot0_plotType_1")));
@@ -350,7 +349,7 @@ public class TargetedMSQCTest extends TargetedMSTest
         // verify that on refresh, the selections are persisted to the inputs
         refresh();
         qcPlotsWebPart = qcDashboard.getQcPlotsWebPart();
-        qcPlotsWebPart.waitForPlots(1, true);
+        qcPlotsWebPart.waitForPlots(1);
         assertEquals("Metric Type not round tripped as expected", QCPlotsWebPart.MetricType.TOTAL_PEAK, qcPlotsWebPart.getCurrentMetricType());
         assertEquals("Y-Axis Scale not round tripped as expected", QCPlotsWebPart.Scale.PERCENT_OF_MEAN, qcPlotsWebPart.getCurrentScale());
         assertTrue("Group X-Axis not round tripped as expected", qcPlotsWebPart.isGroupXAxisValuesByDateChecked());
@@ -366,18 +365,17 @@ public class TargetedMSQCTest extends TargetedMSTest
         selectedPlotTypes.add(MovingRange);
         selectedPlotTypes.add(CUSUMm);
         qcPlotsWebPart.setQCPlotTypes(selectedPlotTypes.toArray(QCPlotsWebPart.QCPlotType[]::new));
-        qcPlotsWebPart.waitForPlots(2, true);
+        qcPlotsWebPart.waitForPlots(2);
 
         // test plot type selection is persisted
         refresh();
         qcPlotsWebPart = qcDashboard.getQcPlotsWebPart();
-        qcPlotsWebPart.waitForPlots(2, true);
+        qcPlotsWebPart.waitForPlots(2);
         assertEquals("QC Plot Type not round tripped as expected", selectedPlotTypes, qcPlotsWebPart.getCurrentQCPlotTypes());
 
         // impersonate a different user in this container and verify that initial form fields used
         impersonate(USER);
         qcPlotsWebPart = qcDashboard.getQcPlotsWebPart();
-        qcPlotsWebPart.waitForPlots(1, false);
         assertEquals("Metric Type not set to default value", QCPlotsWebPart.MetricType.RETENTION, qcPlotsWebPart.getCurrentMetricType());
         assertEquals("Y-Axis Scale not set to default value", QCPlotsWebPart.Scale.LINEAR, qcPlotsWebPart.getCurrentScale());
         assertFalse("Group X-Axis not set to default value", qcPlotsWebPart.isGroupXAxisValuesByDateChecked());
@@ -387,7 +385,6 @@ public class TargetedMSQCTest extends TargetedMSTest
         stopImpersonating();
         goToProjectHome();
         qcPlotsWebPart = qcDashboard.getQcPlotsWebPart();
-        qcPlotsWebPart.waitForPlots(1, false);
 
         // reset plot type selection
         qcPlotsWebPart.resetInitialQCPlotFields();
@@ -412,7 +409,6 @@ public class TargetedMSQCTest extends TargetedMSTest
         createGuideSetFromTable(new GuideSet("2013-08-09", "2013-08-28", "all initial data points"));
         clickTab("Panorama Dashboard");
         qcPlotsWebPart = qcDashboard.getQcPlotsWebPart();
-        qcPlotsWebPart.waitForPlots(1, false);
         assertEquals("Y-axis Scale selection wasn't persisted", QCPlotsWebPart.Scale.LOG, qcPlotsWebPart.getCurrentScale());
         qcPlotsWebPart.setMetricType(QCPlotsWebPart.MetricType.TOTAL_PEAK);
         assertEquals("Unexpected number of plots with invalid log scale.", 0, qcPlotsWebPart.getLogScaleInvalidCount());
@@ -432,16 +428,16 @@ public class TargetedMSQCTest extends TargetedMSTest
 
         log("Verify Plot Types and Legends");
         qcPlotsWebPart.setQCPlotTypes(LeveyJennings);
-        qcPlotsWebPart.waitForPlots(PRECURSORS.length, true);
+        qcPlotsWebPart.waitForPlots(PRECURSORS.length);
 
         qcPlotsWebPart.checkPlotType(MovingRange);
-        qcPlotsWebPart.waitForPlots(PRECURSORS.length * 2, true);
+        qcPlotsWebPart.waitForPlots(PRECURSORS.length * 2);
 
         assertElementNotPresent(qcPlotsWebPart.getLegendItemLocator("CUSUM Group", true));
 
         qcPlotsWebPart.checkPlotType(CUSUMm);
         qcPlotsWebPart.checkPlotType(QCPlotsWebPart.QCPlotType.CUSUMv);
-        qcPlotsWebPart.waitForPlots(PRECURSORS.length * 4, true);
+        qcPlotsWebPart.waitForPlots(PRECURSORS.length * 4);
 
         assertElementPresent(qcPlotsWebPart.getLegendItemLocator("CUSUM Group", true));
 
@@ -483,8 +479,6 @@ public class TargetedMSQCTest extends TargetedMSTest
 
         PanoramaDashboard qcDashboard = new PanoramaDashboard(this);
         QCPlotsWebPart qcPlotsWebPart = qcDashboard.getQcPlotsWebPart();
-        refresh();
-        qcPlotsWebPart.waitForPlots(1, false);
         // check that there are two series per plot by doing a point count by color
         int count = qcPlotsWebPart.getPointElements("fill", yLeftColor, false).size();
         assertEquals("Unexpected number of points for yLeft metric", pointsPerSeries * PRECURSORS.length, count);
@@ -522,7 +516,7 @@ public class TargetedMSQCTest extends TargetedMSTest
         qcPlotsWebPart.setStartDate("2014-08-09");
         qcPlotsWebPart.setEndDate("2014-08-27");
         qcPlotsWebPart.applyRange();
-        qcPlotsWebPart.waitForPlots(0, true);
+        qcPlotsWebPart.waitForPlots(0);
 
         // reset to avoid test case dependency
         qcPlotsWebPart.resetInitialQCPlotFields();
@@ -655,7 +649,7 @@ public class TargetedMSQCTest extends TargetedMSTest
             qcPlotsWebPart.setGroupXAxisValuesByDate(false);
             qcPlotsWebPart.setQCPlotTypes(plotType);
 
-            testEachCombinedPlots(plotType);
+            testEachCombinedPlots(qcPlotsWebPart, plotType);
         }
         // reset to avoid test case dependency
         qcPlotsWebPart.resetInitialQCPlotFields();
@@ -672,7 +666,7 @@ public class TargetedMSQCTest extends TargetedMSTest
 
         log("Verifying TIC Area QC Plots");
         qcPlotsWebPart.setMetricType(QCPlotsWebPart.MetricType.TICAREA);
-        qcPlotsWebPart.waitForPlots(1, true);
+        qcPlotsWebPart.waitForPlots(1);
         String ticPlotSVGText = qcPlotsWebPart.getSVGPlotText("precursorPlot0");
         assertFalse(ticPlotSVGText.isEmpty());
 
@@ -683,7 +677,7 @@ public class TargetedMSQCTest extends TargetedMSTest
 
         log("Verifying tic_area information in hover plot");
         qcPlotsWebPart.setMetricType(QCPlotsWebPart.MetricType.TICAREA);
-        qcPlotsWebPart.waitForPlots(1, true);
+        qcPlotsWebPart.waitForPlots(1);
         mouseOver(qcPlotsWebPart.getPointByAcquiredDate(acquiredDate));
         waitForElement(qcPlotsWebPart.getBubble());
         String ticAreahoverText = waitForElement(qcPlotsWebPart.getBubbleContent()).getText();
@@ -700,7 +694,7 @@ public class TargetedMSQCTest extends TargetedMSTest
         portalHelper.exitAdminMode();
     }
 
-    private void testEachCombinedPlots(QCPlotsWebPart.QCPlotType plotType)
+    private void testEachCombinedPlots(QCPlotsWebPart qcPlotsWebPart, QCPlotsWebPart.QCPlotType plotType)
     {
         log("Testing combined plot for " + plotType.getLabel());
         int count;
@@ -710,11 +704,6 @@ public class TargetedMSQCTest extends TargetedMSTest
 
         // Use the same color assignments that Skyline generates for multi-molecule plots
         String[] legendItemColors = new String[]{"#755538", "#A1A4AD", "#E2A0AF", "#ED8CFF", "#D19D00", "#70A783", "#00625F"};
-
-        PanoramaDashboard qcDashboard = new PanoramaDashboard(this);
-        QCPlotsWebPart qcPlotsWebPart = qcDashboard.getQcPlotsWebPart();
-        refresh();
-        qcPlotsWebPart.waitForPlots(1, false);
 
         //select "Show All Peptides in Single Plot"
         qcPlotsWebPart.setShowAllPeptidesInSinglePlot(true, 1);
@@ -770,13 +759,13 @@ public class TargetedMSQCTest extends TargetedMSTest
 
         QCPlotsWebPart qcPlotsWebPart = new QCPlotsWebPart(this.getWrappedDriver());
         int currentPagePlotCount = 50;
-        qcPlotsWebPart.waitForPlots(currentPagePlotCount, true);
+        qcPlotsWebPart.waitForPlots(currentPagePlotCount);
         assertTrue("Unexpected overflow warning text", qcPlotsWebPart.getPaginationText().startsWith("Showing 1 - 50 of 91 precursors"));
 
         // go to the second page of plots
         qcPlotsWebPart.goToNextPage();
         currentPagePlotCount = 41;
-        qcPlotsWebPart.waitForPlots(currentPagePlotCount, true);
+        qcPlotsWebPart.waitForPlots(currentPagePlotCount);
         assertTrue("Unexpected overflow warning text", qcPlotsWebPart.getPaginationText().startsWith("Showing 51 - 91 of 91 precursors"));
 
         //select "Show All Peptides in Single Plot"
@@ -836,7 +825,7 @@ public class TargetedMSQCTest extends TargetedMSTest
         PanoramaDashboard qcDashboard = new PanoramaDashboard(this);
         QCPlotsWebPart qcPlotsWebPart = qcDashboard.getQcPlotsWebPart();
         qcPlotsWebPart.setShowExcludedPoints(true);
-        qcPlotsWebPart.waitForPlots(2, true);
+        qcPlotsWebPart.waitForPlots(2);
 
         int includedPointCount = qcPlotsWebPart.getPointElements("d", SvgShapes.CIRCLE.getPathPrefix(), true).size();
         assertEquals("Unexpected number of included data points in plot SVG", 6, includedPointCount);
@@ -883,7 +872,6 @@ public class TargetedMSQCTest extends TargetedMSTest
         QCPlotsWebPart qcPlotsWebPart = qcDashboard.getQcPlotsWebPart();
         log("Enabling Moving range along with Levey-Jennings");
         qcPlotsWebPart.checkPlotType(MovingRange);
-        qcPlotsWebPart.waitForPlots(1, false);
 
         log("Verifying standard deviations plots");
         qcPlotsWebPart.setScale(QCPlotsWebPart.Scale.STANDARD_DEVIATIONS);
@@ -937,7 +925,7 @@ public class TargetedMSQCTest extends TargetedMSTest
         }
         else
             qcPlotsWebPart.closeBubble();
-        qcPlotsWebPart.waitForPlots(waitForPlotCount, true);
+        qcPlotsWebPart.waitForPlots(waitForPlotCount);
     }
 
     @LogMethod

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -299,7 +299,7 @@ public class TargetedMSQCTest extends TargetedMSTest
         assertElementPresent(qcPlotsWebPart.getLegendItemLocator("+/-3 x Std Dev", true));
 
         // test that plot0_plotType_1 (CUSUMm) does not change from linear
-        qcPlotsWebPart.checkPlotType(CUSUMm, true);
+        qcPlotsWebPart.checkPlotType(CUSUMm);
         qcPlotsWebPart.waitForPlots(2, true);
         initialSVGText = qcPlotsWebPart.getSVGPlotText("precursorPlot0_plotType_1");
         qcPlotsWebPart.setScale(QCPlotsWebPart.Scale.LOG);
@@ -364,8 +364,8 @@ public class TargetedMSQCTest extends TargetedMSTest
         List<QCPlotsWebPart.QCPlotType> selectedPlotTypes = new ArrayList<>();
         selectedPlotTypes.add(MovingRange);
         selectedPlotTypes.add(CUSUMm);
-        qcPlotsWebPart.checkPlotType(selectedPlotTypes.get(0), true);
-        qcPlotsWebPart.checkPlotType(selectedPlotTypes.get(1), true);
+        qcPlotsWebPart.checkPlotType(selectedPlotTypes.get(0));
+        qcPlotsWebPart.checkPlotType(selectedPlotTypes.get(1));
         qcPlotsWebPart.waitForPlots(2, true);
 
         // test plot type selection is persisted
@@ -433,16 +433,16 @@ public class TargetedMSQCTest extends TargetedMSTest
 
         log("Verify Plot Types and Legends");
         qcPlotsWebPart.checkAllPlotTypes(false);
-        qcPlotsWebPart.checkPlotType(LeveyJennings, true);
+        qcPlotsWebPart.checkPlotType(LeveyJennings);
         qcPlotsWebPart.waitForPlots(PRECURSORS.length, true);
 
-        qcPlotsWebPart.checkPlotType(MovingRange, true);
+        qcPlotsWebPart.checkPlotType(MovingRange);
         qcPlotsWebPart.waitForPlots(PRECURSORS.length * 2, true);
 
         assertElementNotPresent(qcPlotsWebPart.getLegendItemLocator("CUSUM Group", true));
 
-        qcPlotsWebPart.checkPlotType(CUSUMm, true);
-        qcPlotsWebPart.checkPlotType(QCPlotsWebPart.QCPlotType.CUSUMv, true);
+        qcPlotsWebPart.checkPlotType(CUSUMm);
+        qcPlotsWebPart.checkPlotType(QCPlotsWebPart.QCPlotType.CUSUMv);
         qcPlotsWebPart.waitForPlots(PRECURSORS.length * 4, true);
 
         assertElementPresent(qcPlotsWebPart.getLegendItemLocator("CUSUM Group", true));
@@ -473,7 +473,7 @@ public class TargetedMSQCTest extends TargetedMSTest
                 qcPlotsWebPart.waitForPlots();
             }
             qcPlotsWebPart.checkAllPlotTypes(false);
-            qcPlotsWebPart.checkPlotType(plotType, true);
+            qcPlotsWebPart.checkPlotType(plotType);
             qcPlotsWebPart.waitForPlots(1, false);
 
             testEachMultiSeriesQCPlot(plotType);
@@ -485,7 +485,7 @@ public class TargetedMSQCTest extends TargetedMSTest
     @LogMethod
     private void testEachMultiSeriesQCPlot(@LoggedParam QCPlotsWebPart.QCPlotType plotType)
     {
-        log("Test plot type " + plotType.getLongLabel());
+        log("Test plot type " + plotType.getLabel());
 
         String yLeftColor = "#66C2A5";
         String yRightColor = "#FC8D62";
@@ -677,7 +677,7 @@ public class TargetedMSQCTest extends TargetedMSTest
                 qcPlotsWebPart.waitForPlots();
             }
             qcPlotsWebPart.checkAllPlotTypes(false);
-            qcPlotsWebPart.checkPlotType(plotType, true);
+            qcPlotsWebPart.checkPlotType(plotType);
             qcPlotsWebPart.waitForPlots(1, false);
 
             testEachCombinedPlots(plotType);
@@ -727,7 +727,7 @@ public class TargetedMSQCTest extends TargetedMSTest
 
     private void testEachCombinedPlots(QCPlotsWebPart.QCPlotType plotType)
     {
-        log("Testing combined plot for " + plotType.getLongLabel());
+        log("Testing combined plot for " + plotType.getLabel());
         int count;
         int expectedNumPointsPerSeries = 47;
         if (plotType == CUSUMm || plotType == QCPlotsWebPart.QCPlotType.CUSUMv)
@@ -907,7 +907,7 @@ public class TargetedMSQCTest extends TargetedMSTest
         PanoramaDashboard qcDashboard = new PanoramaDashboard(this);
         QCPlotsWebPart qcPlotsWebPart = qcDashboard.getQcPlotsWebPart();
         log("Enabling Moving range along with Levey-Jennings");
-        qcPlotsWebPart.checkPlotType(MovingRange, true);
+        qcPlotsWebPart.checkPlotType(MovingRange);
         qcPlotsWebPart.waitForPlots(1, false);
 
         log("Verifying standard deviations plots");

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -301,7 +301,6 @@ public class TargetedMSQCTest extends TargetedMSTest
 
         // test that plot0_plotType_1 (CUSUMm) does not change from linear
         qcPlotsWebPart.checkPlotType(CUSUMm);
-        qcPlotsWebPart.waitForPlots(2);
         initialSVGText = qcPlotsWebPart.getSVGPlotText("precursorPlot0_plotType_1");
         qcPlotsWebPart.setScale(QCPlotsWebPart.Scale.LOG);
         assertTrue(initialSVGText.equals(qcPlotsWebPart.getSVGPlotText("precursorPlot0_plotType_1")));
@@ -468,6 +467,12 @@ public class TargetedMSQCTest extends TargetedMSTest
     @LogMethod
     private void testEachMultiSeriesQCPlot(@LoggedParam QCPlotsWebPart.QCPlotType plotType)
     {
+        if (!plotType.isStandardPointCount())
+        {
+            log("Skipping plot type " + plotType.getLabel());
+            return;
+        }
+
         log("Test plot type " + plotType.getLabel());
 
         String yLeftColor = "#66C2A5";
@@ -696,6 +701,12 @@ public class TargetedMSQCTest extends TargetedMSTest
 
     private void testEachCombinedPlots(QCPlotsWebPart qcPlotsWebPart, QCPlotsWebPart.QCPlotType plotType)
     {
+        if (!plotType.isStandardPointCount())
+        {
+            log("Skipping plot type " + plotType.getLabel());
+            return;
+        }
+
         log("Testing combined plot for " + plotType.getLabel());
         int count;
         int expectedNumPointsPerSeries = 47;

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -49,7 +49,9 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -360,20 +362,17 @@ public class TargetedMSQCTest extends TargetedMSTest
         assertEquals("Unexpected number of points for initial data date range", 21, count);
 
         // test plot type selection persistence
-        qcPlotsWebPart.checkAllPlotTypes(false);
-        List<QCPlotsWebPart.QCPlotType> selectedPlotTypes = new ArrayList<>();
+        Set<QCPlotsWebPart.QCPlotType> selectedPlotTypes = new HashSet<>();
         selectedPlotTypes.add(MovingRange);
         selectedPlotTypes.add(CUSUMm);
-        qcPlotsWebPart.checkPlotType(selectedPlotTypes.get(0));
-        qcPlotsWebPart.checkPlotType(selectedPlotTypes.get(1));
+        qcPlotsWebPart.setQCPlotTypes(selectedPlotTypes.toArray(QCPlotsWebPart.QCPlotType[]::new));
         qcPlotsWebPart.waitForPlots(2, true);
 
         // test plot type selection is persisted
         refresh();
         qcPlotsWebPart = qcDashboard.getQcPlotsWebPart();
         qcPlotsWebPart.waitForPlots(2, true);
-        assertEquals("QC Plot Type not round tripped as expected", true, qcPlotsWebPart.isPlotTypeSelected(selectedPlotTypes.get(0)));
-        assertEquals("QC Plot Type not round tripped as expected", true, qcPlotsWebPart.isPlotTypeSelected(selectedPlotTypes.get(1)));
+        assertEquals("QC Plot Type not round tripped as expected", selectedPlotTypes, qcPlotsWebPart.getCurrentQCPlotTypes());
 
         // impersonate a different user in this container and verify that initial form fields used
         impersonate(USER);
@@ -460,20 +459,9 @@ public class TargetedMSQCTest extends TargetedMSTest
 
         for (QCPlotsWebPart.QCPlotType plotType : QCPlotsWebPart.QCPlotType.values())
         {
-            qcPlotsWebPart.waitForPlots(1, false);
-            if (qcPlotsWebPart.isGroupXAxisValuesByDateChecked())
-            {
-                qcPlotsWebPart.setGroupXAxisValuesByDate(false);
-                qcPlotsWebPart.waitForPlots();
-            }
-            if (qcPlotsWebPart.isShowAllPeptidesInSinglePlotChecked())
-            {
-                qcPlotsWebPart.setShowAllPeptidesInSinglePlot(false, PRECURSORS.length);
-                qcPlotsWebPart.waitForPlots();
-            }
-            qcPlotsWebPart.checkAllPlotTypes(false);
-            qcPlotsWebPart.checkPlotType(plotType);
-            qcPlotsWebPart.waitForPlots(1, false);
+            qcPlotsWebPart.setGroupXAxisValuesByDate(false);
+            qcPlotsWebPart.setShowAllPeptidesInSinglePlot(false, PRECURSORS.length);
+            qcPlotsWebPart.setQCPlotTypes(plotType);
 
             testEachMultiSeriesQCPlot(plotType);
         }
@@ -663,21 +651,9 @@ public class TargetedMSQCTest extends TargetedMSTest
 
         for (QCPlotsWebPart.QCPlotType plotType : QCPlotsWebPart.QCPlotType.values())
         {
-            qcPlotsWebPart.waitForPlots(1, false);
-
-            if (qcPlotsWebPart.isShowAllPeptidesInSinglePlotChecked())
-            {
-                qcPlotsWebPart.setShowAllPeptidesInSinglePlot(false, PRECURSORS.length);
-                qcPlotsWebPart.waitForPlots();
-            }
-            if (qcPlotsWebPart.isGroupXAxisValuesByDateChecked())
-            {
-                qcPlotsWebPart.setGroupXAxisValuesByDate(false);
-                qcPlotsWebPart.waitForPlots();
-            }
-            qcPlotsWebPart.checkAllPlotTypes(false);
-            qcPlotsWebPart.checkPlotType(plotType);
-            qcPlotsWebPart.waitForPlots(1, false);
+            qcPlotsWebPart.setShowAllPeptidesInSinglePlot(false, PRECURSORS.length);
+            qcPlotsWebPart.setGroupXAxisValuesByDate(false);
+            qcPlotsWebPart.setQCPlotTypes(plotType);
 
             testEachCombinedPlots(plotType);
         }

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -432,8 +432,7 @@ public class TargetedMSQCTest extends TargetedMSTest
         QCPlotsWebPart qcPlotsWebPart = qcDashboard.getQcPlotsWebPart();
 
         log("Verify Plot Types and Legends");
-        qcPlotsWebPart.checkAllPlotTypes(false);
-        qcPlotsWebPart.checkPlotType(LeveyJennings);
+        qcPlotsWebPart.setQCPlotTypes(LeveyJennings);
         qcPlotsWebPart.waitForPlots(PRECURSORS.length, true);
 
         qcPlotsWebPart.checkPlotType(MovingRange);

--- a/webapp/TargetedMS/js/BaseQCPlotPanel.js
+++ b/webapp/TargetedMS/js/BaseQCPlotPanel.js
@@ -19,13 +19,11 @@ Ext4.define('LABKEY.targetedms.BaseQCPlotPanel', {
         return undefined;
     },
 
-    isMultiSeries : function(metricId)
-    {
+    isMultiSeries : function(metricId) {
         var metric = Ext4.isNumber(this.metric) ? this.metric : metricId;
-        if (Ext4.isNumber(metric))
-        {
+        if (Ext4.isNumber(metric)) {
             var metricProps = this.getMetricPropsById(metric);
-            if(metricProps) {
+            if (metricProps) {
                 return Ext4.isDefined(metricProps.series2SchemaName) && Ext4.isDefined(metricProps.series2QueryName);
             }
         }

--- a/webapp/TargetedMS/js/LeveyJenningsPlotHelper.js
+++ b/webapp/TargetedMS/js/LeveyJenningsPlotHelper.js
@@ -12,8 +12,7 @@ Ext4.define("LABKEY.targetedms.LeveyJenningsPlotHelper", {
         }
     },
 
-    processLJGuideSetData : function(plotDataRows)
-    {
+    processLJGuideSetData : function(plotDataRows) {
         this.guideSetDataMap = {};
         this.defaultGuideSet = {};
         Ext4.each(plotDataRows, function(plotDataRow) {
@@ -64,8 +63,7 @@ Ext4.define("LABKEY.targetedms.LeveyJenningsPlotHelper", {
     setLJSeriesMinMax: function(dataObject, row) {
         // track the min and max data so we can get the range for including the QC annotations
         var val = row['value'];
-        if (LABKEY.vis.isValid(val))
-        {
+        if (LABKEY.vis.isValid(val)) {
             if (dataObject.min == null || val < dataObject.min) {
                 dataObject.min = val;
             }
@@ -73,8 +71,7 @@ Ext4.define("LABKEY.targetedms.LeveyJenningsPlotHelper", {
                 dataObject.max = val;
             }
 
-            if (this.yAxisScale == 'log' && val <= 0)
-            {
+            if (this.yAxisScale == 'log' && val <= 0) {
                 dataObject.showLogInvalid = true;
             }
 
@@ -82,11 +79,9 @@ Ext4.define("LABKEY.targetedms.LeveyJenningsPlotHelper", {
             var sd = LABKEY.vis.isValid(row['stdDev']) ? row['stdDev'] : 0;
 
             // Issue 28462: don't include the +/-3 stddev error bars in min/max calculation when it isn't being plotted
-            if (!this.singlePlot && LABKEY.vis.isValid(mean))
-            {
+            if (!this.singlePlot && LABKEY.vis.isValid(mean)) {
                 var minSd = (mean - (3 * sd));
-                if (dataObject.showLogInvalid == undefined && this.yAxisScale == 'log' && minSd <= 0)
-                {
+                if (dataObject.showLogInvalid == undefined && this.yAxisScale == 'log' && minSd <= 0) {
                     // Avoid setting our scale to be negative based on the three standard deviations to avoid messing up log plots
                     dataObject.showLogWarning = true;
                     for (var i = 2; i >= 0; i--)
@@ -106,32 +101,26 @@ Ext4.define("LABKEY.targetedms.LeveyJenningsPlotHelper", {
                 }
             }
         }
-        else if (this.isMultiSeries())
-        {
+        else if (this.isMultiSeries()) {
             // check if either of the y-axis metric values are invalid for a log scale
             var val1 = row['value_series1'],
                     val2 = row['value_series2'];
-            if (dataObject.showLogInvalid == undefined && this.yAxisScale == 'log')
-            {
-                if ((LABKEY.vis.isValid(val1) && val1 <= 0) || (LABKEY.vis.isValid(val2) && val2 <= 0))
-                {
+            if (dataObject.showLogInvalid == undefined && this.yAxisScale == 'log') {
+                if ((LABKEY.vis.isValid(val1) && val1 <= 0) || (LABKEY.vis.isValid(val2) && val2 <= 0)) {
                     dataObject.showLogInvalid = true;
                 }
             }
         }
     },
 
-    getLJPlotTypeProperties: function(precursorInfo)
-    {
+    getLJPlotTypeProperties: function(precursorInfo) {
         var plotProperties = {};
         // some properties are specific to whether or not we are showing multiple y-axis series
-        if (this.isMultiSeries())
-        {
+        if (this.isMultiSeries()) {
             plotProperties['value'] = 'value_series1';
             plotProperties['valueRight'] = 'value_series2';
         }
-        else
-        {
+        else {
             plotProperties['value'] = 'value';
             plotProperties['mean'] = 'mean';
             plotProperties['stdDev'] = 'stdDev';
@@ -140,8 +129,7 @@ Ext4.define("LABKEY.targetedms.LeveyJenningsPlotHelper", {
         return plotProperties;
     },
 
-    getLJInitFragmentPlotData: function()
-    {
+    getLJInitFragmentPlotData: function() {
         return {
             min: null,
             max: null

--- a/webapp/TargetedMS/js/LeveyJenningsPlotHelper.js
+++ b/webapp/TargetedMS/js/LeveyJenningsPlotHelper.js
@@ -140,23 +140,19 @@ Ext4.define("LABKEY.targetedms.LeveyJenningsPlotHelper", {
     {
         var data = {};
         // if a guideSetId is defined for this row, include the guide set stats values in the data object
-        if (Ext4.isDefined(row['GuideSetId']) && row['GuideSetId'] > 0)
-        {
+        if (Ext4.isDefined(row['GuideSetId']) && row['GuideSetId'] > 0) {
             var gs = this.guideSetDataMap[row['GuideSetId']];
-            if (Ext4.isDefined(gs) && gs.Series[fragment]&& gs.Series[fragment][seriesType])
-            {
+            if (Ext4.isDefined(gs) && gs.Series[fragment]&& gs.Series[fragment][seriesType]) {
                 data['mean'] = gs.Series[fragment][seriesType]['Mean'];
                 data['stdDev'] = gs.Series[fragment][seriesType]['StdDev'];
             }
         }
 
-        if (this.isMultiSeries())
-        {
+        if (this.isMultiSeries()) {
             data['value_' + seriesType] = row['Value'];
             data['value_' + seriesType + 'Title'] = metricProps[seriesType + 'Label'];
         }
-        else
-        {
+        else {
             data['value'] = row['Value'];
         }
         return data;

--- a/webapp/TargetedMS/js/PlotTypeCheckCombo.js
+++ b/webapp/TargetedMS/js/PlotTypeCheckCombo.js
@@ -1,0 +1,139 @@
+/**
+ * Adapted from:
+ * http://www.sencha.com/forum/showthread.php?198862-Ext.ux.CheckCombo
+ *
+ * however, it has been substantially changed
+ */
+
+Ext4.define('LABKEY.layout.component.BoundList', {
+    extend: 'Ext.layout.component.BoundList',
+    alias: 'layout.boundlist-checkbox',
+    beginLayout: function(ownerContext){
+        this.callParent(arguments);
+        ownerContext.listContext = ownerContext.getEl('outerEl');
+    },
+    measureContentHeight: function(ownerContext) {
+        return this.owner.outerEl.getHeight();
+    }
+});
+
+Ext4.define('Ext.ux.CheckCombo', {
+    extend: 'Ext.form.field.ComboBox',
+    alias: 'widget.plottype-checkcombo',
+    multiSelect: true,
+    addAllSelector: false,
+    allText: 'All',
+    delim: ';',
+
+    initComponent: function() {
+//        this.plugins = this.plugins || [];
+//        this.plugins.push('combo-autowidth');
+        this.listConfig = this.listConfig || {};
+        Ext4.apply(this.listConfig, {
+            tpl: new Ext4.XTemplate(
+                    '<ul><tpl for=".">',
+                    '<li role="option" class="' + Ext4.baseCSSPrefix + 'boundlist-item" onmouseover="createPlotTypeTooltip(event.currentTarget, event.target.textContent)" onmouseout="destroyPlotTypeTooltip()"><span class="' + Ext4.baseCSSPrefix + 'combo-checker"></span>',
+                    '&nbsp;{[this.getDisplayText(values, "' + this.displayField + '", "' + (Ext4.isDefined(this.nullCaption) ? this.nullCaption : "[none]") + '")]}',
+                    '</li></tpl></ul>',
+                    {
+                        getDisplayText : function (values, displayField, nullCaption) {
+                            var text;
+                            if (typeof values === "string") {
+                                text = values;
+                            } else {
+                                if (Ext4.isDefined(values[displayField]) && values[displayField] != null)
+                                    text = values[displayField];
+                                else
+                                    text = nullCaption;
+                            }
+                            return Ext4.util.Format.htmlEncode(text);
+                        }
+                    }
+            ),
+            childEls: [
+                'listEl',
+                'outerEl',
+                'checkAllEl'
+            ],
+            renderTpl: [
+                '<div id="{id}-outerEl" style="overflow:auto" width=auto;>',
+                (this.addAllSelector ? '<div id="{id}-checkAllEl" class="' + Ext4.baseCSSPrefix + 'boundlist-item" role="option"><span class="' + Ext4.baseCSSPrefix + 'combo-checker">&nbsp;</span> '+this.allText+'</div>' : ''),
+                '<div id="{id}-listEl" class="{baseCls}-list-ct"></div>',
+                '{%',
+                'var me=values.$comp, pagingToolbar=me.pagingToolbar;',
+                'if (pagingToolbar) {',
+                'pagingToolbar.ownerLayout = me.componentLayout;',
+                'Ext4.DomHelper.generateMarkup(pagingToolbar.getRenderTree(), out);',
+                '}',
+                '%}',
+                '</div>',
+                {
+                    disableFormats: true
+                }
+            ],
+            componentLayout: 'boundlist-checkbox',
+            onDestroy: function() {
+                Ext4.destroyMembers(this, 'pagingToolbar', 'outerEl', 'listEl');
+                this.callParent();
+            }
+        });
+
+        this.callParent();
+    },
+
+
+
+
+    createPicker: function()
+    {
+        var picker = this.callParent(arguments);
+        picker.on('render', function(picker){
+            if (picker.checkAllEl)
+            {
+                picker.checkAllEl.addClsOnOver(Ext4.baseCSSPrefix + 'boundlist-item-over');
+
+                picker.checkAllEl.on('click', function(e)
+                {
+                    if(picker.checkAllEl.hasCls(Ext4.baseCSSPrefix + 'boundlist-selected'))
+                    {
+                        picker.checkAllEl.removeCls(Ext4.baseCSSPrefix + 'boundlist-selected');
+                        this.setValue('');
+                        this.fireEvent('select', this, []);
+                    }
+                    else
+                    {
+                        var records = [];
+                        this.store.clearFilter();  //if the user has typed text, this can filter the store, causing it to select all visible, rather than selecting all
+                        this.store.each(function(record)
+                        {
+                            records.push(record);
+                        });
+                        this.select(records);
+                        picker.checkAllEl.addCls(Ext4.baseCSSPrefix + 'boundlist-selected');
+                        this.fireEvent('select', this, records);
+                    }
+                }, this);
+            }
+        }, this, {single: true});
+        return picker;
+    },
+
+    getSubmitValue: function()
+    {
+        return this.getValue();
+    },
+
+    onListSelectionChange: function(list, selectedRecords)
+    {
+        this.callParent(arguments);
+
+        var checker = this.getPicker().checkAllEl;
+        if(checker)
+        {
+            if(selectedRecords.length == this.store.getTotalCount())
+                checker.addCls(Ext4.baseCSSPrefix + 'boundlist-selected');
+            else
+                checker.removeCls(Ext4.baseCSSPrefix + 'boundlist-selected');
+        }
+    }
+});

--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -740,7 +740,13 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
     },
 
     addEachIndividualPrecursorPlot: function(plotIndex, id, precursorIndex, precursorInfo, metricProps, plotType, isCUSUMMean, scope) {
-        if (this.yAxisScale == 'log' && plotType != LABKEY.vis.TrendingLinePlotType.LeveyJennings && plotType != LABKEY.vis.TrendingLinePlotType.CUSUM) {
+        if ((plotType === LABKEY.vis.TrendingLinePlotType.TrailingMean ||
+                plotType === LABKEY.vis.TrendingLinePlotType.TrailingCV)
+                && this.trailingRuns >= this.runs) {
+            Ext4.get(id).update("<span class='labkey-error'> " + plotType + " - The number you entered is larger than the number of available runs. Only " + this.runs + " runs are used for calculation</span>");
+            return;
+        }
+        else if (this.yAxisScale == 'log' && plotType != LABKEY.vis.TrendingLinePlotType.LeveyJennings && plotType != LABKEY.vis.TrendingLinePlotType.CUSUM) {
             Ext4.get(id).update("<span style='font-style: italic;'>Values that are 0 have been replaced with 0.0000001 for log scale plot.</span>");
         }
         else if (precursorInfo.showLogInvalid && plotType !== LABKEY.vis.TrendingLinePlotType.CUSUM) {

--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -740,9 +740,9 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
     },
 
     addEachIndividualPrecursorPlot: function(plotIndex, id, precursorIndex, precursorInfo, metricProps, plotType, isCUSUMMean, scope) {
-        if ((plotType === LABKEY.vis.TrendingLinePlotType.TrailingMean ||
-                plotType === LABKEY.vis.TrendingLinePlotType.TrailingCV)
-                && this.trailingRuns >= this.runs) {
+        let trailingMeanORCVPlot = plotType === LABKEY.vis.TrendingLinePlotType.TrailingMean ||
+                plotType === LABKEY.vis.TrendingLinePlotType.TrailingCV;
+        if (trailingMeanORCVPlot && this.trailingRuns >= this.runs) {
             Ext4.get(id).update("<span class='labkey-error'> " + plotType + " - The number you entered is larger than the number of available runs. Only " + this.runs + " runs are used for calculation</span>");
             return;
         }
@@ -862,7 +862,9 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
         var plot = LABKEY.vis.TrendingLinePlot(plotConfig);
         plot.render();
 
-        this.addAnnotationsToPlot(plot, precursorInfo);
+        if (!trailingMeanORCVPlot) {
+            this.addAnnotationsToPlot(plot, precursorInfo);
+        }
 
         this.addGuideSetTrainingRangeToPlot(plot, precursorInfo);
 

--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -742,9 +742,15 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
     addEachIndividualPrecursorPlot: function(plotIndex, id, precursorIndex, precursorInfo, metricProps, plotType, isCUSUMMean, scope) {
         let trailingMeanORCVPlot = plotType === LABKEY.vis.TrendingLinePlotType.TrailingMean ||
                 plotType === LABKEY.vis.TrendingLinePlotType.TrailingCV;
-        if (trailingMeanORCVPlot && this.trailingRuns >= this.runs) {
-            Ext4.get(id).update("<span class='labkey-error'> " + plotType + " - The number you entered is larger than the number of available runs. Only " + this.runs + " runs are used for calculation</span>");
-            return;
+        if (trailingMeanORCVPlot) {
+            if (this.trailingRuns >= this.runs) {
+                Ext4.get(id).update("<span class='labkey-error'> " + plotType + " - The number you entered is larger than the number of available runs. Only " + this.runs + " runs are used for calculation</span>");
+                return;
+            }
+            else if (this.trailingRuns <= 2) {
+                Ext4.get(id).update("<span class='labkey-error'> " + plotType + " - Please enter a positive integer (>2) that is less than or equal to total number of available runs - " + this.runs + " </span>");
+                return;
+            }
         }
         else if (this.yAxisScale == 'log' && plotType != LABKEY.vis.TrendingLinePlotType.LeveyJennings && plotType != LABKEY.vis.TrendingLinePlotType.CUSUM) {
             Ext4.get(id).update("<span style='font-style: italic;'>Values that are 0 have been replaced with 0.0000001 for log scale plot.</span>");

--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -740,16 +740,13 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
     },
 
     addEachIndividualPrecursorPlot: function(plotIndex, id, precursorIndex, precursorInfo, metricProps, plotType, isCUSUMMean, scope) {
-        if (this.yAxisScale == 'log' && plotType != LABKEY.vis.TrendingLinePlotType.LeveyJennings && plotType != LABKEY.vis.TrendingLinePlotType.CUSUM)
-        {
+        if (this.yAxisScale == 'log' && plotType != LABKEY.vis.TrendingLinePlotType.LeveyJennings && plotType != LABKEY.vis.TrendingLinePlotType.CUSUM) {
             Ext4.get(id).update("<span style='font-style: italic;'>Values that are 0 have been replaced with 0.0000001 for log scale plot.</span>");
         }
-        else if (precursorInfo.showLogInvalid && plotType !== LABKEY.vis.TrendingLinePlotType.CUSUM)
-        {
+        else if (precursorInfo.showLogInvalid && plotType !== LABKEY.vis.TrendingLinePlotType.CUSUM) {
             this.showInvalidLogMsg(id, true);
         }
-        else if (precursorInfo.showLogWarning && plotType !== LABKEY.vis.TrendingLinePlotType.CUSUM)
-        {
+        else if (precursorInfo.showLogWarning && plotType !== LABKEY.vis.TrendingLinePlotType.CUSUM) {
             Ext4.get(id).update("<span style='font-style: italic;'>For log scale, standard deviations below "
                     + "the mean with negative values have been omitted.</span>");
         }

--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -169,7 +169,7 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
         if (this.showLJPlot()) {
             this.processLJGuideSetData(plotDataRows);
         }
-        if (this.showMovingRangePlot() || this.showMeanCUSUMPlot() || this.showVariableCUSUMPlot()) {
+        if (this.showMovingRangePlot() || this.showMeanCUSUMPlot() || this.showVariableCUSUMPlot() || this.showTrailingMeanPlot() || this.showTrailingCVPlot()) {
             this.processRawGuideSetData(plotDataRows);
         }
 

--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -6,37 +6,39 @@
 Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
 
     statics: {
-        qcPlotTypes : ['Levey-Jennings', 'Moving Range', 'CUSUMm', 'CUSUMv'],
+        qcPlotTypes : ['Levey-Jennings', 'Moving Range', 'CUSUMm', 'CUSUMv', 'Trailing CV', 'Trailing Mean'],
         maxPointsPerSeries : 300,
     },
 
-    showLJPlot: function()
-    {
+    showLJPlot: function() {
         return this.isPlotTypeSelected('Levey-Jennings');
     },
 
-    showMovingRangePlot: function()
-    {
+    showMovingRangePlot: function() {
         return this.isPlotTypeSelected('Moving Range');
     },
 
-    showMeanCUSUMPlot: function()
-    {
+    showMeanCUSUMPlot: function() {
         return this.isPlotTypeSelected('CUSUMm');
     },
 
-    showVariableCUSUMPlot: function()
-    {
+    showVariableCUSUMPlot: function() {
         return this.isPlotTypeSelected('CUSUMv');
     },
 
-    isPlotTypeSelected: function(plotType)
-    {
+    isPlotTypeSelected: function(plotType) {
         return this.plotTypes.indexOf(plotType) > -1;
     },
 
-    getGuideSetDataObj : function(row)
-    {
+    showTrailingMeanPlot: function() {
+        return this.isPlotTypeSelected('Trailing Mean');
+    },
+
+    showTrailingCVPlot: function() {
+        return this.isPlotTypeSelected('Trailing CV');
+    },
+
+    getGuideSetDataObj : function(row) {
         var guideSet = {
             ReferenceEnd: row['ReferenceEnd'],
             TrainingEnd: row['TrainingEnd'],
@@ -101,6 +103,8 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
     },
 
     getPlotsData: function() {
+        // get input number N
+        // pass includeTrailingCV or includeTrailingMean in plotsConfig
         var plotsConfig = {};
         plotsConfig.metricId = this.metric;
         plotsConfig.includeLJ = this.showLJPlot();
@@ -111,6 +115,9 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
         // show reference guide set for custom date range
         plotsConfig.showReferenceGS = this.showReferenceGS && this.dateRangeOffset !== 0;
         plotsConfig.showExcludedPrecursors = this.showExcludedPrecursors;
+        plotsConfig.trailingRuns = this.trailingRuns;
+        plotsConfig.includeTrailingMeanPlot = this.showTrailingMeanPlot();
+        plotsConfig.includeTrailingCVPlot = this.showTrailingCVPlot();
 
         var config = this.getReportConfig()
 
@@ -129,6 +136,7 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
             plotsConfig.endDate = config.EndDate;
         }
 
+        // pass input number N to plotsConfig
         LABKEY.Ajax.request({
             url: LABKEY.ActionURL.buildURL('targetedms', 'GetQCPlotsData.api'),
             success: function(response) {
@@ -602,6 +610,12 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
         if (plotType !== LABKEY.vis.TrendingLinePlotType.MovingRange && plotType !== LABKEY.vis.TrendingLinePlotType.LeveyJennings) {
             yScaleLabel = 'Sum of Deviations'
         }
+        if (plotType === LABKEY.vis.TrendingLinePlotType.TrailingMean) {
+            yScaleLabel = label;
+        }
+        if (plotType === LABKEY.vis.TrendingLinePlotType.TrailingCV) {
+            yScaleLabel = 'CV (%)';
+        }
         else if (conversion) {
             var options = this.getYAxisOptions();
             for (var i = 0; i < options.data.length; i++) {
@@ -772,16 +786,13 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
         Ext4.apply(trendLineProps, this.getPlotTypeProperties(precursorInfo, plotType, isCUSUMMean));
 
         var plotLegendData = this.getAdditionalPlotLegend(plotType);
-        if (Ext4.isArray(this.legendData))
-        {
+        if (Ext4.isArray(this.legendData)) {
             plotLegendData = plotLegendData.concat(this.legendData);
         }
 
-        if (plotLegendData && plotLegendData.length > 0)
-        {
-            Ext4.each(plotLegendData, function(legend){
-                if (legend.text && legend.text.length > 0)
-                {
+        if (plotLegendData && plotLegendData.length > 0) {
+            Ext4.each(plotLegendData, function(legend) {
+                if (legend.text && legend.text.length > 0) {
                     if ( !this.longestLegendText || (this.longestLegendText && legend.text.length > this.longestLegendText))
                         this.longestLegendText = legend.text.length;
                 }

--- a/webapp/TargetedMS/js/QCPlotHelperWrapper.js
+++ b/webapp/TargetedMS/js/QCPlotHelperWrapper.js
@@ -7,47 +7,49 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperWrapper", {
     mixins: {
         leveyJennings: 'LABKEY.targetedms.LeveyJenningsPlotHelper',
         cusum: 'LABKEY.targetedms.CUSUMPlotHelper',
-        movingRange: 'LABKEY.targetedms.MovingRangePlotHelper'
+        movingRange: 'LABKEY.targetedms.MovingRangePlotHelper',
+        trailingMean: 'LABKEY.targetedms.TrailingMeanPlotHelper',
+        trailingCV: 'LABKEY.targetedms.TrailingMeanCVHelper'
     },
 
     statics: {
-        getQCPlotTypeLabel: function(visPlotType, isCUSUMMean)
-        {
-            if (visPlotType == LABKEY.vis.TrendingLinePlotType.MovingRange)
+        getQCPlotTypeLabel: function(visPlotType, isCUSUMMean) {
+            if (visPlotType === LABKEY.vis.TrendingLinePlotType.MovingRange)
                 return 'Moving Range';
-            else if (visPlotType == LABKEY.vis.TrendingLinePlotType.CUSUM)
-            {
+            else if (visPlotType === LABKEY.vis.TrendingLinePlotType.CUSUM) {
                 if (isCUSUMMean)
                     return 'CUSUMm';
                 else
                     return 'CUSUMv';
+            }
+            else if (visPlotType === LABKEY.vis.TrendingLinePlotType.TrailingMean) {
+                return 'Trailing Mean';
+            }
+            else if (visPlotType === LABKEY.vis.TrendingLinePlotType.TrailingCV) {
+                return 'Trailing CV';
             }
             else
                 return 'Levey-Jennings';
         }
     },
 
-    addIndividualPrecursorPlots : function()
-    {
+    addIndividualPrecursorPlots : function() {
         var addedPlot = false,
                 metricProps = this.getMetricPropsById(this.metric),
                 me = this; // for plot brushing
 
         this.longestLegendText = 0;
 
-        for (var i = 0; i < this.precursors.length; i++)
-        {
+        for (var i = 0; i < this.precursors.length; i++) {
             var precursorInfo = this.fragmentPlotData[this.precursors[i]];
 
             // We don't necessarily have info for all possible precursors, depending on the filters and plot type
-            if (precursorInfo)
-            {
+            if (precursorInfo) {
                 addedPlot = true;
 
                 var id = this.plotDivId + "-precursorPlot" + i;
                 var ids = [id];
-                for (var j = 1; j < this.plotTypes.length; j++)
-                {
+                for (var j = 1; j < this.plotTypes.length; j++) {
                     ids.push(id + '_plotType_' + j);
                 }
 
@@ -55,21 +57,23 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperWrapper", {
 
                 var plotIndex = 0;
                 // add a new panel for each plot so we can add the title to the frame
-                if (this.showLJPlot())
-                {
+                if (this.showLJPlot()) {
                     this.addEachIndividualPrecursorPlot(plotIndex, ids[plotIndex++], i, precursorInfo, metricProps, LABKEY.vis.TrendingLinePlotType.LeveyJennings, undefined, me);
                 }
-                if (this.showMovingRangePlot())
-                {
+                if (this.showMovingRangePlot()) {
                     this.addEachIndividualPrecursorPlot(plotIndex, ids[plotIndex++], i, precursorInfo, metricProps, LABKEY.vis.TrendingLinePlotType.MovingRange, undefined, me);
                 }
-                if (this.showMeanCUSUMPlot())
-                {
+                if (this.showMeanCUSUMPlot()) {
                     this.addEachIndividualPrecursorPlot(plotIndex, ids[plotIndex++], i, precursorInfo, metricProps, LABKEY.vis.TrendingLinePlotType.CUSUM, true, me);
                 }
-                if (this.showVariableCUSUMPlot())
-                {
+                if (this.showVariableCUSUMPlot()) {
                     this.addEachIndividualPrecursorPlot(plotIndex, ids[plotIndex], i, precursorInfo, metricProps, LABKEY.vis.TrendingLinePlotType.CUSUM, false, me);
+                }
+                if (this.showTrailingMeanPlot()) {
+                    this.addEachIndividualPrecursorPlot(plotIndex, ids[plotIndex++], i, precursorInfo, metricProps, LABKEY.vis.TrendingLinePlotType.TrailingMean, undefined, me);
+                }
+                if (this.showTrailingCVPlot()) {
+                    this.addEachIndividualPrecursorPlot(plotIndex, ids[plotIndex++], i, precursorInfo, metricProps, LABKEY.vis.TrendingLinePlotType.TrailingCV, undefined, me);
                 }
             }
         }
@@ -164,6 +168,8 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperWrapper", {
         {
             this.addEachCombinedPrecursorPlot(plotIndex, ids[plotIndex], combinePlotData, groupColors, yAxisCount, metricProps, showLogInvalid, legendMargin, LABKEY.vis.TrendingLinePlotType.CUSUM, false);
         }
+        // if this.showTrailingMean
+        // if this.showTrailingCV
 
         return true;
     },
@@ -178,14 +184,21 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperWrapper", {
             this.setCUSUMSeriesMinMax(dataObject, row, true);
         if (this.showVariableCUSUMPlot())
             this.setCUSUMSeriesMinMax(dataObject, row, false);
+        if (this.showTrailingMeanPlot())
+            this.setTrailingMeanMinMax(dataObject, row);
+        if (this.showTrailingCVPlot())
+            this.setTrailingCVMinMax(dataObject, row);
     },
 
-    getPlotTypeProperties: function(precursorInfo, plotType, isMean)
-    {
+    getPlotTypeProperties: function(precursorInfo, plotType, isMean) {
         if (plotType === LABKEY.vis.TrendingLinePlotType.MovingRange)
             return this.getMovingRangePlotTypeProperties(precursorInfo);
         else if (plotType === LABKEY.vis.TrendingLinePlotType.CUSUM)
             return this.getCUSUMPlotTypeProperties(precursorInfo, isMean);
+        else if (plotType === LABKEY.vis.TrendingLinePlotType.TrailingMean)
+            return this.getTrailingMeanPlotTypeProperties(precursorInfo);
+        else if (plotType === LABKEY.vis.TrendingLinePlotType.TrailingCV)
+            return this.getTrailingCVPlotTypeProperties(precursorInfo);
         else
             return this.getLJPlotTypeProperties(precursorInfo);
     },
@@ -205,25 +218,27 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperWrapper", {
         return fragmentData;
     },
 
-    getInitPlotMinMaxData: function()
-    {
+    getInitPlotMinMaxData: function() {
         var plotData = {};
-        if (this.showLJPlot())
-        {
+        if (this.showLJPlot()) {
             Ext4.apply(plotData, this.getLJInitFragmentPlotData());
         }
-        if (this.showMovingRangePlot())
-        {
+        if (this.showMovingRangePlot()) {
             Ext4.apply(plotData, this.getMRInitFragmentPlotData());
         }
-        if (this.showMeanCUSUMPlot())
-        {
+        if (this.showMeanCUSUMPlot()) {
             Ext4.apply(plotData, this.getCUSUMInitFragmentPlotData(true));
         }
-        if (this.showVariableCUSUMPlot())
-        {
+        if (this.showVariableCUSUMPlot()) {
             Ext4.apply(plotData, this.getCUSUMInitFragmentPlotData(false));
         }
+        if (this.showTrailingMeanPlot()) {
+            Ext4.apply(plotData, this.getTrailingMeanInitFragmentPlotData());
+        }
+        if (this.showTrailingCVPlot()) {
+            Ext4.apply(plotData, this.getTrailingCVInitFragmentPlotData());
+        }
+
         return plotData;
     },
 
@@ -258,11 +273,9 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperWrapper", {
         };
 
         // if a guideSetId is defined for this row, include the guide set stats values in the data object
-        if (Ext4.isDefined(row['GuideSetId']) && row['GuideSetId'] > 0)
-        {
+        if (Ext4.isDefined(row['GuideSetId']) && row['GuideSetId'] > 0) {
             var gs = this.guideSetDataMap[row['GuideSetId']];
-            if (Ext4.isDefined(gs) && gs.Series[fragment])
-            {
+            if (Ext4.isDefined(gs) && gs.Series[fragment]) {
                 data['guideSetId'] = row['GuideSetId'];
                 data['inGuideSetTrainingRange'] = row['InGuideSetTrainingRange'];
                 data['groupedXTick'] = data['groupedXTick'] + '|'
@@ -271,22 +284,25 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperWrapper", {
             }
         }
 
-        if (this.showLJPlot())
-        {
+        if (this.showLJPlot()) {
             Ext4.apply(data, this.processLJPlotDataRow(row, fragment, seriesType, metricProps));
         }
-        if (this.showMovingRangePlot())
-        {
+        if (this.showMovingRangePlot()) {
             Ext4.apply(data, this.processMRPlotDataRow(row, fragment, seriesType, metricProps));
         }
-        if (this.showMeanCUSUMPlot())
-        {
+        if (this.showMeanCUSUMPlot()) {
             Ext4.apply(data, this.processCUSUMPlotDataRow(row, fragment, seriesType, metricProps, true));
         }
-        if (this.showVariableCUSUMPlot())
-        {
+        if (this.showVariableCUSUMPlot()) {
             Ext4.apply(data, this.processCUSUMPlotDataRow(row, fragment, seriesType, metricProps, false));
         }
+        if (this.showTrailingMeanPlot()) {
+            Ext4.apply(data, this.processTrailingMeanPlotDataRow(row, fragment, seriesType, metricProps));
+        }
+        if (this.showTrailingCVPlot()) {
+            Ext4.apply(data, this.processTrailingCVPlotDataRow(row, fragment, seriesType, metricProps));
+        }
+
 
         return data;
     },
@@ -351,6 +367,8 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperWrapper", {
             return LABKEY.targetedms.CUSUMPlotHelper.tooltips['CUSUMm'];
         else if (plotTypeName == 'CUSUMv')
             return LABKEY.targetedms.CUSUMPlotHelper.tooltips['CUSUMv'];
+        else if (plotTypeName === 'Trailing Mean')
+            return LABKEY.targetedms.TrailingMeanPlotHelper.tooltips['Trailing Mean'];
         return '';
     }
 });

--- a/webapp/TargetedMS/js/QCPlotHelperWrapper.js
+++ b/webapp/TargetedMS/js/QCPlotHelperWrapper.js
@@ -101,8 +101,7 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperWrapper", {
         }
 
         // traverse the precursor list for: calculating the longest legend string and combine the plot data
-        for (var i = 0; i < this.precursors.length; i++)
-        {
+        for (var i = 0; i < this.precursors.length; i++) {
             precursorInfo = this.fragmentPlotData[this.precursors[i]];
             // We may not have a match if it's been filtered out - see issue 38720
             if (precursorInfo) {
@@ -135,8 +134,7 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperWrapper", {
         }
         var id = 'combinedPlot';
         var ids = [id];
-        for (var i = 1; i < this.plotTypes.length; i++)
-        {
+        for (var i = 1; i < this.plotTypes.length; i++) {
             ids.push(id + 'plotType' + i.toString());
         }
         this.addPlotsToPlotDiv(ids, 'All Series', this.plotDivId, 'qc-plot-wp');
@@ -152,24 +150,25 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperWrapper", {
         if (legendMargin > 300)
             legendMargin = 300;
 
-        if (this.showLJPlot())
-        {
+        if (this.showLJPlot()) {
             this.addEachCombinedPrecursorPlot(plotIndex, ids[plotIndex++], combinePlotData, groupColors, yAxisCount, metricProps, showLogInvalid, legendMargin, LABKEY.vis.TrendingLinePlotType.LeveyJennings);
         }
-        if (this.showMovingRangePlot())
-        {
+        if (this.showMovingRangePlot()) {
             this.addEachCombinedPrecursorPlot(plotIndex, ids[plotIndex++], combinePlotData, groupColors, yAxisCount, metricProps, showLogInvalid, legendMargin, LABKEY.vis.TrendingLinePlotType.MovingRange);
         }
-        if (this.showMeanCUSUMPlot())
-        {
+        if (this.showMeanCUSUMPlot()) {
             this.addEachCombinedPrecursorPlot(plotIndex, ids[plotIndex++], combinePlotData, groupColors, yAxisCount, metricProps, showLogInvalid, legendMargin, LABKEY.vis.TrendingLinePlotType.CUSUM, true);
         }
-        if (this.showVariableCUSUMPlot())
-        {
+        if (this.showVariableCUSUMPlot()) {
             this.addEachCombinedPrecursorPlot(plotIndex, ids[plotIndex], combinePlotData, groupColors, yAxisCount, metricProps, showLogInvalid, legendMargin, LABKEY.vis.TrendingLinePlotType.CUSUM, false);
         }
-        // if this.showTrailingMean
-        // if this.showTrailingCV
+        if (this.showTrailingMeanPlot()) {
+            this.addEachCombinedPrecursorPlot(plotIndex, ids[plotIndex], combinePlotData, groupColors, yAxisCount, metricProps, showLogInvalid, legendMargin, LABKEY.vis.TrendingLinePlotType.TrailingMean, false);
+        }
+        if (this.showTrailingCVPlot()) {
+            this.addEachCombinedPrecursorPlot(plotIndex, ids[plotIndex], combinePlotData, groupColors, yAxisCount, metricProps, showLogInvalid, legendMargin, LABKEY.vis.TrendingLinePlotType.TrailingCV, false);
+        }
+
 
         return true;
     },

--- a/webapp/TargetedMS/js/QCPlotHelperWrapper.js
+++ b/webapp/TargetedMS/js/QCPlotHelperWrapper.js
@@ -355,15 +355,14 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperWrapper", {
         return [];
     },
 
-    getPlotTypeHelpTooltip: function(plotTypeName)
-    {
-        if (plotTypeName == 'Levey-Jennings')
+    getPlotTypeHelpTooltip: function(plotTypeName) {
+        if (plotTypeName === 'Levey-Jennings')
             return LABKEY.targetedms.LeveyJenningsPlotHelper.tooltips['Levey-Jennings'];
-        else if (plotTypeName == 'Moving Range')
+        else if (plotTypeName === 'Moving Range')
             return LABKEY.targetedms.MovingRangePlotHelper.tooltips['Moving Range'];
-        else if (plotTypeName == 'CUSUMm')
+        else if (plotTypeName === 'CUSUMm')
             return LABKEY.targetedms.CUSUMPlotHelper.tooltips['CUSUMm'];
-        else if (plotTypeName == 'CUSUMv')
+        else if (plotTypeName === 'CUSUMv')
             return LABKEY.targetedms.CUSUMPlotHelper.tooltips['CUSUMv'];
         else if (plotTypeName === 'Trailing Mean')
             return LABKEY.targetedms.TrailingMeanPlotHelper.tooltips['Trailing Mean'];

--- a/webapp/TargetedMS/js/QCPlotHelperWrapper.js
+++ b/webapp/TargetedMS/js/QCPlotHelperWrapper.js
@@ -40,13 +40,13 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperWrapper", {
                 // If it is, call deepCloneArray on it
                 return this.deepCloneArray(item);
             } else if (typeof item === 'object' && item !== null) {
-                // If it's an object, use Object.assign to create a new object with the same properties
-                return Object.assign({}, item);
+                // If it's an object, use deepCloneObject
+                return this.deepCloneObject(item);
             } else {
                 // Otherwise, it's a primitive value and we can just return it
                 return item;
             }
-        });
+        }, this);
     },
 
     deepCloneObject: function (obj) {
@@ -101,7 +101,7 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperWrapper", {
         else {
             for (let ind = 0 ; ind < precursors.data.length; ind++) {
                 let data = precursors.data[ind];
-                if (!data.TrailingMean) {
+                if (!data.TrailingMean || !data.TrailingCV) {
                     precursors.data.splice(ind, 1);
                     ind--;
                 }

--- a/webapp/TargetedMS/js/QCPlotHelperWrapper.js
+++ b/webapp/TargetedMS/js/QCPlotHelperWrapper.js
@@ -419,15 +419,16 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperWrapper", {
             return this.getLJCombinedPlotLegendSeries();
     },
 
-    getAdditionalPlotLegend: function(plotType)
-    {
+    getAdditionalPlotLegend: function(plotType) {
         if (plotType === LABKEY.vis.TrendingLinePlotType.CUSUM)
             return this.getCUSUMGroupLegend();
         if (plotType === LABKEY.vis.TrendingLinePlotType.MovingRange)
             return this.getMRLegend();
         if (plotType === LABKEY.vis.TrendingLinePlotType.LeveyJennings)
             return this.getLJLegend();
-        if (this.showMeanCUSUMPlot() || this.showVariableCUSUMPlot())
+        if (this.showMeanCUSUMPlot() || this.showVariableCUSUMPlot() ||
+                plotType === LABKEY.vis.TrendingLinePlotType.TrailingMean ||
+                plotType === LABKEY.vis.TrendingLinePlotType.TrailingCV)
             return this.getEmptyLegend();
         return [];
     },

--- a/webapp/TargetedMS/js/QCPlotHelperWrapper.js
+++ b/webapp/TargetedMS/js/QCPlotHelperWrapper.js
@@ -9,7 +9,7 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperWrapper", {
         cusum: 'LABKEY.targetedms.CUSUMPlotHelper',
         movingRange: 'LABKEY.targetedms.MovingRangePlotHelper',
         trailingMean: 'LABKEY.targetedms.TrailingMeanPlotHelper',
-        trailingCV: 'LABKEY.targetedms.TrailingMeanCVHelper'
+        trailingCV: 'LABKEY.targetedms.TrailingCVPlotHelper'
     },
 
     statics: {
@@ -369,6 +369,8 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperWrapper", {
             return LABKEY.targetedms.CUSUMPlotHelper.tooltips['CUSUMv'];
         else if (plotTypeName === 'Trailing Mean')
             return LABKEY.targetedms.TrailingMeanPlotHelper.tooltips['Trailing Mean'];
+        else if (plotTypeName === 'Trailing CV')
+            return LABKEY.targetedms.TrailingCVPlotHelper.tooltips['Trailing CV'];
         return '';
     }
 });

--- a/webapp/TargetedMS/js/QCPlotHelperWrapper.js
+++ b/webapp/TargetedMS/js/QCPlotHelperWrapper.js
@@ -242,8 +242,7 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperWrapper", {
         return plotData;
     },
 
-    processPlotDataRow: function(row, plotDataRow, fragment, metricProps)
-    {
+    processPlotDataRow: function(row, plotDataRow, fragment, metricProps) {
         var dataType = plotDataRow['DataType'];
         var mz = Ext4.util.Format.number(plotDataRow['mz'], '0.0000');
         var color = plotDataRow['SeriesColor'];

--- a/webapp/TargetedMS/js/QCPlotHelperWrapper.js
+++ b/webapp/TargetedMS/js/QCPlotHelperWrapper.js
@@ -435,20 +435,4 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperWrapper", {
             return this.getEmptyLegend();
         return [];
     },
-
-    getPlotTypeHelpTooltip: function(plotTypeName) {
-        if (plotTypeName === 'Levey-Jennings')
-            return LABKEY.targetedms.LeveyJenningsPlotHelper.tooltips['Levey-Jennings'];
-        else if (plotTypeName === 'Moving Range')
-            return LABKEY.targetedms.MovingRangePlotHelper.tooltips['Moving Range'];
-        else if (plotTypeName === 'CUSUMm')
-            return LABKEY.targetedms.CUSUMPlotHelper.tooltips['CUSUMm'];
-        else if (plotTypeName === 'CUSUMv')
-            return LABKEY.targetedms.CUSUMPlotHelper.tooltips['CUSUMv'];
-        else if (plotTypeName === 'Trailing Mean')
-            return LABKEY.targetedms.TrailingMeanPlotHelper.tooltips['Trailing Mean'];
-        else if (plotTypeName === 'Trailing CV')
-            return LABKEY.targetedms.TrailingCVPlotHelper.tooltips['Trailing CV'];
-        return '';
-    }
 });

--- a/webapp/TargetedMS/js/QCPlotHelperWrapper.js
+++ b/webapp/TargetedMS/js/QCPlotHelperWrapper.js
@@ -377,7 +377,10 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperWrapper", {
         if (this.showTrailingCVPlot()) {
             Ext4.apply(data, this.processTrailingCVPlotDataRow(row, fragment, seriesType, metricProps));
         }
-
+        if (this.showTrailingMeanPlot() || this.showTrailingCVPlot()) {
+            data['TrailingStartDate'] = row['TrailingStartDate'];
+            data['TrailingEndDate'] = row['TrailingEndDate'];
+        }
 
         return data;
     },

--- a/webapp/TargetedMS/js/QCPlotHelperWrapper.js
+++ b/webapp/TargetedMS/js/QCPlotHelperWrapper.js
@@ -92,7 +92,7 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperWrapper", {
 
             for (let ind = 0 ; ind < precursors.data.length; ind++) {
                 let data = precursors.data[ind];
-                if (new Date(data.date).getTime() < firstGuideSetStartDate.getTime()) {
+                if (new Date(data.fullDate).getTime() < firstGuideSetStartDate.getTime()) {
                     precursors.data.splice(ind, 1);
                     ind--;
                 }

--- a/webapp/TargetedMS/js/QCPlotHelperWrapper.js
+++ b/webapp/TargetedMS/js/QCPlotHelperWrapper.js
@@ -101,7 +101,7 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperWrapper", {
         else {
             for (let ind = 0 ; ind < precursors.data.length; ind++) {
                 let data = precursors.data[ind];
-                if (!data.TrailingMean || !data.TrailingCV) {
+                if (!data.TrailingMean && !data.TrailingCV) {
                     precursors.data.splice(ind, 1);
                     ind--;
                 }

--- a/webapp/TargetedMS/js/QCPlotHoverPanel.js
+++ b/webapp/TargetedMS/js/QCPlotHoverPanel.js
@@ -14,6 +14,9 @@ Ext4.define('LABKEY.targetedms.QCPlotHoverPanel', {
     originalStatus: 0,
     existingExclusions: null,
     canEdit: false,
+    trailingRuns: null,
+    trailingStartDate: null,
+    trailingEndDate: null,
 
     STATE: {
         INCLUDE: 0,
@@ -65,6 +68,14 @@ Ext4.define('LABKEY.targetedms.QCPlotHoverPanel', {
 
     initializePanel : function() {
 
+        let hideExclusionAndPointClickLinks = false;
+        if (this.valueName === "TrailingMean") {
+            hideExclusionAndPointClickLinks = true
+        }
+        if (this.valueName === "TrailingCV") {
+            hideExclusionAndPointClickLinks = true
+        }
+
         if (this.pointData[this.valueName + 'Title'] != undefined) {
             this.add(this.getPlotPointDetailField('Metric', this.pointData[this.valueName + 'Title']));
         }
@@ -92,27 +103,23 @@ Ext4.define('LABKEY.targetedms.QCPlotHoverPanel', {
             this.add(this.getPlotPointDetailField('Value', LABKEY.targetedms.PlotSettingsUtil.formatNumeric(this.valueName ? this.pointData[this.valueName] : this.pointData['value'])));
         }
 
-        this.add(this.getPlotPointDetailField('Replicate', this.pointData['ReplicateName']));
-        this.add(this.getPlotPointDetailField('Acquired', this.pointData['fullDate']));
-        if (!this.pointData.TrailingMean || !this.pointData.TrailingCV) {
-            this.add(this.getPlotPointDetailField('File Path', this.pointData['FilePath'].replace(/\\/g, '\\<wbr>').replace(/\//g, '\/<wbr>').replace(/_/g, '_<wbr>')));
+        if (hideExclusionAndPointClickLinks) {
+            this.add(this.getPlotPointDetailField('Replicate', this.trailingRuns + " runs average"));
+            this.add(this.getPlotPointDetailField('Acquired', this.trailingStartDate + " - " + this.trailingEndDate));
+        }
+        else {
+            this.add(this.getPlotPointDetailField('Replicate', this.pointData['ReplicateName']));
+            this.add(this.getPlotPointDetailField('Acquired', this.pointData['fullDate']));
         }
 
-        let hideExclusionAndPointClickLinks = false;
-        if (this.valueName === "TrailingMean") {
-            hideExclusionAndPointClickLinks = true
-        }
-        if (this.valueName === "TrailingCV") {
-            hideExclusionAndPointClickLinks = true
-        }
         if (!hideExclusionAndPointClickLinks) {
+            this.add(this.getPlotPointDetailField('File Path', this.pointData['FilePath'].replace(/\\/g, '\\<wbr>').replace(/\//g, '\/<wbr>').replace(/_/g, '_<wbr>')));
             if (this.canEdit) {
                 this.add(this.getPlotPointExclusionPanel());
             }
             else {
                 this.add(this.getPlotPointDetailField('Status', this.pointData['IgnoreInQC'] ? 'Not included in QC' : 'Included in QC'));
             }
-
 
             this.add(Ext4.create('Ext.Component', {html: this.getPlotPointClickLinks()}));
         }

--- a/webapp/TargetedMS/js/QCPlotHoverPanel.js
+++ b/webapp/TargetedMS/js/QCPlotHoverPanel.js
@@ -98,7 +98,14 @@ Ext4.define('LABKEY.targetedms.QCPlotHoverPanel', {
             this.add(this.getPlotPointDetailField('File Path', this.pointData['FilePath'].replace(/\\/g, '\\<wbr>').replace(/\//g, '\/<wbr>').replace(/_/g, '_<wbr>')));
         }
 
-        if (!this.pointData.TrailingMean || !this.pointData.TrailingCV) {
+        let hideExclusionAndPointClickLinks = false;
+        if (this.valueName === "TrailingMean") {
+            hideExclusionAndPointClickLinks = true
+        }
+        if (this.valueName === "TrailingCV") {
+            hideExclusionAndPointClickLinks = true
+        }
+        if (!hideExclusionAndPointClickLinks) {
             if (this.canEdit) {
                 this.add(this.getPlotPointExclusionPanel());
             }

--- a/webapp/TargetedMS/js/QCPlotHoverPanel.js
+++ b/webapp/TargetedMS/js/QCPlotHoverPanel.js
@@ -94,16 +94,21 @@ Ext4.define('LABKEY.targetedms.QCPlotHoverPanel', {
 
         this.add(this.getPlotPointDetailField('Replicate', this.pointData['ReplicateName']));
         this.add(this.getPlotPointDetailField('Acquired', this.pointData['fullDate']));
-        this.add(this.getPlotPointDetailField('File Path', this.pointData['FilePath'].replace(/\\/g, '\\<wbr>').replace(/\//g, '\/<wbr>').replace(/_/g, '_<wbr>')));
-
-        if (this.canEdit) {
-            this.add(this.getPlotPointExclusionPanel());
-        }
-        else {
-            this.add(this.getPlotPointDetailField('Status', this.pointData['IgnoreInQC'] ? 'Not included in QC' : 'Included in QC'));
+        if (!this.pointData.TrailingMean || !this.pointData.TrailingCV) {
+            this.add(this.getPlotPointDetailField('File Path', this.pointData['FilePath'].replace(/\\/g, '\\<wbr>').replace(/\//g, '\/<wbr>').replace(/_/g, '_<wbr>')));
         }
 
-        this.add(Ext4.create('Ext.Component', { html: this.getPlotPointClickLinks() }));
+        if (!this.pointData.TrailingMean || !this.pointData.TrailingCV) {
+            if (this.canEdit) {
+                this.add(this.getPlotPointExclusionPanel());
+            }
+            else {
+                this.add(this.getPlotPointDetailField('Status', this.pointData['IgnoreInQC'] ? 'Not included in QC' : 'Included in QC'));
+            }
+
+
+            this.add(Ext4.create('Ext.Component', {html: this.getPlotPointClickLinks()}));
+        }
     },
 
     getPlotPointDetailField : function(label, value, includeCls) {

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -646,11 +646,6 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                 paramValues['plotTypes'] = plotTypes;
             }
         }
-        // paramValue = urlParams['trailingRuns'];
-        // if (paramValue === undefined) {
-        //     paramValues['trailingRuns'] = this.getTrailingRunsField().value;
-        // }
-        // debugger
 
         if (alertMessage.length > 0) {
             LABKEY.Utils.alert('Invalid URL Parameter(s)', alertMessage);

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -319,14 +319,9 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                 listeners: {
                     scope: this,
                     change: function (cmp, newVal, oldVal) {
-                        if (newVal > this.runs) {
-                            Ext4.get(this.plotDivId).update("<span class='labkey-error'>The number you entered is larger than the number of available runs. Only " + this.runs + " runs are used for calculation</span>");
-                        }
-                        else {
-                            this.trailingRuns = newVal;
-                            this.havePlotOptionsChanged = true;
-                            this.displayTrendPlot();
-                        }
+                        this.trailingRuns = newVal;
+                        this.havePlotOptionsChanged = true;
+                        this.displayTrendPlot();
                     }
                 }
             };
@@ -369,17 +364,10 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                 change: function(cmp, newVal, oldVal) {
                     var newValues = newVal;
                     this.plotTypes = newValues ? Ext4.isArray(newValues) ? newValues : [newValues] : [];
-                    if ((newValues.indexOf("Trailing Mean") > -1 || newValues.indexOf("Trailing CV") > -1) &&
-                            this.getFirstPlotOptionsToolbar().items.get('trailingRuns').getValue() > this.runs) {
-                        Ext4.get(this.plotDivId).update("<span class='labkey-error'>The number you entered is larger than the number of available runs. Only " + this.runs + " runs are used for calculation</span>");
-                    }
-                    else {
-                        // this.plotTypeOptionsToolbar.items.push(this.getTrailingRunsField());
-                        this.getFirstPlotOptionsToolbar().items.get('trailingRuns').setVisible(newValues.indexOf("Trailing Mean") > -1 || newValues.indexOf("Trailing CV") > -1);
-                        this.havePlotOptionsChanged = true;
-                        this.setBrushingEnabled(false);
-                        this.displayTrendPlot();
-                    }
+                    this.getFirstPlotOptionsToolbar().items.get('trailingRuns').setVisible(newValues.indexOf("Trailing Mean") > -1 || newValues.indexOf("Trailing CV") > -1);
+                    this.havePlotOptionsChanged = true;
+                    this.setBrushingEnabled(false);
+                    this.displayTrendPlot();
                 }
             }
         }

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -1297,7 +1297,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
 
         let trailingRuns = this.trailingRuns;
         let trailingStartDate = row['TrailingStartDate'];
-        let trailingEndDate = row['TrailingEndDate'];
+        let trailingEndDate = row['fullDate'];
 
         showHoverTask.delay(500, function() {
             var calloutMgr = hopscotch.getCalloutManager(),

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -1298,6 +1298,10 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
             metricProps = this.getMetricPropsById(this.metric),
             me = this;
 
+        let panelY = me.canUserEdit() ? -375 : -270;
+        if (valueName === "TrailingMean" || valueName === "TrailingCV") {
+            panelY = panelY + 200;
+        }
         showHoverTask.delay(500, function() {
             var calloutMgr = hopscotch.getCalloutManager(),
                 hopscotchId = Ext4.id(),
@@ -1310,7 +1314,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                     placement: 'top',
                     xOffset: shiftLeft ? -428 : -53,
                     arrowOffset: shiftLeft ? 410 : 35,
-                    yOffset: me.canUserEdit() ? -375 : -270,
+                    yOffset: panelY,
                     target: point,
                     content: '<div id="' + contentDivId + '"></div>',
                     onShow: function() {

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -355,7 +355,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
             fieldLabel: 'Plot Types',
             width: 275,
             expandToFitContent: true,
-            addAllSelector: true,
+            addAllSelector: false,
             queryMode: 'local',
             store: Ext4.create('Ext.data.Store', {
                 fields: ['inputValue'],

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -1302,6 +1302,11 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         if (valueName === "TrailingMean" || valueName === "TrailingCV") {
             panelY = panelY + 200;
         }
+
+        let trailingRuns = this.trailingRuns;
+        let trailingStartDate = Ext4.Date.format(new Date(this.minAcquiredTime), 'Y-m-d H:i:s');
+        let trailingEndDate = Ext4.Date.format(new Date(this.maxAcquiredTime), 'Y-m-d H:i:s');
+
         showHoverTask.delay(500, function() {
             var calloutMgr = hopscotch.getCalloutManager(),
                 hopscotchId = Ext4.id(),
@@ -1324,6 +1329,9 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                             renderTo: contentDivId,
                             pointData: row,
                             valueName: valueName,
+                            trailingRuns: trailingRuns,
+                            trailingStartDate: trailingStartDate,
+                            trailingEndDate: trailingEndDate,
                             metricProps: metricProps,
                             canEdit: me.canUserEdit(),
                             listeners: {

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -345,7 +345,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         }, this);
 
         return {
-            xtype: 'checkcombo',
+            xtype: 'plottype-checkcombo',
             id: 'qc-plot-type-with-y-options',
             fieldLabel: 'Plot Types',
             width: 275,

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -324,6 +324,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                         }
                         else {
                             this.trailingRuns = newVal;
+                            this.havePlotOptionsChanged = true;
                             this.displayTrendPlot();
                         }
                     }
@@ -645,10 +646,11 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                 paramValues['plotTypes'] = plotTypes;
             }
         }
-        paramValue = urlParams['trailingRuns'];
-        if (paramValue === undefined) {
-            paramValues['trailingRuns'] = this.getTrailingRunsField().value;
-        }
+        // paramValue = urlParams['trailingRuns'];
+        // if (paramValue === undefined) {
+        //     paramValues['trailingRuns'] = this.getTrailingRunsField().value;
+        // }
+        // debugger
 
         if (alertMessage.length > 0) {
             LABKEY.Utils.alert('Invalid URL Parameter(s)', alertMessage);

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -364,6 +364,10 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                 change: function(cmp, newVal, oldVal) {
                     var newValues = newVal;
                     this.plotTypes = newValues ? Ext4.isArray(newValues) ? newValues : [newValues] : [];
+
+                    if (this.trailingRuns === undefined || this.trailingRuns === null) {
+                        this.trailingRuns = 10;
+                    }
                     this.getFirstPlotOptionsToolbar().items.get('trailingRuns').setVisible(newValues.indexOf("Trailing Mean") > -1 || newValues.indexOf("Trailing CV") > -1);
                     this.havePlotOptionsChanged = true;
                     this.setBrushingEnabled(false);

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -1292,8 +1292,24 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         }
 
         let trailingRuns = this.trailingRuns;
-        let trailingStartDate = Ext4.Date.format(new Date(this.minAcquiredTime), 'Y-m-d H:i:s');
-        let trailingEndDate = Ext4.Date.format(new Date(this.maxAcquiredTime), 'Y-m-d H:i:s');
+        let trailingStartDate;
+        let trailingEndDate;
+
+        // for custom date range option of date range combo
+        if (this.getDateRangeCombo().value === -1) {
+            trailingStartDate = Ext4.Date.format(new Date(this.startDateField.value), 'Y-m-d H:i:s');
+            trailingEndDate = Ext4.Date.format(new Date(this.endDateField.value), 'Y-m-d H:i:s');
+        }
+        // for last 7,15..365 days options of date range combo
+        else if (this.getDateRangeCombo().value !== 0) {
+            trailingStartDate = Ext4.Date.format(new Date(this.calculateStartDateByOffset()), 'Y-m-d H:i:s');
+            trailingEndDate = Ext4.Date.format(new Date(this.calculateEndDateByOffset()), 'Y-m-d H:i:s');
+        }
+        // for All dates option of date range combo
+        else {
+            trailingStartDate = Ext4.Date.format(new Date(this.minAcquiredTime), 'Y-m-d H:i:s');
+            trailingEndDate = Ext4.Date.format(new Date(this.maxAcquiredTime), 'Y-m-d H:i:s');
+        }
 
         showHoverTask.delay(500, function() {
             var calloutMgr = hopscotch.getCalloutManager(),

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -1296,24 +1296,8 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         }
 
         let trailingRuns = this.trailingRuns;
-        let trailingStartDate;
-        let trailingEndDate;
-
-        // for custom date range option of date range combo
-        if (this.getDateRangeCombo().value === -1) {
-            trailingStartDate = Ext4.Date.format(new Date(this.startDateField.value), 'Y-m-d H:i:s');
-            trailingEndDate = Ext4.Date.format(new Date(this.endDateField.value), 'Y-m-d H:i:s');
-        }
-        // for last 7,15..365 days options of date range combo
-        else if (this.getDateRangeCombo().value !== 0) {
-            trailingStartDate = Ext4.Date.format(new Date(this.calculateStartDateByOffset()), 'Y-m-d H:i:s');
-            trailingEndDate = Ext4.Date.format(new Date(this.calculateEndDateByOffset()), 'Y-m-d H:i:s');
-        }
-        // for All dates option of date range combo
-        else {
-            trailingStartDate = Ext4.Date.format(new Date(this.minAcquiredTime), 'Y-m-d H:i:s');
-            trailingEndDate = Ext4.Date.format(new Date(this.maxAcquiredTime), 'Y-m-d H:i:s');
-        }
+        let trailingStartDate = row['TrailingStartDate'];
+        let trailingEndDate = row['TrailingEndDate'];
 
         showHoverTask.delay(500, function() {
             var calloutMgr = hopscotch.getCalloutManager(),

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -319,8 +319,13 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                 listeners: {
                     scope: this,
                     change: function (cmp, newVal, oldVal) {
-                        this.trailingRuns = newVal;
-                        this.displayTrendPlot();
+                        if (newVal > this.runs) {
+                            Ext4.get(this.plotDivId).update("<span class='labkey-error'>The number you entered is larger than the number of available runs. Only " + this.runs + " runs are used for calculation</span>");
+                        }
+                        else {
+                            this.trailingRuns = newVal;
+                            this.displayTrendPlot();
+                        }
                     }
                 }
             };
@@ -363,11 +368,17 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                 change: function(cmp, newVal, oldVal) {
                     var newValues = newVal;
                     this.plotTypes = newValues ? Ext4.isArray(newValues) ? newValues : [newValues] : [];
-                    // this.plotTypeOptionsToolbar.items.push(this.getTrailingRunsField());
-                    this.getFirstPlotOptionsToolbar().items.get('trailingRuns').setVisible(newValues.indexOf("Trailing Mean") > -1 || newValues.indexOf("Trailing CV") > -1);
-                    this.havePlotOptionsChanged = true;
-                    this.setBrushingEnabled(false);
-                    this.displayTrendPlot();
+                    if ((newValues.indexOf("Trailing Mean") > -1 || newValues.indexOf("Trailing CV") > -1) &&
+                            this.getFirstPlotOptionsToolbar().items.get('trailingRuns').getValue() > this.runs) {
+                        Ext4.get(this.plotDivId).update("<span class='labkey-error'>The number you entered is larger than the number of available runs. Only " + this.runs + " runs are used for calculation</span>");
+                    }
+                    else {
+                        // this.plotTypeOptionsToolbar.items.push(this.getTrailingRunsField());
+                        this.getFirstPlotOptionsToolbar().items.get('trailingRuns').setVisible(newValues.indexOf("Trailing Mean") > -1 || newValues.indexOf("Trailing CV") > -1);
+                        this.havePlotOptionsChanged = true;
+                        this.setBrushingEnabled(false);
+                        this.displayTrendPlot();
+                    }
                 }
             }
         }

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -306,8 +306,8 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         if (!this.trailingRunsField) {
             this.trailingRunsField = {
                 xtype : 'numberfield',
-                fieldLabel: 'Tailing Last',
-                labelWidth: 65,
+                fieldLabel: 'Trailing Last',
+                labelWidth: 70,
                 width: 115,
                 enableKeyEvents: true,
                 id : 'trailingRuns',

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -315,7 +315,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                 hidden: true,
                 activeError: '',
                 allowDecimals: false,
-                minValue: 0,
+                minValue: 2,
                 listeners: {
                     scope: this,
                     change: function (cmp, newVal, oldVal) {

--- a/webapp/TargetedMS/js/TrailingCVPlotHelper.js
+++ b/webapp/TargetedMS/js/TrailingCVPlotHelper.js
@@ -11,40 +11,30 @@ Ext4.define("LABKEY.targetedms.TrailingCVPlotHelper", {
         }
     },
     processTrailingCVPlotDataRow: function(row, fragment, seriesType, metricProps) {
-        var data = {};
-        // if a guideSetId is defined for this row, include the guide set stats values in the data object
-        if (Ext4.isDefined(row['GuideSetId']) && row['GuideSetId'] > 0)
-        {
-            var gs = this.guideSetDataMap[row['GuideSetId']];
-            if (Ext4.isDefined(gs) && gs.Series[fragment]&& gs.Series[fragment][seriesType])
-            {
-                data['mean'] = gs.Series[fragment][seriesType]['Mean'];
-                data['stdDev'] = gs.Series[fragment][seriesType]['StdDev'];
-            }
-        }
+        let data = {};
 
         if (this.isMultiSeries())
         {
-            data['value_' + seriesType] = row['TrailingCV'];
-            data['value_' + seriesType + 'Title'] = metricProps[seriesType + 'Label'];
+            data['TrailingCV_' + seriesType] = row['TrailingCV'];
+            data['TrailingCV_' + seriesType + 'Title'] = metricProps[seriesType + 'Label'];
         }
         else
         {
-            data['value'] = row['TrailingCV'];
+            data['TrailingCV'] = row['TrailingCV'];
         }
         return data;
 
     },
 
     getTrailingCVPlotTypeProperties: function(precursorInfo) {
-        var plotProperties = {};
+        let plotProperties = {};
         // some properties are specific to whether or not we are showing multiple y-axis series
         if (this.isMultiSeries()) {
-            plotProperties['value'] = 'value_series1';
-            plotProperties['valueRight'] = 'value_series2';
+            plotProperties['TrailingCV'] = 'value_series1';
+            plotProperties['TrailingCVRight'] = 'value_series2';
         }
         else {
-            plotProperties['value'] = 'value';
+            plotProperties['TrailingCV'] = 'TrailingCV';
             plotProperties['yAxisDomain'] = [precursorInfo.min, precursorInfo.max];
         }
         return plotProperties;
@@ -52,7 +42,7 @@ Ext4.define("LABKEY.targetedms.TrailingCVPlotHelper", {
 
     setTrailingCVMinMax: function (dataObject, row) {
         // track the min and max data so we can get the range for including the QC annotations
-        var val = row['value'];
+        var val = row['TrailingCV'];
         if (LABKEY.vis.isValid(val)) {
             if (dataObject.min == null || val < dataObject.min) {
                 dataObject.min = val;
@@ -61,16 +51,16 @@ Ext4.define("LABKEY.targetedms.TrailingCVPlotHelper", {
                 dataObject.max = val;
             }
 
-            if (this.yAxisScale == 'log' && val <= 0) {
+            if (this.yAxisScale === 'log' && val <= 0) {
                 dataObject.showLogInvalid = true;
             }
 
         }
         else if (this.isMultiSeries()) {
             // check if either of the y-axis metric values are invalid for a log scale
-            var val1 = row['value_series1'],
-                    val2 = row['value_series2'];
-            if (dataObject.showLogInvalid == undefined && this.yAxisScale == 'log') {
+            var val1 = row['TrailingCV_series1'],
+                    val2 = row['TrailingCV_series2'];
+            if (dataObject.showLogInvalid === undefined && this.yAxisScale === 'log') {
                 if ((LABKEY.vis.isValid(val1) && val1 <= 0) || (LABKEY.vis.isValid(val2) && val2 <= 0)) {
                     dataObject.showLogInvalid = true;
                 }

--- a/webapp/TargetedMS/js/TrailingCVPlotHelper.js
+++ b/webapp/TargetedMS/js/TrailingCVPlotHelper.js
@@ -7,7 +7,7 @@ Ext4.define("LABKEY.targetedms.TrailingCVPlotHelper", {
     extend: 'LABKEY.targetedms.QCPlotHelperBase',
     statics: {
         tooltips: {
-            'Trailing CV' : 'Blah '
+            'Trailing CV' : 'A Trailing Coefficient of Variation plot shows the moving average of percent coefficient of variation for the previous N runs, as defined by the user.  It is useful for finding long-term trends otherwise disguised by fluctuations caused by outliers.'
         }
     },
     processTrailingCVPlotDataRow: function(row, fragment, seriesType, metricProps) {

--- a/webapp/TargetedMS/js/TrailingCVPlotHelper.js
+++ b/webapp/TargetedMS/js/TrailingCVPlotHelper.js
@@ -35,14 +35,32 @@ Ext4.define("LABKEY.targetedms.TrailingCVPlotHelper", {
         }
         else {
             plotProperties['TrailingCV'] = 'TrailingCV';
-            plotProperties['yAxisDomain'] = [precursorInfo.TrailingCVMin, precursorInfo.TrailingCVMax];
+            let min = Math.min(...precursorInfo.data.map(function(object) {
+                return object.TrailingCV;
+            }));
+            let max = Math.max(...precursorInfo.data.map(function(object) {
+                return object.TrailingCV;
+            }));
+
+            // the number 20 is specified in the specs
+            if (min < 20 && max < 20) {
+                min = 0;
+                max = 20;
+            }
+
+            if (min > 20 || max > 20) {
+                min = 0;
+                max = Math.round(Math.ceil(max / 10) * 10);
+            }
+
+            plotProperties['yAxisDomain'] = [min, max];
         }
         return plotProperties;
     },
 
     setTrailingCVMinMax: function (dataObject, row) {
-        // track the min and max data so we can get the range for including the QC annotations
-        var val = row['TrailingCV'];
+        // track the min and max data, so we can get the range for including the QC annotations
+        let val = row['TrailingCV'];
         if (LABKEY.vis.isValid(val)) {
             if (dataObject.TrailingCVMin == null || val < dataObject.TrailingCVMin) {
                 dataObject.TrailingCVMin = val;
@@ -58,7 +76,7 @@ Ext4.define("LABKEY.targetedms.TrailingCVPlotHelper", {
         }
         else if (this.isMultiSeries()) {
             // check if either of the y-axis metric values are invalid for a log scale
-            var val1 = row['TrailingCV_series1'],
+            let val1 = row['TrailingCV_series1'],
                     val2 = row['TrailingCV_series2'];
             if (dataObject.showLogInvalid === undefined && this.yAxisScale === 'log') {
                 if ((LABKEY.vis.isValid(val1) && val1 <= 0) || (LABKEY.vis.isValid(val2) && val2 <= 0)) {

--- a/webapp/TargetedMS/js/TrailingCVPlotHelper.js
+++ b/webapp/TargetedMS/js/TrailingCVPlotHelper.js
@@ -42,12 +42,13 @@ Ext4.define("LABKEY.targetedms.TrailingCVPlotHelper", {
                 return object.TrailingCV;
             }));
 
-            // the number 20 is specified in the specs
+            // Since 20 is a common limit for acceptable %CV, use that as the default range
             if (min < 20 && max < 20) {
                 min = 0;
                 max = 20;
             }
 
+            // expand range if we have values bigger than 20
             if (min > 20 || max > 20) {
                 min = 0;
                 max = Math.round(Math.ceil(max / 10) * 10);

--- a/webapp/TargetedMS/js/TrailingCVPlotHelper.js
+++ b/webapp/TargetedMS/js/TrailingCVPlotHelper.js
@@ -35,7 +35,7 @@ Ext4.define("LABKEY.targetedms.TrailingCVPlotHelper", {
         }
         else {
             plotProperties['TrailingCV'] = 'TrailingCV';
-            plotProperties['yAxisDomain'] = [precursorInfo.min, precursorInfo.max];
+            plotProperties['yAxisDomain'] = [precursorInfo.TrailingCVMin, precursorInfo.TrailingCVMax];
         }
         return plotProperties;
     },
@@ -44,11 +44,11 @@ Ext4.define("LABKEY.targetedms.TrailingCVPlotHelper", {
         // track the min and max data so we can get the range for including the QC annotations
         var val = row['TrailingCV'];
         if (LABKEY.vis.isValid(val)) {
-            if (dataObject.min == null || val < dataObject.min) {
-                dataObject.min = val;
+            if (dataObject.TrailingCVMin == null || val < dataObject.TrailingCVMin) {
+                dataObject.TrailingCVMin = val;
             }
-            if (dataObject.max == null || val > dataObject.max) {
-                dataObject.max = val;
+            if (dataObject.TrailingCVMax == null || val > dataObject.TrailingCVMax) {
+                dataObject.TrailingCVMax = val;
             }
 
             if (this.yAxisScale === 'log' && val <= 0) {
@@ -70,8 +70,8 @@ Ext4.define("LABKEY.targetedms.TrailingCVPlotHelper", {
 
     getTrailingCVInitFragmentPlotData: function() {
         return {
-            min: null,
-            max: null
+            TrailingCVMin: null,
+            TrailingCVMax: null
         }
     },
 });

--- a/webapp/TargetedMS/js/TrailingCVPlotHelper.js
+++ b/webapp/TargetedMS/js/TrailingCVPlotHelper.js
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2016-2018 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+ */
+Ext4.define("LABKEY.targetedms.TrailingCVPlotHelper", {
+    extend: 'LABKEY.targetedms.QCPlotHelperBase',
+    statics: {
+        tooltips: {
+            'Trailing CV' : 'Blah '
+        }
+    },
+    processTrailingCVPlotDataRow: function(row, fragment, seriesType, metricProps) {
+        var data = {};
+        // if a guideSetId is defined for this row, include the guide set stats values in the data object
+        if (Ext4.isDefined(row['GuideSetId']) && row['GuideSetId'] > 0)
+        {
+            var gs = this.guideSetDataMap[row['GuideSetId']];
+            if (Ext4.isDefined(gs) && gs.Series[fragment]&& gs.Series[fragment][seriesType])
+            {
+                data['mean'] = gs.Series[fragment][seriesType]['Mean'];
+                data['stdDev'] = gs.Series[fragment][seriesType]['StdDev'];
+            }
+        }
+
+        if (this.isMultiSeries())
+        {
+            data['value_' + seriesType] = row['TrailingCV'];
+            data['value_' + seriesType + 'Title'] = metricProps[seriesType + 'Label'];
+        }
+        else
+        {
+            data['value'] = row['TrailingCV'];
+        }
+        return data;
+
+    },
+
+    getTrailingCVPlotTypeProperties: function(precursorInfo) {
+        var plotProperties = {};
+        // some properties are specific to whether or not we are showing multiple y-axis series
+        if (this.isMultiSeries()) {
+            plotProperties['value'] = 'value_series1';
+            plotProperties['valueRight'] = 'value_series2';
+        }
+        else {
+            plotProperties['value'] = 'value';
+            plotProperties['yAxisDomain'] = [precursorInfo.min, precursorInfo.max];
+        }
+        return plotProperties;
+    },
+
+    setTrailingCVMinMax: function (dataObject, row) {
+        // track the min and max data so we can get the range for including the QC annotations
+        var val = row['value'];
+        if (LABKEY.vis.isValid(val)) {
+            if (dataObject.min == null || val < dataObject.min) {
+                dataObject.min = val;
+            }
+            if (dataObject.max == null || val > dataObject.max) {
+                dataObject.max = val;
+            }
+
+            if (this.yAxisScale == 'log' && val <= 0) {
+                dataObject.showLogInvalid = true;
+            }
+
+        }
+        else if (this.isMultiSeries()) {
+            // check if either of the y-axis metric values are invalid for a log scale
+            var val1 = row['value_series1'],
+                    val2 = row['value_series2'];
+            if (dataObject.showLogInvalid == undefined && this.yAxisScale == 'log') {
+                if ((LABKEY.vis.isValid(val1) && val1 <= 0) || (LABKEY.vis.isValid(val2) && val2 <= 0)) {
+                    dataObject.showLogInvalid = true;
+                }
+            }
+        }
+    },
+
+    getTrailingCVInitFragmentPlotData: function() {
+        return {
+            min: null,
+            max: null
+        }
+    },
+});

--- a/webapp/TargetedMS/js/TrailingMeanPlotHelper.js
+++ b/webapp/TargetedMS/js/TrailingMeanPlotHelper.js
@@ -34,7 +34,15 @@ Ext4.define("LABKEY.targetedms.TrailingMeanPlotHelper", {
         }
         else {
             plotProperties['TrailingMean'] = 'TrailingMean';
-            plotProperties['yAxisDomain'] = [precursorInfo.minTrailingMean, precursorInfo.maxTrailingMean];
+
+            let min = Math.min(...precursorInfo.data.map(function(object) {
+                return object.TrailingMean;
+            }));
+            let max = Math.max(...precursorInfo.data.map(function(object) {
+                return object.TrailingMean;
+            }));
+
+            plotProperties['yAxisDomain'] = [min, max];
         }
         return plotProperties;
     },

--- a/webapp/TargetedMS/js/TrailingMeanPlotHelper.js
+++ b/webapp/TargetedMS/js/TrailingMeanPlotHelper.js
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2016-2018 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+ */
+Ext4.define("LABKEY.targetedms.TrailingMeanPlotHelper", {
+    extend: 'LABKEY.targetedms.QCPlotHelperBase',
+    statics: {
+        tooltips: {
+            'Trailing Mean' : 'Blah '
+        }
+    },
+
+    processTrailingMeanPlotDataRow: function(row, fragment, seriesType, metricProps) {
+        var data = {};
+        // if a guideSetId is defined for this row, include the guide set stats values in the data object
+        if (Ext4.isDefined(row['GuideSetId']) && row['GuideSetId'] > 0)
+        {
+            var gs = this.guideSetDataMap[row['GuideSetId']];
+            if (Ext4.isDefined(gs) && gs.Series[fragment]&& gs.Series[fragment][seriesType])
+            {
+                data['mean'] = gs.Series[fragment][seriesType]['Mean'];
+                data['stdDev'] = gs.Series[fragment][seriesType]['StdDev'];
+            }
+        }
+
+        if (this.isMultiSeries())
+        {
+            data['value_' + seriesType] = row['TrailingMean'];
+            data['value_' + seriesType + 'Title'] = metricProps[seriesType + 'Label'];
+        }
+        else
+        {
+            data['value'] = row['TrailingMean'];
+        }
+        return data;
+
+    },
+
+    getTrailingMeanPlotTypeProperties: function(precursorInfo) {
+        var plotProperties = {};
+        // some properties are specific to whether or not we are showing multiple y-axis series
+        if (this.isMultiSeries()) {
+            plotProperties['value'] = 'value_series1';
+            plotProperties['valueRight'] = 'value_series2';
+        }
+        else {
+            plotProperties['value'] = 'value';
+            plotProperties['yAxisDomain'] = [precursorInfo.min, precursorInfo.max];
+        }
+        return plotProperties;
+    },
+
+    setTrailingMeanMinMax: function (dataObject, row) {
+        // track the min and max data so we can get the range for including the QC annotations
+        var val = row['value'];
+        if (LABKEY.vis.isValid(val)) {
+            if (dataObject.min == null || val < dataObject.min) {
+                dataObject.min = val;
+            }
+            if (dataObject.max == null || val > dataObject.max) {
+                dataObject.max = val;
+            }
+
+            if (this.yAxisScale == 'log' && val <= 0) {
+                dataObject.showLogInvalid = true;
+            }
+
+        }
+        else if (this.isMultiSeries()) {
+            // check if either of the y-axis metric values are invalid for a log scale
+            var val1 = row['value_series1'],
+                    val2 = row['value_series2'];
+            if (dataObject.showLogInvalid == undefined && this.yAxisScale == 'log') {
+                if ((LABKEY.vis.isValid(val1) && val1 <= 0) || (LABKEY.vis.isValid(val2) && val2 <= 0)) {
+                    dataObject.showLogInvalid = true;
+                }
+            }
+        }
+    },
+
+    getTrailingMeanInitFragmentPlotData: function() {
+        return {
+            min: null,
+            max: null
+        }
+    },
+});

--- a/webapp/TargetedMS/js/TrailingMeanPlotHelper.js
+++ b/webapp/TargetedMS/js/TrailingMeanPlotHelper.js
@@ -34,7 +34,7 @@ Ext4.define("LABKEY.targetedms.TrailingMeanPlotHelper", {
         }
         else {
             plotProperties['TrailingMean'] = 'TrailingMean';
-            plotProperties['yAxisDomain'] = [precursorInfo.min, precursorInfo.max];
+            plotProperties['yAxisDomain'] = [precursorInfo.minTrailingMean, precursorInfo.maxTrailingMean];
         }
         return plotProperties;
     },
@@ -43,11 +43,11 @@ Ext4.define("LABKEY.targetedms.TrailingMeanPlotHelper", {
         // track the min and max data, so we can get the range for including the QC annotations
         let val = row['TrailingMean'];
         if (LABKEY.vis.isValid(val)) {
-            if (dataObject.min == null || val < dataObject.min) {
-                dataObject.min = val;
+            if (dataObject.minTrailingMean == null || val < dataObject.minTrailingMean) {
+                dataObject.minTrailingMean = val;
             }
-            if (dataObject.max == null || val > dataObject.max) {
-                dataObject.max = val;
+            if (dataObject.maxTrailingMean == null || val > dataObject.maxTrailingMean) {
+                dataObject.maxTrailingMean = val;
             }
 
             if (this.yAxisScale === 'log' && val <= 0) {
@@ -69,8 +69,8 @@ Ext4.define("LABKEY.targetedms.TrailingMeanPlotHelper", {
 
     getTrailingMeanInitFragmentPlotData: function() {
         return {
-            min: null,
-            max: null
+            minTrailingMean: null,
+            maxTrailingMean: null
         }
     },
 });

--- a/webapp/TargetedMS/js/TrailingMeanPlotHelper.js
+++ b/webapp/TargetedMS/js/TrailingMeanPlotHelper.js
@@ -7,7 +7,7 @@ Ext4.define("LABKEY.targetedms.TrailingMeanPlotHelper", {
     extend: 'LABKEY.targetedms.QCPlotHelperBase',
     statics: {
         tooltips: {
-            'Trailing Mean' : 'Blah '
+            'Trailing Mean' : 'A Trailing Mean plot shows the moving average of the previous N runs, as defined by the user.  It is useful for finding long-term trends otherwise disguised by fluctuations caused by outliers.'
         }
     },
 

--- a/webapp/TargetedMS/js/TrailingMeanPlotHelper.js
+++ b/webapp/TargetedMS/js/TrailingMeanPlotHelper.js
@@ -12,48 +12,36 @@ Ext4.define("LABKEY.targetedms.TrailingMeanPlotHelper", {
     },
 
     processTrailingMeanPlotDataRow: function(row, fragment, seriesType, metricProps) {
-        var data = {};
-        // if a guideSetId is defined for this row, include the guide set stats values in the data object
-        if (Ext4.isDefined(row['GuideSetId']) && row['GuideSetId'] > 0)
-        {
-            var gs = this.guideSetDataMap[row['GuideSetId']];
-            if (Ext4.isDefined(gs) && gs.Series[fragment]&& gs.Series[fragment][seriesType])
-            {
-                data['mean'] = gs.Series[fragment][seriesType]['Mean'];
-                data['stdDev'] = gs.Series[fragment][seriesType]['StdDev'];
-            }
-        }
+        let data = {};
 
-        if (this.isMultiSeries())
-        {
-            data['value_' + seriesType] = row['TrailingMean'];
-            data['value_' + seriesType + 'Title'] = metricProps[seriesType + 'Label'];
+        if (this.isMultiSeries()) {
+            data['TrailingMean_' + seriesType] = row['TrailingMean'];
+            data['TrailingMean_' + seriesType + 'Title'] = metricProps[seriesType + 'Label'];
         }
-        else
-        {
-            data['value'] = row['TrailingMean'];
+        else {
+            data['TrailingMean'] = row['TrailingMean'];
         }
         return data;
 
     },
 
     getTrailingMeanPlotTypeProperties: function(precursorInfo) {
-        var plotProperties = {};
+        let plotProperties = {};
         // some properties are specific to whether or not we are showing multiple y-axis series
         if (this.isMultiSeries()) {
-            plotProperties['value'] = 'value_series1';
-            plotProperties['valueRight'] = 'value_series2';
+            plotProperties['TrailingMean'] = 'TrailingMean_series1';
+            plotProperties['TrailingMeanRight'] = 'TrailingMean_series2';
         }
         else {
-            plotProperties['value'] = 'value';
+            plotProperties['TrailingMean'] = 'TrailingMean';
             plotProperties['yAxisDomain'] = [precursorInfo.min, precursorInfo.max];
         }
         return plotProperties;
     },
 
     setTrailingMeanMinMax: function (dataObject, row) {
-        // track the min and max data so we can get the range for including the QC annotations
-        var val = row['value'];
+        // track the min and max data, so we can get the range for including the QC annotations
+        let val = row['TrailingMean'];
         if (LABKEY.vis.isValid(val)) {
             if (dataObject.min == null || val < dataObject.min) {
                 dataObject.min = val;
@@ -62,16 +50,16 @@ Ext4.define("LABKEY.targetedms.TrailingMeanPlotHelper", {
                 dataObject.max = val;
             }
 
-            if (this.yAxisScale == 'log' && val <= 0) {
+            if (this.yAxisScale === 'log' && val <= 0) {
                 dataObject.showLogInvalid = true;
             }
 
         }
         else if (this.isMultiSeries()) {
             // check if either of the y-axis metric values are invalid for a log scale
-            var val1 = row['value_series1'],
-                    val2 = row['value_series2'];
-            if (dataObject.showLogInvalid == undefined && this.yAxisScale == 'log') {
+            let val1 = row['TrailingMean_series1'],
+                    val2 = row['TrailingMean_series2'];
+            if (dataObject.showLogInvalid === undefined && this.yAxisScale === 'log') {
                 if ((LABKEY.vis.isValid(val1) && val1 <= 0) || (LABKEY.vis.isValid(val2) && val2 <= 0)) {
                     dataObject.showLogInvalid = true;
                 }


### PR DESCRIPTION
#### Rationale
This PR adds two new plots to Panorama QC - Access mean and CV for last N runs that would help analytical lab scientists to see trailing mean and CV values across last N runs for all the metrics so that the outliers will have less impact on the plots and they can get a better overall idea of the dataset. 

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3971

#### Changes
* new plots and their helpers
