### PR TITLE
Issue 49131: Improve date alignment for "trailing" plots with dates from other plot types

### DIFF
--- a/src/org/labkey/targetedms/model/GuideSetStats.java
+++ b/src/org/labkey/targetedms/model/GuideSetStats.java
@@ -25,7 +25,6 @@ public class GuideSetStats
 {
     private final GuideSetKey _key;
     private final GuideSet _guideSet;
-    private int _trainingSeqIndex;
 
     /** Rows that define the normal range for this guide set */
     private final List<RawMetricDataSet> _trainingRows = new ArrayList<>();
@@ -49,7 +48,6 @@ public class GuideSetStats
     {
         _key = key;
         _guideSet = guideSet;
-        _trainingSeqIndex = 0;
     }
 
     public double getStandardDeviation()

--- a/src/org/labkey/targetedms/model/GuideSetStats.java
+++ b/src/org/labkey/targetedms/model/GuideSetStats.java
@@ -176,6 +176,7 @@ public class GuideSetStats
         double[] positiveCUSUMv = Stats.getCUSUMS(metricVals, false, true, false, null);
         double[] negativeCUSUMv = Stats.getCUSUMS(metricVals, true, true, false, null);
 
+        int j = 0; // index to traverse trailingMeans and trailingCVs array
         for (int i = 0; i < includedRows.size(); i++)
         {
             RawMetricDataSet row = includedRows.get(i);
@@ -191,15 +192,9 @@ public class GuideSetStats
                 row.setCUSUMvP(positiveCUSUMv[i]);
                 row.setCUSUMvN(negativeCUSUMv[i]);
             }
-        }
-        // start trailingCVs and trailingMeans from number of trailingRuns after the beginning
-        int j = 0; // index to traverse trailingMeans and trailingCVs array
-        if (null != trailingRuns)
-        {
-            for (int i = trailingRuns-1; i < includedRows.size(); i++)
+            RawMetricDataSet trailingStartRow = includedRows.get(j);
+            if (null != trailingRuns)
             {
-                RawMetricDataSet row = includedRows.get(i);
-                RawMetricDataSet trailingStartRow = includedRows.get(j);
                 if (trailingMeans.length > 0 && j < trailingMeans.length)
                 {
                     if (row.getMetricValue() == null)

--- a/src/org/labkey/targetedms/model/GuideSetStats.java
+++ b/src/org/labkey/targetedms/model/GuideSetStats.java
@@ -192,6 +192,7 @@ public class GuideSetStats
                 row.setCUSUMvP(positiveCUSUMv[i]);
                 row.setCUSUMvN(negativeCUSUMv[i]);
             }
+
             RawMetricDataSet trailingStartRow = includedRows.get(j);
             if (null != trailingRuns)
             {

--- a/src/org/labkey/targetedms/model/GuideSetStats.java
+++ b/src/org/labkey/targetedms/model/GuideSetStats.java
@@ -25,6 +25,7 @@ public class GuideSetStats
 {
     private final GuideSetKey _key;
     private final GuideSet _guideSet;
+    private int _trainingSeqIndex;
 
     /** Rows that define the normal range for this guide set */
     private final List<RawMetricDataSet> _trainingRows = new ArrayList<>();
@@ -48,6 +49,7 @@ public class GuideSetStats
     {
         _key = key;
         _guideSet = guideSet;
+        _trainingSeqIndex = 0;
     }
 
     public double getStandardDeviation()
@@ -102,6 +104,7 @@ public class GuideSetStats
                 _guideSet.getTrainingStart().compareTo(row.getSampleFile().getAcquiredTime()) <= 0 &&
                 (_guideSet.getTrainingEnd() == null || _guideSet.getTrainingEnd().compareTo(row.getSampleFile().getAcquiredTime()) >= 0))
         {
+            row.setInsideGuideSet(true);
             _trainingRows.add(row);
         }
         else
@@ -177,6 +180,7 @@ public class GuideSetStats
         double[] negativeCUSUMv = Stats.getCUSUMS(metricVals, true, true, false, null);
 
         int j = 0; // index to traverse trailingMeans and trailingCVs array
+        int start = 0;
         for (int i = 0; i < includedRows.size(); i++)
         {
             RawMetricDataSet row = includedRows.get(i);
@@ -193,7 +197,7 @@ public class GuideSetStats
                 row.setCUSUMvN(negativeCUSUMv[i]);
             }
 
-            RawMetricDataSet trailingStartRow = includedRows.get(j);
+            RawMetricDataSet trailingStartRow = includedRows.get(start);
             if (null != trailingRuns)
             {
                 if (trailingMeans.length > 0 && j < trailingMeans.length)
@@ -233,6 +237,10 @@ public class GuideSetStats
                     // when the metric value is null (bad data), the corresponding trailing mean/cv is set to the previous trailing mean/cv
                     // so only move forward for the actual metric values
                     j++;
+                }
+                if (j >= trailingRuns)
+                {
+                    start++;
                 }
             }
         }

--- a/src/org/labkey/targetedms/model/QCPlotFragment.java
+++ b/src/org/labkey/targetedms/model/QCPlotFragment.java
@@ -176,6 +176,7 @@ public class QCPlotFragment
                 {
                     dataJsonObject.put("TrailingStartDate", plotData.getTrailingStart());
                 }
+                dataJsonObject.put("InsideGuideSet", plotData.isInsideGuideSet());
                 dataJsonArray.put(dataJsonObject);
             }
         }

