### PR TITLE
Use scientific notation for sample chromatograms with large values

### DIFF
--- a/src/org/labkey/targetedms/chart/ChromatogramChartMaker.java
+++ b/src/org/labkey/targetedms/chart/ChromatogramChartMaker.java
@@ -140,7 +140,20 @@ class ChromatogramChartMaker
             @Override
             public StringBuffer format(double number, StringBuffer toAppendTo, FieldPosition pos)
             {
-                String pattern = (yAxis.getUpperBound() - yAxis.getLowerBound()) / chromatogramDataset.getIntensityScale() > 100 ? "#,##0" : "#,##0.0";
+                double max = (yAxis.getUpperBound() - yAxis.getLowerBound()) / chromatogramDataset.getIntensityScale();
+                String pattern;
+                if (max > 10_000)
+                {
+                    pattern = "0.###E0";
+                }
+                else if (max > 100)
+                {
+                    pattern = "#,##0";
+                }
+                else
+                {
+                    pattern = "#,##0.0";
+                }
                 // Display the scaled value in the tick label.
                 return toAppendTo.append(new DecimalFormat(pattern).format(number / chromatogramDataset.getIntensityScale()));
             }


### PR DESCRIPTION
#### Rationale
It's clunky to see values like 500,000,000 on the y-axis for sample-scoped chromatograms like TIC or pressure traces.

#### Changes
* Switch to scientific notation for large values.