### PR TITLE
Issue 46783: Line indicating break between guide set and other data is too short on multi-series plots

### DIFF
--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -1635,7 +1635,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                 var guideSetEndIndex = guideSetTrainingData[0]['EndIndex'];
                 this.getSvgElForPlot(plot).selectAll("line.separator").data([{'StartIndex': guideSetEndIndex + 1, 'EndIndex': guideSetEndIndex + 1}])
                         .enter().append("line").attr("class", "separator")
-                        .attr('x1', xSep).attr('y1', yRange[0]).attr('x2', xSep).attr('y2', (yRange[0] - yRange[1]) - 110)
+                        .attr('x1', xSep).attr('y1', yRange[0]).attr('x2', xSep).attr('y2', yRange[1])
                         .attr('stroke', '#000000').attr('stroke-opacity', 1)
                         .attr('fill', '#000000').attr('fill-opacity', 1);
             }


### PR DESCRIPTION
#### Rationale
When show reference guideset is selected and there is break in long ranges of data, there is a line break that is shown between reference guideset and previous samples. When show all series in a single plot is selected, line indicating a break is too-short. This PR fixes the short line break on multi-serires plot.

#### Related Pull Requests
* #343 

#### Changes
* fix y2 of line
