### PR TITLE
Avoid leaking reference to TargetedMSModule

### DIFF
--- a/src/org/labkey/targetedms/SkylineAuditLogManager.java
+++ b/src/org/labkey/targetedms/SkylineAuditLogManager.java
@@ -31,6 +31,7 @@ import org.labkey.api.data.SqlExecutor;
 import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.Table;
 import org.labkey.api.data.TableInfo;
+import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.module.ModuleProperty;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.security.User;
@@ -504,7 +505,7 @@ public class SkylineAuditLogManager
 
         private void enableHashValidation()
         {
-            ModuleProperty logLevelProperty = TargetedMSModule.SKYLINE_AUDIT_LEVEL_PROPERTY;
+            ModuleProperty logLevelProperty = ModuleLoader.getInstance().getModule(TargetedMSModule.class).SKYLINE_AUDIT_LEVEL_PROPERTY;
             logLevelProperty.saveValue(null, _container, Integer.toString(SkylineAuditLogSecurityManager.INTEGRITY_LEVEL.HASH.getValue()));
         }
 

--- a/src/org/labkey/targetedms/SkylineDocImporter.java
+++ b/src/org/labkey/targetedms/SkylineDocImporter.java
@@ -412,10 +412,11 @@ public class SkylineDocImporter
 
             if (!parser.shouldSaveTransitionChromInfos())
             {
+                TargetedMSModule targetedMSModule = ModuleLoader.getInstance().getModule(TargetedMSModule.class);
                 _log.info("None of the " + parser.getTransitionChromInfoCount() + " TransitionChromInfos in the file " +
                         "were imported because they exceed the limit of " +
-                        ModuleLoader.getInstance().getModule(TargetedMSModule.class).MAX_TRANSITION_CHROM_INFOS_PROPERTY.getEffectiveValue(_container) + " and there are more than " +
-                        ModuleLoader.getInstance().getModule(TargetedMSModule.class).MAX_PRECURSORS_PROPERTY.getEffectiveValue(_container) + " precursors");
+                        targetedMSModule.MAX_TRANSITION_CHROM_INFOS_PROPERTY.getEffectiveValue(_container) + " and there are more than " +
+                        targetedMSModule.MAX_PRECURSORS_PROPERTY.getEffectiveValue(_container) + " precursors");
                 SQLFragment whereClause = new SQLFragment("WHERE r.Id = ?", _runId);
 
                 // Clear out any of the TransitionChromInfo and related tables that we inserted before we exceeded

--- a/src/org/labkey/targetedms/SkylineDocImporter.java
+++ b/src/org/labkey/targetedms/SkylineDocImporter.java
@@ -38,6 +38,7 @@ import org.labkey.api.data.TableSelector;
 import org.labkey.api.exp.XarContext;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExperimentService;
+import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.pipeline.CancelledException;
 import org.labkey.api.pipeline.LocalDirectory;
 import org.labkey.api.pipeline.PipeRoot;
@@ -413,8 +414,8 @@ public class SkylineDocImporter
             {
                 _log.info("None of the " + parser.getTransitionChromInfoCount() + " TransitionChromInfos in the file " +
                         "were imported because they exceed the limit of " +
-                        TargetedMSModule.MAX_TRANSITION_CHROM_INFOS_PROPERTY.getEffectiveValue(_container) + " and there are more than " +
-                        TargetedMSModule.MAX_PRECURSORS_PROPERTY.getEffectiveValue(_container) + " precursors");
+                        ModuleLoader.getInstance().getModule(TargetedMSModule.class).MAX_TRANSITION_CHROM_INFOS_PROPERTY.getEffectiveValue(_container) + " and there are more than " +
+                        ModuleLoader.getInstance().getModule(TargetedMSModule.class).MAX_PRECURSORS_PROPERTY.getEffectiveValue(_container) + " precursors");
                 SQLFragment whereClause = new SQLFragment("WHERE r.Id = ?", _runId);
 
                 // Clear out any of the TransitionChromInfo and related tables that we inserted before we exceeded

