### PR TITLE
Issue 47774: Remove TargetedMS module properties related to reading chromatogram data

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -44,7 +44,6 @@ import org.labkey.api.protein.ProteomicsModule;
 import org.labkey.api.query.QueryView;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.ApplicationAdminPermission;
-import org.labkey.api.security.permissions.SiteAdminPermission;
 import org.labkey.api.settings.AdminConsole;
 import org.labkey.api.targetedms.TargetedMSService;
 import org.labkey.api.usageMetrics.UsageMetricsService;
@@ -195,7 +194,7 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
         MAX_TRANSITION_CHROM_INFOS_PROPERTY.setInputType(ModuleProperty.InputType.text);
         MAX_TRANSITION_CHROM_INFOS_PROPERTY.setDefaultValue(Integer.toString(DEFAULT_MAX_TRANSITION_CHROM_INFOS));
         // Issue 47774: Remove TargetedMS module properties related to reading chromatogram data.
-        // Property is can be set only at the site level
+        // Property can be set only at the site level.
         MAX_TRANSITION_CHROM_INFOS_PROPERTY.setCanSetPerContainer(false);
         MAX_TRANSITION_CHROM_INFOS_PROPERTY.setDescription("Large DIA Skyline documents may have many transition/replicate chromatograms which may not be very useful to store in the database. Panorama can skip importing them to save storage space and import time, if the number of separately configured precursors is also exceeded");
         MAX_TRANSITION_CHROM_INFOS_PROPERTY.setShowDescriptionInline(true);
@@ -205,7 +204,7 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
         MAX_PRECURSORS_PROPERTY.setInputType(ModuleProperty.InputType.text);
         MAX_PRECURSORS_PROPERTY.setDefaultValue(Integer.toString(DEFAULT_MAX_PRECURSORS));
         // Issue 47774: Remove TargetedMS module properties related to reading chromatogram data.
-        // Property is can be set only at the site level
+        // Property can be set only at the site level.
         MAX_PRECURSORS_PROPERTY.setCanSetPerContainer(false);
         MAX_PRECURSORS_PROPERTY.setDescription("If a document has more than a specified number of precursors AND more than the separate transition/replicate chromatogram limit, Panorama will skip storing them in the database to save space and import time");
         MAX_PRECURSORS_PROPERTY.setShowDescriptionInline(true);

--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -44,6 +44,7 @@ import org.labkey.api.protein.ProteomicsModule;
 import org.labkey.api.query.QueryView;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.ApplicationAdminPermission;
+import org.labkey.api.security.permissions.SiteAdminPermission;
 import org.labkey.api.settings.AdminConsole;
 import org.labkey.api.targetedms.TargetedMSService;
 import org.labkey.api.usageMetrics.UsageMetricsService;
@@ -147,8 +148,6 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
     public static final String[] QC_FOLDER_WEB_PARTS = new String[] {TARGETED_MS_QC_SUMMARY, TARGETED_MS_QC_PLOTS};
 
     public final ModuleProperty FOLDER_TYPE_PROPERTY;
-    public final ModuleProperty SKIP_CHROMATOGRAM_IMPORT_PROPERTY;
-    public final ModuleProperty PREFER_SKYD_FILE_CHROMATOGRAMS_PROPERTY;
     public final ModuleProperty SKYLINE_AUDIT_LEVEL_PROPERTY;
     public final ModuleProperty MAX_TRANSITION_CHROM_INFOS_PROPERTY;
     public static final int DEFAULT_MAX_TRANSITION_CHROM_INFOS = 100_000;
@@ -165,21 +164,6 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
         FOLDER_TYPE_PROPERTY.setShowDescriptionInline(true);
         addModuleProperty(FOLDER_TYPE_PROPERTY);
 
