### PR TITLE
Issue 47948: Problems with available Panorama QC metrics

### DIFF
--- a/resources/queries/targetedms/QCMetricEnabled_precursorAndTransitionAreas.sql
+++ b/resources/queries/targetedms/QCMetricEnabled_precursorAndTransitionAreas.sql
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2016-2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-- We need both transition and precursor areas
+SELECT 1 AS E
+WHERE
+    EXISTS (SELECT E FROM QCMetricEnabled_precursorArea)
+    AND EXISTS (SELECT E FROM QCMetricEnabled_transitionArea)

--- a/resources/queries/targetedms/QCMetricEnabled_precursorArea.sql
+++ b/resources/queries/targetedms/QCMetricEnabled_precursorArea.sql
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2016-2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-- We need to check both the proteomics and small molecule data. Use two separate EXISTS subqueries so we stop as
+-- soon as we find any data
+SELECT 1 AS E WHERE
+EXISTS (SELECT Id, FragmentType, Quantitative FROM Transition t WHERE FragmentType = 'precursor' AND Charge IS NULL)
+OR EXISTS (SELECT Id, FragmentType, Quantitative FROM MoleculeTransition t WHERE FragmentType = 'precursor' AND Charge IS NULL)

--- a/resources/queries/targetedms/QCMetricEnabled_transitionArea.sql
+++ b/resources/queries/targetedms/QCMetricEnabled_transitionArea.sql
@@ -31,8 +31,7 @@ SELECT Id, FragmentType, Quantitative FROM Transition t
                                                                                                   ))
         )
 )
