### PR TITLE
Updates to data deletion queries

### DIFF
--- a/src/org/labkey/targetedms/SkylineDocImporter.java
+++ b/src/org/labkey/targetedms/SkylineDocImporter.java
@@ -1935,14 +1935,14 @@ public class SkylineDocImporter
             precursorChromInfo.setSampleFileId(sampleFile.getId());
             precursorChromInfo.setGeneralMoleculeChromInfoId(sampleFileIdGeneralMolChromInfoIdMap.get(sampleFile.getId()));
 
-             insertPrecursorChromInfo(precursorChromInfo);
+            insertPrecursorChromInfo(precursorChromInfo);
 
             sampleFilePrecursorChromInfoIdMap.put(sampleFileKey, precursorChromInfo.getId());
 
             for (PrecursorChromInfoAnnotation annotation : precursorChromInfo.getAnnotations())
             {
                 annotation.setPrecursorChromInfoId(precursorChromInfo.getId());
-                 insertPrecursorChromInfoAnnotation(annotation);
+                insertPrecursorChromInfoAnnotation(annotation);
             }
         }
 

--- a/src/org/labkey/targetedms/SkylineDocImporter.java
+++ b/src/org/labkey/targetedms/SkylineDocImporter.java
@@ -423,7 +423,8 @@ public class SkylineDocImporter
                 // the max
                 TargetedMSManager.deleteTransitionChromInfoDependent(TargetedMSManager.getTableInfoTransitionChromInfoAnnotation(), whereClause);
                 TargetedMSManager.deleteTransitionChromInfoDependent(TargetedMSManager.getTableInfoTransitionAreaRatio(), whereClause);
-                TargetedMSManager.deleteGeneralTransitionDependent(getTableInfoTransitionChromInfo(), "TransitionId", whereClause);
+                TargetedMSManager.deleteSampleFileDependent(getTableInfoTransitionChromInfo(), whereClause);
+                _log.info("Cleared rows from TransitionChromInfo and related tables.");
 
                 // Since we don't have the TransitionChromInfos to use for the indices, copy them from the temp table
                 // into PrecursorChromInfo (but filter to only touch the rows where we have matches in the temp table)
