### PR TITLE
Issue 49772: StringIndexOutOfBoundsException from PeptideCol.initialize()

### DIFF
--- a/src/org/labkey/targetedms/query/ModifiedSequenceDisplayColumn.java
+++ b/src/org/labkey/targetedms/query/ModifiedSequenceDisplayColumn.java
@@ -283,7 +283,7 @@ public abstract class ModifiedSequenceDisplayColumn extends IconColumn
                                 int startIndex = p.getSequence().indexOf(sequence);
                                 int aaIndex = index - startIndex - 1;
 
-                                if (sequence.charAt(aaIndex) == aa)
+                                if (sequence.length() > aaIndex && sequence.charAt(aaIndex) == aa)
                                 {
                                     peptideModifiedSequence = sequence;
                                     strModIndices = new HashSet<>();
@@ -291,13 +291,13 @@ public abstract class ModifiedSequenceDisplayColumn extends IconColumn
                                 }
                                 else
                                 {
-                                    LOG.debug("Modified residue didn't match for " + modificationSite + " on peptide " + sequence);
+                                    LOG.debug("Modified residue didn't match for " + modificationSite + " on peptide " + sequence + " in document " + runId);
                                 }
                             }
                         }
                         catch (NumberFormatException ignored)
                         {
-                            LOG.debug("Bad modificationSite value: " + modificationSite);
+                            LOG.debug("Bad modificationSite value: " + modificationSite + " in document " + runId);
                         }
                     }
                 }

--- a/src/org/labkey/targetedms/query/ModifiedSequenceDisplayColumn.java
+++ b/src/org/labkey/targetedms/query/ModifiedSequenceDisplayColumn.java
@@ -280,8 +280,16 @@ public abstract class ModifiedSequenceDisplayColumn extends IconColumn
                             Protein p = getHtmlMaker().getProtein(peptideGroupId, runId);
                             if (p != null && p.getSequence() != null)
                             {
-                                int startIndex = p.getSequence().indexOf(sequence);
-                                int aaIndex = index - startIndex - 1;
+                                int startIndex = -1;
+                                int aaIndex;
+                                // The peptide may be repeated in the protein sequence so look for a match
+                                // in the right range
+                                do
+                                {
+                                    startIndex = p.getSequence().indexOf(sequence, startIndex + 1);
+                                    aaIndex = index - startIndex - 1;
+                                }
+                                while (aaIndex > sequence.length());
 
                                 if (sequence.length() > aaIndex && sequence.charAt(aaIndex) == aa)
                                 {

--- a/src/org/labkey/targetedms/query/ModifiedSequenceDisplayColumn.java
+++ b/src/org/labkey/targetedms/query/ModifiedSequenceDisplayColumn.java
@@ -291,7 +291,7 @@ public abstract class ModifiedSequenceDisplayColumn extends IconColumn
                                 }
                                 else
                                 {
-                                    LOG.debug("Modified residue didn't match for " + modificationSite + " on peptide " + sequence + " in document " + runId);
+                                    LOG.debug("Modified residue didn't match for " + modificationSite + " at calculated index " + aaIndex + " on peptide " + sequence + " in document " + runId);
                                 }
                             }
                         }


### PR DESCRIPTION
#### Rationale
A peptide may appear multiple times in a protein sequence. We need to find the right subsequence for highlighting purposes

#### Changes
* Ensure we have the right region for our modification site
* Don't highlight anything when values don't align
* Log more detail if there's a problem