### PR TITLE
Use new constructor

### DIFF
--- a/src/org/labkey/targetedms/view/PeptidePrecursorsView.java
+++ b/src/org/labkey/targetedms/view/PeptidePrecursorsView.java
@@ -36,7 +36,7 @@ public class PeptidePrecursorsView extends DocumentPrecursorsView
     {
         super(ctx, schema, queryName, runId, !forExport,
                 new QueryNestingOption(FieldKey.fromParts("PeptideId", "PeptideGroupId"),
-                        FieldKey.fromParts("PeptideId", "PeptideGroupId", "Id"), null), DATAREGION_NAME);
+                        FieldKey.fromParts("PeptideId", "PeptideGroupId", "Id")), DATAREGION_NAME);
         setTitle(TITLE);
 
     }

--- a/src/org/labkey/targetedms/view/PeptideTransitionsView.java
+++ b/src/org/labkey/targetedms/view/PeptideTransitionsView.java
@@ -35,7 +35,7 @@ public class PeptideTransitionsView extends DocumentTransitionsView
     {
         super(ctx, schema, queryName, runId, !forExport,
                 new QueryNestingOption(FieldKey.fromParts("PrecursorId", "PeptideId", "PeptideGroupId"),
-                        FieldKey.fromParts("PrecursorId", "PeptideId", "PeptideGroupId", "Id"), null), DATAREGION_NAME, TITLE);
+                        FieldKey.fromParts("PrecursorId", "PeptideId", "PeptideGroupId", "Id")), DATAREGION_NAME, TITLE);
     }
 
     /**

--- a/src/org/labkey/targetedms/view/QuantificationView.java
+++ b/src/org/labkey/targetedms/view/QuantificationView.java
@@ -35,7 +35,7 @@ public abstract class QuantificationView extends DocumentPrecursorsView
     {
         super(ctx, schema, tableName, form.getId(), forExport,
                 new QueryNestingOption(FieldKey.fromParts("PeptideGroupId"),
-                        FieldKey.fromParts("PeptideGroupId", "Id"), null), dataRegionName);
+                        FieldKey.fromParts("PeptideGroupId", "Id")), dataRegionName);
         setAllowableContainerFilterTypes();
         getSettings().setContainerFilterName(null);
     }

--- a/src/org/labkey/targetedms/view/SmallMoleculePrecursorsView.java
+++ b/src/org/labkey/targetedms/view/SmallMoleculePrecursorsView.java
@@ -35,7 +35,7 @@ public class SmallMoleculePrecursorsView extends DocumentPrecursorsView
     {
         super(ctx, schema, queryName, runId, !forExport,
                 new QueryNestingOption(FieldKey.fromParts("MoleculeId", "PeptideGroupId"),
-                        FieldKey.fromParts("MoleculeId", "PeptideGroupId", "Id"), null), DATAREGION_NAME);
+                        FieldKey.fromParts("MoleculeId", "PeptideGroupId", "Id")), DATAREGION_NAME);
         setTitle(TITLE);
     }
 

--- a/src/org/labkey/targetedms/view/SmallMoleculeTransitionsView.java
+++ b/src/org/labkey/targetedms/view/SmallMoleculeTransitionsView.java
@@ -35,7 +35,7 @@ public class SmallMoleculeTransitionsView extends DocumentTransitionsView
     {
         super(ctx, schema, queryName, runId, !forExport,
                 new QueryNestingOption(FieldKey.fromParts("MoleculePrecursorId", "MoleculeId", "PeptideGroupId"),
-                        FieldKey.fromParts("MoleculePrecursorId", "MoleculeId", "PeptideGroupId", "Id"), null), DATAREGION_NAME, TITLE);
+                        FieldKey.fromParts("MoleculePrecursorId", "MoleculeId", "PeptideGroupId", "Id")), DATAREGION_NAME, TITLE);
     }
 
     /**


### PR DESCRIPTION
#### Rationale
A new `QueryNestingOption` constructor made it easier to focus on callers that were actually passing a URL.