### PR TITLE
Wait for toolip text

### DIFF
--- a/test/src/org/labkey/test/components/targetedms/SequenceCoverageWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/SequenceCoverageWebPart.java
@@ -85,7 +85,7 @@ public class SequenceCoverageWebPart extends BodyWebPart<SequenceCoverageWebPart
             return elementCache().peptideDetailsHelp.isDisplayed();
         }, "Peptide details tooltip did not appear", 5000);
 
-        return Locator.id("helpDivBody").withText().findElement(elementCache().peptideDetailsHelp).getText();
+        return Locator.id("helpDivBody").withText().waitForElement(elementCache().peptideDetailsHelp, 1_000).getText();
     }
 
     public SequenceCoverageWebPart doAndWaitForUpdate(Runnable runnable)

--- a/test/src/org/labkey/test/components/targetedms/SequenceCoverageWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/SequenceCoverageWebPart.java
@@ -85,7 +85,7 @@ public class SequenceCoverageWebPart extends BodyWebPart<SequenceCoverageWebPart
             return elementCache().peptideDetailsHelp.isDisplayed();
         }, "Peptide details tooltip did not appear", 5000);
 
-        return Locator.id("helpDivBody").findElement(elementCache().peptideDetailsHelp).getText();
+        return Locator.id("helpDivBody").withText().findElement(elementCache().peptideDetailsHelp).getText();
     }
 
     public SequenceCoverageWebPart doAndWaitForUpdate(Runnable runnable)


### PR DESCRIPTION
#### Rationale
This sometimes returns an empty string; it needs to wait for the tooltip to have some text.
```
org.labkey.test.util.DeferredErrorCollector$DeferredAssertionError: Incorrect peptide details for Intensity 12(light red) and single replicate expected:<[Mass: 1630.88
Start: 165
End: 178
Unmodified: 1
Intensity Rank: 12
Raw Intensity: 2.436E+05
Log 10 Base Intensity: 5.39]> but was:<[]>
Screen shot name: 0_Intensity_And_SingleReplicate_Errors
  org.labkey.test.tests.targetedms.TargetedMSProteinSequenceViewTest.testIntensityAndConfidenceScale(TargetedMSProteinSequenceViewTest.java:87)
  org.labkey.test.BaseWebDriverTest$6$1.evaluate(BaseWebDriverTest.java:699)
```
![image](https://user-images.githubusercontent.com/5263798/210463002-dbc1223e-c29b-437a-aaa1-cf43123f454e.png)


#### Related Pull Requests
* N/A

#### Changes
* Wait for popup to have some text
