### PR TITLE
Migrate .view.xml files from deprecated <permissions> elements

### DIFF
--- a/resources/views/configureQCGroups.view.xml
+++ b/resources/views/configureQCGroups.view.xml
@@ -1,5 +1,5 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Include or Exclude Precursors">
-    <permissions>
-        <permission name="update"/>
-    </permissions>
+    <permissionClasses>
+        <permissionClass name="org.labkey.api.security.permissions.UpdatePermission"/>
+    </permissionClasses>
 </view>

--- a/resources/views/configureQCMetric.view.xml
+++ b/resources/views/configureQCMetric.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Configure QC Metrics">
-    <permissions>
-        <permission name="admin"/>
-    </permissions>
+    <permissionClasses>
+        <permissionClass name="org.labkey.api.security.permissions.AdminPermission"/>
+    </permissionClasses>
     <dependencies>
         <dependency path="internal/jQuery"/>
         <dependency path="Ext4"/>

--- a/resources/views/subscribeOutlierNotifications.view.xml
+++ b/resources/views/subscribeOutlierNotifications.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Panorama QC Notifications">
-    <permissions>
-        <permission name="read"/>
-    </permissions>
+    <permissionClasses>
+        <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
+    </permissionClasses>
     <dependencies>
         <dependency path="internal/jQuery"/>
     </dependencies>


### PR DESCRIPTION
#### Rationale
Update `.view.xml` files to calm aggressive warnings