### PR TITLE
Ticket 49838 - Early Stage PTM Report updates for Pre-IPA data

### DIFF
--- a/resources/queries/targetedms/PTMPercentsGrouped.sql
+++ b/resources/queries/targetedms/PTMPercentsGrouped.sql
@@ -6,18 +6,16 @@ SELECT
     Location,
     PeptideModifiedSequence,
     Sequence @hidden,
-    -- We have a special rule for this C-term modification - we're actually interested in the _unmodified_ percentage
-    (CASE WHEN Modification.Name = 'Lys-loss (Protein C-term K)' THEN 'C-term K' ELSE Modification.Name END) AS Modification,
+    Modification,
     MIN(Id) AS Id @hidden,
     PreviousAA @hidden,
     NextAA @hidden,
     SampleName,
-    -- Normally we want to show the max percentage modified across all replicates (5%, 10%, 20% -> 20% as the worst case)
-    -- However, for this one special modification, we invert the percentage. So 95% -> 5%, 90% -> 10%, 80% -> 20%. Thus,
-    -- we need to find the one with the lowest value, which becomes the highest percentage when we subtract it from 100%.
-    (CASE WHEN Modification.Name = 'Lys-loss (Protein C-term K)' THEN (1 - MIN(MinPercentModified)) ELSE MAX(MaxPercentModified) END) AS MaxPercentModified,
-    (CASE WHEN Modification.Name = 'Lys-loss (Protein C-term K)' THEN (1 - SUM(PercentModified)) ELSE SUM(PercentModified) END) AS PercentModified,
-    (CASE WHEN Modification.Name = 'Lys-loss (Protein C-term K)' THEN (1 - SUM(TotalPercentModified)) ELSE SUM(TotalPercentModified) END) AS TotalPercentModified,
+
+    MAX(MaxPercentModified) AS MaxPercentModified,
+    SUM(PercentModified) AS PercentModified,
+    SUM(TotalPercentModified) AS TotalPercentModified,
+
     MAX(ModificationCount) AS ModificationCount @hidden
 
 FROM
@@ -31,5 +29,5 @@ GROUP BY
     PeptideGroupId,
     AminoAcid,
     Location,
-    Modification.Name
+    Modification
 PIVOT PercentModified, TotalPercentModified BY SampleName

--- a/resources/queries/targetedms/PTMPercentsGroupedPrepivot.query.xml
+++ b/resources/queries/targetedms/PTMPercentsGroupedPrepivot.query.xml
@@ -14,11 +14,27 @@
                         </displayColumnFactory>
                         <columnTitle>Sequence</columnTitle>
                     </column>
-                    <column columnName="PeptideGroupId">
-                        <columnTitle>Chain</columnTitle>
+                    <column columnName="TotalPercentModified">
+                        <formatString>0.00%</formatString>
+                    </column>
+                    <column columnName="PercentModified">
+                        <formatString>0.00%</formatString>
+                    </column>
+                    <column columnName="MaxPercentModified">
+                        <formatString>0.00%</formatString>
                     </column>
                     <column columnName="Sequence">
                         <columnTitle>UnmodifiedSequence</columnTitle>
+                    </column>
+                    <column columnName="IsCdr">
+                        <displayColumnFactory>
+                           <className>org.labkey.targetedms.query.CDRDisplayColumnFactory</className>
+                        </displayColumnFactory>
+                    </column>
+                    <column columnName="Risk">
+                        <displayColumnFactory>
+                           <className>org.labkey.targetedms.query.PTMRiskDisplayColumnFactory</className>
+                        </displayColumnFactory>
                     </column>
                 </columns>
             </table>

--- a/resources/queries/targetedms/PTMPercentsGroupedPrepivot.sql
+++ b/resources/queries/targetedms/PTMPercentsGroupedPrepivot.sql
@@ -23,7 +23,7 @@ SELECT
 
        p1.PeptideGroupId.RunId AS RunId,
 
-       CAST(NULL AS BOOLEAN) IsCdr,
+       CAST(NULL AS VARCHAR) IsCdr,
        CAST(NULL AS VARCHAR) Risk
 
 FROM

