### PR TITLE
Set ExpRun's filePathRoot to be the container's file root

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSManager.java
+++ b/src/org/labkey/targetedms/TargetedMSManager.java
@@ -55,6 +55,7 @@ import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExperimentService;
+import org.labkey.api.files.FileContentService;
 import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.module.ModuleProperty;
@@ -692,12 +693,11 @@ public class TargetedMSManager
             }
 
             ExpData expData = ExperimentService.get().getExpData(run.getDataId());
-            Path skylineFile = pipeRoot.resolveToNioPathFromUrl(expData.getDataFileUrl());
 
             ExpRun expRun = ExperimentService.get().createExperimentRun(container, run.getDescription());
             expRun.setProtocol(protocol);
             expRun.setJobId(jobId);
-            expRun.setFilePathRootPath(null != skylineFile ? skylineFile.getParent() : null);
+            expRun.setFilePathRootPath(FileContentService.get().getFileRootPath(container, FileContentService.ContentType.files));
             ViewBackgroundInfo info = new ViewBackgroundInfo(container, user, null);
 
             Map<ExpData, String> inputDatas = new HashMap<>();


### PR DESCRIPTION
#### Rationale
Skyline documents are typically uploaded and imported from the container's file root when the import is driven by Skyline. However, it is possible to manually upload and import documents from a subfolder of the container's file root.  When these runs are exported as part of folder export, the exported directory path does not include the subfolder.  For example, for a run imported from `@files/SkylineFiles` the contents of the export folder look like this:
```
Run202
  |-- skyline_docr.sky.zip
  |-- skyline_doc
```
This does not include the `SkylineFiles` subfolder, and makes it difficult to adjust the dataFileUrls on ExpData in the folder import part of the Panorama Public pipeline. Setting ExpRun's filePathRoot to always be the container's file root will ensure that the exported run files are at the same relative path as they are in the source container:
```
Run202
  |-- SkylineFiles
        |-- skyline_doc.sky.zip
        |-- skyline_doc
```

#### Related Pull Requests
* https://github.com/LabKey/MacCossLabModules/pull/344