@@ -705,30 +706,36 @@ public class SkylineDocImporter
     private void deleteOldSampleFiles(ReplicateInfo replicateInfo)
     {
         int total = replicateInfo.oldSamplesToDelete.values().stream().mapToInt(Set::size).sum();
-        int s = 0;
         IProgressStatus status = _progressMonitor.getQcCleanupProgressTracker();
-        for(Map.Entry<String, Set<SampleFile>> entry: replicateInfo.oldSamplesToDelete.entrySet())
-        {
-            for (SampleFile existingSample : entry.getValue())
-            {
-                String srcFile = TargetedMSManager.deleteSampleFileAndDependencies(existingSample.getId());
-                _log.debug(String.format("Updating previously imported data for sample file %s in QC folder. %d of %d", entry.getKey(), ++s, total));
 
-                if (null != srcFile)
+        if (total == 0)
+        {
+            status.complete("Did not find any older sample file data to delete.");
+            return;
+        }
+
+        _log.info(String.format("Updating previously imported data for the following sample files in the QC folder. %d old sample files were found.", total));
+        replicateInfo.oldSamplesToDelete.keySet().forEach(key -> _log.debug(String.format("  %s", key)));
+
+        List<Long> existingSamples = new ArrayList<>(total);
+        replicateInfo.oldSamplesToDelete.forEach((key, value) -> value.forEach(existingSample -> existingSamples.add(existingSample.getId())));
+
+        List<String> srcFiles = TargetedMSManager.deleteSampleFilesAndDependencies(existingSamples);
+        for (String srcFile: srcFiles)
+        {
+            if (null != srcFile)
+            {
+                try
                 {
-                    try
-                    {
-                        replicateInfo.potentiallyUnusedFiles.add(new URI(srcFile));
-                    }
-                    catch (URISyntaxException e)
-                    {
-                        _log.error("Unable to delete file " + srcFile + ". May be an invalid path. This file is no longer needed on the server.");
-                    }
+                    replicateInfo.potentiallyUnusedFiles.add(new URI(srcFile));
                 }
-                status.updateProgress(s, total);
+                catch (URISyntaxException e)
+                {
+                    _log.error("Unable to delete file " + srcFile + ". May be an invalid path. This file is no longer needed on the server.");
+                }
             }
         }
-        status.complete(total > 0 ? "Done updating previously imported sample file data." : "Did not find any older sample file data to delete.");
+        status.complete("Done updating previously imported sample file data.");
     }
 
     @NotNull
@@ -1928,14 +1935,14 @@ public class SkylineDocImporter
             precursorChromInfo.setSampleFileId(sampleFile.getId());
             precursorChromInfo.setGeneralMoleculeChromInfoId(sampleFileIdGeneralMolChromInfoIdMap.get(sampleFile.getId()));
 
-            insertPrecursorChromInfo(precursorChromInfo);
+             insertPrecursorChromInfo(precursorChromInfo);
 
             sampleFilePrecursorChromInfoIdMap.put(sampleFileKey, precursorChromInfo.getId());
 
             for (PrecursorChromInfoAnnotation annotation : precursorChromInfo.getAnnotations())
             {
                 annotation.setPrecursorChromInfoId(precursorChromInfo.getId());
-                insertPrecursorChromInfoAnnotation(annotation);
+                 insertPrecursorChromInfoAnnotation(annotation);
             }
         }
 

--- a/src/org/labkey/targetedms/TargetedMSManager.java
+++ b/src/org/labkey/targetedms/TargetedMSManager.java
@@ -1450,56 +1450,61 @@ public class TargetedMSManager
     }
 
     /**
-     * @return the file path of the import file containing the sample
+     * @return the file paths of the Skyline documents containing the given sample files
      */
     @Nullable
-    public static String deleteSampleFileAndDependencies(long sampleFileId)
+    public static List<String> deleteSampleFilesAndDependencies(List<Long> sampleFileIds)
     {
-        purgeDeletedSampleFiles(sampleFileId);
+        purgeDeletedSampleFiles(sampleFileIds);
 
-        String file = getSampleFileUploadFile(sampleFileId);
+        List<String> files = sampleFileIds.stream().map(sampleFileId -> getSampleFileUploadFile(sampleFileId)).collect(Collectors.toList());
 
-        execute("DELETE FROM " + getTableInfoSampleFile() + " WHERE Id = " + sampleFileId);
+        execute(getSqlDialect().appendInClauseSql(new SQLFragment("DELETE FROM " + getTableInfoSampleFile() + " WHERE Id "), sampleFileIds));
 
-        return file;
+        return files;
     }
 