--- a/src/org/labkey/targetedms/model/RawMetricDataSet.java
+++ b/src/org/labkey/targetedms/model/RawMetricDataSet.java
@@ -44,6 +44,7 @@ public class RawMetricDataSet
     Double trailingCV;
     Date trailingStart;
     PrecursorInfo _precursor;
+    boolean insideGuideSet;
 
     private GuideSetKey _guideSetKey;
 
@@ -423,4 +424,13 @@ public class RawMetricDataSet
         this.trailingStart = trailingStart;
     }
 
+    public boolean isInsideGuideSet()
+    {
+        return insideGuideSet;
+    }
+
+    public void setInsideGuideSet(boolean insideGuideSet)
+    {
+        this.insideGuideSet = insideGuideSet;
+    }
 }

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -59,6 +59,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.labkey.test.components.targetedms.QCPlotsWebPart.QCPlotType.CUSUMm;
+import static org.labkey.test.components.targetedms.QCPlotsWebPart.QCPlotType.CUSUMv;
 import static org.labkey.test.components.targetedms.QCPlotsWebPart.QCPlotType.LeveyJennings;
 import static org.labkey.test.components.targetedms.QCPlotsWebPart.QCPlotType.MovingRange;
 
@@ -396,7 +397,10 @@ public class TargetedMSQCTest extends TargetedMSTest
         PanoramaDashboard qcDashboard = new PanoramaDashboard(this);
         QCPlotsWebPart qcPlotsWebPart = qcDashboard.getQcPlotsWebPart();
         qcPlotsWebPart.filterQCPlotsToInitialData(PRECURSORS.length, true);
-        qcPlotsWebPart.checkAllPlotTypes(true);
+        qcPlotsWebPart.checkPlotType(LeveyJennings);
+        qcPlotsWebPart.checkPlotType(MovingRange);
+        qcPlotsWebPart.checkPlotType(CUSUMm);
+        qcPlotsWebPart.checkPlotType(CUSUMv);
 
         // if metric has negative values and we pick log y-axis scale, we should revert to linear scale and show message
         qcPlotsWebPart.setMetricType(QCPlotsWebPart.MetricType.MASSACCURACY);

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSTrailingMeanAndCVTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSTrailingMeanAndCVTest.java
@@ -87,7 +87,7 @@ public class TargetedMSTrailingMeanAndCVTest extends TargetedMSTest
                 qcPlotsWebPart.getSVGPlotText("precursorPlot0").contains("Minutes"));
 
         log("Verifying the count of points on the plot");
