### PR TITLE
Issue 47949: Viewing transition list for a Skyline doc is very slow

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSSchema.java
+++ b/src/org/labkey/targetedms/TargetedMSSchema.java
@@ -687,7 +687,7 @@ public class TargetedMSSchema extends UserSchema
                 "\nFROM " + TargetedMSManager.getTableInfoRuns() + " tmsRuns " +
                 "\nWHERE tmsRuns.ExperimentRunLSID = " + ExprColumn.STR_TABLE_ALIAS + ".LSID AND tmsRuns.Deleted = ?)");
         sql.add(Boolean.FALSE);
-        var skyDocDetailColumn = new ExprColumn(result, "File", sql, JdbcType.INTEGER);
+        var skyDocDetailColumn = new ExprColumn(result, "File", sql, JdbcType.BIGINT);
 
         ActionURL url = TargetedMSController.getShowRunURL(getContainer());
 


### PR DESCRIPTION
#### Rationale
Viewing the transition list for a Skyline doc on PanoramaWeb has gotten painfully slow.

#### Changes
* Identify data type of calculated column correctly so no casting is necessary, letting the DB use the index