### PR TITLE
Fix intermittent failure while hovering over replicate summary link

### DIFF
--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCConfigureMetricTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCConfigureMetricTest.java
@@ -178,13 +178,14 @@ public class TargetedMSQCConfigureMetricTest extends TargetedMSPremiumTest
         qcSummaryWebPart = new QCSummaryWebPart(getDriver());
         scrollIntoView(Locator.tagContainingText("div", replicate));
         mouseOver(Locator.tagContainingText("div", replicate));
+        mouseOver(Locator.tagContainingText("div", replicate));
         waitForElement(qcSummaryWebPart.getBubble());
         WebElement bubbleContentEl = qcSummaryWebPart.getBubbleContent().findElement(getDriver());
         waitFor(()-> !bubbleContentEl.getText().isEmpty(), WAIT_FOR_PAGE);
         String bubbleContent = bubbleContentEl.getText();
         log("Bubble content " + bubbleContent);
-        Assert.assertTrue("Outlier count for metric " + metricType + "is not correct",
-                        Pattern.compile(Pattern.quote(metricType + " " + count), Pattern.CASE_INSENSITIVE).matcher(bubbleContent).find());
+        checker().verifyTrue("Outlier count for metric " + metricType + " is not correct",
+                Pattern.compile(Pattern.quote(metricType + " " + count), Pattern.CASE_INSENSITIVE).matcher(bubbleContent).find());
         mouseOver(Locator.css(".labkey-page-nav")); //to close the bubble.
     }
 


### PR DESCRIPTION
#### Rationale
Due to the addition of peptide summary webpart on qc summary history page, the replicate summary webpart is pushed all the way down at the bottom that is causing the treatmentOrderButtons to fail as it hovers over the replicate summary hopscotch bubble. The change here makes sure it scrolls down properly.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
