### PR TITLE
Issue 49427: Inconsistent number of metrics in Panorama QC folder

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -1037,7 +1037,7 @@ public class TargetedMSController extends SpringActionController
             autoQCPingMap.put("isRecent", lastModified.getTime() >= timeoutMinutesAgo);
         }
         properties.put("autoQCPing", autoQCPingMap);
-        TargetedMSSchema schema = new TargetedMSSchema(getUser(), getContainer());
+        TargetedMSSchema schema = new TargetedMSSchema(getUser(), container);
         properties.put("metricCount", TargetedMSManager.getEnabledQCMetricConfigurations(schema).size());
 
         return properties;


### PR DESCRIPTION
#### Rationale
Different QC folders may have different numbers of active QC metrics. We're currently looking at the parent folder to get the count.

#### Changes
* Use the child folder when resolving the active metrics