### PR TITLE
Migrate commonAssay to new JSONObject

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSSchema.java
+++ b/src/org/labkey/targetedms/TargetedMSSchema.java
@@ -19,7 +19,7 @@ package org.labkey.targetedms;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.json.old.JSONObject;
+import org.json.JSONObject;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.*;

--- a/src/org/labkey/targetedms/view/SkylineAuditLogExtraInfoAJAXDisplayColumnFactory.java
+++ b/src/org/labkey/targetedms/view/SkylineAuditLogExtraInfoAJAXDisplayColumnFactory.java
@@ -1,6 +1,6 @@
 package org.labkey.targetedms.view;
 
-import org.json.old.JSONObject;
+import org.json.JSONObject;
 import org.labkey.api.data.AJAXDetailsDisplayColumn;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
@@ -32,5 +32,4 @@ public class SkylineAuditLogExtraInfoAJAXDisplayColumnFactory implements Display
             }
         };
     }
-
 }


### PR DESCRIPTION
#### Rationale
Clearing out commonAssay of old `JSONObject` uses