### PR TITLE
Optimize info getting PrecursorChromInfo objects

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -2121,7 +2121,7 @@ public class TargetedMSController extends SpringActionController
             ChromatogramsDataRegion dRegion = new ChromatogramsDataRegion(getViewContext(), tableInfo,
                     ChromatogramsDataRegion.PRECURSOR_CHROM_DATA_REGION, form.isSplitGraph(), canBeSplitView);
 
-            pageToSelectedChromatogram(form, dRegion, PrecursorManager.getChromInfosLitePlusForPrecursor(form.getId(), getUser(), getContainer()));
+            pageToSelectedChromatogram(form, dRegion, PrecursorManager.getChromInfosLitePlusForPrecursor(form.getId(), getContainer()));
 
             GridView gridView = new ChromatogramGridView(dRegion, errors);
             gridView.setFrame(WebPartView.FrameType.PORTAL);

--- a/src/org/labkey/targetedms/TargetedMSSchema.java
+++ b/src/org/labkey/targetedms/TargetedMSSchema.java
@@ -1199,7 +1199,9 @@ public class TargetedMSSchema extends UserSchema
 
         if (TABLE_REPLICATE.equalsIgnoreCase(name))
         {
-            return new AnnotatedTargetedMSTable(getSchema().getTable(name), this, cf, ContainerJoinType.RunFK, TargetedMSManager.getTableInfoReplicateAnnotation(), "ReplicateId", "Replicate", "replicate");
+            AnnotatedTargetedMSTable result = new AnnotatedTargetedMSTable(getSchema().getTable(name), this, cf, ContainerJoinType.RunFK, TargetedMSManager.getTableInfoReplicateAnnotation(), "ReplicateId", "Replicate", "replicate");
+            result.getMutableColumnOrThrow("RunId").setFk(new TargetedMSForeignKey(this, TABLE_RUNS, cf));
+            return result;
         }
 
         // Tables that have a FK to targetedms.Runs

--- a/src/org/labkey/targetedms/chart/ChromatogramDataset.java
+++ b/src/org/labkey/targetedms/chart/ChromatogramDataset.java
@@ -291,7 +291,7 @@ public abstract class ChromatogramDataset
         @Override
         List<PrecursorChromInfoPlus> getPrecursorChromInfosForGeneralMolecule()
         {
-            return PrecursorManager.getPrecursorChromInfosForPeptide(_generalMoleculeId, _sampleFileId, _user, _container);
+            return PrecursorManager.getPrecursorChromInfosForPeptide(_generalMoleculeId, _sampleFileId, _container);
         }
 
         @Override
