### PR TITLE
Issue 50150: Early Stage PTM Report formatting issues

### DIFF
--- a/resources/queries/targetedms/PTMPercentsGrouped.sql
+++ b/resources/queries/targetedms/PTMPercentsGrouped.sql
@@ -18,7 +18,7 @@ SELECT
     (CASE WHEN Modification.Name = 'Lys-loss (Protein C-term K)' THEN (1 - MIN(MinPercentModified)) ELSE MAX(MaxPercentModified) END) AS MaxPercentModified,
     (CASE WHEN Modification.Name = 'Lys-loss (Protein C-term K)' THEN (1 - SUM(PercentModified)) ELSE SUM(PercentModified) END) AS PercentModified,
     (CASE WHEN Modification.Name = 'Lys-loss (Protein C-term K)' THEN (1 - SUM(TotalPercentModified)) ELSE SUM(TotalPercentModified) END) AS TotalPercentModified,
-    ModificationCount @hidden
+    MAX(ModificationCount) AS ModificationCount @hidden
 
 FROM
     PTMPercentsGroupedPrepivot
@@ -31,6 +31,5 @@ GROUP BY
     PeptideGroupId,
     AminoAcid,
     Location,
-    Modification.Name,
-    ModificationCount
+    Modification.Name
 PIVOT PercentModified, TotalPercentModified BY SampleName


### PR DESCRIPTION
#### Rationale
When not all replicates have quantitation results (PrecursorChromInfos) for each peptide sequence variant, the early stage PTM report's formatting can get mangled

#### Changes
* Allow different replicates to have different modification counts for each peptide