### PR TITLE
Fix TargetedMSMxNReproducibilityReportTest - update expected DOM

### DIFF
--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSMxNReproducibilityReportTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSMxNReproducibilityReportTest.java
@@ -59,7 +59,7 @@ public class TargetedMSMxNReproducibilityReportTest extends TargetedMSTest
         log("Clicking on the protein");
         clickAndWait(reproducibilityReportLink());
 
-        waitForElement(Locator.tagWithName("a", "Protein"));
+        waitForElement(Locator.tagWithId("a", "Protein"));
 
         checker().verifyTrue("Reproducibility Report is not present", isTextPresent("Reproducibility Report"));
         checker().verifyEquals("Incorrect number of graphs for EAEDLQVGQVE", getPrecursorChromeInfoCount("EAEDLQVGQVE"),


### PR DESCRIPTION
#### Rationale
The test broke because a recent PR changed the DOM slightly when finding a framed web part.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4683

#### Changes
* Match the latest DOM