-        List<ModuleProperty.Option> options = List.of(
-            new ModuleProperty.Option("Enabled", Boolean.TRUE.toString()),
-            new ModuleProperty.Option("Disabled", Boolean.FALSE.toString())
-        );
-        // Set up the properties for controlling how chromatograms are managed in DB vs files
-        SKIP_CHROMATOGRAM_IMPORT_PROPERTY = new ModuleProperty(this, "Skip chromatogram import into database");
-        SKIP_CHROMATOGRAM_IMPORT_PROPERTY.setInputType(ModuleProperty.InputType.combo);
-        SKIP_CHROMATOGRAM_IMPORT_PROPERTY.setOptions(options);
-        SKIP_CHROMATOGRAM_IMPORT_PROPERTY.setDefaultValue(Boolean.toString(false));
-        SKIP_CHROMATOGRAM_IMPORT_PROPERTY.setCanSetPerContainer(true);
-        SKIP_CHROMATOGRAM_IMPORT_PROPERTY.setDescription("Skyline stores chromatograms in SKYD files. Panorama can import them into its database, or leave them to be loaded from the file on demand");
-        SKIP_CHROMATOGRAM_IMPORT_PROPERTY.setShowDescriptionInline(true);
-        addModuleProperty(SKIP_CHROMATOGRAM_IMPORT_PROPERTY);
-
-        //------------------------
         List<ModuleProperty.Option> auditOptions = List.of(
             new ModuleProperty.Option("0 - No Verification", "0"),
             new ModuleProperty.Option("1 - Hash Verification", "1"),
@@ -199,15 +183,6 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
         addModuleProperty(SKYLINE_AUDIT_LEVEL_PROPERTY);
         //------------------------rr
 
-        PREFER_SKYD_FILE_CHROMATOGRAMS_PROPERTY = new ModuleProperty(this, "Prefer loading chromatograms from SKYD file when possible");
-        PREFER_SKYD_FILE_CHROMATOGRAMS_PROPERTY.setInputType(ModuleProperty.InputType.combo);
-        PREFER_SKYD_FILE_CHROMATOGRAMS_PROPERTY.setOptions(options);
-        PREFER_SKYD_FILE_CHROMATOGRAMS_PROPERTY.setDefaultValue(Boolean.toString(false));
-        PREFER_SKYD_FILE_CHROMATOGRAMS_PROPERTY.setCanSetPerContainer(true);
-        PREFER_SKYD_FILE_CHROMATOGRAMS_PROPERTY.setDescription("Skyline stores chromatograms in SKYD files. Panorama can load them directly from the file, when preset, even if they have been previously imported into the database.");
-        PREFER_SKYD_FILE_CHROMATOGRAMS_PROPERTY.setShowDescriptionInline(true);
-        addModuleProperty(PREFER_SKYD_FILE_CHROMATOGRAMS_PROPERTY);
-
         // setup the QC Summary webpart AutoQCPing timeout
         AUTO_QC_PING_TIMEOUT_PROPERTY = new ModuleProperty(this, "TargetedMS AutoQCPing Timeout");
         AUTO_QC_PING_TIMEOUT_PROPERTY.setDescription("The number of minutes before the most recent AutoQCPing indicator is considered stale.");
@@ -219,7 +194,9 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
         MAX_TRANSITION_CHROM_INFOS_PROPERTY = new ModuleProperty(this, "TransitionChromInfo storage limit");
         MAX_TRANSITION_CHROM_INFOS_PROPERTY.setInputType(ModuleProperty.InputType.text);
         MAX_TRANSITION_CHROM_INFOS_PROPERTY.setDefaultValue(Integer.toString(DEFAULT_MAX_TRANSITION_CHROM_INFOS));
-        MAX_TRANSITION_CHROM_INFOS_PROPERTY.setCanSetPerContainer(true);
+        // Issue 47774: Remove TargetedMS module properties related to reading chromatogram data.
+        // Property is can be set only at the site level
+        MAX_TRANSITION_CHROM_INFOS_PROPERTY.setCanSetPerContainer(false);
         MAX_TRANSITION_CHROM_INFOS_PROPERTY.setDescription("Large DIA Skyline documents may have many transition/replicate chromatograms which may not be very useful to store in the database. Panorama can skip importing them to save storage space and import time, if the number of separately configured precursors is also exceeded");
         MAX_TRANSITION_CHROM_INFOS_PROPERTY.setShowDescriptionInline(true);
         addModuleProperty(MAX_TRANSITION_CHROM_INFOS_PROPERTY);
@@ -227,7 +204,9 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
         MAX_PRECURSORS_PROPERTY = new ModuleProperty(this, "Precursor storage limit");
         MAX_PRECURSORS_PROPERTY.setInputType(ModuleProperty.InputType.text);
         MAX_PRECURSORS_PROPERTY.setDefaultValue(Integer.toString(DEFAULT_MAX_PRECURSORS));
-        MAX_PRECURSORS_PROPERTY.setCanSetPerContainer(true);
+        // Issue 47774: Remove TargetedMS module properties related to reading chromatogram data.
+        // Property is can be set only at the site level
+        MAX_PRECURSORS_PROPERTY.setCanSetPerContainer(false);
         MAX_PRECURSORS_PROPERTY.setDescription("If a document has more than a specified number of precursors AND more than the separate transition/replicate chromatogram limit, Panorama will skip storing them in the database to save space and import time");
         MAX_PRECURSORS_PROPERTY.setShowDescriptionInline(true);
         addModuleProperty(MAX_PRECURSORS_PROPERTY);

--- a/src/org/labkey/targetedms/parser/AbstractChromInfo.java
+++ b/src/org/labkey/targetedms/parser/AbstractChromInfo.java
@@ -23,11 +23,9 @@ import org.labkey.api.cache.CacheManager;
 import org.labkey.api.data.Container;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExperimentService;
-import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.util.Tuple3;
 import org.labkey.api.util.UnexpectedException;
 import org.labkey.targetedms.PanoramaBadDataException;
-import org.labkey.targetedms.TargetedMSModule;
 import org.labkey.targetedms.TargetedMSRun;
 
 import java.io.IOException;
@@ -175,16 +173,8 @@ public abstract class AbstractChromInfo extends ChromInfo<PrecursorChromInfoAnno
     }
 
 
