### PR TITLE
Migrate inline javascript event handlers

### DIFF
--- a/src/org/labkey/targetedms/view/calibrationCurve.jsp
+++ b/src/org/labkey/targetedms/view/calibrationCurve.jsp
@@ -59,13 +59,15 @@
 
 <div style="width: 100%; text-align: center">
     <label for="calCurveXScale">X-axis:</label>
-    <select id="calCurveXScale"onchange="calibrationCurvePlot.refreshPlot();">
+    <% addHandler("calCurveXScale", "change", "calibrationCurvePlot.refreshPlot()"); %>
+    <select id="calCurveXScale">
         <option value="linear" selected>Linear</option>
         <option value="log">Log</option>
     </select>
     &nbsp;&nbsp;
     <label for="calCurveYScale">Y-axis:</label>
-    <select id="calCurveYScale" onchange="calibrationCurvePlot.refreshPlot();">
+    <% addHandler("calCurveYScale", "change", "calibrationCurvePlot.refreshPlot()"); %>
+    <select id="calCurveYScale">
         <option value="linear" selected>Linear</option>
         <option value="log">Log</option>
     </select>

--- a/src/org/labkey/targetedms/view/chromatogramsForm.jsp
+++ b/src/org/labkey/targetedms/view/chromatogramsForm.jsp
@@ -497,7 +497,7 @@
 }(jQuery);
 </script>
 <div id="headContainer">
-    <% addHandler("showChartHeadContainer", "onclick", "showChart()"); %>
+    <% addHandler("showChartHeadContainer", "click", "showChart()"); %>
     <div id="showChartHeadContainer" style="margin-bottom: 10px;"><img id="showGraphImg" src="<%=getWebappURL("_images/plus.gif")%>"> <strong>Display Chart Settings</strong></div>
     <div id="formContainer" style="float:left; width:550px; height: 160px; padding-bottom: 25px; display: none;"></div>
     <div id="allFilters" style="float:left; display: none;">

--- a/src/org/labkey/targetedms/view/chromatogramsForm.jsp
+++ b/src/org/labkey/targetedms/view/chromatogramsForm.jsp
@@ -93,11 +93,6 @@
 </style>
 <script type="text/javascript" nonce="<%=getScriptNonce()%>">
 
-    LABKEY.Utils.onReady(function() {
-        document.getElementById("clear-rep")['onclick'] = clearReplicates;
-        document.getElementById("clear-annot")['onclick'] = clearAnnotations;
-    });
-
 +function($){
 
     var hiddenFields;
@@ -281,6 +276,9 @@
                 }
             ],
         });
+
+        document.getElementById("clear-rep")['onclick'] = clearReplicates;
+        document.getElementById("clear-annot")['onclick'] = clearAnnotations;
 
         // This has to happen after form is rendered.
         form.getForm().findField("annotationsFilter").setValue(selectedAnnotationsFilterList);

--- a/src/org/labkey/targetedms/view/chromatogramsForm.jsp
+++ b/src/org/labkey/targetedms/view/chromatogramsForm.jsp
@@ -93,6 +93,11 @@
 </style>
 <script type="text/javascript" nonce="<%=getScriptNonce()%>">
 
+    LABKEY.Utils.onReady(function() {
+        document.getElementById("clear-rep")['onclick'] = clearReplicates;
+        document.getElementById("clear-annot")['onclick'] = clearAnnotations;
+    });
+
 +function($){
 
     var hiddenFields;
@@ -233,7 +238,7 @@
                 {
                     xtype: 'displayfield',
                     name: "hideReplicates",
-                    value:'<a style="color:#069; cursor:pointer;" id="clear-rep" onclick="clearReplicates()">Clear</a>',
+                    value:'<a style="color:#069; cursor:pointer;" id="clear-rep"">Clear</a>',
                     style:'margin-left:15px;'
                 },
                 {
@@ -257,7 +262,7 @@
                 },
                 {
                     xtype: 'displayfield',
-                    value:'<a style="color:#069; cursor:pointer;" id="clear-annot" onclick="clearAnnotations()">Clear</a>',
+                    value:'<a style="color:#069; cursor:pointer;" id="clear-annot">Clear</a>',
                     style:'margin-left:15px;',
                     name: "hideAnnotations"
                 },
@@ -320,11 +325,15 @@
         <%}%>
 
         // appendFilterItem adds a filter table row & column to the appropriate parent filter box.
