### PR TITLE
Issue 47097: Extra guide sets shown when checking Show Reference Guidset option

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -1473,8 +1473,8 @@ public class TargetedMSController extends SpringActionController
                     // 4. startDate is same as guideset training end
                     boolean startDateAfterGuideSet = guideSet.getTrainingEnd().before(startDate);
                     boolean startDateBetweenGuideSet = guideSet.getTrainingStart().before(startDate) && guideSet.getTrainingEnd().after(startDate);
-                    boolean startDateOverlapGuideSetStart = DateUtil.getDateOnly(guideSet.getTrainingStart()).compareTo(DateUtil.getDateOnly(startDate)) == 0;
-                    boolean startDateOverlapGuideSetEnd = DateUtil.getDateOnly(guideSet.getTrainingEnd()).compareTo(DateUtil.getDateOnly(startDate)) == 0;
+                    boolean startDateOverlapGuideSetStart = DateUtil.getDateOnly(guideSet.getTrainingStart()).equals(DateUtil.getDateOnly(startDate));
+                    boolean startDateOverlapGuideSetEnd = DateUtil.getDateOnly(guideSet.getTrainingEnd()).equals(DateUtil.getDateOnly(startDate));
                     if (startDateAfterGuideSet ||
                             startDateBetweenGuideSet ||
                             startDateOverlapGuideSetStart ||

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -1473,12 +1473,12 @@ public class TargetedMSController extends SpringActionController
                     // 4. startDate is same as guideset training end
                     boolean startDateAfterGuideSet = guideSet.getTrainingEnd().before(startDate);
                     boolean startDateBetweenGuideSet = guideSet.getTrainingStart().before(startDate) && guideSet.getTrainingEnd().after(startDate);
-                    boolean startDateOverlapGuideSet = DateUtil.getDateOnly(guideSet.getTrainingStart()).compareTo(DateUtil.getDateOnly(startDate)) == 0;
-                    boolean endDateOverlapGuideSet = DateUtil.getDateOnly(guideSet.getTrainingEnd()).compareTo(DateUtil.getDateOnly(startDate)) == 0;
+                    boolean startDateOverlapGuideSetStart = DateUtil.getDateOnly(guideSet.getTrainingStart()).compareTo(DateUtil.getDateOnly(startDate)) == 0;
+                    boolean startDateOverlapGuideSetEnd = DateUtil.getDateOnly(guideSet.getTrainingEnd()).compareTo(DateUtil.getDateOnly(startDate)) == 0;
                     if (startDateAfterGuideSet ||
                             startDateBetweenGuideSet ||
-                            startDateOverlapGuideSet ||
-                            endDateOverlapGuideSet)
+                            startDateOverlapGuideSetStart ||
+                            startDateOverlapGuideSetEnd)
                     {
                         if (null == gs)
                         {

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentalQCLinkTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentalQCLinkTest.java
@@ -152,7 +152,7 @@ public class TargetedMSExperimentalQCLinkTest extends TargetedMSTest
         checker().verifyEquals("Incorrect guideSet information", guideSetTitle, qcPlotsWebPart.getGuideSetTrainingRectTitle(2));
         checker().screenShotIfNewError("InitialRangeFiltering");
 
-        String testStartDate = "2013-08-19";
+        String testStartDate = "2013-08-18";
         String testEndDate = "2013-08-27";
         qcPlotsWebPart.filterQCPlots(testStartDate, testEndDate, 7);
 


### PR DESCRIPTION
#### Rationale
Extra guideset is shown when checking Show reference guideset option because of the bug when comparing dates from the custom date range selected by the user and guideset training range.

#### Related Pull Requests
* https://github.com/LabKey/targetedms/pull/343