-        Assert.assertEquals("Invalid point count for all replicates", REPLICATE_COUNT * (RUN_COUNT - Integer.parseInt(trailingLast) + 1) , qcPlotsWebPart.getPointElements("d", SvgShapes.CIRCLE.getPathPrefix(), true).size());
+        Assert.assertEquals("Invalid point count for all replicates", REPLICATE_COUNT * RUN_COUNT, qcPlotsWebPart.getPointElements("d", SvgShapes.CIRCLE.getPathPrefix(), true).size());
 
         log("Verifying tooltips");
         qcPlotsWebPart.waitForPlots(7);
@@ -100,7 +100,7 @@ public class TargetedMSTrailingMeanAndCVTest extends TargetedMSTest
                 "Replicate:\n" +
                 "3 runs average\n" +
                 "Acquired:\n" +
-                "2013-08-09 11:39:00 - 2013-08-12 04:54:55", toolTipText);
+                "2013-08-09 11:39 - 2013-08-12 04:54", toolTipText);
 
         log("Selecting multiple plot types with trailing mean");
         qcPlotsWebPart.setQCPlotTypes(QCPlotsWebPart.QCPlotType.LeveyJennings, QCPlotsWebPart.QCPlotType.MovingRange, QCPlotsWebPart.QCPlotType.TrailingMean);
@@ -121,10 +121,10 @@ public class TargetedMSTrailingMeanAndCVTest extends TargetedMSTest
                 "Replicate:\n" +
                 "3 runs average\n" +
                 "Acquired:\n" +
-                "2013-08-11 18:34:14 - 2013-08-14 00:44:46", toolTipText);
+                "2013-08-11 18:34 - 2013-08-14 00:44", toolTipText);
 
         log("Verifying the count of points on the plots with guide set");
-        Assert.assertEquals("Invalid point count for all replicates", 308 , qcPlotsWebPart.getPointElements("d", SvgShapes.CIRCLE.getPathPrefix(), true).size());
+        Assert.assertEquals("Invalid point count for all replicates", 322 , qcPlotsWebPart.getPointElements("d", SvgShapes.CIRCLE.getPathPrefix(), true).size());
     }
 
     @Test

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSTrailingMeanAndCVTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSTrailingMeanAndCVTest.java
@@ -165,10 +165,10 @@ public class TargetedMSTrailingMeanAndCVTest extends TargetedMSTest
                 "Replicate:\n" +
                 "3 runs average\n" +
                 "Acquired:\n" +
-                "2013-08-09 11:39:00 - 2013-08-12 04:54:55", toolTipText);
+                "2013-08-09 11:39 - 2013-08-12 04:54", toolTipText);
         qcPlotsWebPart.closeBubble();
         log("Verifying the count of points on the plot");
-        Assert.assertEquals("Invalid point count for all replicates", REPLICATE_COUNT * (RUN_COUNT - Integer.parseInt(trailingLast) + 1) -1 ,
+        Assert.assertEquals("Invalid point count for all replicates", REPLICATE_COUNT * RUN_COUNT,
                 qcPlotsWebPart.getPointElements("d", SvgShapes.CIRCLE.getPathPrefix(), true).size());
 
         log("Verifying values with guide set");
@@ -186,11 +186,11 @@ public class TargetedMSTrailingMeanAndCVTest extends TargetedMSTest
                 "Replicate:\n" +
                 "3 runs average\n" +
                 "Acquired:\n" +
-                "2013-08-21 04:46:18 - 2013-08-21 09:07:36", toolTipText);
+                "2013-08-21 04:46 - 2013-08-21 09:07", toolTipText);
         qcPlotsWebPart.closeBubble();
 
         log("Verifying the count of points on the plot with guide set");