--- a/src/org/labkey/targetedms/TargetedMSSchema.java
+++ b/src/org/labkey/targetedms/TargetedMSSchema.java
@@ -1588,15 +1588,18 @@ public class TargetedMSSchema extends UserSchema
                         // the selected display columns
                         getDisplayColumns();
 
+                        Long runId = PTMPercentsGroupedCustomizer.getRunId(getTable());
+
                         CrosstabDataRegion rgn = new CrosstabDataRegion(table.getSettings(), _numRowAxisCols, _numMeasures, _numMemberMeasures)
                         {
-                            private final Map<String, Pair<Boolean, String>> _metadata = PTMPercentsGroupedCustomizer.getSampleMetadata(table);
+                            private final Map<Pair<String, Long>, Pair<Boolean, String>> _metadata = PTMPercentsGroupedCustomizer.getSampleMetadata(getContainer());
                             @Override
                             protected String getMemberCaptionWithUrl(String caption, String url)
                             {
-                                if (_metadata.containsKey(caption))
+                                var key = Pair.of(caption, runId);
+                                if (_metadata.containsKey(key))
                                 {
-                                    caption = _metadata.get(caption).getValue();
+                                    caption = _metadata.get(key).getValue();
                                 }
                                 return super.getMemberCaptionWithUrl(caption, url);
                             }

--- a/src/org/labkey/targetedms/query/CDRConditionalFormattingDisplayColumnFactory.java
+++ b/src/org/labkey/targetedms/query/CDRConditionalFormattingDisplayColumnFactory.java
@@ -1,0 +1,196 @@
+package org.labkey.targetedms.query;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.CompareType;
+import org.labkey.api.data.ConditionalFormat;
+import org.labkey.api.data.DataColumn;
+import org.labkey.api.data.DisplayColumn;
+import org.labkey.api.data.DisplayColumnFactory;
+import org.labkey.api.data.RenderContext;
+import org.labkey.api.data.SimpleFilter;
+import org.labkey.api.query.FieldKey;
+import org.labkey.api.util.Pair;
+import org.labkey.targetedms.parser.Protein;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+class CDRConditionalFormattingDisplayColumnFactory implements DisplayColumnFactory
+{
+    private final Function<Long, Protein> _proteinGetter;
+    private final Map<Pair<String, Long>, Pair<Boolean, String>> _stressedSamples;
+    private final long _runId;
+
+    public CDRConditionalFormattingDisplayColumnFactory(Function<Long, Protein> proteinGetter, Map<Pair<String, Long>, Pair<Boolean, String>> stressedSamples, long runId)
+    {
+        _proteinGetter = proteinGetter;
+        _stressedSamples = stressedSamples;
+        _runId = runId;
+    }
+
+    public static RiskLevel getRiskLevel(Number value, boolean inCDR, boolean stressed)
+    {
+        if (value == null)
+        {
+            return null;
+        }
+
+        double highCutoff = inCDR ? 0.1 : 0.3;
+        double mediumCutoff = inCDR ? 0.05 : 0.15;
+
+        if (stressed)
+        {
+            highCutoff *= 2;
+            mediumCutoff *= 2;
+        }
+
+        if (value.doubleValue() > highCutoff)
+        {
+            return RiskLevel.High;
+        }
+        else if (value.doubleValue() > mediumCutoff)
+        {
+            return RiskLevel.Medium;
+        }
+        return RiskLevel.Low;
+
+    }
+
+    public static boolean isInCDR(FieldKey parentFieldKey, RenderContext ctx, Function<Long, Protein> proteinGetter)
+    {
+        boolean inCDR = false;
+        Long peptideGroupId = ctx.get(FieldKey.fromString(parentFieldKey, "PeptideGroupId"), Long.class);
+        Integer siteLocation = ctx.get(FieldKey.fromString(parentFieldKey, "Location"), Integer.class);
+        if (peptideGroupId != null && siteLocation != null)
+        {
+            int modificationIndex = siteLocation.intValue();
+            Protein protein = proteinGetter.apply(peptideGroupId);
+            if (protein != null)
+            {
+                for (Pair<Integer, Integer> cdrRange : protein.getCdrRangesList())
+                {
+                    if (cdrRange.first <= modificationIndex && cdrRange.second >= modificationIndex)
+                    {
+                        inCDR = true;
+                        break;
+                    }
+                }
+            }
+        }
+        return inCDR;
+    }
+
+    @Override
+    public DisplayColumn createRenderer(ColumnInfo boundCol)
+    {
+        return new Col(boundCol, _proteinGetter, _stressedSamples, _runId);
+    }
+
+    public enum RiskLevel
+    {
+        Low("89ca53"), // Green for low risk
+        Medium("feff3f"), // Yellow
+        High("fa081a"); // Red
+
+        private final String _color;
+
+        RiskLevel(String color)
+        {
+            _color = color;
+        }
+
+        public String getColor()
+        {
+            return _color;
+        }
+    }
+
+    /** Chooses the background color based the percentage compared to low/medium/high range definitions
+     * based on whether sample described by this pivot column is "stressed" and whether the modification is within a
+     * CDR (complementarity-determining region) */
+    private static class Col extends DataColumn
+    {
+        private final Function<Long, Protein> _proteinGetter;
+        private final Map<Pair<String, Long>, Pair<Boolean, String>> _stressedSamples;
+        private final long _runId;
+
+        public Col(ColumnInfo colInfo, Function<Long, Protein> proteinGetter, Map<Pair<String, Long>, Pair<Boolean, String>> stressedSamples, long runId)
+        {
+            super(colInfo);
+            _proteinGetter = proteinGetter;
+            _stressedSamples = stressedSamples;
+            _runId = runId;
+        }
+
+        @Override
+        public void addQueryFieldKeys(Set<FieldKey> keys)
+        {
+            super.addQueryFieldKeys(keys);
+            keys.add(FieldKey.fromString(getBoundColumn().getFieldKey().getParent(), "PeptideGroupId"));
+            keys.add(FieldKey.fromString(getBoundColumn().getFieldKey().getParent(), "Location"));
+            keys.add(FieldKey.fromString(getBoundColumn().getFieldKey().getParent(), "Modification"));
+            keys.add(FieldKey.fromString(getBoundColumn().getFieldKey().getParent(), "RunId"));
+        }
+
+        @NotNull
+        private ConditionalFormat createConditionalFormat(Number value, boolean inCDR, boolean stressed)
+        {
+            RiskLevel level = getRiskLevel(value, inCDR, stressed);
+
+            ConditionalFormat result = new ConditionalFormat()
+            {
+                @Override
+                public SimpleFilter getSimpleFilter()
+                {
+                    SimpleFilter result = new SimpleFilter();
+                    result.addClause(new CompareType.CompareClause(getBoundColumn().getFieldKey(), CompareType.GT, value)
+                    {
+                        @Override
+                        protected void appendFilterText(StringBuilder sb, SimpleFilter.ColumnNameFormatter formatter)
+                        {
+                            sb.append("the peptide is ");
+                            sb.append(inCDR ? "" : "not ");
+                            sb.append("part of a CDR sequence and observed in a ");
+                            sb.append(stressed ? "" : "non-");
+                            sb.append("stressed sample");
+                        }
+                    });
+                    return result;
+                }
+            };
+            result.setBackgroundColor(level.getColor());
+            return result;
+        }
+
+        @Override
+        protected @Nullable ConditionalFormat findApplicableFormat(RenderContext ctx)
+        {
+            Number value = ctx.get(getBoundColumn().getFieldKey(), Number.class);
+            if (value == null)
+            {
+                return null;
+            }
+
+            String modification = ctx.get(new FieldKey(getBoundColumn().getFieldKey().getParent(), "Modification"), String.class);
+            if ("Gln->pyro-Glu (N-term Q)".equalsIgnoreCase(modification))
+            {
+                return null;
+            }
+
+            boolean inCDR = isInCDR(getBoundColumn().getFieldKey().getParent(), ctx, _proteinGetter);
+
+            String sampleName = getBoundColumn().getName();
+            if (sampleName.contains("::"))
+            {
+                // Strip off the suffix to get to the sample name
+                sampleName = sampleName.substring(0, sampleName.indexOf("::"));
+            }
+            Pair<Boolean, String> metadata = _stressedSamples.get(Pair.of(sampleName, _runId));
+            return createConditionalFormat(value, inCDR, metadata != null && metadata.first.booleanValue());
+        }
+    }
+
+}

--- a/src/org/labkey/targetedms/query/CDRConditionalFormattingDisplayColumnFactory.java
+++ b/src/org/labkey/targetedms/query/CDRConditionalFormattingDisplayColumnFactory.java
@@ -38,6 +38,9 @@ class CDRConditionalFormattingDisplayColumnFactory implements DisplayColumnFacto
             return null;
         }
 
