### PR TITLE
Avoid duplicate join through precursors for transition queries

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSSchema.java
+++ b/src/org/labkey/targetedms/TargetedMSSchema.java
@@ -317,7 +317,7 @@ public class TargetedMSSchema extends UserSchema
                 return FieldKey.fromParts("GeneralMoleculeChromInfoId", "GeneralMoleculeId", "PeptideGroupId", "RunId", "Container");
             }
         },
-        GeneralPrecursorFK
+        PrecursorFK
         {
             @Override
             public SQLFragment getSQL()
@@ -333,7 +333,26 @@ public class TargetedMSSchema extends UserSchema
             @Override
             public FieldKey getContainerFieldKey()
             {
-                return FieldKey.fromParts("GeneralPrecursorId", "GeneralMoleculeId", "PeptideGroupId", "RunId", "Container");
+                return FieldKey.fromParts("PrecursorId", "PeptideId", "PeptideGroupId", "RunId", "Container");
+            }
+        },
+        MoleculePrecursorFK
+        {
+            @Override
+            public SQLFragment getSQL()
+            {
+                SQLFragment sql = new SQLFragment();
+                sql.append(makeInnerJoin(TargetedMSManager.getTableInfoGeneralPrecursor(), "pre", "GeneralPrecursorId"));
+                sql.append(makeInnerJoin(TargetedMSManager.getTableInfoGeneralMolecule(), "gm", "pre.GeneralMoleculeId"));
+                sql.append(makeInnerJoin(TargetedMSManager.getTableInfoPeptideGroup(), "pg", "gm.PeptideGroupId"));
+                sql.append(getJoinToRunsTable("pg"));
+                return sql;
+
+            }
+            @Override
+            public FieldKey getContainerFieldKey()
+            {
+                return FieldKey.fromParts("PrecursorId", "PeptideId", "PeptideGroupId", "RunId", "Container");
             }
         },
         GeneralTransitionFK
@@ -370,7 +389,7 @@ public class TargetedMSSchema extends UserSchema
                 return FieldKey.fromParts("PrecursorChromInfoId", "Container");
             }
         },
-        PrecursorFK
+        SpectraLibraryPrecursorFK
         {
             @Override
             public SQLFragment getSQL()
@@ -385,7 +404,7 @@ public class TargetedMSSchema extends UserSchema
             @Override
             public FieldKey getContainerFieldKey()
             {
-                return FieldKey.fromParts("PrecursorId", "GeneralMoleculeId", "PeptideGroupId", "RunId", "Container");
+                return FieldKey.fromParts("PrecursorId", "PeptideId", "PeptideGroupId", "RunId", "Container");
             }
         },
         PrecursorTableFK
@@ -1495,7 +1514,7 @@ public class TargetedMSSchema extends UserSchema
             TABLE_SPECTRAST_LIB_INFO.equalsIgnoreCase(name) ||
             TABLE_CHROMATOGRAM_LIB_INFO.equalsIgnoreCase(name))
         {
-            return new TargetedMSTable(getSchema().getTable(name), this, cf, ContainerJoinType.PrecursorFK);
+            return new TargetedMSTable(getSchema().getTable(name), this, cf, ContainerJoinType.SpectraLibraryPrecursorFK);
         }
 
         if (TABLE_KEYWORD_CATEGORIES.equalsIgnoreCase(name) ||

--- a/src/org/labkey/targetedms/query/AbstractGeneralTransitionTableInfo.java
+++ b/src/org/labkey/targetedms/query/AbstractGeneralTransitionTableInfo.java
@@ -29,10 +29,10 @@ import org.labkey.targetedms.TargetedMSSchema;
 
 public class AbstractGeneralTransitionTableInfo extends JoinedTargetedMSTable
 {
-    public AbstractGeneralTransitionTableInfo(final TargetedMSSchema schema, TableInfo tableInfo, ContainerFilter cf, boolean omitAnnotations)
+    public AbstractGeneralTransitionTableInfo(final TargetedMSSchema schema, TableInfo tableInfo, ContainerFilter cf, boolean omitAnnotations, TargetedMSSchema.ContainerJoinType joinType)
     {
         super(TargetedMSManager.getTableInfoGeneralTransition(), tableInfo,
-                schema, cf, TargetedMSSchema.ContainerJoinType.GeneralPrecursorFK,
+                schema, cf, joinType,
                 TargetedMSManager.getTableInfoTransitionAnnotation(), "TransitionId", omitAnnotations ? null : "Transition", "transition");
     }
 

--- a/src/org/labkey/targetedms/query/DocTransitionsTableInfo.java
+++ b/src/org/labkey/targetedms/query/DocTransitionsTableInfo.java
@@ -46,7 +46,7 @@ public class DocTransitionsTableInfo extends AbstractGeneralTransitionTableInfo
 
     public DocTransitionsTableInfo(final TargetedMSSchema schema, ContainerFilter cf, boolean omitAnnotations)
     {
-        super(schema, TargetedMSManager.getTableInfoTransition(), cf, omitAnnotations);
+        super(schema, TargetedMSManager.getTableInfoTransition(), cf, omitAnnotations, TargetedMSSchema.ContainerJoinType.PrecursorFK);
 
         setDescription(TargetedMSManager.getTableInfoTransition().getDescription());
 

--- a/src/org/labkey/targetedms/query/MoleculeTransitionsTableInfo.java
+++ b/src/org/labkey/targetedms/query/MoleculeTransitionsTableInfo.java
@@ -36,7 +36,7 @@ public class MoleculeTransitionsTableInfo extends AbstractGeneralTransitionTable
 {
     public MoleculeTransitionsTableInfo(final TargetedMSSchema schema, ContainerFilter cf, boolean omitAnnotations)
     {
-        super(schema, TargetedMSManager.getTableInfoMoleculeTransition(), cf, omitAnnotations);
+        super(schema, TargetedMSManager.getTableInfoMoleculeTransition(), cf, omitAnnotations, TargetedMSSchema.ContainerJoinType.MoleculePrecursorFK);
 
         setDescription(TargetedMSManager.getTableInfoMoleculeTransition().getDescription());
 


### PR DESCRIPTION
#### Rationale
Some queries involving either the `Transition` or `MoleculeTransition` tables are running slowly. They have a duplicate join through the precursor tables which is making the database go with a less efficient query plan.

#### Changes
* Use proteomics- and molecule-specific lookups to avoid needing to pull in GeneralPrecursorId joins to get the Container column