### PR TITLE
Issue 50927 - Add apply button to peptide summary custom date range

### DIFF
--- a/resources/views/peptideSummary.html
+++ b/resources/views/peptideSummary.html
@@ -71,6 +71,7 @@
     <input type="date" id="ps-start-date">
     <label for="ps-end-date">End Date:</label>
     <input type="date" id="ps-end-date">
+    <button id="apply-button">Apply</button>
 </div>
 
 <div class="legend-container">
@@ -384,6 +385,7 @@
         const datePickerContainer = document.getElementById('date-picker-container');
         const startDateInput = document.getElementById('ps-start-date');
         const endDateInput = document.getElementById('ps-end-date');
+        const applyButton = document.getElementById('apply-button');
 
         dateRangeSelect.addEventListener('change', function () {
             if (dateRangeSelect.value === '-1') {  // Custom range selected
@@ -402,11 +404,7 @@
             persistDateRange(parseInt(dateRangeSelect.value));
         });
 
-        startDateInput.addEventListener('change', function () {
-            customDateRange();
-        });
-
-        endDateInput.addEventListener('change', function () {
+        applyButton.addEventListener('click', function () {
             customDateRange();
         });
 

--- a/test/src/org/labkey/test/components/targetedms/PeptideSummaryWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/PeptideSummaryWebPart.java
@@ -50,6 +50,14 @@ public class PeptideSummaryWebPart extends BodyWebPart<PeptideSummaryWebPart.Ele
         return this;
     }
 
+    public PeptideSummaryWebPart apply()
+    {
+        doAndWaitForElementToRefresh(() -> elementCache().applyButton.findElement(this).click(),
+                elementCache().heatmapLoc, getWrapper().defaultWaitForPage);
+
+        return this;
+    }
+
     public PeptideSummaryWebPart setCustomDateRange(String startDate, String endDate)
     {
         elementCache().dateRange.selectByVisibleText(HeatmapDateRange.Custom_Range.getLabel());
@@ -125,6 +133,7 @@ public class PeptideSummaryWebPart extends BodyWebPart<PeptideSummaryWebPart.Ele
         final Input startDate = new Input(Locator.id("ps-start-date").findWhenNeeded(this), getDriver());
         final Input endDate = new Input(Locator.id("ps-end-date").findWhenNeeded(this), getDriver());
         final Locator heatmapLoc = Locator.id("heatmap-table");
+        final Locator applyButton = Locator.id("apply-button");
         final Table heatmapTable = new Table(getDriver(), heatmapLoc.refindWhenNeeded(this));
         final WebElement replicateCount = Locator.id("total-replicates").findWhenNeeded(this);
     }

--- a/test/src/org/labkey/test/components/targetedms/PeptideSummaryWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/PeptideSummaryWebPart.java
@@ -44,9 +44,7 @@ public class PeptideSummaryWebPart extends BodyWebPart<PeptideSummaryWebPart.Ele
 
     public PeptideSummaryWebPart setEndDate(String value)
     {
-        doAndWaitForElementToRefresh(() -> elementCache().endDate.set(value),
-                elementCache().heatmapLoc, getWrapper().defaultWaitForPage);
-
+        elementCache().endDate.set(value);
         return this;
     }
 
@@ -61,10 +59,8 @@ public class PeptideSummaryWebPart extends BodyWebPart<PeptideSummaryWebPart.Ele
     public PeptideSummaryWebPart setCustomDateRange(String startDate, String endDate)
     {
         elementCache().dateRange.selectByVisibleText(HeatmapDateRange.Custom_Range.getLabel());
-        doAndWaitForTableUpdate(() -> {
-            setStartDate(startDate);
-            setEndDate(endDate);
-        });
+        setStartDate(startDate);
+        setEndDate(endDate);
         return this;
     }
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSPeptideSummaryHeatmapTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSPeptideSummaryHeatmapTest.java
@@ -79,6 +79,7 @@ public class TargetedMSPeptideSummaryHeatmapTest extends TargetedMSTest
 
         log("Verify Custom date range");
         peptideSummaryHeatMap.setCustomDateRange("2013-08-01", "2013-08-15");
+        log("hitting apply button");
         peptideSummaryHeatMap.apply();
         Assert.assertEquals("Incorrect outlier count for " + QCPlotsWebPart.MetricType.PRECURSOR_AREA, "11",
                 peptideSummaryHeatMap.getCellElement(1, QCPlotsWebPart.MetricType.PRECURSOR_AREA).getText());

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSPeptideSummaryHeatmapTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSPeptideSummaryHeatmapTest.java
@@ -78,7 +78,8 @@ public class TargetedMSPeptideSummaryHeatmapTest extends TargetedMSTest
                 peptideSummaryHeatMap.getCellElement(1, QCPlotsWebPart.MetricType.FWHM).getCssValue("background-color"));
 
         log("Verify Custom date range");
-        peptideSummaryHeatMap.setCustomDateRange("2013-08-01","2013-08-15");
+        peptideSummaryHeatMap.setCustomDateRange("2013-08-01", "2013-08-15");
+        peptideSummaryHeatMap.apply();
         Assert.assertEquals("Incorrect outlier count for " + QCPlotsWebPart.MetricType.PRECURSOR_AREA, "11",
                 peptideSummaryHeatMap.getCellElement(1, QCPlotsWebPart.MetricType.PRECURSOR_AREA).getText());
     }


### PR DESCRIPTION
#### Rationale
Each keystroke in peptide summary's custom date range selection fires a query to the server which is expensive. This PR adds an 'Apply' button next to the date range selections.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
