### PR TITLE
Highlight just the modification site of interest in early stage PTM report

### DIFF
--- a/resources/queries/targetedms/PTMPercentsGrouped.query.xml
+++ b/resources/queries/targetedms/PTMPercentsGrouped.query.xml
@@ -10,6 +10,7 @@
                             <properties>
                                 <property name="showNextAndPrevious">true</property>
                                 <property name="useParens">true</property>
+                                <property name="modificationSite">SiteLocation</property>
                             </properties>
                         </displayColumnFactory>
                         <columnTitle>Sequence</columnTitle>

--- a/resources/queries/targetedms/PTMPercentsGroupedPrepivot.query.xml
+++ b/resources/queries/targetedms/PTMPercentsGroupedPrepivot.query.xml
@@ -9,6 +9,7 @@
                             <properties>
                                 <property name="showNextAndPrevious">true</property>
                                 <property name="useParens">true</property>
+                                <property name="modificationSite">SiteLocation</property>
                             </properties>
                         </displayColumnFactory>
                         <columnTitle>Sequence</columnTitle>

--- a/src/org/labkey/targetedms/query/ModificationManager.java
+++ b/src/org/labkey/targetedms/query/ModificationManager.java
@@ -303,7 +303,10 @@ public class ModificationManager
             modIndexes.add(Pair.of(peptideIndex, indexAA));
         });
 
-        return Collections.unmodifiableMap(peptideModIndexMap);
+        Map<Long, Set<Pair<Integer, Integer>>> immutableMap = new HashMap<>();
+        peptideModIndexMap.forEach((k, v) -> immutableMap.put(k, Collections.unmodifiableSet(v)));
+
+        return Collections.unmodifiableMap(immutableMap);
     }
 
     /**

--- a/src/org/labkey/targetedms/query/PTMPercentsGroupedCustomizer.java
+++ b/src/org/labkey/targetedms/query/PTMPercentsGroupedCustomizer.java
@@ -53,14 +53,14 @@ public class PTMPercentsGroupedCustomizer extends PTMPercentsCustomizer
     /** These are the sorts we need to span rows, because we know that the related rows will be adjacent to each other */
     public static final List<FieldKey> EXPECTED_SORTS = Collections.unmodifiableList(Arrays.asList(
             FieldKey.fromParts("PeptideGroupId"),
-            FieldKey.fromParts("Sequence"),
-            FieldKey.fromParts("SiteLocation")
+            FieldKey.fromParts("Location"),
+            FieldKey.fromParts("Sequence")
     ));
 
     /** Sorts that are safe because they overlap with the expected sorts in terms of grouping rows together */
     public static final List<FieldKey> ALLOWABLE_SORTS = Collections.unmodifiableList(Arrays.asList(
             FieldKey.fromParts("PeptideGroupId", "Label"),
-            FieldKey.fromParts("Location"),
+            FieldKey.fromParts("SiteLocation"),
             FieldKey.fromParts("AminoAcid")
     ));
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSEarlyStagePTMReportTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSEarlyStagePTMReportTest.java
@@ -47,20 +47,23 @@ public class TargetedMSEarlyStagePTMReportTest extends TargetedMSTest
         Assert.assertEquals("Incorrect Sample Names displayed as headers", "Sample1 Sc_WCL-250ng-5ngNIST_rKCTi_3hRP-20cm_DE30_QE_2",
                 Locator.xpath("//table/thead[2]/tr").findElement(reportTable).getText());
 
+        int vtnRowIndex = 8;
+        int wqqRowIndex = 13;
+
         log("Verifying the modified percentage for sequence with CDR Range and stressed or not stressed updates");