-UNION
-SELECT 1 AS E WHERE EXISTS (
+OR EXISTS (
 SELECT Id, FragmentType, Quantitative FROM MoleculeTransition t
 WHERE
     (Quantitative = TRUE) OR (Quantitative IS NULL AND

--- a/resources/schemas/dbscripts/postgresql/targetedms-23.002-23.003.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-23.002-23.003.sql
@@ -1,0 +1,4 @@
+UPDATE targetedms.QCMetricConfiguration SET EnabledQueryName = 'QCMetricEnabled_precursorAndTransitionAreas', EnabledSchemaName = 'targetedms' WHERE Name = 'Transition/Precursor Area Ratio';
+UPDATE targetedms.QCMetricConfiguration SET EnabledQueryName = 'QCMetricEnabled_precursorAndTransitionAreas', EnabledSchemaName = 'targetedms' WHERE Name = 'Transition & Precursor Areas';
+UPDATE targetedms.QCMetricConfiguration SET EnabledQueryName = 'QCMetricEnabled_precursorAndTransitionAreas', EnabledSchemaName = 'targetedms' WHERE Name = 'Total Peak Area (Precursor + Transition)';
+UPDATE targetedms.QCMetricConfiguration SET EnabledQueryName = 'QCMetricEnabled_precursorArea', EnabledSchemaName = 'targetedms' WHERE Name = 'Precursor Area';

--- a/resources/schemas/dbscripts/sqlserver/targetedms-23.002-23.003.sql
+++ b/resources/schemas/dbscripts/sqlserver/targetedms-23.002-23.003.sql
@@ -1,0 +1,4 @@
+UPDATE targetedms.QCMetricConfiguration SET EnabledQueryName = 'QCMetricEnabled_precursorAndTransitionAreas', EnabledSchemaName = 'targetedms' WHERE Name = 'Transition/Precursor Area Ratio';
+UPDATE targetedms.QCMetricConfiguration SET EnabledQueryName = 'QCMetricEnabled_precursorAndTransitionAreas', EnabledSchemaName = 'targetedms' WHERE Name = 'Transition & Precursor Areas';
+UPDATE targetedms.QCMetricConfiguration SET EnabledQueryName = 'QCMetricEnabled_precursorAndTransitionAreas', EnabledSchemaName = 'targetedms' WHERE Name = 'Total Peak Area (Precursor + Transition)';
+UPDATE targetedms.QCMetricConfiguration SET EnabledQueryName = 'QCMetricEnabled_precursorArea', EnabledSchemaName = 'targetedms' WHERE Name = 'Precursor Area';

--- a/src/org/labkey/targetedms/SkylineDocImporter.java
+++ b/src/org/labkey/targetedms/SkylineDocImporter.java
@@ -266,7 +266,7 @@ public class SkylineDocImporter
         }
         catch (CancelledException e)
         {
-            addPostRollbackCommitTask("Cancelled  Skyline document import.", "Import cancelled (see pipeline log)");
+            addPostRollbackCommitTask("Cancelled Skyline document import.", "Import cancelled (see pipeline log)");
             throw e;
         }
         catch (IOException | XMLStreamException | RuntimeException | PipelineJobException | AuditLogException e)
@@ -582,6 +582,8 @@ public class SkylineDocImporter
         // See which entries matched up with data in the Skyline document
         List<IrtPeptide> matchedIrts = parser.getiRTScaleSettings().stream().filter(irt -> irt.getGeneralMoleculeId() != null).toList();
 
+        int updatedCount = 0;
+
         // Find the retention times for each tracked iRT entry in each sample file
         for (SampleFile sampleFile : replicateInfo.skylineIdSampleFileIdMap.values())
         {
@@ -595,7 +597,7 @@ public class SkylineDocImporter
                 sql.add(irtPeptide.getGeneralMoleculeId());
 
                 List<Double> retentionTimes = new SqlSelector(TargetedMSManager.getSchema(), sql).getArrayList(Double.class);
-                if (retentionTimes.size() > 0)
+                if (!retentionTimes.isEmpty())
                 {
                     IrtPeptide p = new IrtPeptide();
                     p.setModifiedSequence(irtPeptide.getModifiedSequence());
@@ -617,9 +619,10 @@ public class SkylineDocImporter
                 sampleFile.setIrtCorrelation(regressionLine.getCorrelation());
 
                 Table.update(_user, TargetedMSManager.getTableInfoSampleFile(), sampleFile, sampleFile.getId());
+                updatedCount++;
             }
         }
-        _log.info("Finished calculating iRT correlations for all samples");
+        _log.info("Finished calculating iRT correlations for all samples. " + updatedCount + " had a regression line calculated.");
 
     }
 
@@ -1073,7 +1076,7 @@ public class SkylineDocImporter
     {
 
         Integer iRTScaleId = null; // Not all imports are expected to have iRT data
-        List<IrtPeptide> importScale = parser.getiRTScaleSettings();
+        List<IrtPeptide> importScale = new ArrayList<>(parser.getiRTScaleSettings());
 
         if (! importScale.isEmpty())
         {

--- a/src/org/labkey/targetedms/TargetedMSManager.java
+++ b/src/org/labkey/targetedms/TargetedMSManager.java
@@ -1829,7 +1829,7 @@ public class TargetedMSManager
         }
     }
 
-    public static ArrayList<Integer> getIrtScaleIds(Container c)
+    public static List<Integer> getIrtScaleIds(Container c)
     {
         SimpleFilter conFil = SimpleFilter.createContainerFilter(c);
         return new TableSelector(TargetedMSManager.getTableInfoiRTScale().getColumn(FieldKey.fromParts("id")), conFil , null).getArrayList(Integer.class);
@@ -1841,9 +1841,9 @@ public class TargetedMSManager
         TargetedMSModule targetedMSModule = null;
         for (Module m : c.getActiveModules())
         {
-            if (m instanceof TargetedMSModule)
+            if (m instanceof TargetedMSModule tm)
             {
-                targetedMSModule = (TargetedMSModule) m;
+                targetedMSModule = tm;
             }
         }
         if (targetedMSModule == null)

--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -221,7 +221,7 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
     @Override
     public Double getSchemaVersion()
     {
-        return 23.002;
+        return 23.003;
     }
 
     @Override

--- a/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
+++ b/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
@@ -459,7 +459,7 @@ public class SkylineDocumentParser implements AutoCloseable
 
     public List<IrtPeptide> getiRTScaleSettings()
     {
-        return _iRTScaleSettings;
+        return Collections.unmodifiableList(_iRTScaleSettings);
     }
 
     public List<SkylineReplicate> getReplicates()

--- a/src/org/labkey/targetedms/query/QCEnabledMetricsTable.java
+++ b/src/org/labkey/targetedms/query/QCEnabledMetricsTable.java
@@ -40,8 +40,8 @@ public class QCEnabledMetricsTable extends SimpleUserSchema.SimpleTable<Targeted
     public QCEnabledMetricsTable(TargetedMSSchema schema, ContainerFilter cf)
     {
         super(schema, TargetedMSManager.getTableInfoQCEnabledMetrics(), cf);
-        TargetedMSTable.fixupLookups(this);
         wrapAllColumns(true);
+        TargetedMSTable.fixupLookups(this);
     }
 
     @Override

--- a/test/src/org/labkey/test/components/targetedms/ParetoPlotsWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/ParetoPlotsWebPart.java
@@ -22,8 +22,11 @@ import org.labkey.test.selenium.LazyWebElement;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 public class ParetoPlotsWebPart extends BodyWebPart<ParetoPlotsWebPart.ElementCache>
 {
@@ -102,22 +105,29 @@ public class ParetoPlotsWebPart extends BodyWebPart<ParetoPlotsWebPart.ElementCa
             return _suffix;
         }
     }
-    public List<String> getTicks(int guideSetNum)
+    public Set<String> getTicks(int guideSetNum)
     {
         return getTicks(guideSetNum, ParetoPlotType.LeveyJennings);
     }
-    public List<String> getTicks(int guideSetNum, ParetoPlotType plotType)
+    public Set<String> getTicks(int guideSetNum, ParetoPlotType plotType)
     {
-        List<String> ticks = new LinkedList<>();
-        int maxIndex = 5;
-        int minIndex = 1;
+        Set<String> ticks = new LinkedHashSet<>();
+        int maxIndex = 20;
+        int index = 1;
 
-        while(minIndex <= maxIndex)
+        while (index <= maxIndex)
         {
-            String tickText = Locator.css("#paretoPlot-GuideSet-" + guideSetNum  + plotType.getIdSuffix() +
-                    " > svg > g:nth-child(1) > g.tick-text > a:nth-child(" + minIndex + ")").findElement(getDriver()).getText();
-            ticks.add(tickText);
-            minIndex++;
+            Optional<WebElement> element = Locator.css("#paretoPlot-GuideSet-" + guideSetNum  + plotType.getIdSuffix() +
+                    " > svg > g:nth-child(1) > g.tick-text > a:nth-child(" + index + ")").findOptionalElement(getDriver());
+            if (element.isPresent())
+            {
+                ticks.add(element.get().getText());
+            }
+            else
+            {
+                break;
+            }
+            index++;
         }
         return ticks;
     }

--- a/test/src/org/labkey/test/components/targetedms/ParetoPlotsWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/ParetoPlotsWebPart.java
@@ -119,7 +119,7 @@ public class ParetoPlotsWebPart extends BodyWebPart<ParetoPlotsWebPart.ElementCa
         while (index <= maxIndex)
         {
             Optional<WebElement> element = Locator.css("#paretoPlot-GuideSet-" + guideSetNum  + plotType.getIdSuffix() +
-                    " > svg > g:nth-child(1) > g.tick-text > a:nth-child(" + index + ")").findOptionalElement(getDriver());
+                    " > svg > g:nth-child(1) > g.tick-text > a:nth-child(" + index + ") > text > title").findOptionalElement(getDriver());
             if (element.isPresent())
             {
                 ticks.add(element.get().getText());

--- a/test/src/org/labkey/test/components/targetedms/ParetoPlotsWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/ParetoPlotsWebPart.java
@@ -40,7 +40,7 @@ public class ParetoPlotsWebPart extends BodyWebPart<ParetoPlotsWebPart.ElementCa
     public enum MetricTypeTicks
     {
         RETENTION("Retention Time"),
-        PEAK("Peak Area"),
+        TOTAL_PEAK("Total Peak Area"),
         FWHM("Full Width at Half Maximum (FWHM)"),
         FWB("Full Width at Base (FWB)"),
         LHRATIO("Light/Heavy Ratio"),
@@ -48,6 +48,7 @@ public class ParetoPlotsWebPart extends BodyWebPart<ParetoPlotsWebPart.ElementCa
         PAREA("Precursor Area"),
         TAREA("Transition Area"),
         MASSACCURACY("Mass Accuracy"),
+        TIC_AREA("TIC Area"),
         ISOTOPE_DOTP("Isotope dotp"),
         LIBRARY_DOTP("Library dotp");
 
@@ -105,13 +106,13 @@ public class ParetoPlotsWebPart extends BodyWebPart<ParetoPlotsWebPart.ElementCa
             return _suffix;
         }
     }
-    public Set<String> getTicks(int guideSetNum)
+    public List<String> getTicks(int guideSetNum)
     {
         return getTicks(guideSetNum, ParetoPlotType.LeveyJennings);
     }
-    public Set<String> getTicks(int guideSetNum, ParetoPlotType plotType)
+    public List<String> getTicks(int guideSetNum, ParetoPlotType plotType)
     {
-        Set<String> ticks = new LinkedHashSet<>();
+        List<String> ticks = new LinkedList<>();
         int maxIndex = 20;
         int index = 1;
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCGuideSetTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCGuideSetTest.java
@@ -49,6 +49,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -237,7 +238,18 @@ public class TargetedMSQCGuideSetTest extends TargetedMSTest
         assertEquals("Wrong number of non-conformers for RT", 16, paretoPlotsWebPart.getPlotBarHeight(guideSetId, 5));
         assertEquals("Wrong number of non-conformers for FWHM", 13, paretoPlotsWebPart.getPlotBarHeight(guideSetId, 6));
         assertEquals("Wrong number of non-conformers for FWB", 7, paretoPlotsWebPart.getPlotBarHeight(guideSetId, 7));
-        verifyTicksOnPlots(paretoPlotsWebPart, guideSetId, plotType);
+        verifyTicksOnPlots(paretoPlotsWebPart, guideSetId, plotType,
+                ParetoPlotsWebPart.MetricTypeTicks.TOTAL_PEAK,
+                ParetoPlotsWebPart.MetricTypeTicks.PAREA,
+                ParetoPlotsWebPart.MetricTypeTicks.TAREA,
+                ParetoPlotsWebPart.MetricTypeTicks.MASSACCURACY,
+                ParetoPlotsWebPart.MetricTypeTicks.TPAREARATIO,
+                ParetoPlotsWebPart.MetricTypeTicks.RETENTION,
+                ParetoPlotsWebPart.MetricTypeTicks.FWHM,
+                ParetoPlotsWebPart.MetricTypeTicks.FWB,
+                ParetoPlotsWebPart.MetricTypeTicks.TIC_AREA,
+                ParetoPlotsWebPart.MetricTypeTicks.ISOTOPE_DOTP
+                );
         verifyNavigationToPanoramaDashboard(guideSetId, 0, QCPlotsWebPart.MetricType.TOTAL_PEAK, true);
 
         clickAndWait(Locator.linkWithText("Pareto Plot")); //go to Pareto Plot tab
@@ -254,7 +266,17 @@ public class TargetedMSQCGuideSetTest extends TargetedMSTest
         assertEquals("Wrong number of non-conformers for Isotope dotp", 5, paretoPlotsWebPart.getPlotBarHeight(guideSetId, plotType, 7));
         assertEquals("Wrong number of non-conformers for area ratio", 4, paretoPlotsWebPart.getPlotBarHeight(guideSetId, plotType, 8));
         assertEquals("Wrong number of non-conformers for TIC area", 2, paretoPlotsWebPart.getPlotBarHeight(guideSetId, plotType, 9));
-        verifyTicksOnPlots(paretoPlotsWebPart, guideSetId, plotType);
+        verifyTicksOnPlots(paretoPlotsWebPart, guideSetId, plotType,
+                ParetoPlotsWebPart.MetricTypeTicks.TOTAL_PEAK,
+                ParetoPlotsWebPart.MetricTypeTicks.TAREA,
+                ParetoPlotsWebPart.MetricTypeTicks.FWB,
+                ParetoPlotsWebPart.MetricTypeTicks.PAREA,
+                ParetoPlotsWebPart.MetricTypeTicks.MASSACCURACY,
+                ParetoPlotsWebPart.MetricTypeTicks.RETENTION,
+                ParetoPlotsWebPart.MetricTypeTicks.FWHM,
+                ParetoPlotsWebPart.MetricTypeTicks.ISOTOPE_DOTP,
+                ParetoPlotsWebPart.MetricTypeTicks.TPAREARATIO,
+                ParetoPlotsWebPart.MetricTypeTicks.TIC_AREA);
         verifyNavigationToPanoramaDashboard(guideSetId, QCPlotsWebPart.QCPlotType.MovingRange, 0, QCPlotsWebPart.MetricType.TOTAL_PEAK, true);
 
         clickAndWait(Locator.linkWithText("Pareto Plot")); //go to Pareto Plot tab
@@ -263,7 +285,17 @@ public class TargetedMSQCGuideSetTest extends TargetedMSTest
         log("Verifying non-conformers for " + plotType.getLabel());
         assertEquals("Wrong number of non-conformers for FWHM", "CUSUM-: 2 CUSUM+: 0 Total: 2", paretoPlotsWebPart.getPlotBarTooltip(guideSetId, plotType, 0));
         assertEquals("Wrong number of non-conformers for T Area", "CUSUM-: 1 CUSUM+: 0 Total: 1", paretoPlotsWebPart.getPlotBarTooltip(guideSetId, plotType, 1));
-        verifyTicksOnPlots(paretoPlotsWebPart, guideSetId, plotType);
+        verifyTicksOnPlots(paretoPlotsWebPart, guideSetId, plotType,
+                ParetoPlotsWebPart.MetricTypeTicks.FWHM,
+                ParetoPlotsWebPart.MetricTypeTicks.TAREA,
+                ParetoPlotsWebPart.MetricTypeTicks.FWB,
+                ParetoPlotsWebPart.MetricTypeTicks.ISOTOPE_DOTP,
+                ParetoPlotsWebPart.MetricTypeTicks.MASSACCURACY,
+                ParetoPlotsWebPart.MetricTypeTicks.PAREA,
+                ParetoPlotsWebPart.MetricTypeTicks.RETENTION,
+                ParetoPlotsWebPart.MetricTypeTicks.TIC_AREA,
+                ParetoPlotsWebPart.MetricTypeTicks.TOTAL_PEAK,
+                ParetoPlotsWebPart.MetricTypeTicks.TPAREARATIO);
         verifyNavigationToPanoramaDashboard(guideSetId, QCPlotsWebPart.QCPlotType.CUSUMv, 0, QCPlotsWebPart.MetricType.FWHM, true);
 
         clickAndWait(Locator.linkWithText("Pareto Plot")); //go to Pareto Plot tab
@@ -276,9 +308,18 @@ public class TargetedMSQCGuideSetTest extends TargetedMSTest
         assertEquals("Wrong number of non-conformers for MA", "CUSUM-: 0 CUSUM+: 5 Total: 5", paretoPlotsWebPart.getPlotBarTooltip(guideSetId, plotType, 2));
         assertEquals("Wrong number of non-conformers for T Area", "CUSUM-: 4 CUSUM+: 0 Total: 4", paretoPlotsWebPart.getPlotBarTooltip(guideSetId, plotType, 3));
         assertEquals("Wrong number of non-conformers for T/P Ratio", "CUSUM-: 3 CUSUM+: 1 Total: 4", paretoPlotsWebPart.getPlotBarTooltip(guideSetId, plotType, 4));
-        verifyTicksOnPlots(paretoPlotsWebPart, guideSetId, plotType);
+        verifyTicksOnPlots(paretoPlotsWebPart, guideSetId, plotType,
+                ParetoPlotsWebPart.MetricTypeTicks.TOTAL_PEAK,
+                ParetoPlotsWebPart.MetricTypeTicks.PAREA,
+                ParetoPlotsWebPart.MetricTypeTicks.MASSACCURACY,
+                ParetoPlotsWebPart.MetricTypeTicks.TAREA,
+                ParetoPlotsWebPart.MetricTypeTicks.TPAREARATIO,
+                ParetoPlotsWebPart.MetricTypeTicks.ISOTOPE_DOTP,
+                ParetoPlotsWebPart.MetricTypeTicks.FWB,
+                ParetoPlotsWebPart.MetricTypeTicks.FWHM,
+                ParetoPlotsWebPart.MetricTypeTicks.RETENTION,
+                ParetoPlotsWebPart.MetricTypeTicks.TIC_AREA);
         verifyNavigationToPanoramaDashboard(guideSetId, QCPlotsWebPart.QCPlotType.CUSUMm, 0, QCPlotsWebPart.MetricType.TOTAL_PEAK, true);
-
     }
 
     public void testEmptyParetoPlot()
@@ -311,7 +352,11 @@ public class TargetedMSQCGuideSetTest extends TargetedMSTest
         ParetoPlotPage paretoPage = new ParetoPlotPage(getDriver());
         ParetoPlotsWebPart paretoPlotsWebPart = paretoPage.getParetoPlotsWebPart();
 
-        verifyTicksOnPlots(paretoPlotsWebPart, 1);
+        verifyTicksOnPlots(paretoPlotsWebPart, 1, ParetoPlotsWebPart.ParetoPlotType.LeveyJennings,
+                        ParetoPlotsWebPart.MetricTypeTicks.FWB,
+                        ParetoPlotsWebPart.MetricTypeTicks.FWHM,
+                        ParetoPlotsWebPart.MetricTypeTicks.RETENTION,
+                        ParetoPlotsWebPart.MetricTypeTicks.TAREA);
 
         clickExportPDFIcon("chart-render-div", 0);
         clickExportPNGIcon("chart-render-div", 0);
@@ -546,23 +591,13 @@ public class TargetedMSQCGuideSetTest extends TargetedMSTest
         guideSet.setRowId(guideSetWebPart.getRowId(guideSet));
     }
 
