### PR TITLE
Increase length of the CustomIonName columns

### DIFF
--- a/resources/schemas/dbscripts/postgresql/targetedms-23.004-23.005.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-23.004-23.005.sql
@@ -1,0 +1,4 @@
+ALTER TABLE targetedms.molecule ALTER COLUMN customionname TYPE TEXT;
+ALTER TABLE targetedms.moleculeprecursor ALTER COLUMN customionname TYPE TEXT;
+ALTER TABLE targetedms.moleculetransition ALTER COLUMN customionname TYPE TEXT;
+ALTER TABLE targetedms.excludedprecursors ALTER COLUMN customionname TYPE TEXT;

--- a/resources/schemas/dbscripts/sqlserver/targetedms-23.004-23.005.sql
+++ b/resources/schemas/dbscripts/sqlserver/targetedms-23.004-23.005.sql
@@ -1,0 +1,4 @@
+ALTER TABLE targetedms.molecule ALTER COLUMN customionname NVARCHAR(MAX);
+ALTER TABLE targetedms.moleculeprecursor ALTER COLUMN customionname NVARCHAR(MAX);
+ALTER TABLE targetedms.moleculetransition ALTER COLUMN customionname NVARCHAR(MAX);
+ALTER TABLE targetedms.excludedprecursors ALTER COLUMN customionname NVARCHAR(MAX);

--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -221,7 +221,7 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
     @Override
     public Double getSchemaVersion()
     {
-        return 23.004;
+        return 23.005;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Custom ion names can be really long.  Increase the length of the CustomIonName column in the following tables:
- Molecule
- MoleculePrecursor
- MoleculeTransition
- ExcludedPrecursors