-        Assert.assertEquals("Invalid number of point count for all replicates - plots with guide set", 133 ,
+        Assert.assertEquals("Invalid number of point count for all replicates - plots with guide set", REPLICATE_COUNT * RUN_COUNT ,
                 qcPlotsWebPart.getPointElements("d", SvgShapes.CIRCLE.getPathPrefix(), true).size());
     }
 }

--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -181,6 +181,8 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
 
 
         var tempData; // temp variable to store data for setting the date
+        let foundTrue = false
+        let trainingSeqIdx = 1;
         for (var i = this.pagingStartIndex; i < this.pagingEndIndex; i++) {
             var plotDataRow = plotDataRows[i];
             tempData = plotDataRow;
@@ -196,6 +198,20 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
                 plotData['ReplicateName'] = sampleFile['ReplicateName'];
                 plotData['InGuideSetTrainingRange'] = sampleFile['InGuideSetTrainingRange'];
 
+                var gs = this.guideSetDataMap[plotData['GuideSetId']];
+
+                if (Ext4.isDefined(gs) && gs.Series[fragment]) {
+                    if (plotData['InsideGuideSet']) {
+                        if (!foundTrue) {
+                            foundTrue = true;
+                            trainingSeqIdx = 1;
+                        }
+                    } else {
+                        foundTrue = false;
+                    }
+                    plotData['TrainingSeqIdx'] = trainingSeqIdx;
+                    trainingSeqIdx++
+                }
                 var data = this.processPlotDataRow(plotData, plotDataRow, fragment, metricProps);
                 this.fragmentPlotData[fragment].data.push(data);
                 this.fragmentPlotData[fragment].precursorScoped = metricProps.precursorScoped;

--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -182,7 +182,7 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
 
         var tempData; // temp variable to store data for setting the date
         let foundTrue = false
-        let trainingSeqIdx = 1;
+        let trainingSeqIdx = 1; // this index is used for displaying the average number of runs in tooltip (QCPlotHoverPanel.js L110)
         for (var i = this.pagingStartIndex; i < this.pagingEndIndex; i++) {
             var plotDataRow = plotDataRows[i];
             tempData = plotDataRow;

--- a/webapp/TargetedMS/js/QCPlotHelperWrapper.js
+++ b/webapp/TargetedMS/js/QCPlotHelperWrapper.js
@@ -78,38 +78,6 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperWrapper", {
         }
     },
 
-    zoomDateRangeForTrailingGraphs: function (precursorInfo) {
-        let precursors = this.deepCloneObject(precursorInfo);
-        if (Object.keys(this.guideSetDataMap).length !== 0) {
-            let firstGuideSetStartDate = new Date();
-            // setting to tomorrow's date
-            firstGuideSetStartDate.setDate(firstGuideSetStartDate.getDate() + 1);
-            Ext4.Object.each(this.guideSetDataMap, function (id, gs) {
-                if (new Date(gs.TrainingStart).getTime() < firstGuideSetStartDate.getTime()) {
-                    firstGuideSetStartDate = new Date(gs.TrainingStart);
-                }
-            });
-
-            for (let ind = 0 ; ind < precursors.data.length; ind++) {
-                let data = precursors.data[ind];
-                if (new Date(data.fullDate).getTime() < firstGuideSetStartDate.getTime()) {
-                    precursors.data.splice(ind, 1);
-                    ind--;
-                }
-            }
-        }
-        else {
-            for (let ind = 0 ; ind < precursors.data.length; ind++) {
-                let data = precursors.data[ind];
-                if (!data.TrailingMean && !data.TrailingCV) {
-                    precursors.data.splice(ind, 1);
-                    ind--;
-                }
-            }
-        }
-        return precursors;
-    },
-
     addIndividualPrecursorPlots : function() {
         var addedPlot = false,
                 metricProps = this.getMetricPropsById(this.metric),
@@ -147,10 +115,10 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperWrapper", {
                     this.addEachIndividualPrecursorPlot(plotIndex, ids[plotIndex], i, precursorInfo, metricProps, LABKEY.vis.TrendingLinePlotType.CUSUM, false, me);
                 }
                 if (this.showTrailingMeanPlot()) {
-                    this.addEachIndividualPrecursorPlot(plotIndex, ids[plotIndex++], i, this.zoomDateRangeForTrailingGraphs(precursorInfo), metricProps, LABKEY.vis.TrendingLinePlotType.TrailingMean, undefined, me);
+                    this.addEachIndividualPrecursorPlot(plotIndex, ids[plotIndex++], i, precursorInfo, metricProps, LABKEY.vis.TrendingLinePlotType.TrailingMean, undefined, me);
                 }
                 if (this.showTrailingCVPlot()) {
-                    this.addEachIndividualPrecursorPlot(plotIndex, ids[plotIndex++], i, this.zoomDateRangeForTrailingGraphs(precursorInfo), metricProps, LABKEY.vis.TrendingLinePlotType.TrailingCV, undefined, me);
+                    this.addEachIndividualPrecursorPlot(plotIndex, ids[plotIndex++], i, precursorInfo, metricProps, LABKEY.vis.TrendingLinePlotType.TrailingCV, undefined, me);
                 }
             }
         }

