### PR TITLE
Issue 47647: Panorama: Annotation missing from QC plot

### DIFF
--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -1200,11 +1200,11 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         // Filter on start/end dates
         var separator = " WHERE ";
         if (config.StartDate) {
-            annotationSql += separator + "Date >= '" + config.StartDate + "'";
+            annotationSql += separator + "CAST(Date AS Date) >= '" + config.StartDate + "'";
             separator = " AND ";
         }
         if (config.EndDate) {
-            annotationSql += separator + "Date <= '" + config.EndDate + "'";
+            annotationSql += separator + "CAST(Date AS Date) <= '" + config.EndDate + "'";
         }
 
         LABKEY.Query.executeSql({


### PR DESCRIPTION
#### Rationale
If the date and time of the annotation match the acquisition date and time of the last sample in the QC folder, then the annotation does not appear. This PR fixes the date filters to get the annotation data.


#### Changes
* cast date as date in annotation sql