@@ -772,7 +772,7 @@ public abstract class ChromatogramDataset
             List<PrecursorChromInfoPlus> precursorChromInfoList = PrecursorManager.getPrecursorChromInfosForGeneralMoleculeChromInfo(
                     _precursorChromInfo.getGeneralMoleculeChromInfoId(),
                     _precursorChromInfo.getPrecursorId(),
-                    _precursorChromInfo.getSampleFileId(), _user, _container);
+                    _precursorChromInfo.getSampleFileId(), _container);
 
             precursorChromInfoList.sort((o1, o2) ->
             {
@@ -1544,7 +1544,7 @@ public abstract class ChromatogramDataset
             }
             for (Peptide peptide : PeptideManager.getPeptidesForGroup(_group.getId()))
             {
-                List<PrecursorChromInfoPlus> chromInfos = PrecursorManager.getPrecursorChromInfosForPeptide(peptide.getId(), _sampleFile.getId(), _user, _container);
+                List<PrecursorChromInfoPlus> chromInfos = PrecursorManager.getPrecursorChromInfosForPeptide(peptide.getId(), _sampleFile.getId(), _container);
                 if (!chromInfos.isEmpty())
                 {
                     _allMolecules.put(peptide, chromInfos);

--- a/src/org/labkey/targetedms/chart/ComparisonChartMaker.java
+++ b/src/org/labkey/targetedms/chart/ComparisonChartMaker.java
@@ -78,7 +78,7 @@ public class ComparisonChartMaker
         }
 
         List<PrecursorChromInfoLitePlus> pciPlusList = getInputData(peptideGroup, replicateId, peptide, precursor, chartConfig.second, user, container);
-        if (pciPlusList == null || pciPlusList.size() == 0)
+        if (pciPlusList == null || pciPlusList.isEmpty())
         {
             return null;
         }
@@ -92,19 +92,6 @@ public class ComparisonChartMaker
                                          String groupByAnnotation, String filterByAnnotation,
                                          boolean cvValues, boolean logValues, User user, Container container)
     {
-        String title;
-        ComparisonDataset.ChartType chartType;
-        if (molecule == null)
-        {
-            title = peptideGroup.getLabel();
-            chartType = ComparisonDataset.ChartType.MOLECULE_COMPARISON;
-        }
-        else
-        {
-            title = molecule.getCustomIonName();
-            chartType = ComparisonDataset.ChartType.REPLICATE_COMPARISON;
-        }
-
         String yLabel = cvValues ? "Peak Area CV(%)" : "Peak Area ";
         if(cvValues && logValues){
             yLabel = "Log Peak Area CV(%)";
@@ -113,13 +100,14 @@ public class ComparisonChartMaker
             yLabel =   "Log Peak Area";
         }
 
-        List<PrecursorChromInfoLitePlus> pciPlusList = getInputData(peptideGroup, replicateId, molecule, precursor, chartType, user, container);
-        if (pciPlusList == null || pciPlusList.size() == 0)
+        var titleAndType = getTitleAndType(peptideGroup, molecule);
+        List<PrecursorChromInfoLitePlus> pciPlusList = getInputData(peptideGroup, replicateId, molecule, precursor, titleAndType.second, user, container);
+        if (pciPlusList == null || pciPlusList.isEmpty())
         {
             return null;
         }
 
-        return makeChart(peptideGroup, title, chartType, pciPlusList, groupByAnnotation, filterByAnnotation, cvValues, logValues,
+        return makeChart(peptideGroup, titleAndType.first, titleAndType.second, pciPlusList, groupByAnnotation, filterByAnnotation, cvValues, logValues,
                 new ComparisonDataset.PeakAreasSeriesItemMaker(), yLabel, true, user, container);
     }
 
@@ -144,7 +132,7 @@ public class ComparisonChartMaker
     {
         Pair<String, ComparisonDataset.ChartType> chartConfig = getChartConfig(peptideGroup, peptide);
         List<PrecursorChromInfoLitePlus> pciPlusList = getInputData(peptideGroup, replicateId, peptide, precursor, chartConfig.second, user, container);
-        if (pciPlusList == null || pciPlusList.size() == 0)
+        if (pciPlusList == null || pciPlusList.isEmpty())
         {
             return null;
         }
@@ -153,31 +141,28 @@ public class ComparisonChartMaker
                                        filterByAnnotation,  value, cvValues, user, container);
     }
 
+    private Pair<String, ComparisonDataset.ChartType> getTitleAndType(PeptideGroup peptideGroup, Molecule molecule)
+    {
+        if (molecule == null)
+        {
+            return Pair.of(peptideGroup.getLabel(), ComparisonDataset.ChartType.MOLECULE_COMPARISON);
+        }
+        return Pair.of(molecule.getCustomIonName(), ComparisonDataset.ChartType.REPLICATE_COMPARISON);
+    }
+
     public JFreeChart makeRetentionTimesChart(long replicateId, PeptideGroup peptideGroup,
                                           Molecule molecule, MoleculePrecursor precursor,
                                           String groupByAnnotation, String filterByAnnotation, String value, boolean cvValues,
                                           User user, Container container)
     {
-        String title;
-        ComparisonDataset.ChartType chartType;
-        if (molecule == null)
-        {
-            title = peptideGroup.getLabel();
-            chartType = ComparisonDataset.ChartType.MOLECULE_COMPARISON;
-        }
-        else
-        {
-            title = molecule.getCustomIonName();
-            chartType = ComparisonDataset.ChartType.REPLICATE_COMPARISON;
-        }
-
-        List<PrecursorChromInfoLitePlus> pciPlusList = getInputData(peptideGroup, replicateId, molecule, precursor, chartType, user, container);
-        if (pciPlusList == null || pciPlusList.size() == 0)
+        var titleAndType = getTitleAndType(peptideGroup, molecule);
+        List<PrecursorChromInfoLitePlus> pciPlusList = getInputData(peptideGroup, replicateId, molecule, precursor, titleAndType.second, user, container);
+        if (pciPlusList == null || pciPlusList.isEmpty())
         {
             return null;
         }
 
-        return makeRetentionTimesChart(peptideGroup, title, chartType, pciPlusList, groupByAnnotation,
+        return makeRetentionTimesChart(peptideGroup, titleAndType.first, titleAndType.second, pciPlusList, groupByAnnotation,
                                        filterByAnnotation,  value, cvValues, user, container);
     }
 
@@ -357,10 +342,10 @@ public class ComparisonChartMaker
         }
         else
         {
-            pciPlusList = getPrecursorChromInfo(peptide, precursor, user, container);
+            pciPlusList = getPrecursorChromInfo(peptide, precursor, container);
         }
 
-        if (pciPlusList.size() == 0)
+        if (pciPlusList.isEmpty())
         {
             return null;
         }
@@ -381,7 +366,7 @@ public class ComparisonChartMaker
             pciPlusList = getPrecursorChromInfo(molecule, precursor, user, container);
         }
 
-        if (pciPlusList.size() == 0)
+        if (pciPlusList.isEmpty())
         {
             return null;
         }