-    /** Use the module property to decide whether to try fetching from disk*/
     @Nullable
     public Chromatogram createChromatogram(TargetedMSRun run)
-    {
-        return createChromatogram(run, Boolean.parseBoolean(ModuleLoader.getInstance().getModule(TargetedMSModule.class)
-                .PREFER_SKYD_FILE_CHROMATOGRAMS_PROPERTY.getEffectiveValue(_container)));
-    }
-
-    @Nullable
-    public Chromatogram createChromatogram(TargetedMSRun run, boolean loadFromSkyd)
     {
         try
         {
@@ -195,7 +185,7 @@ public abstract class AbstractChromInfo extends ChromInfo<PrecursorChromInfoAnno
 
             ChromatogramBinaryFormat binaryFormat = ChromatogramBinaryFormat.values()[getChromatogramFormat()];
 
-            CompressedBytesAndStatus compressedBytesAndStatus = getCompressedBytesAndStatus(run, loadFromSkyd);
+            CompressedBytesAndStatus compressedBytesAndStatus = getCompressedBytesAndStatus(run);
             byte[] compressedBytes = compressedBytesAndStatus.getCompressedBytes();
             Chromatogram.SourceStatus status = compressedBytesAndStatus.getStatus();
 
@@ -218,60 +208,54 @@ public abstract class AbstractChromInfo extends ChromInfo<PrecursorChromInfoAnno
         }
     }
 
