### PR TITLE
Clear the previously saved properties when saving a new default view

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -744,6 +744,7 @@ public class TargetedMSController extends SpringActionController
         {
             PropertyManager.PropertyMap current = PropertyManager.getProperties(getUser(), getContainer(), QCFolderConstants.CATEGORY);
             PropertyManager.PropertyMap defaults = PropertyManager.getWritableProperties(getContainer(), QCFolderConstants.CATEGORY, true);
+            defaults.clear(); // Clear the map. There may be properties that are no longer applicable (e.g. selectedAnnotations, startDate, endDate).
             defaults.putAll(current);
             defaults.save();
 


### PR DESCRIPTION
#### Rationale
Some settings, such as "selectedAnnotations", have to be cleared if the last saved default view had a filter on replicate annotations but the current view that is being saved does not have any replicate annotation filters. 

