### PR TITLE
Issue 50011: Outliers for Fixed Deviation from mean for some metric is incorrect

### DIFF
--- a/resources/queries/targetedms/qcMetricsConfig.sql
+++ b/resources/queries/targetedms/qcMetricsConfig.sql
@@ -41,4 +41,3 @@ FROM
       qcmetricconfiguration qmc
 FULL JOIN   qcenabledmetrics qem
        ON   qem.metric=qmc.id
-WHERE qmc.Series2QueryName IS NULL -- hide paired metric configs in configureQCMetric.html

--- a/resources/queries/targetedms/qcMetricsConfig.sql
+++ b/resources/queries/targetedms/qcMetricsConfig.sql
@@ -41,3 +41,4 @@ FROM
       qcmetricconfiguration qmc
 FULL JOIN   qcenabledmetrics qem
        ON   qem.metric=qmc.id
+WHERE qmc.Series2QueryName IS NULL -- hide paired metric configs in configureQCMetric.html

--- a/resources/views/configureQCMetric.html
+++ b/resources/views/configureQCMetric.html
@@ -121,6 +121,10 @@
                     sort: 'name',
                     scope: this,
                     success: function (result) {
+                        // remove all paired metric configs
+                        result.rows = result.rows.filter(function(row) {
+                            return row.Series2QueryName === null;
+                        });
                         result.rows.sort(function(row1, row2) { return row1.name.toLowerCase().localeCompare(row2.name.toLowerCase()); });
                         qcMetrics = result.rows;
                         showQCMetrics();

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -1206,7 +1206,7 @@ public class TargetedMSController extends SpringActionController
                     List<GuideSet> guideSets = TargetedMSManager.getGuideSets(getContainer(), getUser());
                     Map<Integer, QCMetricConfiguration> metricMap = enabledQCMetricConfigurations.stream().collect(Collectors.toMap(QCMetricConfiguration::getId, Function.identity()));
 
-                    List<RawMetricDataSet> rawMetricDataSets = OutlierGenerator.get().getRawMetricDataSets(schema, enabledQCMetricConfigurations, null, null, Collections.emptyList(), true, false);
+                    List<RawMetricDataSet> rawMetricDataSets = OutlierGenerator.get().getRawMetricDataSets(schema, enabledQCMetricConfigurations, null, null, Collections.emptyList(), true, false, true);
 
                     Map<GuideSetKey, GuideSetStats> stats = OutlierGenerator.get().getAllProcessedMetricGuideSets(rawMetricDataSets, guideSets.stream().collect(Collectors.toMap(GuideSet::getRowId, Function.identity())));
 
@@ -1484,7 +1484,7 @@ public class TargetedMSController extends SpringActionController
             Date qcFolderEndDate = (Date) qcFolderDateRange.get("endDate");
 
             // always query for the full range
-            List<RawMetricDataSet> rawMetricDataSets = generator.getRawMetricDataSets(schema, qcMetricConfigurations, qcFolderStartDate, qcFolderEndDate, form.getSelectedAnnotations(), form.isShowExcluded(), form.isShowExcludedPrecursors());
+            List<RawMetricDataSet> rawMetricDataSets = generator.getRawMetricDataSets(schema, qcMetricConfigurations, qcFolderStartDate, qcFolderEndDate, form.getSelectedAnnotations(), form.isShowExcluded(), form.isShowExcludedPrecursors(), false);
             Map<GuideSetKey, GuideSetStats> stats;
             if ((form.includeTrailingCVPlot || form.includeTrailingMeanPlot) && form._trailingRuns > 2)
             {

--- a/src/org/labkey/targetedms/TargetedMSManager.java
+++ b/src/org/labkey/targetedms/TargetedMSManager.java
@@ -2280,7 +2280,7 @@ public class TargetedMSManager
             List<GuideSet> guideSets = TargetedMSManager.getGuideSets(container, user);
             Map<Integer, QCMetricConfiguration> metricMap = enabledQCMetricConfigurations.stream().collect(Collectors.toMap(QCMetricConfiguration::getId, Function.identity()));
 
-            List<RawMetricDataSet> rawMetricDataSets = OutlierGenerator.get().getRawMetricDataSets(schema, enabledQCMetricConfigurations, null, null, Collections.emptyList(), true, false);
+            List<RawMetricDataSet> rawMetricDataSets = OutlierGenerator.get().getRawMetricDataSets(schema, enabledQCMetricConfigurations, null, null, Collections.emptyList(), true, false, false);
 
             Map<GuideSetKey, GuideSetStats> stats = OutlierGenerator.get().getAllProcessedMetricGuideSets(rawMetricDataSets, guideSets.stream().collect(Collectors.toMap(GuideSet::getRowId, Function.identity())));
 

--- a/src/org/labkey/targetedms/outliers/OutlierGenerator.java
+++ b/src/org/labkey/targetedms/outliers/OutlierGenerator.java
@@ -156,12 +156,22 @@ public class OutlierGenerator
         // Deduplicate for metrics that are shown both standalone and paired with another
         for (QCMetricConfiguration configuration : configurations)
         {
-            String label1 = configuration.getSeries1Label();
-            retainIfPreferred(preferredConfigs, configuration, label1, configurations, forOutlierSummary);
-            String label2 = configuration.getSeries2Label();
-            if (label2 != null)
+            if (forOutlierSummary)
             {
-                retainIfPreferred(preferredConfigs, configuration, label2, configurations, forOutlierSummary);
+                if (configuration.getSeries2Label() == null)
+                {
+                    preferredConfigs.put(configuration.getSeries1Label(), configuration);
+                }
+            }
+            else
+            {
+                String label1 = configuration.getSeries1Label();
+                retainIfPreferred(preferredConfigs, configuration, label1);
+                String label2 = configuration.getSeries2Label();
+                if (label2 != null)
+                {
+                    retainIfPreferred(preferredConfigs, configuration, label2);
+                }
             }
         }
         return preferredConfigs;
@@ -238,31 +248,12 @@ public class OutlierGenerator
     }
 
     /** Prefer the standalone variant of a metric if it's also part of a paired config so that we avoid double-counting */
-    private void retainIfPreferred(Map<String, QCMetricConfiguration> preferredConfigs, QCMetricConfiguration configuration, String label, List<QCMetricConfiguration> configurations, boolean forOutliers)
+    private void retainIfPreferred(Map<String, QCMetricConfiguration> preferredConfigs, QCMetricConfiguration configuration, String label)
     {
         QCMetricConfiguration existingConfig1 = preferredConfigs.get(label);
         if (existingConfig1 == null || existingConfig1.getSeries2Label() == null)
         {
-            if (forOutliers)
-            {
-                if (configuration.getName().equalsIgnoreCase(label))
-                {
-                    preferredConfigs.put(label, configuration);
-                }
-                else
-                {
-                    configurations.forEach(c -> {
-                        if (c.getName().equalsIgnoreCase(label))
-                        {
-                            preferredConfigs.put(label, c);
-                        }
-                    });
-                }
-            }
-            else
-            {
-                preferredConfigs.put(label, configuration);
-            }
+            preferredConfigs.put(label, configuration);
         }
     }
 


### PR DESCRIPTION
#### Rationale
Outliers for fixed deviation from mean/value is incorrect for metrics that are part of a paired config. We were incorrectly mapping metric configuration of stand alone metrics that are part of a paired config i.e. for the stand alone metric we were mapping it to the paired metric configurations instead of their own configuration that was causing incorrect calculations of stand alone metric outliers.

#### Related Pull Requests
* https://github.com/LabKey/targetedms/pull/431

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
