### PR TITLE
Issue 50773: Pressure traces without a TextId can't be used for QC trace metrics

### DIFF
--- a/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
+++ b/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
@@ -3113,6 +3113,7 @@ public class SkylineDocumentParser implements AutoCloseable
         {
             return Collections.emptyList();
         }
+        int traceMetricIndex = 1;
         for (ChromGroupHeaderInfo chromatogram : _binaryParser.getChromatograms())
         {
             // Sample-scoped chromatograms have a magic precursor MZ value
@@ -3144,7 +3145,14 @@ public class SkylineDocumentParser implements AutoCloseable
                     ChromatogramGroupId chromatogramGroupId = _binaryParser.getTextId(chromatogram);
                     if (chromatogramGroupId != null)
                     {
-                        info.setTextId(chromatogramGroupId.getQcTraceName());
+                        if (chromatogramGroupId.getQcTraceName() == null && chromatogram.getFlagValues().contains(ChromGroupHeaderInfo.FlagValues.extracted_qc_trace))
+                        {
+                            info.setTextId("QC Trace " + traceMetricIndex++);
+                        }
+                        else
+                        {
+                            info.setTextId(chromatogramGroupId.getQcTraceName());
+                        }
                     }
                     info.setChromatogramFormat(chromatogram.getChromatogramBinaryFormat().ordinal());
                     info.setChromatogramOffset(chromatogram.getLocationPoints());


### PR DESCRIPTION
#### Rationale
Label the trace metrics as "QC Trace 1", "QC Trace 2", "QC Trace 3".. when sample-scoped pressure traces don't have a TextId value in the SKYD file.