@@ -398,7 +383,7 @@ public class ComparisonChartMaker
         if(replicateId == 0)
         {
             if (asProteomics)
-                return PrecursorManager.getChromInfosLitePlusForPeptideGroup(peptideGroup.getId(), user, container);
+                return PrecursorManager.getChromInfosLitePlusForPeptideGroup(peptideGroup.getId(), container);
             else
                 return MoleculePrecursorManager.getChromInfosLitePlusForPeptideGroup(peptideGroup.getId(), user, container);
         }
@@ -416,7 +401,7 @@ public class ComparisonChartMaker
                 // chromatograms for this precursor from a single sample file.
                 List<PrecursorChromInfoLitePlus> samplePrecChromInfos;
                 if (asProteomics)
-                    samplePrecChromInfos = PrecursorManager.getChromInfosLitePlusForPeptideGroup(peptideGroup.getId(), file.getId(), user, container);
+                    samplePrecChromInfos = PrecursorManager.getChromInfosLitePlusForPeptideGroup(peptideGroup.getId(), file.getId(), container);
                 else
                     samplePrecChromInfos = MoleculePrecursorManager.getChromInfosLitePlusForPeptideGroup(peptideGroup.getId(), file.getId(), user, container);
 
@@ -426,10 +411,10 @@ public class ComparisonChartMaker
         }
     }
 
-    private List<PrecursorChromInfoLitePlus> getPrecursorChromInfo(Peptide peptide, Precursor precursor, User user, Container container)
+    private List<PrecursorChromInfoLitePlus> getPrecursorChromInfo(Peptide peptide, Precursor precursor, Container container)
     {
-        return precursor == null ? PrecursorManager.getChromInfosLitePlusForPeptide(peptide.getId(), user, container) :
-                                   PrecursorManager.getChromInfosLitePlusForPrecursor(precursor.getId(), user, container);
+        return precursor == null ? PrecursorManager.getChromInfosLitePlusForPeptide(peptide.getId(), container) :
+                                   PrecursorManager.getChromInfosLitePlusForPrecursor(precursor.getId(), container);
     }
 
     private List<PrecursorChromInfoLitePlus> getPrecursorChromInfo(Molecule molecule, MoleculePrecursor precursor, User user, Container container)

--- a/src/org/labkey/targetedms/query/AnnotatedTargetedMSTable.java
+++ b/src/org/labkey/targetedms/query/AnnotatedTargetedMSTable.java
@@ -214,7 +214,7 @@ public class AnnotatedTargetedMSTable extends TargetedMSTable
      */
     protected static Pair<SQLFragment, DataSettings.AnnotationType> generateSQL(TableInfo annotationTableInfo, String annotationFKName, String pkColumnName, AnnotationSettingForTyping annotationSetting, SqlDialect dialect)
     {
-        SQLFragment sql = new SQLFragment("(SELECT ", annotationSetting.getName());
+        SQLFragment sql = new SQLFragment("(SELECT ");
         DataSettings.AnnotationType annotationType = DataSettings.AnnotationType.text;
 
         if (annotationSetting.getMaxType().equals(annotationSetting.getMinType()))
@@ -243,7 +243,7 @@ public class AnnotatedTargetedMSTable extends TargetedMSTable
         }
 
         getAnnotationJoinSQL(annotationTableInfo, annotationFKName, sql);
-        sql.append(".").append(pkColumnName).append(" AND a.name = ?)");
+        sql.append(".").append(pkColumnName).append(" AND a.name = ").appendStringLiteral(annotationSetting.getName(), annotationTableInfo.getSqlDialect()).append(")");
 
         return Pair.of(sql, annotationType);
     }

--- a/src/org/labkey/targetedms/query/SampleFileTable.java
+++ b/src/org/labkey/targetedms/query/SampleFileTable.java
@@ -205,7 +205,10 @@ public class SampleFileTable extends TargetedMSTable
         urlParams.put("id", "Id");
         DetailsURL detailsURL = new DetailsURL(url, urlParams);
         setDetailsURL(detailsURL);
-        getMutableColumn("ReplicateId").setURL(detailsURL);
+        getMutableColumnOrThrow("ReplicateId").setURL(detailsURL);
+        getMutableColumnOrThrow("ReplicateId").setFk(new TargetedMSForeignKey(schema, TargetedMSSchema.TABLE_REPLICATE, cf));
+
+        getMutableColumnOrThrow("InstrumentId").setFk(new TargetedMSForeignKey(schema, TargetedMSSchema.TABLE_INSTRUMENT, cf));
 
 
         // Add a column to display the file name extracted from the value in the sampleFile.FilePath column


### PR DESCRIPTION
#### Rationale
PrecursorAllChromatogramsChart and other similar actions were running a query that took 6 seconds. It can be a lot faster.

We can also optimize the SampleFileAssayResults query by avoiding redundant joins to filter by container

#### Changes
* Eliminate redundant joins
* No need to pass User object through so many method calls
* Consolidate duplicate code
* Use TargetedMSForeignKey to eliminate redundant joins to filter by container