-    private void verifyTicksOnPlots(ParetoPlotsWebPart paretoPlotsWebPart, int guideSetNum)
-    {
-        verifyTicksOnPlots(paretoPlotsWebPart, guideSetNum, ParetoPlotsWebPart.ParetoPlotType.LeveyJennings);
-    }
-
-    private void verifyTicksOnPlots(ParetoPlotsWebPart paretoPlotsWebPart, int guideSetNum, ParetoPlotsWebPart.ParetoPlotType plotType)
+    private void verifyTicksOnPlots(ParetoPlotsWebPart paretoPlotsWebPart, int guideSetNum, ParetoPlotsWebPart.ParetoPlotType plotType, ParetoPlotsWebPart.MetricTypeTicks... metrics)
     {
         paretoPlotsWebPart.waitForTickLoad(guideSetNum, plotType);
 
-        Set<String> ticks = paretoPlotsWebPart.getTicks(guideSetNum, plotType);
+        List<String> ticks = paretoPlotsWebPart.getTicks(guideSetNum, plotType);
 
-        assertEquals("Wrong metrics shown in Pareto Plot", Set.of(
-                ParetoPlotsWebPart.MetricTypeTicks.FWB.toString(),
-                ParetoPlotsWebPart.MetricTypeTicks.FWHM.toString(),
-                ParetoPlotsWebPart.MetricTypeTicks.RETENTION.toString(),
-                ParetoPlotsWebPart.MetricTypeTicks.TAREA.toString()
-                ), ticks);
+        assertEquals("Wrong metrics shown in Pareto Plot", Arrays.stream(metrics).map(ParetoPlotsWebPart.MetricTypeTicks::toString).toList(), ticks);
     }
 
     private void verifyDownloadableParetoPlots(int expectedPlotCount)

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCGuideSetTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCGuideSetTest.java
@@ -48,6 +48,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -554,10 +555,14 @@ public class TargetedMSQCGuideSetTest extends TargetedMSTest
     {
         paretoPlotsWebPart.waitForTickLoad(guideSetNum, plotType);
 
-        List<String> ticks = paretoPlotsWebPart.getTicks(guideSetNum, plotType);
+        Set<String> ticks = paretoPlotsWebPart.getTicks(guideSetNum, plotType);
 
-        for(String metricType : ticks)
-            assertTrue("Metric Type tick '" + metricType + "' is not valid", paretoPlotsWebPart.isMetricTypeTickValid(metricType));
+        assertEquals("Wrong metrics shown in Pareto Plot", Set.of(
+                ParetoPlotsWebPart.MetricTypeTicks.FWB.toString(),
+                ParetoPlotsWebPart.MetricTypeTicks.FWHM.toString(),
+                ParetoPlotsWebPart.MetricTypeTicks.RETENTION.toString(),
+                ParetoPlotsWebPart.MetricTypeTicks.TAREA.toString()
+                ), ticks);
     }
 
     private void verifyDownloadableParetoPlots(int expectedPlotCount)

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -862,9 +862,12 @@ public class TargetedMSQCTest extends TargetedMSTest
         verifyQCSummarySampleFileOutliers(sampleFileAcquiredDates[1], "excluded");
         verifyQCSummarySampleFileOutliers(sampleFileAcquiredDates[2], "0");
 
