### PR TITLE
Issue 49751: NullPointerException sending outlier email notifications

### DIFF
--- a/resources/views/subscribeOutlierNotifications.html
+++ b/resources/views/subscribeOutlierNotifications.html
@@ -26,8 +26,8 @@
                                   +         '<option value="4" ' + (userSubscription ? (userSubscription.samples === 4 && userSubscription.enabled ? "selected":"") :"" ) + '>four most</option>'
                                   +         '<option value="5" ' + (userSubscription ? (userSubscription.samples === 5 && userSubscription.enabled ? "selected":"") :"" ) + '>five most</option>'
                                   +     '</select> '
-                                  +     'recently imported samples each have at least '
-                                  +     '<input type="number" style="width: 3em" min="0" name="outlierCount"/> outliers'
+                                  +     'recently imported samples each have '
+                                  +     '<input type="number" style="width: 3em" min="0" name="outlierCount" value="0"/> or more outliers'
                                   +  '</p>'
                                   + '<input type="button" value="Save" class="labkey-button primary"  onclick="LABKEY.internal.SubscribeQCNotification.onSave()"/> '
                                   + '<input type="button" value="Cancel" class="labkey-button" onclick="LABKEY.internal.SubscribeQCNotification.onCancel()" />' ;

--- a/src/org/labkey/panoramapremium/QCNotificationSender.java
+++ b/src/org/labkey/panoramapremium/QCNotificationSender.java
@@ -53,7 +53,7 @@ public class QCNotificationSender implements SkylineDocumentImportListener
 
                 userSubscriptions.forEach(userSubscription -> {
                     int totalOutliers = 0;
-                    int totalOutlierSubscribed = userSubscription.getOutliers();
+                    int totalOutlierSubscribed = userSubscription.getOutliers() == null ? 0 : userSubscription.getOutliers();
                     int sampleCount = 0;
 
                     List<SampleFileInfo> samplesToEmail = new ArrayList<>();


### PR DESCRIPTION
#### Rationale
We haven't historically required users to enter an outlier threshold for email notifications.

#### Changes
* Handle unset thresholds in the UI and when figuring out whether to notify