-    public static void purgeDeletedSampleFiles(long sampleFileId)
+    public static void purgeDeletedSampleFiles(List<Long> sampleFileIds)
     {
+        if (sampleFileIds == null || sampleFileIds.isEmpty())
+            return;
+
+        SQLFragment whereClause = getSqlDialect().appendInClauseSql(new SQLFragment(" WHERE SampleFileId "), sampleFileIds);
+
         // Delete from TransitionChromInfoAnnotation (dependent of TransitionChromInfo)
-        execute(getDependentSampleFileDeleteSql(getTableInfoTransitionChromInfoAnnotation(), "TransitionChromInfoId", getTableInfoTransitionChromInfo()), sampleFileId);
+        execute(getDependentSampleFileDeleteSql(getTableInfoTransitionChromInfoAnnotation(), "TransitionChromInfoId", getTableInfoTransitionChromInfo(), whereClause));
 
         // Delete from TransitionAreaRatio (dependent of TransitionChromInfo)
-        execute(getDependentSampleFileDeleteSql(getTableInfoTransitionAreaRatio(), "TransitionChromInfoId", getTableInfoTransitionChromInfo()), sampleFileId);
+        execute(getDependentSampleFileDeleteSql(getTableInfoTransitionAreaRatio(), "TransitionChromInfoId", getTableInfoTransitionChromInfo(), whereClause));
 
         // Delete from TransitionChromInfo
-        execute("DELETE FROM " + getTableInfoTransitionChromInfo() + " WHERE SampleFileId = ?", sampleFileId);
+        execute(new SQLFragment("DELETE FROM ").append(getTableInfoTransitionChromInfo()).append(whereClause));
 
         // Delete from PrecursorChromInfoAnnotation (dependent of PrecursorChromInfo)
-        execute(getDependentSampleFileDeleteSql(getTableInfoPrecursorChromInfoAnnotation(), "PrecursorChromInfoId", getTableInfoPrecursorChromInfo()), sampleFileId);
+        execute(getDependentSampleFileDeleteSql(getTableInfoPrecursorChromInfoAnnotation(), "PrecursorChromInfoId", getTableInfoPrecursorChromInfo(), whereClause));
 
         // Delete from PrecursorAreaRatio (dependent of PrecursorChromInfo)
-        execute(getDependentSampleFileDeleteSql(getTableInfoPrecursorAreaRatio(), "PrecursorChromInfoId", getTableInfoPrecursorChromInfo()), sampleFileId);
+        execute(getDependentSampleFileDeleteSql(getTableInfoPrecursorAreaRatio(), "PrecursorChromInfoId", getTableInfoPrecursorChromInfo(), whereClause));
 
         // Delete from PrecursorChromInfo
-        execute("DELETE FROM " + getTableInfoPrecursorChromInfo() + " WHERE SampleFileId = ?", sampleFileId);
+        execute(new SQLFragment("DELETE FROM ").append(getTableInfoPrecursorChromInfo()).append(whereClause));
 
         // Delete from PeptideAreaRatio (dependent of PeptideChromInfo)
-        execute(getDependentSampleFileDeleteSql(getTableInfoPeptideAreaRatio(), "PeptideChromInfoId", getTableInfoGeneralMoleculeChromInfo()), sampleFileId);
+        execute(getDependentSampleFileDeleteSql(getTableInfoPeptideAreaRatio(), "PeptideChromInfoId", getTableInfoGeneralMoleculeChromInfo(), whereClause));
 
         // Delete from PeptideChromInfo
-        execute("DELETE FROM " + getTableInfoGeneralMoleculeChromInfo() + " WHERE SampleFileId = ?", sampleFileId);
+        execute(new SQLFragment("DELETE FROM ").append(getTableInfoGeneralMoleculeChromInfo()).append(whereClause));
 
         // Delete from QCTraceMetricValues
-        execute("DELETE FROM " + getTableQCTraceMetricValues() + " WHERE SampleFileId = ?", sampleFileId);
+        execute(new SQLFragment("DELETE FROM ").append(getTableQCTraceMetricValues()).append(whereClause));
 
         // Delete from SampleFileChromInfo
-        execute("DELETE FROM " + getTableInfoSampleFileChromInfo() + " WHERE SampleFileId = ?", sampleFileId);
+        execute(new SQLFragment("DELETE FROM ").append(getTableInfoSampleFileChromInfo()).append(whereClause));
     }
 
-    private static String getDependentSampleFileDeleteSql(TableInfo fromTable, String fromFk, TableInfo dependentTable)
+    private static SQLFragment getDependentSampleFileDeleteSql(TableInfo fromTable, String fromFk, TableInfo dependentTable, SQLFragment whereClause)
     {
-        return "DELETE FROM " + fromTable + " WHERE " + fromFk + " IN (SELECT Id FROM " + dependentTable + " WHERE SampleFileId = ?)";
+        return new SQLFragment("DELETE FROM " + fromTable + " WHERE " + fromFk + " IN (SELECT Id FROM " + dependentTable).append(whereClause).append(")");
     }
 
     /** Actually delete runs that have been marked as deleted from the database */
@@ -1710,6 +1715,15 @@ public class TargetedMSManager
                 " INNER JOIN " + getTableInfoRuns() + " r ON pg.RunId = r.Id ").append(whereClause).append(")"));
     }
 