--- a/src/org/labkey/targetedms/TargetedMSExperimentRunType.java
+++ b/src/org/labkey/targetedms/TargetedMSExperimentRunType.java
@@ -28,7 +28,7 @@ import org.labkey.api.exp.api.ExpProtocol;
  */
 public class TargetedMSExperimentRunType extends ExperimentRunType
 {
-    private String[] _protocolPrefixes;
+    private final String[] _protocolPrefixes;
 
     public TargetedMSExperimentRunType()
     {

--- a/src/org/labkey/targetedms/TargetedMSManager.java
+++ b/src/org/labkey/targetedms/TargetedMSManager.java
@@ -56,6 +56,7 @@ import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.module.Module;
+import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.module.ModuleProperty;
 import org.labkey.api.pipeline.LocalDirectory;
 import org.labkey.api.pipeline.PipeRoot;
@@ -2009,7 +2010,8 @@ public class TargetedMSManager
 
         try
         {
-            timeoutValue = Integer.parseInt(TargetedMSModule.AUTO_QC_PING_TIMEOUT_PROPERTY.getEffectiveValue(container));
+            timeoutValue = Integer.parseInt(ModuleLoader.getInstance().getModule(TargetedMSModule.class)
+                    .AUTO_QC_PING_TIMEOUT_PROPERTY.getEffectiveValue(container));
         }
         catch (NumberFormatException e)
         {

--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -30,7 +30,6 @@ import org.labkey.api.data.PropertySchema;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.UpgradeCode;
-import org.labkey.api.exp.ExperimentRunType;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.files.DirectoryPattern;
 import org.labkey.api.files.FileContentService;
@@ -102,7 +101,6 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
     // Protocol prefix for importing .zip archives from Skyline
     public static final String IMPORT_SKYZIP_PROTOCOL_OBJECT_PREFIX = "TargetedMS.ImportSkyZip";
 
-    public static final ExperimentRunType EXP_RUN_TYPE = new TargetedMSExperimentRunType();
     public static final String TARGETED_MS_SETUP = "Targeted MS Setup";
     public static final String TARGETED_MS_CHROMATOGRAM_LIBRARY_DOWNLOAD = "Chromatogram Library Download";
     public static final String TARGETED_MS_PRECURSOR_VIEW = "Targeted MS Precursor View";
@@ -147,15 +145,15 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
 
     public static final String[] QC_FOLDER_WEB_PARTS = new String[] {TARGETED_MS_QC_SUMMARY, TARGETED_MS_QC_PLOTS};
 
-    public static ModuleProperty FOLDER_TYPE_PROPERTY;
-    public static ModuleProperty SKIP_CHROMATOGRAM_IMPORT_PROPERTY;
-    public static ModuleProperty PREFER_SKYD_FILE_CHROMATOGRAMS_PROPERTY;
-    public static ModuleProperty SKYLINE_AUDIT_LEVEL_PROPERTY;
-    public static ModuleProperty MAX_TRANSITION_CHROM_INFOS_PROPERTY;
+    public final ModuleProperty FOLDER_TYPE_PROPERTY;
+    public final ModuleProperty SKIP_CHROMATOGRAM_IMPORT_PROPERTY;
+    public final ModuleProperty PREFER_SKYD_FILE_CHROMATOGRAMS_PROPERTY;
+    public final ModuleProperty SKYLINE_AUDIT_LEVEL_PROPERTY;
+    public final ModuleProperty MAX_TRANSITION_CHROM_INFOS_PROPERTY;
     public static final int DEFAULT_MAX_TRANSITION_CHROM_INFOS = 100_000;
-    public static ModuleProperty MAX_PRECURSORS_PROPERTY;
+    public final ModuleProperty MAX_PRECURSORS_PROPERTY;
     public static final int DEFAULT_MAX_PRECURSORS = 1_000;
-    public static ModuleProperty AUTO_QC_PING_TIMEOUT_PROPERTY;
+    public final ModuleProperty AUTO_QC_PING_TIMEOUT_PROPERTY;
 
     public TargetedMSModule()
     {
@@ -595,7 +593,7 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
         ExperimentService.get().registerExperimentRunTypeSource(container -> {
             if (container == null || container.getActiveModules().contains(TargetedMSModule.this))
             {
-                return Collections.singleton(EXP_RUN_TYPE);
+                return Collections.singleton(TargetedMSService.get().getExperimentRunType());
             }
             return Collections.emptySet();
         });

--- a/src/org/labkey/targetedms/TargetedMSServiceImpl.java
+++ b/src/org/labkey/targetedms/TargetedMSServiceImpl.java
@@ -58,6 +58,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
  */
 public class TargetedMSServiceImpl implements TargetedMSService
 {
+    private final ExperimentRunType EXP_RUN_TYPE = new TargetedMSExperimentRunType();
+
     // CopyOnWriteArrayList is a thread-safe variant of ArrayList in which all mutative operations (add, set, and so on)
     // are implemented by making a fresh copy of the underlying array.
     private final List<SkylineDocumentImportListener> _skylineDocumentImportListeners = new CopyOnWriteArrayList<>();
@@ -249,7 +251,7 @@ public class TargetedMSServiceImpl implements TargetedMSService
     @Override
     public ExperimentRunType getExperimentRunType()
     {
-        return TargetedMSModule.EXP_RUN_TYPE;
+        return EXP_RUN_TYPE;
     }
 
     @Override

--- a/src/org/labkey/targetedms/parser/AbstractChromInfo.java
+++ b/src/org/labkey/targetedms/parser/AbstractChromInfo.java
@@ -23,6 +23,7 @@ import org.labkey.api.cache.CacheManager;
 import org.labkey.api.data.Container;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExperimentService;
+import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.util.Tuple3;
 import org.labkey.api.util.UnexpectedException;
 import org.labkey.targetedms.PanoramaBadDataException;
@@ -178,7 +179,8 @@ public abstract class AbstractChromInfo extends ChromInfo<PrecursorChromInfoAnno
     @Nullable
     public Chromatogram createChromatogram(TargetedMSRun run)
     {
-        return createChromatogram(run, Boolean.parseBoolean(TargetedMSModule.PREFER_SKYD_FILE_CHROMATOGRAMS_PROPERTY.getEffectiveValue(_container)));
+        return createChromatogram(run, Boolean.parseBoolean(ModuleLoader.getInstance().getModule(TargetedMSModule.class)
+                .PREFER_SKYD_FILE_CHROMATOGRAMS_PROPERTY.getEffectiveValue(_container)));
     }
 
     @Nullable
@@ -298,7 +300,8 @@ public abstract class AbstractChromInfo extends ChromInfo<PrecursorChromInfoAnno
     @Nullable
     public byte[] getChromatogramBytes(TargetedMSRun run)
     {
-        boolean loadFromSkyd = Boolean.parseBoolean(TargetedMSModule.PREFER_SKYD_FILE_CHROMATOGRAMS_PROPERTY.getEffectiveValue(_container));
+        boolean loadFromSkyd = Boolean.parseBoolean(ModuleLoader.getInstance().getModule(TargetedMSModule.class)
+                .PREFER_SKYD_FILE_CHROMATOGRAMS_PROPERTY.getEffectiveValue(_container));
         CompressedBytesAndStatus compressedBytesAndStatus = getCompressedBytesAndStatus(run, loadFromSkyd);
         return compressedBytesAndStatus.getCompressedBytes();
     }

--- a/src/org/labkey/targetedms/parser/PrecursorChromInfo.java
+++ b/src/org/labkey/targetedms/parser/PrecursorChromInfo.java
@@ -20,6 +20,7 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
+import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.util.logging.LogHelper;
 import org.labkey.targetedms.TargetedMSModule;
@@ -409,7 +410,8 @@ public class PrecursorChromInfo extends AbstractChromInfo implements Comparable<
     @Nullable @Override
     public Chromatogram createChromatogram(TargetedMSRun run)
     {
-        return createChromatogram(run, Boolean.parseBoolean(TargetedMSModule.PREFER_SKYD_FILE_CHROMATOGRAMS_PROPERTY.getEffectiveValue(getContainer())));
+        return createChromatogram(run, Boolean.parseBoolean(ModuleLoader.getInstance().getModule(TargetedMSModule.class)
+                .PREFER_SKYD_FILE_CHROMATOGRAMS_PROPERTY.getEffectiveValue(getContainer())));
     }
 
     @Override

--- a/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
+++ b/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
@@ -244,27 +244,28 @@ public class SkylineDocumentParser implements AutoCloseable
         _log = log;
         readDocumentVersion(_reader);
 
+        TargetedMSModule targetedMSModule = ModuleLoader.getInstance().getModule(TargetedMSModule.class);
         try
         {
-            _maxPrecursors = Integer.parseInt(ModuleLoader.getInstance().getModule(TargetedMSModule.class)
-                    .MAX_PRECURSORS_PROPERTY.getEffectiveValue(container));
+            _maxPrecursors = Integer.parseInt(targetedMSModule.MAX_PRECURSORS_PROPERTY.getEffectiveValue(container));
         }
         catch (NumberFormatException e)
         {
             _maxPrecursors = TargetedMSModule.DEFAULT_MAX_PRECURSORS;
-            _log.warn("Unable to parse MAX_PRECURSORS_PROPERTY value: " + ModuleLoader.getInstance().getModule(TargetedMSModule.class)
-                    .MAX_PRECURSORS_PROPERTY.getEffectiveValue(container) + ", defaulting to " + _maxPrecursors);
+            _log.warn("Unable to parse MAX_PRECURSORS_PROPERTY value: {}, defaulting to {}",
+                    targetedMSModule.MAX_PRECURSORS_PROPERTY.getEffectiveValue(container),
+                    _maxPrecursors);
         }
         try
         {
-            _maxTransitionChromInfos = Integer.parseInt(ModuleLoader.getInstance().getModule(TargetedMSModule.class)
-                    .MAX_TRANSITION_CHROM_INFOS_PROPERTY.getEffectiveValue(container));
+            _maxTransitionChromInfos = Integer.parseInt(targetedMSModule.MAX_TRANSITION_CHROM_INFOS_PROPERTY.getEffectiveValue(container));
         }
         catch (NumberFormatException e)
         {
             _maxTransitionChromInfos = TargetedMSModule.DEFAULT_MAX_TRANSITION_CHROM_INFOS;
-            _log.warn("Unable to parse MAX_TRANSITION_CHROM_INFOS_PROPERTY value: " + ModuleLoader.getInstance().getModule(TargetedMSModule.class)
-                    .MAX_TRANSITION_CHROM_INFOS_PROPERTY.getEffectiveValue(container) + ", defaulting to " + _maxTransitionChromInfos);
+            _log.warn();"Unable to parse MAX_TRANSITION_CHROM_INFOS_PROPERTY value: {}, defaulting to {}",
+                    targetedMSModule.MAX_TRANSITION_CHROM_INFOS_PROPERTY.getEffectiveValue(container),
+                    _maxTransitionChromInfos);
         }
     }
 

--- a/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
+++ b/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
@@ -263,7 +263,7 @@ public class SkylineDocumentParser implements AutoCloseable
         catch (NumberFormatException e)
         {
             _maxTransitionChromInfos = TargetedMSModule.DEFAULT_MAX_TRANSITION_CHROM_INFOS;
-            _log.warn();"Unable to parse MAX_TRANSITION_CHROM_INFOS_PROPERTY value: {}, defaulting to {}",
+            _log.warn("Unable to parse MAX_TRANSITION_CHROM_INFOS_PROPERTY value: {}, defaulting to {}",
                     targetedMSModule.MAX_TRANSITION_CHROM_INFOS_PROPERTY.getEffectiveValue(container),
                     _maxTransitionChromInfos);
         }

--- a/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
+++ b/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
@@ -26,6 +26,7 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.RuntimeSQLException;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExperimentService;
+import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.reader.TabLoader;
 import org.labkey.api.security.User;
 import org.labkey.api.util.FileUtil;
@@ -245,21 +246,25 @@ public class SkylineDocumentParser implements AutoCloseable
 
         try
         {
-            _maxPrecursors = Integer.parseInt(TargetedMSModule.MAX_PRECURSORS_PROPERTY.getEffectiveValue(container));
+            _maxPrecursors = Integer.parseInt(ModuleLoader.getInstance().getModule(TargetedMSModule.class)
+                    .MAX_PRECURSORS_PROPERTY.getEffectiveValue(container));
         }
         catch (NumberFormatException e)
         {
             _maxPrecursors = TargetedMSModule.DEFAULT_MAX_PRECURSORS;
-            _log.warn("Unable to parse MAX_PRECURSORS_PROPERTY value: " + TargetedMSModule.MAX_PRECURSORS_PROPERTY.getEffectiveValue(container) + ", defaulting to " + _maxPrecursors);
+            _log.warn("Unable to parse MAX_PRECURSORS_PROPERTY value: " + ModuleLoader.getInstance().getModule(TargetedMSModule.class)
+                    .MAX_PRECURSORS_PROPERTY.getEffectiveValue(container) + ", defaulting to " + _maxPrecursors);
         }
         try
         {
-            _maxTransitionChromInfos = Integer.parseInt(TargetedMSModule.MAX_TRANSITION_CHROM_INFOS_PROPERTY.getEffectiveValue(container));
+            _maxTransitionChromInfos = Integer.parseInt(ModuleLoader.getInstance().getModule(TargetedMSModule.class)
+                    .MAX_TRANSITION_CHROM_INFOS_PROPERTY.getEffectiveValue(container));
         }
         catch (NumberFormatException e)
         {
             _maxTransitionChromInfos = TargetedMSModule.DEFAULT_MAX_TRANSITION_CHROM_INFOS;
-            _log.warn("Unable to parse MAX_TRANSITION_CHROM_INFOS_PROPERTY value: " + TargetedMSModule.MAX_TRANSITION_CHROM_INFOS_PROPERTY.getEffectiveValue(container) + ", defaulting to " + _maxTransitionChromInfos);
+            _log.warn("Unable to parse MAX_TRANSITION_CHROM_INFOS_PROPERTY value: " + ModuleLoader.getInstance().getModule(TargetedMSModule.class)
+                    .MAX_TRANSITION_CHROM_INFOS_PROPERTY.getEffectiveValue(container) + ", defaulting to " + _maxTransitionChromInfos);
         }
     }
 
@@ -2312,7 +2317,7 @@ public class SkylineDocumentParser implements AutoCloseable
                 // Read it out of the file on-demand, so we only load the subset that we need
                 try
                 {
-                    if (!Boolean.parseBoolean(TargetedMSModule.SKIP_CHROMATOGRAM_IMPORT_PROPERTY.getEffectiveValue(_container)))
+                    if (!Boolean.parseBoolean(ModuleLoader.getInstance().getModule(TargetedMSModule.class).SKIP_CHROMATOGRAM_IMPORT_PROPERTY.getEffectiveValue(_container)))
                     {
                         chromInfo.setChromatogram(_binaryParser.readChromatogramBytes(chromatogram));
                     }

--- a/src/org/labkey/targetedms/parser/skyaudit/SkylineAuditLogSecurityManager.java
+++ b/src/org/labkey/targetedms/parser/skyaudit/SkylineAuditLogSecurityManager.java
@@ -49,7 +49,8 @@ public class SkylineAuditLogSecurityManager
     {
         _jobLogger = jobLogger;
 
-        int propIndex = Integer.parseInt(ModuleLoader.getInstance().getModule(TargetedMSModule.class).SKYLINE_AUDIT_LEVEL_PROPERTY.getEffectiveValue(container));
+        int propIndex = Integer.parseInt(ModuleLoader.getInstance().getModule(TargetedMSModule.class)
+                .SKYLINE_AUDIT_LEVEL_PROPERTY.getEffectiveValue(container));
         _verificationLevel = INTEGRITY_LEVEL.values()[propIndex];
     }
 

--- a/src/org/labkey/targetedms/parser/skyaudit/SkylineAuditLogSecurityManager.java
+++ b/src/org/labkey/targetedms/parser/skyaudit/SkylineAuditLogSecurityManager.java
@@ -19,6 +19,7 @@ package org.labkey.targetedms.parser.skyaudit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.labkey.api.data.Container;
+import org.labkey.api.module.ModuleLoader;
 import org.labkey.targetedms.TargetedMSModule;
 
 import javax.annotation.Nullable;
@@ -48,7 +49,7 @@ public class SkylineAuditLogSecurityManager
     {
         _jobLogger = jobLogger;
 
-        int propIndex = Integer.parseInt(TargetedMSModule.SKYLINE_AUDIT_LEVEL_PROPERTY.getEffectiveValue(container));
+        int propIndex = Integer.parseInt(ModuleLoader.getInstance().getModule(TargetedMSModule.class).SKYLINE_AUDIT_LEVEL_PROPERTY.getEffectiveValue(container));
         _verificationLevel = INTEGRITY_LEVEL.values()[propIndex];
     }
 

--- a/src/org/labkey/targetedms/view/TargetedMsRunListView.java
+++ b/src/org/labkey/targetedms/view/TargetedMsRunListView.java
@@ -67,7 +67,7 @@ public class TargetedMsRunListView extends ExperimentRunListView
 
     public TargetedMsRunListView(UserSchema schema, QuerySettings settings, boolean hasDocVersions, boolean showAllVersions)
     {
-        super(schema, settings, TargetedMSModule.EXP_RUN_TYPE);
+        super(schema, settings, TargetedMSService.get().getExperimentRunType());
         _hasDocVersions = hasDocVersions;
         _showAllVersions = showAllVersions;
         setShowAddToRunGroupButton(false);
@@ -201,7 +201,7 @@ public class TargetedMsRunListView extends ExperimentRunListView
     public static TargetedMsRunListView createView(ViewContext model, ViewType viewType)
     {
         UserSchema schema = new TargetedMSSchema(model.getUser(), model.getContainer());
-        QuerySettings querySettings = getRunListQuerySettings(schema, model, TargetedMSModule.EXP_RUN_TYPE.getTableName(), true);
+        QuerySettings querySettings = getRunListQuerySettings(schema, model, TargetedMSService.get().getExperimentRunType().getTableName(), true);
 
         TargetedMsRunListView view = new TargetedMsRunListView(schema, querySettings,
                 TargetedMSManager.containerHasDocVersions(model.getContainer()),


### PR DESCRIPTION
#### Rationale
When using startup properties to exclude modules, `TargetedMSModule` get flagged as a memory leak because it contains static references to itself by way of its module properties. Making the module properties non-static (as they are in other modules) should fix this.

#### Related Pull Requests
* N/A

#### Changes
* Use non-static members for targetedms module properties
