### PR TITLE
Update psi-ms-PARSED.xml to includes the Orbitrap Astral

### DIFF
--- a/resources/psi-ms-PARSED.xml
+++ b/resources/psi-ms-PARSED.xml
@@ -22,6 +22,7 @@
     <instrument id="MS:1003005" name="timsTOF Pro" vendor="Bruker Daltonics timsTOF series" description="Bruker Daltonics' timsTOF Pro."/>
     <instrument id="MS:1003231" name="timsTOF SCP" vendor="Bruker Daltonics timsTOF series" description="Bruker Daltonics' timsTOF SCP."/>
     <instrument id="MS:1003230" name="timsTOF Pro 2" vendor="Bruker Daltonics timsTOF series" description="Bruker Daltonics' timsTOF Pro 2."/>
+    <instrument id="MS:1003383" name="timsTOF Ultra" vendor="Bruker Daltonics timsTOF series" description="Bruker Daltonics' timsTOF Ultra."/>
     <instrument id="MS:1002279" name="maXis 4G" vendor="Bruker Daltonics maXis series" description="Bruker Daltonics' maXis 4G: ESI Q-TOF, Nanospray, APCI, APPI, GC-APCI, CaptiveSpray."/>
     <instrument id="MS:1001541" name="maXis" vendor="Bruker Daltonics maXis series" description="Bruker Daltonics' maXis: ESI Q-TOF, Nanospray, APCI, APPI."/>
     <instrument id="MS:1003004" name="maXis II" vendor="Bruker Daltonics maXis series" description="Bruker Daltonics' maXis II."/>
@@ -152,8 +153,10 @@
     <instrument id="MS:1002726" name="SYNAPT G2-Si" vendor="Waters" description="Waters Corporation SYNAPT G2-Si orthogonal acceleration time-of-flight mass spectrometer."/>
     <instrument id="MS:1000150" name="Auto Spec Ultima NT" vendor="Waters" description="Waters magnetic sector based AutoSpec Ultima NT MS."/>
     <instrument id="MS:1000159" name="GCT" vendor="Waters" description="Waters oa-ToF based GCT."/>
+    <instrument id="MS:1003381" name="ACQUITY RDa Detector" vendor="Waters" description="Waters Corporation RDa time-of-flight mass detector."/>
     <instrument id="MS:1001764" name="ACQUITY UPLC I-Class" vendor="Waters" description="Waters LC-system ACQUITY UPLC I-Class."/>
     <instrument id="MS:1001765" name="ACQUITY UPLC Systems with 2D Technology" vendor="Waters" description="Waters LC-system ACQUITY UPLC Systems with 2D Technology."/>
+    <instrument id="MS:1003380" name="Xevo G3 QTof" vendor="Waters" description="Waters Corporation Xevo G3 QTof quadrupole time-of-flight mass spectrometer."/>
     <instrument id="MS:1001763" name="ACQUITY UPLC H-Class Bio" vendor="Waters" description="Waters LC-system ACQUITY UPLC H-Class Bio."/>
     <instrument id="MS:1001762" name="ACQUITY UPLC H-Class" vendor="Waters" description="Waters LC-system ACQUITY UPLC H-Class."/>
     <instrument id="MS:1001768" name="nanoACQUITY UPLC with HDX Technology" vendor="Waters" description="Waters LC-system nanoACQUITY UPLC with HDX Technology."/>

--- a/resources/psi-ms-PARSED.xml
+++ b/resources/psi-ms-PARSED.xml
@@ -233,6 +233,7 @@
     <instrument id="MS:1003028" name="Orbitrap Exploris 480" vendor="Thermo Scientific" description="Thermo Scientific Orbitrap Exploris 480 Quadrupole Orbitrap MS."/>
     <instrument id="MS:1000642" name="MALDI LTQ XL" vendor="Thermo Scientific" description="Thermo Scientific MALDI LTQ XL MS."/>
     <instrument id="MS:1000643" name="MALDI LTQ Orbitrap" vendor="Thermo Scientific" description="Thermo Scientific MALDI LTQ Orbitrap MS."/>
+    <instrument id="MS:1003378" name="Orbitrap Astral" vendor="Thermo Scientific" description="Thermo Scientific Orbitrap Astral mass spectrometer contains three mass analyzers: a quadrupole analyzer, an Orbitrap analyzer, and the Astral analyzer."/>
     <instrument id="MS:1000637" name="ITQ 1100" vendor="Thermo Scientific" description="Thermo Scientific ITQ 1100 GC-MS."/>
     <instrument id="MS:1000638" name="LTQ XL ETD" vendor="Thermo Scientific" description="Thermo Scientific LTQ XL MS with ETD."/>
     <instrument id="MS:1000635" name="ITQ 700" vendor="Thermo Scientific" description="Thermo Scientific ITQ 700 GC-MS."/>


### PR DESCRIPTION
#### Rationale
The Orbitrap Astral instrument was added to the PSI-MS CV in v4.1.124. Update psi-ms-PARSED.xml so that this instruments can be selected in the "Instrument" field of the Targeted MS Experiment form.


