### PR TITLE
Fix NPE in Peptide.modifiedSequencesMatch()

### DIFF
--- a/src/org/labkey/targetedms/parser/Peptide.java
+++ b/src/org/labkey/targetedms/parser/Peptide.java
@@ -334,14 +334,15 @@ public class Peptide extends GeneralMolecule
 
     public static boolean modifiedSequencesMatch(String modSeq1, String modSeq2)
     {
+        if (modSeq1 == null || modSeq2 == null || modSeq1.startsWith("#") || modSeq2.startsWith("#"))
+        {
+            return false;
+        }
         if (modSeq1.equals(modSeq2))
         {
             return true;
         }
-        if (modSeq1.startsWith("#") || modSeq2.startsWith("#"))
-        {
-            return false;
-        }
+
         List<Pair<Integer, String>> mods1 = new ArrayList<>();
         String unmodSeq1 = stripModifications(modSeq1, mods1);
         List<Pair<Integer, String>> mods2 = new ArrayList<>();


### PR DESCRIPTION
#### Rationale
NPE in Peptide.modifiedSequencesMatch was causing Skyline document uploads to fail in a QC folder on PanoramaWeb.  The document in question has both peptides and small molecule targets.  One of the peptide precursors in the document has the same m/z (within tolerance) as a molecule precursor. When getting a list of chromatograms from the .skyd file that match a given peptide precursor m/z, we also compare the value of the "modifiedPeptideSequence".  For the small molecule precursor this was null, resulting in the exception. 

More details are here: https://panoramaweb.org/00Developer/vsharma/Issues/PR-830%20NPE%20in%20Peptide.modifiedSequencesMatch/project-begin.view
