### PR TITLE
Sample getMaterialDetailsBaseURL to use the sample container instead of the sample type container

### DIFF
--- a/src/org/labkey/targetedms/query/SampleFileTable.java
+++ b/src/org/labkey/targetedms/query/SampleFileTable.java
@@ -182,15 +182,16 @@ public class SampleFileTable extends TargetedMSTable
 
             if (matchingContainers.size() == 1 && matchingSampleTypeLSIDs.size() == 1)
             {
+                Container matchingContainer = matchingContainers.iterator().next();
                 ExpSampleType sampleType = SampleTypeService.get().getSampleType(matchingSampleTypeLSIDs.iterator().next());
                 if (sampleType != null)
                 {
-                    ActionURL sampleUrl = PageFlowUtil.urlProvider(ExperimentUrls.class, true).getMaterialDetailsBaseURL(sampleType.getContainer(), SAMPLE_FIELD_KEY + "/RowId");
+                    ActionURL sampleUrl = PageFlowUtil.urlProvider(ExperimentUrls.class, true).getMaterialDetailsBaseURL(matchingContainer, SAMPLE_FIELD_KEY + "/RowId");
                     DetailsURL url = new DetailsURL(sampleUrl, "rowId", FieldKey.fromParts(SAMPLE_FIELD_KEY, "RowId"));
                     url.setContainerContext(new ContainerContext.FieldKeyContext(FieldKey.fromParts(SAMPLE_FIELD_KEY, "Folder"), true), false);
                     url.setStrictContainerContextEval(true);
 
-                    return new QueryForeignKey.Builder(new SamplesSchema(getUserSchema().getUser(), matchingContainers.iterator().next()), null).
+                    return new QueryForeignKey.Builder(new SamplesSchema(getUserSchema().getUser(), matchingContainer), null).
                             table(sampleType.getName()).
                             key("Name").
                             url(url).


### PR DESCRIPTION
#### Rationale
The TargetedMSSampleManagerIntegrationTest.testSampleTypeNavigation test case started failing yesterday because the call at line 185 in the SampleFileTable.java class gets the ExpSampleType previously was returning the current container for the `sampleType.getContainer()` call. It is now returning the container where the sample type is defined in, which seems more correct (not sure exactly which PR changed this). The test however is expecting the current container (i.e. the sample's container). This PR fixes that by using the `matchingContainers` var in that file.

#### Changes
* SampleFileTable to use matchingContainer in getMaterialDetailsBaseURL() call
