### PR TITLE
Issue 48646: Can't create guide sets by dragging over LJ plots w/ > 300 points

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -3838,7 +3838,18 @@ public class TargetedMSController extends SpringActionController
 
     private JspView<?> getSummaryView(RunDetailsForm form, TargetedMSRun run)
     {
-        Set<Integer> ids = Collections.singleton(ExperimentService.get().getExpRun(run.getExperimentRunLSID()).getRowId());
+        String lsid = run.getExperimentRunLSID();
+        if (lsid == null)
+        {
+            throw new NotFoundException("Document is not fully loaded and initialized");
+        }
+        ExpRun expRun = ExperimentService.get().getExpRun(lsid);
+        if (expRun == null)
+        {
+            throw new NotFoundException("Document is not fully loaded and initialized");
+        }
+
+        Set<Integer> ids = Collections.singleton(expRun.getRowId());
 
         RunDetailsBean bean = new RunDetailsBean();
         bean.setForm(form);

--- a/src/org/labkey/targetedms/parser/TimeIntensities.java
+++ b/src/org/labkey/targetedms/parser/TimeIntensities.java
@@ -16,8 +16,8 @@ package org.labkey.targetedms.parser;
 
 public class TimeIntensities
 {
-    private float[] _times;
-    private float[] _intensities;
+    private final float[] _times;
+    private final float[] _intensities;
     public TimeIntensities(float[] times, float[] intensities) {
         _times = times;
         _intensities = intensities;
@@ -36,7 +36,7 @@ public class TimeIntensities
     public TimeIntensities interpolate(float[] timesNew)
     {
         float[] intensNew = new float[timesNew.length];
-        if (timesNew.length == 0)
+        if (timesNew.length == 0 || _intensities.length == 0)
         {
             return new TimeIntensities(timesNew, intensNew);
         }
@@ -48,7 +48,6 @@ public class TimeIntensities
             double intenNext;
             float time = _times[i];
             float inten = _intensities[i];
-            double totalInten = inten;
 
             // Continue enumerating points until one is encountered
             // that has a greater time value than the point being assigned.

--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -318,6 +318,14 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
             }
         }
 
+        var maxPointsPerSeries = 0;
+        for (var i = 0; i < this.precursors.length; i++) {
+            if (this.fragmentPlotData[this.precursors[i]]) {
+                maxPointsPerSeries = Math.max(this.fragmentPlotData[this.precursors[i]].data.length, maxPointsPerSeries);
+            }
+        }
+        this.showDataPoints = maxPointsPerSeries <= LABKEY.targetedms.QCPlotHelperBase.maxPointsPerSeries;
+
         if (this.showExpRunRange && this.filterPoints) {
 
             for (let i = 0; i < plotDataRows.length; i++) {
@@ -360,6 +368,7 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
         }
 
         this.setLoadingMsg();
+        this.setBrushingEnabled(false);
         this.setPlotWidth(this.plotDivId);
 
         var addedPlot = false;
@@ -656,14 +665,6 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
             disableRange = false;
         }
 
-        var maxPointsPerSeries = 0;
-        for (var i = 0; i < this.precursors.length; i++) {
-            if (this.fragmentPlotData[this.precursors[i]]) {
-                maxPointsPerSeries = Math.max(this.fragmentPlotData[this.precursors[i]].data.length, maxPointsPerSeries);
-            }
-        }
-        var showDataPoints = maxPointsPerSeries <= LABKEY.targetedms.QCPlotHelperBase.maxPointsPerSeries;
-
         let shapeProp = 'IgnoreInQC';
         let shapeDomain = [undefined, true];
         if (plotType === 'Levey-Jennings') {
@@ -691,7 +692,7 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
             shapeRange: [LABKEY.vis.Scale.Shape()[0] /* circle */, LABKEY.vis.Scale.DataspaceShape()[0] /* open circle */, LABKEY.vis.Scale.Shape()[1], LABKEY.vis.Scale.Shape()[2]],
             shapeDomain: shapeDomain,
             showTrendLine: true,
-            showDataPoints: showDataPoints,
+            showDataPoints: this.showDataPoints,
             mouseOverFn: this.plotPointMouseOver,
             mouseOverFnScope: this,
             mouseOutFn: this.plotPointMouseOut,

--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -706,7 +706,7 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
             pathMouseOverFnScope: this,
             pathMouseOutFn: this.plotPointMouseOut,
             pathMouseOutFnScope: this,
-            hoverTextFn: !showDataPoints ? function(pathData) {
+            hoverTextFn: !this.showDataPoints ? function(pathData) {
                 return Ext4.htmlEncode(pathData.group) + '\nNarrow the date range to show individual data points.'
             } : undefined
         };


### PR DESCRIPTION
#### Rationale
We use the data points in the dragged area to determine the date range. When many samples are being displayed, we can't tell what start/end dates to use, and odds are the user can't really either. Disable the Create Guide Set button and add some tooltip guidance for how to enable it.

#### Changes
* Move where we determine if we're showing data points, use it to enable/disable the button
* Misc fixes, including:
  * Silence warning about caching a mutable array for chromatogram bytes
  * Fix protein-level chromatogram rendering when one peptide doesn't have data
  * Avoid NPE showing a document that failed to import