### PR TITLE
Migrate DatabaseCache uses to non-database caches

### DIFF
--- a/src/org/labkey/targetedms/view/peptideSummaryView.jsp
+++ b/src/org/labkey/targetedms/view/peptideSummaryView.jsp
@@ -20,6 +20,7 @@
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.targetedms.TargetedMSController" %>
+<%@ page import="org.labkey.targetedms.TargetedMSRun" %>
 <%@ page import="org.labkey.targetedms.parser.PeptideSettings" %>
 <%@ page import="org.labkey.targetedms.parser.Precursor" %>
 <%@ page import="org.labkey.targetedms.view.IconFactory" %>
@@ -27,7 +28,6 @@
 <%@ page import="org.labkey.targetedms.view.PrecursorHtmlMaker" %>
 <%@ page import="java.util.HashMap" %>
 <%@ page import="java.util.Map" %>
-<%@ page import="org.labkey.targetedms.TargetedMSRun" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
     JspView<TargetedMSController.PeptideChromatogramsViewBean> me = (JspView<TargetedMSController.PeptideChromatogramsViewBean>) HttpView.currentView();

--- a/src/org/labkey/targetedms/view/precursorConflictResolutionView.jsp
+++ b/src/org/labkey/targetedms/view/precursorConflictResolutionView.jsp
@@ -1,4 +1,3 @@
-<%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%
 /*
  * Copyright (c) 2012-2019 LabKey Corporation
@@ -23,9 +22,8 @@
 <%@ page import="org.labkey.targetedms.TargetedMSController" %>
 <%@ page import="org.labkey.targetedms.TargetedMSSchema" %>
 <%@ page import="org.labkey.targetedms.conflict.ConflictPrecursor" %>
-<%@ page import="org.labkey.targetedms.query.PrecursorManager" %>
 <%@ page import="org.labkey.targetedms.view.ModifiedPeptideHtmlMaker" %>
-<%@ page import="org.labkey.targetedms.view.PrecursorHtmlMaker" %>
+<%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%!
     @Override


### PR DESCRIPTION
#### Rationale
`DatabaseCache` is useful only when transactions are involved

Remove some unused code
