### PR TITLE
Issue 49989: "Show metric in plots, but don't identify outliers" should not display bound lines

### DIFF
--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -841,6 +841,7 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
             disableRangeDisplay: this.isMultiSeries(),
             hoverTextFn: !showDataPoints ? function() { return 'Narrow the date range to show individual data points.' } : undefined,
             hideSDLines: true,
+            showBoundLines: metricProps.metricStatus !== LABKEY.targetedms.MetricStatus.PlotOnly
         };
 
         // lines are not separated when indices are not present


### PR DESCRIPTION
#### Rationale
Do not display bound lines when plot only option is selected in the metric configuration.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5489

#### Changes
* add new plotConfig property - showBoundLines