-        Assert.assertEquals("Incorrect percentages for (K)VTNMDPADTATYYCAR(D) sequence", Arrays.asList("11.3%", "11.3%", "11.1%", "11.1%"),
-                reportTable.getRowDataAsText(7, "Sc_WCL-250ng-5ngNIST_rKCTi_3hRP-20cm_DE30_QE_1::PercentModified", "Sc_WCL-250ng-5ngNIST_rKCTi_3hRP-20cm_DE30_QE_1::TotalPercentModified",
+        Assert.assertEquals("Incorrect percentages for (K)VTNMDPADTATYYCAR(D) sequence", Arrays.asList("(K)VTNMDPADTATYYCAR(D)", "11.3%", "11.3%", "11.1%", "11.1%"),
+                reportTable.getRowDataAsText(vtnRowIndex, "Sequence", "Sc_WCL-250ng-5ngNIST_rKCTi_3hRP-20cm_DE30_QE_1::PercentModified", "Sc_WCL-250ng-5ngNIST_rKCTi_3hRP-20cm_DE30_QE_1::TotalPercentModified",
                         "Sc_WCL-250ng-5ngNIST_rKCTi_3hRP-20cm_DE30_QE_2::PercentModified", "Sc_WCL-250ng-5ngNIST_rKCTi_3hRP-20cm_DE30_QE_2::TotalPercentModified"));
-        Assert.assertEquals("Incorrect percentages for (R)WQQGNVFSCSVMHEALHNHYTQK(S) sequence", Arrays.asList("22.1%", "22.1%", "24.1%", "24.1%"),
-                reportTable.getRowDataAsText(8, "Sc_WCL-250ng-5ngNIST_rKCTi_3hRP-20cm_DE30_QE_1::PercentModified", "Sc_WCL-250ng-5ngNIST_rKCTi_3hRP-20cm_DE30_QE_1::TotalPercentModified",
+        Assert.assertEquals("Incorrect percentages for (R)WQQGNVFSCSVMHEALHNHYTQK(S) sequence", Arrays.asList("(R)WQQGNVFSCSVMHEALHNHYTQK(S)", "22.1%", "22.1%", "24.1%", "24.1%"),
+                reportTable.getRowDataAsText(wqqRowIndex, "Sequence", "Sc_WCL-250ng-5ngNIST_rKCTi_3hRP-20cm_DE30_QE_1::PercentModified", "Sc_WCL-250ng-5ngNIST_rKCTi_3hRP-20cm_DE30_QE_1::TotalPercentModified",
                         "Sc_WCL-250ng-5ngNIST_rKCTi_3hRP-20cm_DE30_QE_2::PercentModified", "Sc_WCL-250ng-5ngNIST_rKCTi_3hRP-20cm_DE30_QE_2::TotalPercentModified"));
 
         log("Verifying the cell colors:Green, Yellow and Red");
         Assert.assertEquals("Incorrect risk category color for - Green", "rgb(137, 202, 83)",
-                Locator.xpath("//table/tbody/tr[9]/td[6]").findElement(reportTable).getCssValue("background-color"));
+                Locator.xpath("//table/tbody/tr[" + wqqRowIndex + "]/td[6]").findElement(reportTable).getCssValue("background-color"));
         Assert.assertEquals("Incorrect risk category color for - Yellow", "rgb(254, 255, 63)",
-                Locator.xpath("//table/tbody/tr[8]/td[6]").findElement(reportTable).getCssValue("background-color"));
+                Locator.xpath("//table/tbody/tr[" + vtnRowIndex + "]/td[6]").findElement(reportTable).getCssValue("background-color"));
         Assert.assertEquals("Incorrect risk category color for - Red", "rgb(250, 8, 26)",
-                Locator.xpath("//table/tbody/tr[8]/td[8]").findElement(reportTable).getCssValue("background-color"));
+                Locator.xpath("//table/tbody/tr[" + vtnRowIndex + "]/td[8]").findElement(reportTable).getCssValue("background-color"));
     }
 }

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSEarlyStagePTMReportTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSEarlyStagePTMReportTest.java
@@ -47,8 +47,8 @@ public class TargetedMSEarlyStagePTMReportTest extends TargetedMSTest
         Assert.assertEquals("Incorrect Sample Names displayed as headers", "Sample1 Sc_WCL-250ng-5ngNIST_rKCTi_3hRP-20cm_DE30_QE_2",
                 Locator.xpath("//table/thead[2]/tr").findElement(reportTable).getText());
 
-        int vtnRowIndex = 8;
-        int wqqRowIndex = 13;
+        int vtnRowIndex = 1;
+        int wqqRowIndex = 7;
 
         log("Verifying the modified percentage for sequence with CDR Range and stressed or not stressed updates");
         Assert.assertEquals("Incorrect percentages for (K)VTNMDPADTATYYCAR(D) sequence", Arrays.asList("(K)VTNMDPADTATYYCAR(D)", "11.3%", "11.3%", "11.1%", "11.1%"),
@@ -60,10 +60,10 @@ public class TargetedMSEarlyStagePTMReportTest extends TargetedMSTest
 
         log("Verifying the cell colors:Green, Yellow and Red");
         Assert.assertEquals("Incorrect risk category color for - Green", "rgb(137, 202, 83)",
-                Locator.xpath("//table/tbody/tr[" + wqqRowIndex + "]/td[6]").findElement(reportTable).getCssValue("background-color"));
+                Locator.xpath("//table/tbody/tr[" + (wqqRowIndex + 1) + "]/td[6]").findElement(reportTable).getCssValue("background-color"));
         Assert.assertEquals("Incorrect risk category color for - Yellow", "rgb(254, 255, 63)",
-                Locator.xpath("//table/tbody/tr[" + vtnRowIndex + "]/td[6]").findElement(reportTable).getCssValue("background-color"));
+                Locator.xpath("//table/tbody/tr[" + (vtnRowIndex + 1) + "]/td[6]").findElement(reportTable).getCssValue("background-color"));
         Assert.assertEquals("Incorrect risk category color for - Red", "rgb(250, 8, 26)",
-                Locator.xpath("//table/tbody/tr[" + vtnRowIndex + "]/td[8]").findElement(reportTable).getCssValue("background-color"));
+                Locator.xpath("//table/tbody/tr[" + (vtnRowIndex + 1) + "]/td[8]").findElement(reportTable).getCssValue("background-color"));
     }
 }


### PR DESCRIPTION
#### Rationale
While peptides may have multiple and overlapping modifications, for the early stage PTM MAM report, we want to just highlight the modification that's being reported for that data row.

#### Changes
* New optional config on the formatted peptide column to point at a specific location to highlight
* Adjust sorting to use location instead of including the amino acid in the sort