-        function appendFilterItem(element, displayValue, parentTable, id)
-        {
-            if(displayValue != null)
-            {
-                element.append("<tr id=\'"+id+"\'><td class="+"item"+"><img src='<%=getWebappURL("_images/delete.png")%>' style='width:10px; height:10px; margin-right:3px;' onclick=\"deleteFilter(this, \'"+parentTable+"\')\">"+displayValue+"</td></tr>");
+        function appendFilterItem(element, displayValue, parentTable, id) {
+            if(displayValue != null) {
+                let deleteIconId = 'delete-' + id;
+                let newRowContent = "<tr id=\'"+id+"\'><td class="+"item"+"><img id=\'"+deleteIconId+"\' src='<%=getWebappURL("_images/delete.png")%>' style='width:10px; height:10px; margin-right:3px;'>"+displayValue+"</td></tr>";
+                element.append(newRowContent);
+
+                document.getElementById(deleteIconId).addEventListener('click', function() {
+                    deleteFilter(this, parentTable);
+                });
             }
         }
 
@@ -488,7 +497,8 @@
 }(jQuery);
 </script>
 <div id="headContainer">
-    <div onclick="showChart()" style="margin-bottom: 10px;"><img id="showGraphImg" src="<%=getWebappURL("_images/plus.gif")%>"> <strong>Display Chart Settings</strong></div>
+    <% addHandler("showChartHeadContainer", "onclick", "showChart()"); %>
+    <div id="showChartHeadContainer" style="margin-bottom: 10px;"><img id="showGraphImg" src="<%=getWebappURL("_images/plus.gif")%>"> <strong>Display Chart Settings</strong></div>
     <div id="formContainer" style="float:left; width:550px; height: 160px; padding-bottom: 25px; display: none;"></div>
     <div id="allFilters" style="float:left; display: none;">
 

--- a/src/org/labkey/targetedms/view/pharmacokinetics.jsp
+++ b/src/org/labkey/targetedms/view/pharmacokinetics.jsp
@@ -82,9 +82,8 @@
                 <span id="nonIVC0Controls-Warn-<%=h(subgroup)%>" class="labkey-error"><h4>WARNING: Please enter a non-IV C0 and recalculate.</h4></span>
                 non-IV C0
                 <input type="number" id="nonIVC0-<%=h(subgroup)%>" label="non-IV C0"/>
-                <%=
-                  button("Recalculate").id("btnNonIVC0-" + h(subgroup)).onClick("updateStatsForNonIVC0('" + h(subgroup) + "')" )
-                %>
+                <% addHandler("btnNonIVC0-"+h(subgroup), "click", "updateStatsForNonIVC0('"+ h(subgroup) + "')"); %>
+                <button id="btnNonIVC0-<%=h(subgroup)%>">Recalculate</button>
             </div>
         </labkey:panel>
 

--- a/src/org/labkey/targetedms/view/pharmacokinetics.jsp
+++ b/src/org/labkey/targetedms/view/pharmacokinetics.jsp
@@ -52,7 +52,7 @@
     %>
     <labkey:panel title="<%=subgroupTitle%>" type="portal">
         <div id="targetedms-fom-export" class="export-icon" data-toggle="tooltip" title="Export to Excel">
-            <% iconLink("fa fa-file-excel-o", "", null).onClick("exportExcel(" + h(subgroup) + ")");%>
+            <%=iconLink("fa fa-file-excel-o", "", null).onClick("exportExcel('" + h(subgroup) + "')") %>
         </div>
 
         <labkey:panel title="Statistics">
@@ -82,8 +82,8 @@
                 <span id="nonIVC0Controls-Warn-<%=h(subgroup)%>" class="labkey-error"><h4>WARNING: Please enter a non-IV C0 and recalculate.</h4></span>
                 non-IV C0
                 <input type="number" id="nonIVC0-<%=h(subgroup)%>" label="non-IV C0"/>
-                <%
-                  button("Recalculate").id("btnNonIVC0-" + h(subgroup)).onClick("updateStatsForNonIVC0('" + h(subgroup) + "')" );
+                <%=
+                  button("Recalculate").id("btnNonIVC0-" + h(subgroup)).onClick("updateStatsForNonIVC0('" + h(subgroup) + "')" )
                 %>
             </div>
         </labkey:panel>

--- a/src/org/labkey/targetedms/view/pharmacokinetics.jsp
+++ b/src/org/labkey/targetedms/view/pharmacokinetics.jsp
@@ -52,7 +52,7 @@
     %>
     <labkey:panel title="<%=subgroupTitle%>" type="portal">
         <div id="targetedms-fom-export" class="export-icon" data-toggle="tooltip" title="Export to Excel">
-            <%=iconLink("fa fa-file-excel-o", "", null).onClick("exportExcel('" + h(subgroup) + "')") %>
+            <%=iconLink("fa fa-file-excel-o", "", null).onClick("exportExcel('" + subgroup + "')") %>
         </div>
 
         <labkey:panel title="Statistics">
@@ -82,7 +82,7 @@
                 <span id="nonIVC0Controls-Warn-<%=h(subgroup)%>" class="labkey-error"><h4>WARNING: Please enter a non-IV C0 and recalculate.</h4></span>
                 non-IV C0
                 <input type="number" id="nonIVC0-<%=h(subgroup)%>" label="non-IV C0"/>
-                <% addHandler("btnNonIVC0-"+h(subgroup), "click", "updateStatsForNonIVC0('"+ h(subgroup) + "')"); %>
+                <% addHandler("btnNonIVC0-"+h(subgroup), "click", "updateStatsForNonIVC0('"+ subgroup + "')"); %>
                 <button id="btnNonIVC0-<%=h(subgroup)%>">Recalculate</button>
             </div>
         </labkey:panel>

--- a/src/org/labkey/targetedms/view/pharmacokinetics.jsp
+++ b/src/org/labkey/targetedms/view/pharmacokinetics.jsp
@@ -52,7 +52,7 @@
     %>
     <labkey:panel title="<%=subgroupTitle%>" type="portal">
         <div id="targetedms-fom-export" class="export-icon" data-toggle="tooltip" title="Export to Excel">
-            <i class="fa fa-file-excel-o" onclick="exportExcel('<%=h(subgroup)%>')"></i>
+            <% iconLink("fa fa-file-excel-o", "", null).onClick("exportExcel(" + h(subgroup) + ")");%>
         </div>
 
         <labkey:panel title="Statistics">
@@ -82,7 +82,9 @@
                 <span id="nonIVC0Controls-Warn-<%=h(subgroup)%>" class="labkey-error"><h4>WARNING: Please enter a non-IV C0 and recalculate.</h4></span>
                 non-IV C0
                 <input type="number" id="nonIVC0-<%=h(subgroup)%>" label="non-IV C0"/>
-                <button id="btnNonIVC0-<%=h(subgroup)%>" onclick="updateStatsForNonIVC0('<%=h(subgroup)%>')">Recalculate</button>
+                <%
+                  button("Recalculate").id("btnNonIVC0-" + h(subgroup)).onClick("updateStatsForNonIVC0('" + h(subgroup) + "')" );
+                %>
             </div>
         </labkey:panel>
 

--- a/webapp/TargetedMS/js/PlotTypeCheckCombo.js
+++ b/webapp/TargetedMS/js/PlotTypeCheckCombo.js
@@ -32,7 +32,7 @@ Ext4.define('Ext.ux.CheckCombo', {
         Ext4.apply(this.listConfig, {
             tpl: new Ext4.XTemplate(
                     '<ul><tpl for=".">',
-                    '<li role="option" class="' + Ext4.baseCSSPrefix + 'boundlist-item" onmouseover="createPlotTypeTooltip(event.currentTarget, event.target.textContent)" onmouseout="destroyPlotTypeTooltip()"><span class="' + Ext4.baseCSSPrefix + 'combo-checker"></span>',
+                    '<li role="option" class="' + Ext4.baseCSSPrefix + 'boundlist-item"><span class="' + Ext4.baseCSSPrefix + 'combo-checker"></span>',
                     '&nbsp;{[this.getDisplayText(values, "' + this.displayField + '", "' + (Ext4.isDefined(this.nullCaption) ? this.nullCaption : "[none]") + '")]}',
                     '</li></tpl></ul>',
                     {
@@ -75,6 +75,23 @@ Ext4.define('Ext.ux.CheckCombo', {
             onDestroy: function() {
                 Ext4.destroyMembers(this, 'pagingToolbar', 'outerEl', 'listEl');
                 this.callParent();
+            }
+        });
+
+        this.on({
+            expand: function(combo) {
+                var boundList = combo.getPicker();
+
+                boundList.getEl().on({
+                    mouseover: function(event, target) {
+                        createPlotTypeTooltip(event.currentTarget, target.textContent);
+                    },
+                    mouseout: function() {
+                        destroyPlotTypeTooltip();
+                    },
+                    delegate: "." + Ext4.baseCSSPrefix + 'boundlist-item',
+                    scope: this
+                });
             }
         });
 

--- a/webapp/passport/js/MxN/protein.js
+++ b/webapp/passport/js/MxN/protein.js
@@ -642,8 +642,17 @@ protein =
 
             summaryDataTable.forEach(function(row, index) {
                 const commonRows = '<tr' + (row.enabled ? '' : ' style="text-decoration: line-through; background-color: LightGray"') + '>' +
-                        '<td colspan="2"><input type="radio" ' + (row.precursorId === protein.selectedPrecursor.PrecursorId ? 'checked="true"' : '') + ' name="precursorRadio" id="precursorRadio' + row.precursorId + '" onclick="protein.selectPrecursor(' + row.precursorId + ', true)" /><a href="#chrom' + row.precursorChromInfoId + '" onclick="protein.selectPrecursor(' + row.precursorId + ', true)">' + LABKEY.Utils.encodeHtml(row.sequence) + '</a></td>' +
+                        '<td colspan="2"><input type="radio" ' + (row.precursorId === protein.selectedPrecursor.PrecursorId ? 'checked="true"' : '') + ' name="precursorRadio" id="precursorRadio' + row.precursorId + '"/><a href="#chrom' + row.precursorChromInfoId + '" id="precursorAnchor' + row.precursorId + '">' + LABKEY.Utils.encodeHtml(row.sequence) + '</a></td>' +
                         '<td>' + LABKEY.Utils.encodeHtml(protein.renderCharge(row.charge)) + '</td>';
+
+                $("#precursorRadio" + row.precursorId).on("click", function() {
+                    protein.selectPrecursor(row.precursorId, true);
+                });
+                $("#precursorAnchor" + row.precursorId).on("click", function() {
+                    protein.selectPrecursor(row.precursorId, true);
+                });
+
+
 
                 tableHTML += commonRows +
                         '<td style="text-align: right">' + LABKEY.Utils.encodeHtml(row.mz.toFixed(4)) + '</td>' +


### PR DESCRIPTION
#### Rationale
A strict (no 'unsafe-inline' directive) CSP forbids all inline events. Instead, events must be attached via JavaScript inside a properly nonced script tag

#### Changes
*  PlotTypeCheckCombo.js
* protein.js
* calibrationCurve.jsp (2 onchange handlers)
* chromatogramsForm.jsp (4 onclick handlers)
* figuresOfMerit.jsp (1 onclick handler)
* pharmacokinetics.jsp (2 onclick handlers)