+        // Ensure that we've auto-hidden metrics without data
+        assertTextPresent("4 metrics");
+
         // create a guide set and verify updated QC Summary outliers info
         qcPlotsWebPart.createGuideSet(new GuideSet(sampleFileAcquiredDates[0], sampleFileAcquiredDates[1], null, 2), null);
-        verifyQCSummarySampleFileOutliers(sampleFileAcquiredDates[2], "20");
+        verifyQCSummarySampleFileOutliers(sampleFileAcquiredDates[2], "16");
 
         // change data point to only be excluded for a single metric and verify outliers changed
         changePointExclusionState(getAcquiredDateDisplayStr(sampleFileAcquiredDates[1]), QCPlotsWebPart.QCPlotExclusionState.ExcludeMetric, 2);


### PR DESCRIPTION
#### Rationale
We aren't correctly regenerating iRT regressions when importing overlapping samples across different Skyline folders, a key scenario in QC folders.

We also aren't auto-hiding Precursor Area as a metric when it doesn't have any data.

#### Changes
* Calculate iRT regression for each sample based on the original list from the Skyline doc, not the pruned list from merging the iRT scales
* Introduce new enabled query for Precursor Area
* Introduce new query for a few metrics that combine precursor and transition areas
* Optimize the queries
* Minor misc code cleanup