-    private CompressedBytesAndStatus getCompressedBytesAndStatus(TargetedMSRun run, boolean loadFromSkyd)
+    private CompressedBytesAndStatus getCompressedBytesAndStatus(TargetedMSRun run)
     {
         byte[] databaseBytes = getChromatogram();
         byte[] compressedBytes = databaseBytes;
         Chromatogram.SourceStatus status;
 
-        if (loadFromSkyd || databaseBytes == null)
+        if (run.getSkydDataId() != null && _chromatogramLength != null && _chromatogramOffset != null)
         {
-            if (run.getSkydDataId() != null && _chromatogramLength != null && _chromatogramOffset != null)
+            ExpData skydData = ExperimentService.get().getExpData(run.getSkydDataId());
+            if (skydData != null)
             {
-                ExpData skydData = ExperimentService.get().getExpData(run.getSkydDataId());
-                if (skydData != null)
+                Path skydPath = skydData.getFilePath();
+                if (skydPath == null)
                 {
-                    Path skydPath = skydData.getFilePath();
-                    if (skydPath == null)
-                    {
-                        status = Chromatogram.SourceStatus.skydMissing;
-                        LOG.debug("No path available for " + this + ", bucket may be unavailable for URL " + skydData.getDataFileUrl());
-                    }
-                    else
-                    {
-                        LOG.debug("Attempting to fetch chromatogram bytes (possibly cached) from " + skydPath + " for " + this);
-                        byte[] diskBytes = ON_DEMAND_CHROM_CACHE.get(new Tuple3<>(skydPath, _chromatogramOffset, _chromatogramLength));
-                        if (diskBytes == null)
-                        {
-                            status = Chromatogram.SourceStatus.skydMissing;
-                        }
-                        else if (databaseBytes != null && !Arrays.equals(databaseBytes, diskBytes))
-                        {
-                            LOG.error("Chromatogram bytes for " + this + " do not match between .skyd and DB. Using database copy. Lengths: " + diskBytes.length + " vs " + databaseBytes.length);
-                            status = Chromatogram.SourceStatus.mismatch;
-                        }
-                        else
-                        {
-                            compressedBytes = diskBytes;
-                            status = databaseBytes == null ? Chromatogram.SourceStatus.diskOnly : Chromatogram.SourceStatus.match;
-                        }
-                    }
+                    status = Chromatogram.SourceStatus.skydMissing;
+                    LOG.debug("No path available for " + this + ", bucket may be unavailable for URL " + skydData.getDataFileUrl());
                 }
                 else
                 {
-                    status = Chromatogram.SourceStatus.noSkydResolved;
+                    LOG.debug("Attempting to fetch chromatogram bytes (possibly cached) from " + skydPath + " for " + this);
+                    byte[] diskBytes = ON_DEMAND_CHROM_CACHE.get(new Tuple3<>(skydPath, _chromatogramOffset, _chromatogramLength));
+                    if (diskBytes == null)
+                    {
+                        status = Chromatogram.SourceStatus.skydMissing;
+                    }
+                    else if (databaseBytes != null && !Arrays.equals(databaseBytes, diskBytes))
+                    {
+                        LOG.error("Chromatogram bytes for " + this + " do not match between .skyd and DB. Using database copy. Lengths: " + diskBytes.length + " vs " + databaseBytes.length);
+                        status = Chromatogram.SourceStatus.mismatch;
+                    }
+                    else
+                    {
+                        compressedBytes = diskBytes;
+                        status = databaseBytes == null ? Chromatogram.SourceStatus.diskOnly : Chromatogram.SourceStatus.match;
+                    }
                 }
             }
             else
             {
-                LOG.debug("No length, offset, and/or SKYD DataId for " + this);
-                status = Chromatogram.SourceStatus.dbOnly;
+                status = Chromatogram.SourceStatus.noSkydResolved;
             }
         }
         else
         {
+            LOG.debug("No length, offset, and/or SKYD DataId for " + this);
             status = Chromatogram.SourceStatus.dbOnly;
         }
+
         return new CompressedBytesAndStatus(compressedBytes, status);
     }
 
