### PR TITLE
Issue 46743: Include peptide/small molecule info in tooltip for QC plot line

### DIFF
--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -693,7 +693,7 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
             pathMouseOutFn: this.plotPointMouseOut,
             pathMouseOutFnScope: this,
             hoverTextFn: !showDataPoints ? function(pathData) {
-                return pathData.group + '\nNarrow the date range to show individual data points.'
+                return Ext4.htmlEncode(pathData.group) + '\nNarrow the date range to show individual data points.'
             } : undefined
         };
 

--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -692,7 +692,9 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
             pathMouseOverFnScope: this,
             pathMouseOutFn: this.plotPointMouseOut,
             pathMouseOutFnScope: this,
-            hoverTextFn: !showDataPoints ? function() { return 'Narrow the date range to show individual data points.' } : undefined
+            hoverTextFn: !showDataPoints ? function(pathData) {
+                return pathData.group + '\nNarrow the date range to show individual data points.'
+            } : undefined
         };
 
         Ext4.apply(trendLineProps, this.getPlotTypeProperties(combinePlotData, plotType, isCUSUMMean));


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46743
This PR passes the data back from the LABKEY.vis.TrendingLinePlot hoverTextFn so that we can include the plotData.group name in the hover text display in the Panorama QC combined plot case.

#### Related Pull Requests
* https://github.com/LabKey/targetedms/pull/688
* https://github.com/LabKey/platform/pull/4212

#### Changes
* include the plotData.group name in the hover text display
