### PR TITLE
47668: Early Stage PTM Report - formatting issue w/ multi modifications

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -4458,7 +4458,9 @@ public class TargetedMSController extends SpringActionController
             // run anyway
             settings.setContainerFilterName(null);
             settings.setBaseFilter(new SimpleFilter(FieldKey.fromParts("PeptideGroupId", "RunId"), form.getId()));
-            settings.setBaseSort(new Sort("PeptideGroupId, Sequence"));
+            // Issue 47668 - need to sort on PeptideGroupId, Sequence, and SiteLocation to make sure peptides
+            // with multiple modification sites have them reported in the right order
+            settings.setBaseSort(new Sort("PeptideGroupId, Sequence, SiteLocation"));
             TargetedMSSchema schema = new TargetedMSSchema(getUser(), getContainer());
             QueryView result = schema.createView(getViewContext(), settings, errors);
             result.setShadeAlternatingRows(false);


### PR DESCRIPTION
#### Rationale
The table layout gets mangled when a peptide has multiple modifications at different sites. We need to group them together

#### Changes
* Include the SiteLocation in the sort for the Early Stage PTM report