@@ -300,9 +284,7 @@ public abstract class AbstractChromInfo extends ChromInfo<PrecursorChromInfoAnno
     @Nullable
     public byte[] getChromatogramBytes(TargetedMSRun run)
     {
-        boolean loadFromSkyd = Boolean.parseBoolean(ModuleLoader.getInstance().getModule(TargetedMSModule.class)
-                .PREFER_SKYD_FILE_CHROMATOGRAMS_PROPERTY.getEffectiveValue(_container));
-        CompressedBytesAndStatus compressedBytesAndStatus = getCompressedBytesAndStatus(run, loadFromSkyd);
+        CompressedBytesAndStatus compressedBytesAndStatus = getCompressedBytesAndStatus(run);
         return compressedBytesAndStatus.getCompressedBytes();
     }
 }

--- a/src/org/labkey/targetedms/parser/PrecursorChromInfo.java
+++ b/src/org/labkey/targetedms/parser/PrecursorChromInfo.java
@@ -20,11 +20,8 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
-import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.util.logging.LogHelper;
-import org.labkey.targetedms.TargetedMSModule;
-import org.labkey.targetedms.TargetedMSRun;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
@@ -404,14 +401,6 @@ public class PrecursorChromInfo extends AbstractChromInfo implements Comparable<
         }
 
         return result;
-    }
-
-    /** Use the module property to decide whether to try fetching from disk*/
-    @Nullable @Override
-    public Chromatogram createChromatogram(TargetedMSRun run)
-    {
-        return createChromatogram(run, Boolean.parseBoolean(ModuleLoader.getInstance().getModule(TargetedMSModule.class)
-                .PREFER_SKYD_FILE_CHROMATOGRAMS_PROPERTY.getEffectiveValue(getContainer())));
     }
 
     @Override

--- a/src/org/labkey/targetedms/parser/SampleFileChromInfo.java
+++ b/src/org/labkey/targetedms/parser/SampleFileChromInfo.java
@@ -17,7 +17,6 @@ package org.labkey.targetedms.parser;
 
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
-import org.labkey.targetedms.TargetedMSRun;
 import org.labkey.targetedms.parser.skyd.ChromGroupHeaderInfo;
 
 import java.util.EnumSet;
@@ -45,15 +44,6 @@ public class SampleFileChromInfo extends AbstractChromInfo
         super(c);
     }
 
-
-
-    /** Always load from disk */
-    @Nullable
-    @Override
-    public Chromatogram createChromatogram(TargetedMSRun run)
-    {
-        return createChromatogram(run, true);
-    }
 
     @Nullable
     @Override