--- a/webapp/TargetedMS/js/QCPlotHelperWrapper.js
+++ b/webapp/TargetedMS/js/QCPlotHelperWrapper.js
@@ -348,6 +348,8 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperWrapper", {
         if (this.showTrailingMeanPlot() || this.showTrailingCVPlot()) {
             data['TrailingStartDate'] = row['TrailingStartDate'];
             data['TrailingEndDate'] = row['TrailingEndDate'];
+            data['TrainingSeqIdx'] = row['TrainingSeqIdx'];
+            data['InsideGuideSet'] = row['InsideGuideSet'];
         }
 
         return data;

--- a/webapp/TargetedMS/js/QCPlotHoverPanel.js
+++ b/webapp/TargetedMS/js/QCPlotHoverPanel.js
@@ -104,7 +104,15 @@ Ext4.define('LABKEY.targetedms.QCPlotHoverPanel', {
         }
 
         if (hideExclusionAndPointClickLinks) {
-            this.add(this.getPlotPointDetailField('Replicate', this.trailingRuns + " runs average"));
+            let numOfRunsAverage = 0;
+            // check if guide set is present
+           if (this.pointData['inGuideSetTrainingRange'] !== undefined) {
+               numOfRunsAverage = this.trailingRuns > this.pointData['TrainingSeqIdx'] ? this.pointData['TrainingSeqIdx'] : this.trailingRuns
+           }
+           else {
+               numOfRunsAverage = this.trailingRuns > this.pointData['seqValue'] + 1 ? this.pointData['seqValue'] + 1 : this.trailingRuns;
+           }
+            this.add(this.getPlotPointDetailField('Replicate', numOfRunsAverage + " runs average"));
             this.add(this.getPlotPointDetailField('Acquired', this.trailingStartDate + " - " + this.trailingEndDate));
         }
         else {

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -1307,8 +1307,8 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         }
 
         let trailingRuns = this.trailingRuns;
-        let trailingStartDate = Ext4.util.Format.date(row['TrailingStartDate'], 'Y-m-d H:i:s');
-        let trailingEndDate = Ext4.util.Format.date(row['fullDate'], 'Y-m-d H:i:s');
+        let trailingStartDate = Ext4.util.Format.date(row['TrailingStartDate'], 'Y-m-d H:i');
+        let trailingEndDate = Ext4.util.Format.date(row['fullDate'], 'Y-m-d H:i');
 
         showHoverTask.delay(500, function() {
             var calloutMgr = hopscotch.getCalloutManager(),


### PR DESCRIPTION
#### Rationale
This PR fixes the trailing CVs and trailing means for the values aligned with dates of other plot types i.e. When the plot shows a date range that omits samples at the beginning, use the data that's been cropped to calculate the trailing means and CVs.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5039

#### Changes
* Calculate the trailing values for all the dates