+        // Apply different cutoffs when the peptide is part of the complementarity determining region (CDR)
+        // for the antibody. If it's in the region we're significantly more stringent about how much
+        // of a PTM we consider medium or high risk.
         double highCutoff = inCDR ? 0.1 : 0.3;
         double mediumCutoff = inCDR ? 0.05 : 0.15;
 

--- a/src/org/labkey/targetedms/query/CDRDisplayColumnFactory.java
+++ b/src/org/labkey/targetedms/query/CDRDisplayColumnFactory.java
@@ -1,0 +1,69 @@
+package org.labkey.targetedms.query;
+
+import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.DataColumn;
+import org.labkey.api.data.DisplayColumn;
+import org.labkey.api.data.DisplayColumnFactory;
+import org.labkey.api.data.RenderContext;
+import org.labkey.api.query.FieldKey;
+import org.labkey.targetedms.parser.Protein;
+
+import java.util.Set;
+import java.util.function.Function;
+
+public class CDRDisplayColumnFactory implements DisplayColumnFactory
+{
+    @Override
+    public DisplayColumn createRenderer(ColumnInfo colInfo)
+    {
+        return new Col(colInfo);
+    }
+
+    private static class Col extends DataColumn
+    {
+        private final Function<Long, Protein> _proteinGetter = new PTMPercentsGroupedCustomizer.PeptideGroupIdProteinGetter();
+        public Col(ColumnInfo col)
+        {
+            super(col);
+        }
+
+        @Override
+        public boolean isSortable()
+        {
+            return false;
+        }
+
+        @Override
+        public boolean isFilterable()
+        {
+            return false;
+        }
+
+        @Override
+        public Object getValue(RenderContext ctx)
+        {
+            Object result = super.getValue(ctx);
+            if (result == null)
+            {
+                result = CDRConditionalFormattingDisplayColumnFactory.isInCDR(getBoundColumn().getFieldKey().getParent(), ctx, _proteinGetter);
+            }
+            return result;
+        }
+
+        @Override
+        public Object getDisplayValue(RenderContext ctx)
+        {
+            return getValue(ctx);
+        }
+
+        @Override
+        public void addQueryFieldKeys(Set<FieldKey> keys)
+        {
+            super.addQueryFieldKeys(keys);
+            keys.add(FieldKey.fromString(getBoundColumn().getFieldKey().getParent(), "PeptideGroupId"));
+            keys.add(FieldKey.fromString(getBoundColumn().getFieldKey().getParent(), "Location"));
+        }
+    }
+
+
+}

