### PR TITLE
Adjust sort to let SQLServer sort according to our intention

### DIFF
--- a/src/org/labkey/targetedms/view/CalibrationCurvesView.java
+++ b/src/org/labkey/targetedms/view/CalibrationCurvesView.java
@@ -56,7 +56,7 @@ public class CalibrationCurvesView extends QuantificationView
 
         if (isSmallMolecule())
         {
-            getSettings().setBaseSort(new Sort("GeneralMoleculeId/CustomIonName"));
+            getSettings().setBaseSort(new Sort("GeneralMoleculeId/Molecule"));
         }
         else
         {


### PR DESCRIPTION
#### Rationale
Fix the test which broke when `CustomIonName` switched to `NVARCHAR(MAX)` and stopped sorting the same way.

https://teamcity.labkey.org/buildConfiguration/LabKey_2311Release_Premium_ModulesSuites_TargetedMSSqlserver/2750860?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildTestsSection=true&expandBuildChangesSection=true

#### Changes
* Point to a column that SQL Server knows how to sort