### PR TITLE
Issue 50842: Fix upper and lower bounds legends on qc plots

### DIFF
--- a/webapp/TargetedMS/js/LeveyJenningsPlotHelper.js
+++ b/webapp/TargetedMS/js/LeveyJenningsPlotHelper.js
@@ -217,11 +217,10 @@ Ext4.define("LABKEY.targetedms.LeveyJenningsPlotHelper", {
                 }
             }
 
+            let upper = Number.isFinite(metricInfo.upperBound) ? metricInfo.upperBound : 3;
+            let lower = Number.isFinite(metricInfo.lowerBound) ? metricInfo.lowerBound : -3;
             if ( (metricInfo.metricStatus === LABKEY.targetedms.MetricStatus.LeveyJennings || metricInfo.metricStatus === LABKEY.targetedms.MetricStatus.PlotOnly) &&
                     (!this.singlePlot && this.yAxisScale === 'standardDeviation')) {
-
-                let upper = Number.isFinite(metricInfo.upperBound) ? metricInfo.upperBound : 3;
-                let lower = Number.isFinite(metricInfo.lowerBound) ? metricInfo.lowerBound : -3;
 
                 if (lower === upper * -1) {
                     ljLegend.push({
@@ -245,6 +244,23 @@ Ext4.define("LABKEY.targetedms.LeveyJenningsPlotHelper", {
                     color: 'darkgrey',
                     shape: LABKEY.vis.TrendingLineShape.meanLJ
                 });
+            }
+
+            if (this.singlePlot && this.yAxisScale === 'standardDeviation' && metricInfo.metricStatus === LABKEY.targetedms.MetricStatus.LeveyJennings) {
+                if (lower === upper * -1) {
+                    ljLegend.push({
+                        text: '+/- ' + upper + ' Std Dev',
+                        color: 'red',
+                        shape: LABKEY.vis.TrendingLineShape.stdDevLJ
+                    });
+                }
+                else {
+                    ljLegend.push({
+                        text: (upper > 0 ? '+' : '') + upper + '/' + (lower > 0 ? '+' : '') + lower + ' Std Dev',
+                        color: 'red',
+                        shape: LABKEY.vis.TrendingLineShape.stdDevLJ
+                    });
+                }
             }
         }
 

--- a/webapp/TargetedMS/js/LeveyJenningsPlotHelper.js
+++ b/webapp/TargetedMS/js/LeveyJenningsPlotHelper.js
@@ -194,13 +194,15 @@ Ext4.define("LABKEY.targetedms.LeveyJenningsPlotHelper", {
         return ['value_series1', 'value_series2'];
     },
 
-    getLJLegend: function () {
+    getLJLegend: function (combinedPlot) {
         var ljLegend = [];
 
         if (!this.getMetricPropsById(this.metric).series2Label) {
             let metricInfo = this.getMetricPropsById(this.metric);
-
-            if (metricInfo.metricStatus === LABKEY.targetedms.MetricStatus.ValueCutoff || metricInfo.metricStatus === LABKEY.targetedms.MetricStatus.MeanDeviationCutoff) {
+            let isCombinedValueCutOff = LABKEY.targetedms.MetricStatus.ValueCutoff && combinedPlot;
+            let isYAxisScaleLinearOrLog = this.yAxisScale === 'linear' || this.yAxisScale === 'log';
+            let showLegend = (isYAxisScaleLinearOrLog && isCombinedValueCutOff) || !isCombinedValueCutOff;
+            if (showLegend|| metricInfo.metricStatus === LABKEY.targetedms.MetricStatus.MeanDeviationCutoff) {
                 if (Number.isFinite(metricInfo.upperBound)) {
                     ljLegend.push({
                         text: 'Upper: ' + metricInfo.upperBound,

--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -627,7 +627,7 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
             newLegendData = newLegendData.concat(ionLegend);
         }
 
-        var extraPlotLegendData = this.getAdditionalPlotLegend(plotType);
+        var extraPlotLegendData = this.getAdditionalPlotLegend(plotType, true);
         newLegendData = newLegendData.concat(extraPlotLegendData);
 
         return newLegendData;
@@ -856,7 +856,7 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
 
         Ext4.apply(trendLineProps, this.getPlotTypeProperties(precursorInfo, plotType, isCUSUMMean, metricProps));
 
-        var plotLegendData = this.getAdditionalPlotLegend(plotType);
+        var plotLegendData = this.getAdditionalPlotLegend(plotType, false);
         if (Ext4.isArray(this.legendData)) {
             plotLegendData = plotLegendData.concat(this.legendData);
         }

--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -736,6 +736,10 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
             hideSDLines: true
         };
 
+
+        if (plotType === 'Levey-Jennings') {
+            trendLineProps.showBoundLines = false;
+        }
         Ext4.apply(trendLineProps, this.getPlotTypeProperties(combinePlotData, plotType, isCUSUMMean, metricProps));
 
         // Suppress the mean line for multi-series plots

--- a/webapp/TargetedMS/js/QCPlotHelperWrapper.js
+++ b/webapp/TargetedMS/js/QCPlotHelperWrapper.js
@@ -392,13 +392,13 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperWrapper", {
             return this.getLJCombinedPlotLegendSeries();
     },
 
-    getAdditionalPlotLegend: function(plotType) {
+    getAdditionalPlotLegend: function(plotType, combinedPlot) {
         if (plotType === LABKEY.vis.TrendingLinePlotType.CUSUM)
             return this.getCUSUMGroupLegend();
         if (plotType === LABKEY.vis.TrendingLinePlotType.MovingRange)
             return this.getMRLegend();
         if (plotType === LABKEY.vis.TrendingLinePlotType.LeveyJennings)
-            return this.getLJLegend();
+            return this.getLJLegend(combinedPlot);
         if (this.showMeanCUSUMPlot() || this.showVariableCUSUMPlot() ||
                 plotType === LABKEY.vis.TrendingLinePlotType.TrailingMean ||
                 plotType === LABKEY.vis.TrendingLinePlotType.TrailingCV)


### PR DESCRIPTION
#### Rationale
Hide upper bound and lower bound legends on fixed value cutoff for 'percent of mean' and 'standard deviation' yAxis scale

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
