### PR TITLE
Speed up QC metric enabled queries, especially mass error

### DIFF
--- a/resources/queries/targetedms/QCMetricEnabled_IsotopologuePrecursorAccuracy.sql
+++ b/resources/queries/targetedms/QCMetricEnabled_IsotopologuePrecursorAccuracy.sql
@@ -1,1 +1,1 @@
-SELECT Id FROM targetedms.PrecursorChromInfoAnnotation WHERE Name = 'PrecursorAccuracy'
+SELECT 1 AS E WHERE EXISTS (SELECT Id FROM targetedms.PrecursorChromInfoAnnotation WHERE Name = 'PrecursorAccuracy')

--- a/resources/queries/targetedms/QCMetricEnabled_IsotopologuePrecursorLOD.sql
+++ b/resources/queries/targetedms/QCMetricEnabled_IsotopologuePrecursorLOD.sql
@@ -1,1 +1,1 @@
-SELECT Id FROM targetedms.PrecursorChromInfoAnnotation WHERE Name = 'LOD'
+SELECT 1 AS E WHERE EXISTS (SELECT Id FROM targetedms.PrecursorChromInfoAnnotation WHERE Name = 'LOD')

--- a/resources/queries/targetedms/QCMetricEnabled_IsotopologuePrecursorLOQ.sql
+++ b/resources/queries/targetedms/QCMetricEnabled_IsotopologuePrecursorLOQ.sql
@@ -1,1 +1,1 @@
-SELECT Id FROM targetedms.PrecursorChromInfoAnnotation WHERE Name = 'LOQ'
+SELECT 1 AS E WHERE EXISTS (SELECT Id FROM targetedms.PrecursorChromInfoAnnotation WHERE Name = 'LOQ')

--- a/resources/queries/targetedms/QCMetricEnabled_IsotopologuePrecursorRSquared.sql
+++ b/resources/queries/targetedms/QCMetricEnabled_IsotopologuePrecursorRSquared.sql
@@ -1,1 +1,1 @@
-SELECT Id FROM targetedms.PrecursorChromInfoAnnotation WHERE Name = 'RSquared'
+SELECT 1 AS E WHERE EXISTS (SELECT Id FROM targetedms.PrecursorChromInfoAnnotation WHERE Name = 'RSquared')

--- a/resources/queries/targetedms/QCMetricEnabled_isotopeDotp.sql
+++ b/resources/queries/targetedms/QCMetricEnabled_isotopeDotp.sql
@@ -1,1 +1,1 @@
-SELECT Id FROM targetedms.PrecursorChromInfo WHERE IsotopeDotp IS NOT NULL
+SELECT 1 AS E WHERE EXISTS (SELECT Id FROM targetedms.PrecursorChromInfo WHERE IsotopeDotp IS NOT NULL)

--- a/resources/queries/targetedms/QCMetricEnabled_lhRatio.sql
+++ b/resources/queries/targetedms/QCMetricEnabled_lhRatio.sql
@@ -1,1 +1,1 @@
-SELECT Id FROM targetedms.PrecursorAreaRatio
+SELECT 1 AS E WHERE EXISTS (SELECT Id FROM targetedms.PrecursorAreaRatio)

--- a/resources/queries/targetedms/QCMetricEnabled_libraryDotp.sql
+++ b/resources/queries/targetedms/QCMetricEnabled_libraryDotp.sql
@@ -1,1 +1,1 @@
-SELECT Id FROM targetedms.PrecursorChromInfo WHERE LibraryDotp IS NOT NULL
+SELECT 1 AS E WHERE EXISTS (SELECT Id FROM targetedms.PrecursorChromInfo WHERE LibraryDotp IS NOT NULL)

--- a/resources/queries/targetedms/QCMetricEnabled_massErrorPrecursor.sql
+++ b/resources/queries/targetedms/QCMetricEnabled_massErrorPrecursor.sql
@@ -1,1 +1,1 @@
-SELECT Id FROM targetedms.TransitionChromInfo WHERE MassErrorPPM IS NOT NULL AND TransitionId.Charge IS NULL
+SELECT 1 AS E WHERE EXISTS (SELECT Id FROM targetedms.TransitionChromInfo WHERE MassErrorPPM IS NOT NULL AND TransitionId.Charge IS NULL)

--- a/resources/queries/targetedms/QCMetricEnabled_massErrorTransition.sql
+++ b/resources/queries/targetedms/QCMetricEnabled_massErrorTransition.sql
@@ -1,1 +1,1 @@
-SELECT Id FROM targetedms.TransitionChromInfo WHERE MassErrorPPM IS NOT NULL AND TransitionId.Charge IS NOT NULL
+SELECT 1 AS E WHERE EXISTS (SELECT Id FROM targetedms.TransitionChromInfo WHERE MassErrorPPM IS NOT NULL AND TransitionId.Charge IS NOT NULL)


### PR DESCRIPTION
#### Rationale
The new mass error metric queries s are very slow on some large databases. This should help speed them up, though more optimizations may still be needed

#### Changes
* Avoid selecting real values from the table in the enabled queries, as they can bring in unwanted joins to also fetch the Container value when we generate SQL