### PR TITLE
Remove deprecated ContainerFilter.getSQLFragment

### DIFF
--- a/src/org/labkey/targetedms/query/SkylineListManager.java
+++ b/src/org/labkey/targetedms/query/SkylineListManager.java
@@ -96,7 +96,7 @@ public class SkylineListManager
         fragment.append(" WHERE t.RunId IN (SELECT Id FROM ");
         fragment.append(TargetedMSSchema.getSchema().getTable(TargetedMSSchema.TABLE_RUNS), "r");
         fragment.append(new SQLFragment(" WHERE StatusId = ? AND deleted = ? AND ", SkylineDocImporter.STATUS_SUCCESS, Boolean.FALSE));
-        fragment.append(containerFilter.getSQLFragment(getListDefTable().getSchema(), new SQLFragment("Container"), container));
+        fragment.append(containerFilter.getSQLFragment(getListDefTable().getSchema(), new SQLFragment("Container")));
         fragment.append(") ORDER BY t.Name, t.RunId DESC");
         return new SqlSelector(TargetedMSSchema.getSchema(), fragment).getArrayList(ListDefinition.class);
     }
@@ -115,7 +115,7 @@ public class SkylineListManager
 
         SQLFragment sqlFragmentContainer = new SQLFragment("(SELECT CONTAINER FROM " + TargetedMSManager.getTableInfoRuns() + " WHERE Id = ?)", runId);
         fragment.append(" AND ");
-        fragment.append(containerFilter.getSQLFragment(TargetedMSSchema.getSchema(), sqlFragmentContainer, container));
+        fragment.append(containerFilter.getSQLFragment(TargetedMSSchema.getSchema(), sqlFragmentContainer));
 
         for (ListDefinition listDefinition : new SqlSelector(TargetedMSSchema.getSchema(), fragment).getCollection(ListDefinition.class))
         {


### PR DESCRIPTION
#### Rationale
See https://github.com/LabKey/platform/pull/5073 for rationale.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5073

#### Changes
* Remove `ContainerFilter.getSQLFragment(DbSchema, SQLFragment, Container)` and replace usages with calls to `ContainerFilter.getSQLFragment(DbSchema, SQLFragment)`.
