### PR TITLE
Wait for color picker in `AnnotationTypeInsertPage`

### DIFF
--- a/test/src/org/labkey/test/pages/targetedms/AnnotationTypeInsertPage.java
+++ b/test/src/org/labkey/test/pages/targetedms/AnnotationTypeInsertPage.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.test.pages.targetedms;
 
-import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.pages.InsertPage;
 import org.openqa.selenium.WebDriver;
@@ -34,7 +33,7 @@ public class AnnotationTypeInsertPage extends InsertPage
         Elements elements = elements();
         setFormElement(elements.name, name);
         setFormElement(elements.description, description);
-        click(Locator.xpath("//a[contains(@class, " + Locator.xq("color-" + color) + ")]"));
+        waitAndClick(Locator.xpath("//a[contains(@class, " + Locator.xq("color-" + color) + ")]"));
         clickAndWait(elements.submit);
     }
 


### PR DESCRIPTION
#### Rationale
Tests have started hitting an intermittent timing failure. The test can't find the color picker. It is missing from the html artifact but the `png` screenshot shows it. Probably just need to wait before clicking.
```
org.openqa.selenium.NoSuchElementException: Unable to find element: xpath=//a[contains(@class, "color-808080")]
[...]
  at app//org.labkey.test.pages.targetedms.AnnotationTypeInsertPage.insert(AnnotationTypeInsertPage.java:37)
  at app//org.labkey.test.tests.targetedms.TargetedMSQCTest.createAndInsertAnnotations(TargetedMSQCTest.java:1015)
  at app//org.labkey.test.tests.targetedms.TargetedMSQCTest.doInit(TargetedMSQCTest.java:181)
  at app//org.labkey.test.tests.targetedms.TargetedMSQCTest.initProject(TargetedMSQCTest.java:166)
```

#### Related Pull Requests
* N/A

#### Changes
* Wait for color picker in `AnnotationTypeInsertPage`
