### PR TITLE
Optimize queries for getting Precursor objects

### DIFF
--- a/src/org/labkey/targetedms/query/MoleculePrecursorManager.java
+++ b/src/org/labkey/targetedms/query/MoleculePrecursorManager.java
@@ -48,16 +48,7 @@ public class MoleculePrecursorManager
     {
         SQLFragment sql = new SQLFragment("SELECT pre.* FROM ");
         sql.append(new MoleculePrecursorTableInfo(schema, null, true), "pre");
-        sql.append(", ");
-        sql.append(new MoleculeTableInfo(schema, null, true), "mol");
-        sql.append(", ");
-        sql.append(TargetedMSManager.getTableInfoPeptideGroup(), "pg");
-        sql.append(", ");
-        sql.append(TargetedMSManager.getTableInfoRuns(), "r");
-        sql.append(" WHERE pre.GeneralMoleculeId = mol.Id AND ");
-        sql.append("mol.PeptideGroupId = pg.Id AND pg.RunId = r.Id AND r.Deleted = ? AND r.Container = ? AND pre.Id = ?");
-        sql.add(false);
-        sql.add(schema.getContainer().getId());
+        sql.append(" WHERE pre.Id = ?");
         sql.add(id);
 
         return new SqlSelector(TargetedMSManager.getSchema(), sql).getObject(MoleculePrecursor.class);

--- a/src/org/labkey/targetedms/query/PrecursorManager.java
+++ b/src/org/labkey/targetedms/query/PrecursorManager.java
@@ -69,16 +69,7 @@ public class PrecursorManager
 
         SQLFragment sql = new SQLFragment("SELECT pre.* FROM ");
         sql.append(new PrecursorTableInfo(schema, null, true), "pre");
-        sql.append(", ");
-        sql.append(new PeptideTableInfo(schema, null, true), "pep");
-        sql.append(", ");
-        sql.append(TargetedMSManager.getTableInfoPeptideGroup(), "pg");
-        sql.append(", ");
-        sql.append(TargetedMSManager.getTableInfoRuns(), "r");
-        sql.append(" WHERE pre.GeneralMoleculeId = pep.Id AND ");
-        sql.append("pep.PeptideGroupId = pg.Id AND pg.RunId = r.Id AND r.Deleted = ? AND r.Container = ? AND pre.Id = ?");
-        sql.add(false);
-        sql.add(c.getId());
+        sql.append(" WHERE pre.Id = ?");
         sql.add(id);
 
         return new SqlSelector(TargetedMSManager.getSchema(), sql).getObject(Precursor.class);


### PR DESCRIPTION
#### Rationale
These queries are very slow for some QC folders on PanoramaWeb. They're doing redundant joins, resulting in a bad execution plan

#### Changes
* Rely on the container filtering that `PrecursorTableInfo` and `MoleculePrecursorTableInfo` are already doing