### PR TITLE
Ticket 48872: Unable to customize columns in PTM reports

### DIFF
--- a/resources/queries/targetedms/PTMPercents.query.xml
+++ b/resources/queries/targetedms/PTMPercents.query.xml
@@ -2,6 +2,7 @@
     <metadata>
         <tables xmlns="http://labkey.org/data/xml">
             <table tableName="PTMPercents" tableDbType="TABLE">
+                <javaCustomizer class="org.labkey.targetedms.query.PTMPercentsCustomizer" />
                 <columns>
                     <column columnName="PeptideModifiedSequence">
                         <displayColumnFactory>

--- a/resources/queries/targetedms/PTMPercents.sql
+++ b/resources/queries/targetedms/PTMPercents.sql
@@ -10,6 +10,8 @@ SELECT
   SampleName,
   -- Explicitly cast for SQLServer to avoid trying to add as numeric types
   SUBSTRING(Sequence, IndexAA + 1, 1) || CAST(StartIndex + IndexAA + 1 AS VARCHAR) AS SiteLocation,
+  SUBSTRING(Sequence, IndexAA + 1, 1) AS AminoAcid,
+  StartIndex + IndexAA + 1 AS Location,
   PeptideGroupId
 FROM PTMPercentsPrepivot
 GROUP BY

--- a/resources/queries/targetedms/PTMPercentsGrouped.sql
+++ b/resources/queries/targetedms/PTMPercentsGrouped.sql
@@ -1,6 +1,9 @@
 SELECT
     PeptideGroupId,
-    SiteLocation,
+    -- Explicitly cast for SQLServer to avoid trying to add as numeric types
+    AminoAcid || CAST(Location AS VARCHAR) AS SiteLocation,
+    AminoAcid,
+    Location,
     PeptideModifiedSequence,
     Sequence @hidden,
     -- We have a special rule for this C-term modification - we're actually interested in the _unmodified_ percentage
@@ -26,7 +29,8 @@ GROUP BY
     NextAA,
     PeptideModifiedSequence,
     PeptideGroupId,
-    SiteLocation,
+    AminoAcid,
+    Location,
     Modification.Name,
     ModificationCount
 PIVOT PercentModified, TotalPercentModified BY SampleName

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -268,6 +268,8 @@ import static org.labkey.targetedms.TargetedMSModule.PEPTIDE_TAB_WEB_PARTS;
 import static org.labkey.targetedms.TargetedMSModule.PROTEIN_TAB_NAME;
 import static org.labkey.targetedms.TargetedMSModule.PROTEIN_TAB_WEB_PARTS;
 import static org.labkey.targetedms.TargetedMSModule.QC_FOLDER_WEB_PARTS;
