### PR TITLE
Issue 48119: Slow run deletes in TargetedMS

### DIFF
--- a/src/org/labkey/targetedms/pipeline/TargetedMSImportTask.java
+++ b/src/org/labkey/targetedms/pipeline/TargetedMSImportTask.java
@@ -63,7 +63,7 @@ public class TargetedMSImportTask extends PipelineJob.Task<TargetedMSImportTask.
             TargetedMSRun run = importer.importRun(job.getRunInfo(), job);
 
             Integer jobId = PipelineService.get().getJobId(getJob().getUser(), getJob().getContainer(), getJob().getJobGUID());
-            TargetedMSManager.ensureWrapped(run, job.getUser(), job.getPipeRoot(), jobId);
+            TargetedMSManager.ensureWrapped(run, job.getUser(), jobId);
             TargetedMSService.get().getSkylineDocumentImportListener().forEach(listener -> listener.onDocumentImport(job.getContainer(), job.getUser(), run));
             transaction.commit();
         }

--- a/src/org/labkey/targetedms/query/RepresentativeStateManager.java
+++ b/src/org/labkey/targetedms/query/RepresentativeStateManager.java
@@ -308,7 +308,7 @@ public class RepresentativeStateManager
         sql.append(StringUtils.join(stdPepGrpIdsInRun, ","));
         sql.append(")");
         sql.append(")");
-        sql.append(" AND pg.RepresentativeDataState=").append(RepresentativeDataState.Representative.ordinal());
+        sql.append(" AND pg.RepresentativeDataState=").appendValue(RepresentativeDataState.Representative.ordinal());
 
         return new SqlSelector(TargetedMSManager.getSchema(), sql).getArrayList(Long.class);
     }

--- a/src/org/labkey/targetedms/query/SkylineListTable.java
+++ b/src/org/labkey/targetedms/query/SkylineListTable.java
@@ -93,7 +93,7 @@ public class SkylineListTable extends AbstractTableInfo
                     break;
             }
             sqlFragment.append(new SQLFragment(" FROM targetedms.ListItemValue WHERE ListItemId = " + tableAliasName +".Id AND ColumnIndex = ")
-                    .append(_listColumn.getColumnIndex())).append(")");
+                    .appendValue(_listColumn.getColumnIndex())).append(")");
             return sqlFragment;
         }
     }

--- a/src/org/labkey/targetedms/view/TransitionProteinSearchViewProvider.java
+++ b/src/org/labkey/targetedms/view/TransitionProteinSearchViewProvider.java
@@ -91,7 +91,7 @@ public class TransitionProteinSearchViewProvider implements QueryViewProvider<Pr
                     for (int seqId : form.getSeqId())
                     {
                         sql.append(separator);
-                        sql.append(seqId);
+                        sql.appendValue(seqId);
                         separator = ",";
                     }
                     sql.append(")");


### PR DESCRIPTION
#### Rationale
We can speed things up by skipping a bunch of work when the full container is being deleted

#### Changes
* Don't bother rearranging the representative state tracking for each run when the whole container is being deleted
* Minor code cleanup