--- a/src/org/labkey/targetedms/query/PTMPercentsGroupedCustomizer.java
+++ b/src/org/labkey/targetedms/query/PTMPercentsGroupedCustomizer.java
@@ -1,19 +1,13 @@
 package org.labkey.targetedms.query;
 
 import org.apache.commons.collections4.MultiValuedMap;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.ColumnInfo;
-import org.labkey.api.data.CompareType;
-import org.labkey.api.data.ConditionalFormat;
-import org.labkey.api.data.DataColumn;
+import org.labkey.api.data.Container;
 import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.DisplayColumnFactory;
 import org.labkey.api.data.MutableColumnInfo;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.data.SQLFragment;
-import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
 import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.TableInfo;
@@ -26,13 +20,15 @@ import org.labkey.targetedms.parser.Protein;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 
 /**
- * Customizes the set of columns available on a pivot query that operates on samples, hiding all of the pivot values
+ * Customizes the set of columns available on a pivot query that operates on samples, hiding all the pivot values
  * that aren't part of the run that's being filtered on. This lets you view a single document's worth of data
  * without seeing empty columns for all the other samples in the same container.
  */
@@ -94,9 +90,14 @@ public class PTMPercentsGroupedCustomizer extends PTMPercentsCustomizer
     @Override
     public void customize(TableInfo tableInfo)
     {
-        Map<String, Pair<Boolean, String>> stressedSamples = getSampleMetadata(tableInfo);
+        var stressedSamples = getSampleMetadata(tableInfo.getUserSchema().getContainer());
+        long runId = getRunId(tableInfo);
 
-        List<Protein> proteins = getProteins(tableInfo);
+        List<Protein> proteins = PeptideGroupManager.getProteinsForRun(runId);
+        Function<Long, Protein> proteinGetter = (peptideGroupId) -> {
+            Optional<Protein> opt = proteins.stream().filter(p -> p.getPeptideGroupId() == peptideGroupId.intValue()).findFirst();
+            return opt.orElse(null);
+        };
 
         for (ColumnInfo c : tableInfo.getColumns())
         {
@@ -105,7 +106,7 @@ public class PTMPercentsGroupedCustomizer extends PTMPercentsCustomizer
             if (col.getName().endsWith("::TotalPercentModified") || col.getName().endsWith("::PercentModified"))
             {
                 col.setFormat("0.0%");
-                col.setDisplayColumnFactory((boundCol) -> new CDRConditionalFormatDisplayColumn(boundCol, proteins, stressedSamples));
+                col.setDisplayColumnFactory(new CDRConditionalFormattingDisplayColumnFactory(proteinGetter, stressedSamples, runId));
             }
 
             if (col.getName().endsWith("::TotalPercentModified") ||
@@ -164,29 +165,25 @@ public class PTMPercentsGroupedCustomizer extends PTMPercentsCustomizer
         super.customize(tableInfo);
     }
 
-    @NotNull
-    private static List<Protein> getProteins(TableInfo tableInfo)
+    public static long getRunId(TableInfo tableInfo)
     {
-        List<Protein> proteins = Collections.emptyList();
-
         // Table name should be PTMPercentsGrouped_X, where X is the runId
         String tableName = tableInfo.getName();
         if (tableName.toLowerCase().startsWith(TargetedMSSchema.QUERY_PTM_PERCENTS_GROUPED_PREFIX.toLowerCase()))
         {
             try
             {
-                long runId = Long.parseLong(tableName.substring(TargetedMSSchema.QUERY_PTM_PERCENTS_GROUPED_PREFIX.length()));
-                proteins = PeptideGroupManager.getProteinsForRun(runId);
+                return Long.parseLong(tableName.substring(TargetedMSSchema.QUERY_PTM_PERCENTS_GROUPED_PREFIX.length()));
             }
             catch (NumberFormatException ignored) {}
         }
-        return proteins;
+        return -1;
     }
 
-    /** Key is the sample name, value is a pair of boolean (stressed or not) and description, both annotation-based */
-    public static Map<String, Pair<Boolean, String>> getSampleMetadata(TableInfo tableInfo)
+    /** Key is the sample name and run ID, value is a pair of boolean (stressed or not) and description, both annotation-based */
+    public static Map<Pair<String, Long>, Pair<Boolean, String>> getSampleMetadata(Container container)
     {
-        SQLFragment sql = new SQLFragment("SELECT DISTINCT sf.SampleName, raStressed.Value AS Stressed, COALESCE(raDescription.Value, sf.SampleName) AS Description FROM ");
+        SQLFragment sql = new SQLFragment("SELECT DISTINCT sf.SampleName, r.RunId, raStressed.Value AS Stressed, COALESCE(raDescription.Value, sf.SampleName) AS Description FROM ");
         sql.append(TargetedMSManager.getTableInfoSampleFile(), "sf");
         sql.append(" INNER JOIN ");
         sql.append(TargetedMSManager.getTableInfoReplicate(), "r");
@@ -194,131 +191,32 @@ public class PTMPercentsGroupedCustomizer extends PTMPercentsCustomizer
         sql.append(" INNER JOIN ");
         sql.append(TargetedMSManager.getTableInfoRuns(), "run");
         sql.append(" ON r.RunId = run.Id AND run.Container = ?");
-        sql.add(tableInfo.getUserSchema().getContainer());
+        sql.add(container);
         sql.append(" LEFT OUTER JOIN ");
         sql.append(TargetedMSManager.getTableInfoReplicateAnnotation(), "raStressed");
         sql.append(" ON r.Id = raStressed.ReplicateId AND raStressed.Name = 'Stressed or Non-stressed'");
         sql.append(" LEFT OUTER JOIN ");
         sql.append(TargetedMSManager.getTableInfoReplicateAnnotation(), "raDescription");
         sql.append(" ON r.Id = raDescription.ReplicateId AND raDescription.Name = 'Sample Description'");
-        CaseInsensitiveHashMap<Pair<Boolean, String>> result = new CaseInsensitiveHashMap<>();
+        Map<Pair<String, Long>, Pair<Boolean, String>> result = new HashMap<>();
         new SqlSelector(TargetedMSManager.getSchema(), sql).forEach(rs -> {
             String sampleName = rs.getString("SampleName");
+            Long runId = rs.getLong("RunId");
             Boolean stressed = "Stressed".equalsIgnoreCase(rs.getString("Stressed"));
             String description = rs.getString("Description");
-            result.put(sampleName, Pair.of(stressed, description));
+            result.put(Pair.of(sampleName, runId), Pair.of(stressed, description));
         });
         return result;
     }
 
-    /** Chooses the background color based the percentage compared to low/medium/high range definitions
-     * based on whether sample described by this pivot column is "stressed" and whether the modification is within a
-     * CDR (complementarity-determining region) */
-    private static class CDRConditionalFormatDisplayColumn extends DataColumn
+    /** Look up proteins on demand by peptideGroupId, caching them for reuse */
+    public static class PeptideGroupIdProteinGetter implements Function<Long, Protein>
     {
-        private final List<Protein> _proteins;
-        private final Map<String, Pair<Boolean, String>> _stressedSamples;
-
-        public CDRConditionalFormatDisplayColumn(ColumnInfo colInfo, List<Protein> proteins, Map<String, Pair<Boolean, String>> stressedSamples)
-        {
-            super(colInfo);
-            _proteins = proteins;
-            _stressedSamples = stressedSamples;
-        }
-
+        private final Map<Long, Protein> _proteins = new HashMap<>();
         @Override
-        public void addQueryFieldKeys(Set<FieldKey> keys)
+        public Protein apply(Long peptideGroupId)
         {
-            super.addQueryFieldKeys(keys);
-            keys.add(FieldKey.fromString(getBoundColumn().getFieldKey().getParent(), "PeptideGroupId"));
-            keys.add(FieldKey.fromString(getBoundColumn().getFieldKey().getParent(), "SiteLocation"));
-        }
-
-        @NotNull
-        private ConditionalFormat createConditionalFormat(Number value, boolean inCDR, boolean stressed)
-        {
-            double highCutoff = inCDR ? 0.1 : 0.3;
-            double mediumCutoff = inCDR ? 0.05 : 0.15;
-
-            if (stressed)
-            {
-                highCutoff *= 2;
-                mediumCutoff *= 2;
-            }
-
-            String backgroundColor = "89ca53"; // Green for low risk
-            if (value.doubleValue() > highCutoff)
-            {
-                backgroundColor = "fa081a"; // Red
-            }
-            else if (value.doubleValue() > mediumCutoff)
-            {
-                backgroundColor = "feff3f"; // Yellow
-            }
-            ConditionalFormat result = new ConditionalFormat()
-            {
-                @Override
-                public SimpleFilter getSimpleFilter()
-                {
-                    SimpleFilter result = new SimpleFilter();
-                    result.addClause(new CompareType.CompareClause(getBoundColumn().getFieldKey(), CompareType.GT, value)
-                    {
-                        @Override
-                        protected void appendFilterText(StringBuilder sb, SimpleFilter.ColumnNameFormatter formatter)
-                        {
-                            sb.append("the peptide is ");
-                            sb.append(inCDR ? "" : "not ");
-                            sb.append("part of a CDR sequence and observed in a ");
-                            sb.append(stressed ? "" : "non-");
-                            sb.append("stressed sample");
-                        }
-                    });
-                    return result;
-                }
-            };
-            result.setBackgroundColor(backgroundColor);
-            return result;
-        }
-
-        @Override
-        protected @Nullable ConditionalFormat findApplicableFormat(RenderContext ctx)
-        {
-            Number value = ctx.get(getBoundColumn().getFieldKey(), Number.class);
-            if (value == null)
-            {
-                return null;
-            }
-
-            boolean inCDR = false;
-            Long peptideGroupId = ctx.get(FieldKey.fromString(getBoundColumn().getFieldKey().getParent(), "PeptideGroupId"), Long.class);
-            String siteLocation = ctx.get(FieldKey.fromString(getBoundColumn().getFieldKey().getParent(), "SiteLocation"), String.class);
-            if (peptideGroupId != null && siteLocation != null)
-            {
-                // Strip off the leading letter, which is the amino acid, leaving us with
-                // the one-based index within the full protein sequence
-                int modificationIndex = Integer.parseInt(siteLocation.substring(1));
-                Optional<Protein> match = _proteins.stream().filter(p -> p.getPeptideGroupId() == peptideGroupId.intValue()).findFirst();
-                if (match.isPresent())
-                {
-                    for (Pair<Integer, Integer> cdrRange : match.get().getCdrRangesList())
-                    {
-                        if (cdrRange.first <= modificationIndex && cdrRange.second >= modificationIndex)
-                        {
-                            inCDR = true;
-                            break;
-                        }
-                    }
-                }
-            }
-
-            String sampleName = getBoundColumn().getName();
-            if (sampleName.contains("::"))
-            {
-                // Strip off the suffix to get to the sample name
-                sampleName = sampleName.substring(0, sampleName.indexOf("::"));
-            }
-            Pair<Boolean, String> metadata = _stressedSamples.get(sampleName);
-            return createConditionalFormat(value, inCDR, metadata != null && metadata.first.booleanValue());
+            return _proteins.computeIfAbsent(peptideGroupId, PeptideGroupManager::getProteinForPeptideGroupId);
         }
     }
 }

--- a/src/org/labkey/targetedms/query/PTMRiskDisplayColumnFactory.java
+++ b/src/org/labkey/targetedms/query/PTMRiskDisplayColumnFactory.java
@@ -1,0 +1,91 @@
+package org.labkey.targetedms.query;
+
+import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.DataColumn;
+import org.labkey.api.data.DisplayColumnFactory;
+import org.labkey.api.data.RenderContext;
+import org.labkey.api.query.FieldKey;
+import org.labkey.api.util.Pair;
+import org.labkey.targetedms.parser.Protein;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+public class PTMRiskDisplayColumnFactory implements DisplayColumnFactory
+{
+    @Override
+    public org.labkey.api.data.DisplayColumn createRenderer(ColumnInfo colInfo)
+    {
+        return new Col(colInfo);
+    }
+
+    private static class Col extends DataColumn
+    {
+        private final Function<Long, Protein> _proteinGetter = new PTMPercentsGroupedCustomizer.PeptideGroupIdProteinGetter();
+        private Map<Pair<String, Long>, Pair<Boolean, String>> _stressedSamples;
+
+        public Col(ColumnInfo col)
+        {
+            super(col);
+        }
+
+        @Override
+        public boolean isSortable()
+        {
+            return false;
+        }
+
+        @Override
+        public boolean isFilterable()
+        {
+            return false;
+        }
+
+        @Override
+        public Object getValue(RenderContext ctx)
+        {
+            Object result = super.getValue(ctx);
+            if (result == null)
+            {
+                Number modified = ctx.get(FieldKey.fromString(getBoundColumn().getFieldKey().getParent(), "PercentModified"), Number.class);
+                String sampleName = ctx.get(FieldKey.fromString(getBoundColumn().getFieldKey().getParent(), "SampleName"), String.class);
+                Long runId = ctx.get(FieldKey.fromString(getBoundColumn().getFieldKey().getParent(), "RunId"), Long.class);
+                if (modified == null || sampleName == null || runId == null)
+                {
+                    return null;
+                }
+
+                if (_stressedSamples == null)
+                {
+                    _stressedSamples = PTMPercentsGroupedCustomizer.getSampleMetadata(getBoundColumn().getParentTable().getUserSchema().getContainer());
+                }
+
+                boolean cdr = CDRConditionalFormattingDisplayColumnFactory.isInCDR(getBoundColumn().getFieldKey().getParent(), ctx, _proteinGetter);
+                Pair<Boolean, String> metadata = _stressedSamples.get(Pair.of(sampleName, runId));
+                boolean stressed = metadata != null && metadata.first.booleanValue();
+
+                result = CDRConditionalFormattingDisplayColumnFactory.getRiskLevel(modified, cdr, stressed);
+            }
+            return result;
+        }
+
+        @Override
+        public Object getDisplayValue(RenderContext ctx)
+        {
+            return getValue(ctx);
+        }
+
+        @Override
+        public void addQueryFieldKeys(Set<FieldKey> keys)
+        {
+            super.addQueryFieldKeys(keys);
+            keys.add(FieldKey.fromString(getBoundColumn().getFieldKey().getParent(), "PercentModified"));
+            keys.add(FieldKey.fromString(getBoundColumn().getFieldKey().getParent(), "SampleName"));
+            keys.add(FieldKey.fromString(getBoundColumn().getFieldKey().getParent(), "PeptideGroupId"));
+            keys.add(FieldKey.fromString(getBoundColumn().getFieldKey().getParent(), "Location"));
+            keys.add(FieldKey.fromString(getBoundColumn().getFieldKey().getParent(), "RunId"));
+        }
+    }
+
+}

--- a/src/org/labkey/targetedms/query/PeptideGroupManager.java
+++ b/src/org/labkey/targetedms/query/PeptideGroupManager.java
@@ -88,6 +88,17 @@ public class PeptideGroupManager
 
     public static List<Protein> getProteinsForRun(long runId)
     {
+        return getProteins(new SQLFragment("pg.RunId = ?", runId));
+    }
+
+    public static Protein getProteinForPeptideGroupId(long id)
+    {
+        List<Protein> result = getProteins(new SQLFragment("pg.Id = ?", id));
+        return result.isEmpty() ? null : result.get(0);
+    }
+
+    public static List<Protein> getProteins(SQLFragment whereSql)
+    {
         // Include the Sequence from the prot.sequences table
         // and the optional annotation for CDR ranges. It's not great including it this centrally,
         // but it's needed in a few rendering places.
@@ -99,8 +110,8 @@ public class PeptideGroupManager
         sql.append(ProteinService.get().getSequencesTable(), "s");
         sql.append(" ON p.SequenceId = s.SeqId LEFT OUTER JOIN ");
         sql.append(TargetedMSManager.getTableInfoPeptideGroupAnnotation(), "pga");
-        sql.append(" ON pg.Id = pga.PeptideGroupId AND pga.Name = 'CDR Range' WHERE pg.RunId = ?");
-        sql.add(runId);
+        sql.append(" ON pg.Id = pga.PeptideGroupId AND pga.Name = 'CDR Range' WHERE ");
+        sql.append(whereSql);
 
         return new SqlSelector(TargetedMSManager.getSchema(), sql).getArrayList(Protein.class);
     }


### PR DESCRIPTION
#### Rationale
Users want to leverage the "early-stage" PTM reporting in other tools. That means using a non-pivot format, and not relying on conditional formatting to convey risk.

#### Changes
* Configure the pre-pivoted version of the report with CDR and risk info
* Push the flipping of the percentage for `Lys-loss (Protein C-term K)` into the pre pivot query
* Don't highlight `Gln->pyro-Glu (N-term Q)` at all
* Find the stressed/non-stressed annotation from the right Skyline file