+    public static void deleteSampleFileDependent(TableInfo tableInfo, SQLFragment whereClause)
+    {
+        execute(new SQLFragment(" DELETE FROM ").append(tableInfo).append(" WHERE SampleFileId IN ")
+                .append(" (SELECT sf.Id FROM ").append(getTableInfoSampleFile(), "sf")
+                .append(" INNER JOIN ").append(getTableInfoReplicate(), "rep").append(" ON rep.Id = sf.ReplicateId ")
+                .append(" INNER JOIN ").append(getTableInfoRuns(), "r").append(" ON rep.RunId = r.Id ")
+                .append(whereClause).append(")"));
+    }
+
     private static void deleteGeneralPrecursorDependent(TableInfo tableInfo, String colName)
     {
         execute(" DELETE FROM " + tableInfo +
@@ -1753,11 +1767,7 @@ public class TargetedMSManager
 
     private static void deleteSampleFileDependent(TableInfo tableInfo)
     {
-        execute(" DELETE FROM " + tableInfo +
-                " WHERE SampleFileId IN (SELECT sf.Id FROM " + getTableInfoSampleFile() + " sf " +
-                " INNER JOIN " + getTableInfoReplicate() + " rep ON rep.Id = sf.ReplicateId "+
-                " INNER JOIN " + getTableInfoRuns() + " r ON rep.RunId = r.Id " +
-                " WHERE r.Deleted = ?)", true);
+        deleteSampleFileDependent(tableInfo, new SQLFragment(" WHERE r.Deleted = ?", true));
     }
 
     private static void deleteTransitionPredictionSettingsDependent()

--- a/src/org/labkey/targetedms/query/SampleFileTable.java
+++ b/src/org/labkey/targetedms/query/SampleFileTable.java
@@ -29,7 +29,6 @@ import org.labkey.api.data.LazyForeignKey;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SqlSelector;
-import org.labkey.api.data.Table;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.data.dialect.SqlDialect;
@@ -47,7 +46,6 @@ import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.InvalidKeyException;
 import org.labkey.api.query.QueryForeignKey;
-import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.QueryUpdateServiceException;
 import org.labkey.api.security.User;
@@ -309,8 +307,8 @@ public class SampleFileTable extends TargetedMSTable
                 Object id = oldRowMap.get("id");
                 if (id != null)
                 {
-                    int convertedId = Integer.parseInt(id.toString());
-                    TargetedMSManager.purgeDeletedSampleFiles(convertedId);
+                    long convertedId = Long.parseLong(id.toString());
+                    TargetedMSManager.purgeDeletedSampleFiles(Collections.singletonList(convertedId));
                 }
                 return super.deleteRow(user, container, oldRowMap);
             }


### PR DESCRIPTION
#### Rationale
- The query below is executed once for every sample file slated for deletion in a QC folder. When purging hundreds of sample files, the total time taken by these queries can be significant.
```DELETE FROM targetedms.precursorchrominfoannotation WHERE PrecursorChromInfoId IN (SELECT Id FROM targetedms.precursorchrominfo WHERE SampleFileId = ?)```
- The query to delete TransitionChromInfo rows when we exceed the TransitionChromInfo threshold is very slow.  This affects the import time of large documents.
```DELETE FROM targetedms.transitionchrominfo WHERE TransitionId IN (SELECT gt.Id FROM targetedms.generaltransition gt INNER JOIN targetedms.generalprecursor gp ON gt.GeneralPrecursorId = gp.Id INNER JOIN targetedms.generalmolecule gm ON gp.GeneralMoleculeId = gm.Id INNER JOIN targetedms.peptidegroup pg ON gm.PeptideGroupId = pg.Id INNER JOIN targetedms.runs r ON pg.RunId = r.Id WHERE r.Id = ?)``` 

#### Changes
- Rewrite the old sample file deletion code to delete results for all sample files in single queries using the IN clause instead of deleting results one sample file at a time. 
- Rewrite the TransitionChromInfo delete query to join on SampleFile -> Replicate -> Run
