### PR TITLE
Issue 48499: Use preferred SecurityPolicyManager.savePolicy() variant

### DIFF
--- a/src/org/labkey/targetedms/SkylineAuditLogManager.java
+++ b/src/org/labkey/targetedms/SkylineAuditLogManager.java
@@ -429,8 +429,8 @@ public class SkylineAuditLogManager
         {
             UnitTestUtil.cleanupDatabase(_docGUID);
             _user = TestContext.get().getUser();
-            _container = ContainerManager.ensureContainer(JunitUtil.getTestContainer(), FOLDER_NAME);
-            _container2 = ContainerManager.ensureContainer(JunitUtil.getTestContainer(), FOLDER_NAME2);
+            _container = ContainerManager.ensureContainer(JunitUtil.getTestContainer(), FOLDER_NAME, TestContext.get().getUser());
+            _container2 = ContainerManager.ensureContainer(JunitUtil.getTestContainer(), FOLDER_NAME2, TestContext.get().getUser());
         }
 
         private AuditLogTree persistALogFile(String filePath, TargetedMSRun run) throws IOException, AuditLogException

--- a/src/org/labkey/targetedms/datasource/MsDataSourceUtil.java
+++ b/src/org/labkey/targetedms/datasource/MsDataSourceUtil.java
@@ -393,7 +393,7 @@ public class MsDataSourceUtil
             cleanDatabase();
 
             _user = TestContext.get().getUser();
-            _container = ContainerManager.ensureContainer(JunitUtil.getTestContainer(), FOLDER_NAME);
+            _container = ContainerManager.ensureContainer(JunitUtil.getTestContainer(), FOLDER_NAME, _user);
 
             // Create an entry in the targetedms.runs table
             _run = createRun();


### PR DESCRIPTION
#### Rationale
We're uneven in terms of the validation and auditing we do for saving SecurityPolicies and related updates, and want to be more consistent.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4704

#### Changes
* Let modules register ContainerSecurableResourceProviders instead of having Container know about them all
* Remove the `savePolicy` and `createContainer` methods that don't take a user, check permissions, or log for audit purposes
* Introduce `User.getAdminServiceUser()` for `sudo` like scenarios or when we're doing an operation not initiated by a user, like bootstrapping the server
* Update callers