### PR TITLE
Issue 50327: Explicitly enabled QC metrics set to 3 for lower bound

### DIFF
--- a/resources/schemas/dbscripts/postgresql/targetedms-24.003-24.004.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-24.003-24.004.sql
@@ -1,0 +1,1 @@
+UPDATE targetedms.QCEnabledMetrics SET LowerBound = -3 WHERE Status = 'LeveyJennings' AND UpperBound = 3 AND LowerBound = 3;

--- a/resources/schemas/dbscripts/sqlserver/targetedms-24.003-24.004.sql
+++ b/resources/schemas/dbscripts/sqlserver/targetedms-24.003-24.004.sql
@@ -1,0 +1,1 @@
+UPDATE targetedms.QCEnabledMetrics SET LowerBound = -3 WHERE Status = 'LeveyJennings' AND UpperBound = 3 AND LowerBound = 3;

--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -221,7 +221,7 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
     @Override
     public Double getSchemaVersion()
     {
-        return 24.003;
+        return 24.004;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
We're inconsistently defaulting the lower bound for Levey-Jennings outlier-style metrics. It should be -3, not 3.

#### Changes
* Fix up the incorrectly upgraded metric rows