### PR TITLE
Issue 47342: Trailing Mean plot incorrectly treats missing data point as 0

### DIFF
--- a/src/org/labkey/targetedms/model/GuideSetStats.java
+++ b/src/org/labkey/targetedms/model/GuideSetStats.java
@@ -208,6 +208,7 @@ public class GuideSetStats
                     {
                         // when the metric value is null (bad data), setting it to the previous value
                         row.setTrailingMean(trailingMeans[j-1]);
+                        row.setTrailingStart(trailingStartRow.getSampleFile().getAcquiredTime());
                     }
                     else
                     {
@@ -221,6 +222,7 @@ public class GuideSetStats
                     {
                         // when the metric value is null (bad data), setting it to the previous value
                         row.setTrailingCV(trailingCVs[j-1]);
+                        row.setTrailingStart(trailingStartRow.getSampleFile().getAcquiredTime());
                     }
                     else
                     {


### PR DESCRIPTION
#### Rationale
Trailing mean plots are treating missing/bad data as 0. This PR fixes the issue by not considering that data when calculating trailing mean and trailing cv. 

#### Changes
* skip bad data in trailing mean/cv calculation
* set previous trailing mean/cv value for bad data point