+import static org.labkey.targetedms.TargetedMSSchema.QUERY_PTM_PERCENTS_GROUPED_PREFIX;
+import static org.labkey.targetedms.TargetedMSSchema.QUERY_PTM_PERCENTS_PREFIX;
 
 public class TargetedMSController extends SpringActionController
 {
@@ -4470,23 +4472,9 @@ public class TargetedMSController extends SpringActionController
         @Override
         protected QueryView createQueryView(RunDetailsForm form, BindException errors, boolean forExport, String dataRegion)
         {
-            QuerySettings settings = new QuerySettings(getViewContext(), _dataRegionName, "PTMPercents")
-            {
-                @Override
-                protected QueryDefinition createQueryDef(UserSchema schema)
-                {
-                    QueryDefinition queryDef = super.createQueryDef(schema);
 
-                    String queryName = "PTMPercents" + form.getId();
-                    QueryDefinition tempDef = QueryService.get().createQueryDef(getUser(), getContainer(), schema.getSchemaPath(), queryName);
-                    tempDef.setIsHidden(true);
-                    tempDef.setIsTemporary(true);
-                    tempDef.setSql(queryDef.getSql() + " IN (SELECT sf.SampleName FROM targetedms.SampleFile sf WHERE sf.ReplicateId.RunId = " + form.getId() + ")");
-                    tempDef.setMetadataXml(queryDef.getMetadataXml());
-
-                    return tempDef;
-                }
-            };
+            String queryName = QUERY_PTM_PERCENTS_PREFIX + form.getId();
+            QuerySettings settings = new QuerySettings(getViewContext(), _dataRegionName, queryName);
             // Issue 40731- prevent expensive cross-folder queries when the results will always be scoped to the current
             // run anyway
             settings.setContainerFilterName(null);
@@ -4508,30 +4496,21 @@ public class TargetedMSController extends SpringActionController
         @Override
         protected QueryView createQueryView(RunDetailsForm form, BindException errors, boolean forExport, String dataRegion)
         {
-            QuerySettings settings = new QuerySettings(getViewContext(), _dataRegionName, "PTMPercentsGrouped")
-            {
-                @Override
-                protected QueryDefinition createQueryDef(UserSchema schema)
-                {
-                    QueryDefinition queryDef = super.createQueryDef(schema);
-
-                    String queryName = "PTMPercentsGrouped" + form.getId();
-                    QueryDefinition tempDef = QueryService.get().createQueryDef(getUser(), getContainer(), schema.getSchemaPath(), queryName);
-                    tempDef.setIsHidden(true);
-                    tempDef.setIsTemporary(true);
-                    tempDef.setSql(queryDef.getSql() + " IN (SELECT sf.SampleName FROM targetedms.SampleFile sf WHERE sf.ReplicateId.RunId = " + form.getId() + ")");
-                    tempDef.setMetadataXml(queryDef.getMetadataXml());
-
-                    return tempDef;
-                }
-            };
+            String queryName = QUERY_PTM_PERCENTS_GROUPED_PREFIX + form.getId();
+            QuerySettings settings = new QuerySettings(getViewContext(), _dataRegionName, queryName);
             // Issue 40731- prevent expensive cross-folder queries when the results will always be scoped to the current
             // run anyway
             settings.setContainerFilterName(null);
             settings.setBaseFilter(new SimpleFilter(FieldKey.fromParts("PeptideGroupId", "RunId"), form.getId()));
             // Issue 47668 - need to sort on PeptideGroupId, Sequence, and SiteLocation to make sure peptides
             // with multiple modification sites have them reported in the right order
-            settings.setBaseSort(new Sort("PeptideGroupId, Sequence, SiteLocation"));
+            Sort sort = new Sort();
+            for (FieldKey sortField : PTMPercentsGroupedCustomizer.EXPECTED_SORTS)
+            {
+                sort.appendSortColumn(sortField, Sort.SortDirection.ASC, false);
+            }
+            sort.appendSortColumn(FieldKey.fromParts("Modification"), Sort.SortDirection.ASC, false);
+            settings.setBaseSort(sort);
             TargetedMSSchema schema = new TargetedMSSchema(getUser(), getContainer());
             QueryView result = schema.createView(getViewContext(), settings, errors);
             result.setShadeAlternatingRows(false);

--- a/src/org/labkey/targetedms/TargetedMSSchema.java
+++ b/src/org/labkey/targetedms/TargetedMSSchema.java
@@ -1742,35 +1742,33 @@ public class TargetedMSSchema extends UserSchema
 
         if (result == null && StringUtils.startsWithIgnoreCase(queryName, QUERY_PTM_PERCENTS_PREFIX))
         {
-            String runIdString = queryName.substring(QUERY_PTM_PERCENTS_PREFIX.length());
-            try
-            {
-                int runId = Integer.parseInt(runIdString);
-                QueryDefinition queryDef = Objects.requireNonNull(getQueryDef("PTMPercents"));
-                result = QueryService.get().createQueryDef(getUser(), getContainer(), getSchemaPath(), queryName);
-                result.setSql(queryDef.getSql() + " IN (SELECT sf.SampleName FROM targetedms.SampleFile sf WHERE sf.ReplicateId.RunId = " + runId + ")");
-                result.setMetadataXml(queryDef.getMetadataXml());
-            }
-            catch (NumberFormatException ignored) {}
+            result = createRunScopedPTMQuery(QUERY_PTM_PERCENTS_PREFIX, "PTMPercents", queryName);
         }
 
         if (result == null && StringUtils.startsWithIgnoreCase(queryName, QUERY_PTM_PERCENTS_GROUPED_PREFIX))
         {
-            String runIdString = queryName.substring(QUERY_PTM_PERCENTS_GROUPED_PREFIX.length());
-            try
-            {
-                int runId = Integer.parseInt(runIdString);
-                QueryDefinition queryDef = Objects.requireNonNull(getQueryDef("PTMPercentsGrouped"));
-                result = QueryService.get().createQueryDef(getUser(), getContainer(), getSchemaPath(), queryName);
-                result.setSql(queryDef.getSql() + " IN (SELECT sf.SampleName FROM targetedms.SampleFile sf WHERE sf.ReplicateId.RunId = " + runId + ")");
-                result.setMetadataXml(queryDef.getMetadataXml());
-            }
-            catch (NumberFormatException ignored) {}
+            result = createRunScopedPTMQuery(QUERY_PTM_PERCENTS_GROUPED_PREFIX, "PTMPercentsGrouped", queryName);
         }
         return result;
     }
 
-
+    private QueryDefinition createRunScopedPTMQuery(String prefix, String baseQueryName, String queryName)
+    {
+        String runIdString = queryName.substring(prefix.length());
+        try
+        {
+            long runId = Long.parseLong(runIdString);
+            QueryDefinition queryDef = Objects.requireNonNull(getQueryDef(baseQueryName));
+            QueryDefinition result = QueryService.get().createQueryDef(getUser(), getContainer(), getSchemaPath(), queryName);
+            result.setSql(queryDef.getSql() + " IN (SELECT sf.SampleName FROM targetedms.SampleFile sf WHERE sf.ReplicateId.RunId = " + runId + ")");
+            result.setMetadataXml(queryDef.getMetadataXml());
+            return result;
+        }
+        catch (NumberFormatException ignored)
+        {
+            return null;
+        }
+    }
 
     public static class ChromatogramDisplayColumn extends DataColumn
     {

--- a/src/org/labkey/targetedms/TargetedMSSchema.java
+++ b/src/org/labkey/targetedms/TargetedMSSchema.java
@@ -1575,7 +1575,8 @@ public class TargetedMSSchema extends UserSchema
     @Override @NotNull
     public QueryView createView(ViewContext context, @NotNull QuerySettings settings, BindException errors)
     {
-        if ("PTMPercentsGrouped".equalsIgnoreCase(settings.getQueryName()) || settings.getQueryName().toLowerCase().startsWith(QUERY_PTM_PERCENTS_GROUPED_PREFIX.toLowerCase()))
+        String queryName = settings.getQueryName();
+        if (queryName != null && ("PTMPercentsGrouped".equalsIgnoreCase(queryName) || queryName.toLowerCase().startsWith(QUERY_PTM_PERCENTS_GROUPED_PREFIX.toLowerCase())))
         {
             return new CrosstabView(TargetedMSSchema.this, settings, errors)
             {

--- a/src/org/labkey/targetedms/TargetedMSSchema.java
+++ b/src/org/labkey/targetedms/TargetedMSSchema.java
@@ -1575,7 +1575,7 @@ public class TargetedMSSchema extends UserSchema
     @Override @NotNull
     public QueryView createView(ViewContext context, @NotNull QuerySettings settings, BindException errors)
     {
-        if ("PTMPercentsGrouped".equalsIgnoreCase(settings.getQueryName()))
+        if ("PTMPercentsGrouped".equalsIgnoreCase(settings.getQueryName()) || settings.getQueryName().toLowerCase().startsWith(QUERY_PTM_PERCENTS_GROUPED_PREFIX.toLowerCase()))
         {
             return new CrosstabView(TargetedMSSchema.this, settings, errors)
             {

--- a/src/org/labkey/targetedms/query/PTMPercentsCustomizer.java
+++ b/src/org/labkey/targetedms/query/PTMPercentsCustomizer.java
@@ -1,0 +1,55 @@
+package org.labkey.targetedms.query;
+
+import org.apache.commons.collections4.MultiValuedMap;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.CompareType;
+import org.labkey.api.data.ConditionalFormat;
+import org.labkey.api.data.DataColumn;
+import org.labkey.api.data.DisplayColumn;
+import org.labkey.api.data.DisplayColumnFactory;
+import org.labkey.api.data.MutableColumnInfo;
+import org.labkey.api.data.RenderContext;
+import org.labkey.api.data.SQLFragment;
+import org.labkey.api.data.SimpleFilter;
+import org.labkey.api.data.SqlSelector;
+import org.labkey.api.data.TableCustomizer;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.query.FieldKey;
+import org.labkey.api.util.Pair;
+import org.labkey.targetedms.TargetedMSManager;
+import org.labkey.targetedms.parser.Protein;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Customizes the set of columns available on a pivot query that operates on samples, hiding all of the pivot values
+ * that aren't part of the run that's being filtered on. This lets you view a single document's worth of data
+ * without seeing empty columns for all of the other samples in the same container.
+ */
+public class PTMPercentsCustomizer implements TableCustomizer
+{
+
+    /** Referenced from query XML metadata */
+    @SuppressWarnings("unused")
+    public PTMPercentsCustomizer(MultiValuedMap<String, String> props)
+    {
+
+    }
+
+    @Override
+    public void customize(TableInfo tableInfo)
+    {
+        List<FieldKey> defaultCols = new ArrayList<>(tableInfo.getDefaultVisibleColumns());
+        defaultCols.remove(FieldKey.fromParts("AminoAcid"));
+        defaultCols.remove(FieldKey.fromParts("Location"));
+        tableInfo.setDefaultVisibleColumns(defaultCols);
+    }
+}

--- a/src/org/labkey/targetedms/query/PTMPercentsGroupedCustomizer.java
+++ b/src/org/labkey/targetedms/query/PTMPercentsGroupedCustomizer.java
@@ -14,14 +14,16 @@ import org.labkey.api.data.MutableColumnInfo;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
+import org.labkey.api.data.Sort;
 import org.labkey.api.data.SqlSelector;
-import org.labkey.api.data.TableCustomizer;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.util.Pair;
 import org.labkey.targetedms.TargetedMSManager;
 import org.labkey.targetedms.parser.Protein;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -31,9 +33,9 @@ import java.util.Set;
 /**
  * Customizes the set of columns available on a pivot query that operates on samples, hiding all of the pivot values
  * that aren't part of the run that's being filtered on. This lets you view a single document's worth of data
- * without seeing empty columns for all of the other samples in the same container.
+ * without seeing empty columns for all the other samples in the same container.
  */
-public class PTMPercentsGroupedCustomizer implements TableCustomizer
+public class PTMPercentsGroupedCustomizer extends PTMPercentsCustomizer
 {
 
     private static final String QUERY_NAME_PREFIX = "PTMPercentsGrouped";
@@ -42,7 +44,7 @@ public class PTMPercentsGroupedCustomizer implements TableCustomizer
     @SuppressWarnings("unused")
     public PTMPercentsGroupedCustomizer(MultiValuedMap<String, String> props)
     {
-
+        super(props);
     }
 
     private FieldKey getCountFieldKey(ColumnInfo columnInfo)
@@ -50,8 +52,39 @@ public class PTMPercentsGroupedCustomizer implements TableCustomizer
         return FieldKey.fromString(columnInfo.getFieldKey().getParent(), "ModificationCount");
     }
 
+    /** These are the sorts we need to span rows, because we know that the related rows will be adjacent to each other */
+    public static final List<FieldKey> EXPECTED_SORTS = Collections.unmodifiableList(Arrays.asList(
+            FieldKey.fromParts("PeptideGroupId"),
+            FieldKey.fromParts("Sequence"),
+            FieldKey.fromParts("SiteLocation")
+    ));
+
+    /** Sorts that are safe because they overlap with the expected sorts in terms of grouping rows together */
+    public static final List<FieldKey> ALLOWABLE_SORTS = Collections.unmodifiableList(Arrays.asList(
+            FieldKey.fromParts("PeptideGroupId", "Label"),
+            FieldKey.fromParts("Location"),
+            FieldKey.fromParts("AminoAcid")
+    ));
+
     private int getRowSpan(ColumnInfo columnInfo, RenderContext ctx)
     {
+        List<Sort.SortField> sortFields = ctx.getBaseSort().getSortList();
+
+        // Only span rows if we're sorted as expected. Related to ticket 48873
+        List<FieldKey> neededSorts = new ArrayList<>(EXPECTED_SORTS);
+        for (Sort.SortField sortField : sortFields)
+        {
+            neededSorts.remove(sortField.getFieldKey());
+            if (neededSorts.isEmpty())
+            {
+                break;
+            }
+            if (!EXPECTED_SORTS.contains(sortField.getFieldKey()) && !ALLOWABLE_SORTS.contains(sortField.getFieldKey()))
+            {
+                return 1;
+            }
+        }
+
         Integer targetCount = ctx.get(getCountFieldKey(columnInfo), Integer.class);
         if (targetCount != null && targetCount > 1)
         {
@@ -81,6 +114,8 @@ public class PTMPercentsGroupedCustomizer implements TableCustomizer
                     col.getName().equalsIgnoreCase("PeptideGroupId") ||
                     col.getName().equalsIgnoreCase("PeptideModifiedSequence") ||
                     col.getName().equalsIgnoreCase("MaxPercentModified") ||
+                    col.getName().equalsIgnoreCase("AminoAcid") ||
+                    col.getName().equalsIgnoreCase("Location") ||
                     col.getName().equalsIgnoreCase("SiteLocation"))
             {
 
@@ -127,6 +162,8 @@ public class PTMPercentsGroupedCustomizer implements TableCustomizer
                 col.setDisplayColumnFactory(factory);
             }
         }
+
+        super.customize(tableInfo);
     }
 
     @NotNull
@@ -148,7 +185,7 @@ public class PTMPercentsGroupedCustomizer implements TableCustomizer
         return proteins;
     }
 
-    /** Key is the sample name, value is pair of boolean (stressed or not) and description, both annotation-based */
+    /** Key is the sample name, value is a pair of boolean (stressed or not) and description, both annotation-based */
     public static Map<String, Pair<Boolean, String>> getSampleMetadata(TableInfo tableInfo)
     {
         SQLFragment sql = new SQLFragment("SELECT DISTINCT sf.SampleName, raStressed.Value AS Stressed, COALESCE(raDescription.Value, sf.SampleName) AS Description FROM ");

--- a/src/org/labkey/targetedms/query/PTMPercentsGroupedCustomizer.java
+++ b/src/org/labkey/targetedms/query/PTMPercentsGroupedCustomizer.java
@@ -20,6 +20,7 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.util.Pair;
 import org.labkey.targetedms.TargetedMSManager;
+import org.labkey.targetedms.TargetedMSSchema;
 import org.labkey.targetedms.parser.Protein;
 
 import java.util.ArrayList;
@@ -37,9 +38,6 @@ import java.util.Set;
  */
 public class PTMPercentsGroupedCustomizer extends PTMPercentsCustomizer
 {
-
-    private static final String QUERY_NAME_PREFIX = "PTMPercentsGrouped";
-
     /** Referenced from query XML metadata */
     @SuppressWarnings("unused")
     public PTMPercentsGroupedCustomizer(MultiValuedMap<String, String> props)
@@ -171,13 +169,13 @@ public class PTMPercentsGroupedCustomizer extends PTMPercentsCustomizer
     {
         List<Protein> proteins = Collections.emptyList();
 
-        // Table name should be PTMPercentsGroupedX, where X is the runId
+        // Table name should be PTMPercentsGrouped_X, where X is the runId
         String tableName = tableInfo.getName();
-        if (tableName.toLowerCase().startsWith(QUERY_NAME_PREFIX.toLowerCase()))
+        if (tableName.toLowerCase().startsWith(TargetedMSSchema.QUERY_PTM_PERCENTS_GROUPED_PREFIX.toLowerCase()))
         {
             try
             {
-                int runId = Integer.parseInt(tableName.substring(QUERY_NAME_PREFIX.length()));
+                long runId = Long.parseLong(tableName.substring(TargetedMSSchema.QUERY_PTM_PERCENTS_GROUPED_PREFIX.length()));
                 proteins = PeptideGroupManager.getProteinsForRun(runId);
             }
             catch (NumberFormatException ignored) {}


### PR DESCRIPTION
#### Rationale
Users are generally satisfied by the default setup for MAM reports. But sometimes they want to customize the display a bit more

#### Changes
* Scope each run's reporting to a query that allows for its own customization of columns
* Expose `AminoAcid` and `Location` as separate columns, as well as the concatenated `SiteLocation`
* Revert to single-row display in the early stage PTM report when the user customizes the sort in a way that's not reliably grouped together