--- a/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
+++ b/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
@@ -2315,21 +2315,11 @@ public class SkylineDocumentParser implements AutoCloseable
             pciBySkylineSampleFileId.put(chromInfo.getSkylineSampleFileId(), chromInfo);
             if (chromatogram != null)
             {
-                // Read it out of the file on-demand, so we only load the subset that we need
-                try
-                {
-                    if (!Boolean.parseBoolean(ModuleLoader.getInstance().getModule(TargetedMSModule.class).SKIP_CHROMATOGRAM_IMPORT_PROPERTY.getEffectiveValue(_container)))
-                    {
-                        chromInfo.setChromatogram(_binaryParser.readChromatogramBytes(chromatogram));
-                    }
-                    chromInfo.setChromatogramFormat(chromatogram.getChromatogramBinaryFormat().ordinal());
-                    chromInfo.setChromatogramOffset(chromatogram.getLocationPoints());
-                    chromInfo.setChromatogramLength(chromatogram.getCompressedSize());
-                }
-                catch (DataFormatException ignored)
-                {
-                    _log.warn("Failed to extract chromatogram for " + precursor + " in replicate " + chromInfo.getReplicateName());
-                }
+                // Do not load the chromatogram bytes here since we will read them from the skyd file on-demand.
+                chromInfo.setChromatogramFormat(chromatogram.getChromatogramBinaryFormat().ordinal());
+                chromInfo.setChromatogramOffset(chromatogram.getLocationPoints());
+                chromInfo.setChromatogramLength(chromatogram.getCompressedSize());
+
                 chromInfo.setNumPoints(chromatogram.getNumPoints());
                 chromInfo.setNumTransitions(chromatogram.getNumTransitions());
                 chromInfo.setUncompressedSize(chromatogram.getUncompressedSize());

--- a/src/org/labkey/targetedms/pipeline/ChromatogramCrawlerJob.java
+++ b/src/org/labkey/targetedms/pipeline/ChromatogramCrawlerJob.java
@@ -296,7 +296,7 @@ public class ChromatogramCrawlerJob extends PipelineJob
             if (_rowsForCurrentRun++ < 5)
             {
                 PrecursorChromInfo pci = PrecursorManager.getPrecursorChromInfo(_container, id);
-                Chromatogram chromatogram = pci.createChromatogram(_run, true);
+                Chromatogram chromatogram = pci.createChromatogram(_run);
                 if (chromatogram == null)
                 {
                     _currentSummary._noChromatogramCount++;

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSPrecursorLevelDataTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSPrecursorLevelDataTest.java
@@ -14,6 +14,7 @@
  */
 package org.labkey.test.tests.targetedms;
 
+import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.Locator;
@@ -34,14 +35,24 @@ public class TargetedMSPrecursorLevelDataTest extends AbstractQuantificationTest
         return "TargetedMSProject";
     }
     public void setUsePrecursorLevelData() {
+        setStorageLimitModuleProperties("0", "0");
+    }
+
+    /**
+     * Sets the values of the site-level module properties: "TransitionChromInfo storage limit" and "Precursor storage limit".
+     * The values should be set back to defaults {@link #setDefaultStorageLimits} after the test completes.
+     * @param transitionStorageLimit
+     * @param precursorStorageLimit
+     */
+    private void setStorageLimitModuleProperties(String transitionStorageLimit, String precursorStorageLimit) {
         goToProjectHome();
         goToFolderManagement();
         clickAndWait(Locator.linkWithText("Module Properties"));
         setModuleProperties(Arrays.asList(
                 new ModulePropertyValue("TargetedMS", "/",
-                        "TransitionChromInfo storage limit", "0"),
+                        "TransitionChromInfo storage limit", transitionStorageLimit),
                 new ModulePropertyValue("TargetedMS", "/",
-                        "Precursor storage limit", "0")));
+                        "Precursor storage limit",  precursorStorageLimit)));
 
     }
     @Test
@@ -57,5 +68,11 @@ public class TargetedMSPrecursorLevelDataTest extends AbstractQuantificationTest
         fom.setCalc("Blank plus 2 * SD");
 
         runScenario("MergedDocuments", "none", fom);
+    }
+
+    @After
+    public void setDefaultStorageLimits()
+    {
+        setStorageLimitModuleProperties("", "");
     }
 }

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSPrecursorLevelDataTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSPrecursorLevelDataTest.java
@@ -38,9 +38,9 @@ public class TargetedMSPrecursorLevelDataTest extends AbstractQuantificationTest
         goToFolderManagement();
         clickAndWait(Locator.linkWithText("Module Properties"));
         setModuleProperties(Arrays.asList(
-                new ModulePropertyValue("TargetedMS", "/" + getProjectName(),
+                new ModulePropertyValue("TargetedMS", "/",
                         "TransitionChromInfo storage limit", "0"),
-                new ModulePropertyValue("TargetedMS", "/" + getProjectName(),
+                new ModulePropertyValue("TargetedMS", "/",
                         "Precursor storage limit", "0")));
 
     }


### PR DESCRIPTION
#### Rationale
We can remove the following modules properties since we want to always read chromatogram data from skyd files when they are available:
SKIP_CHROMATOGRAM_IMPORT_PROPERTY
PREFER_SKYD_FILE_CHROMATOGRAMS_PROPERTY

Make MAX_TRANSITION_CHROM_INFOS_PROPERTY and MAX_PRECURSORS_PROPERTY  configurable only at the site level.  Removing these properties breaks TargetedMSPrecursorLevelDataTest. This test (https://github.com/LabKey/targetedms/pull/396) changes the values of these two properties to 0 to test that calibration curves and fold changes can be calculated  even if there is nothing in the TransitionChromInfo table. 

