### PR TITLE
Adding wait before selecting the metric type while configuring them.

### DIFF
--- a/test/src/org/labkey/test/components/targetedms/ClustergrammerDialog.java
+++ b/test/src/org/labkey/test/components/targetedms/ClustergrammerDialog.java
@@ -95,7 +95,7 @@ public class ClustergrammerDialog extends Window<ClustergrammerDialog.ElementCac
 
         public void clickYes()
         {
-            clickButton("Yes", 30000);
+            clickButton("Yes", 60000);
         }
 
         public void clickNo()

--- a/test/src/org/labkey/test/pages/panoramapremium/ConfigureMetricsUIPage.java
+++ b/test/src/org/labkey/test/pages/panoramapremium/ConfigureMetricsUIPage.java
@@ -1,6 +1,5 @@
 package org.labkey.test.pages.panoramapremium;
 
-import org.apache.xmlbeans.impl.xb.xsdschema.FieldDocument;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.labkey.test.BaseWebDriverTest;
@@ -10,11 +9,167 @@ import org.labkey.test.components.targetedms.QCPlotsWebPart;
 import org.labkey.test.pages.PortalBodyPanel;
 import org.labkey.test.util.Ext4Helper;
 import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.util.Map;
 
 public class ConfigureMetricsUIPage extends PortalBodyPanel
 {
+    public ConfigureMetricsUIPage(BaseWebDriverTest test)
+    {
+        super(test.getDriver());
+    }
+
+    public ConfigureMetricsUIPage setLeveyJennings(String metric, @Nullable String lowerBound, @Nullable String upperBound)
+    {
+        selectOptionByText(Locator.name(metric), "Levey-Jennings (+/- standard deviations)");
+        if (lowerBound != null)
+            setFormElement(Locator.name(metric + "-lower"), lowerBound);
+        if (upperBound != null)
+            setFormElement(Locator.name(metric + "-upper"), upperBound);
+        return this;
+    }
+
+    public ConfigureMetricsUIPage disableMetric(QCPlotsWebPart.MetricType metricType)
+    {
+        waitForMetricToAppear(metricType);
+        selectOptionByText(Locator.name(metricType.toString()), "Disabled, completely hide the metric");
+        return this;
+    }
+
+    public ConfigureMetricsUIPage disableMetric(String metric)
+    {
+        selectOptionByText(waitForElement(Locator.name(metric)), "Disabled, completely hide the metric");
+        return this;
+    }
+
+    public ConfigureMetricsUIPage setFixedDeviationFromMean(QCPlotsWebPart.MetricType metric, @Nullable String lowerBound, @Nullable String upperBound)
+    {
+        waitForMetricToAppear(metric);
+        selectOptionByText(Locator.name(metric.toString()), "Fixed deviation from mean");
+        if (lowerBound != null)
+            setFormElement(Locator.name(metric + "-lower"), lowerBound);
+        if (upperBound != null)
+            setFormElement(Locator.name(metric + "-upper"), upperBound);
+        return this;
+    }
+
+    public ConfigureMetricsUIPage setFixedValueCutOff(QCPlotsWebPart.MetricType metric, @Nullable String lowerBound, @Nullable String upperBound)
+    {
+        waitForMetricToAppear(metric);
+        selectOptionByText(Locator.name(metric.toString()), "Fixed value cutoff");
+        if (lowerBound != null)
+            setFormElement(Locator.name(metric + "-lower"), lowerBound);
+        if (upperBound != null)
+            setFormElement(Locator.name(metric + "-upper"), upperBound);
+        return this;
+    }
+
+    public ConfigureMetricsUIPage setShowMetricNoOutlier(QCPlotsWebPart.MetricType metric)
+    {
+        waitForMetricToAppear(metric);
+        selectOptionByText(Locator.name(metric.toString()), "Show metric in plots, but don't identify outliers");
+        return this;
+    }
+
+    public void waitForMetricToAppear(QCPlotsWebPart.MetricType metric)
+    {
+        shortWait().until(ExpectedConditions.visibilityOf(Locator.name(metric.toString()).findElement(getDriver())));
+    }
+
+    public String getLowerBound(String metric)
+    {
+        return Locator.name(metric + "-lower").findElement(getDriver()).getText();
+    }
+
+    public String getUpperBound(String metric)
+    {
+        return Locator.name(metric + "-upper").findElement(getDriver()).getText();
+    }
+
+    public void verifyNoDataForMetric(String metricName)
+    {
+        Assert.assertEquals("Data should not be present for this metric - " + metricName, getText(Locator.id(metricName)), "No data in this folder");
+    }
+
+    public void clickSave()
+    {
+        clickAndWait(Locator.buttonContainingText("Save"));
+    }
+
+    public String clickSaveExpectingError()
+    {
+        Locator.buttonContainingText("Save").findElement(getDriver()).click();
+        Locator.XPathLocator errorMsgId = Locator.id("qcMetricsError");
+        waitForElement(errorMsgId);
+        waitFor(() -> !errorMsgId.findElement(getDriver()).getText().isEmpty(), WAIT_FOR_PAGE);
+        return errorMsgId.findElement(getDriver()).getText();
+    }
+
+    public void addNewCustomMetric(Map<CustomMetricProperties, String> metricProperties)
+    {
+        click(Locator.tagWithText("button", "Add New Custom Metric"));
+        waitForElement(Ext4Helper.Locators.window("Add New Metric"));
+        Window<?> metricWindow = new Window.WindowFinder(getDriver()).withTitle("Add New Metric").waitFor();
+        editCustomMetricValues(metricWindow, metricProperties);
+    }
+
+    public void addNewTraceMetric(Map<TraceMetricProperties, String> traceProperties)
+    {
+        click(Locator.tagWithText("button", "Add New Trace Metric"));
+        waitForElement(Ext4Helper.Locators.window("Add New Trace Metric"));
+        Window<?> metricWindow = new Window.WindowFinder(getDriver()).withTitle("Add New Trace Metric").waitFor();
+        editTraceMetricValues(metricWindow, traceProperties);
+    }
+
+    public void editMetric(String metric, Map<CustomMetricProperties, String> metricProperties)
+    {
+        waitAndClick(Locator.linkWithText(metric));
+        waitForElement(Ext4Helper.Locators.window("Edit Metric"));
+        Window<?> metricWindow = new Window.WindowFinder(getDriver()).withTitle("Edit Metric").waitFor();
+        editCustomMetricValues(metricWindow, metricProperties);
+    }
+
+    private void editCustomMetricValues(Window<?> metricWindow, Map<CustomMetricProperties, String> metricProperties)
+    {
+        metricProperties.forEach((prop, val) -> {
+            if (!prop.isSelect)
+            {
+                setFormElement(Locator.name(prop.name()), val);
+            }
+            else
+            {
+                String label = prop.formLabel;
+                //adding waits does not help here, however it passes in catch block
+                try
+                {
+                    _ext4Helper.selectComboBoxItem(label, val);
+                }
+                catch (NoSuchElementException e)
+                {
+                    _ext4Helper.selectComboBoxItem(label, val);
+                }
+            }
+        });
+        clickAndWait(Ext4Helper.Locators.ext4Button("Save").findElement(metricWindow));
+    }
+
+    private void editTraceMetricValues(Window<?> metricWindow, Map<TraceMetricProperties, String> metricProperties)
+    {
+        metricProperties.forEach((prop, val) -> {
+            if (!prop.isSelect)
+            {
+                setFormElement(Locator.name(prop.name()), val);
+            }
+            else
+            {
+                _ext4Helper.selectComboBoxItem(prop.formLabel, val);
+            }
+        });
+        clickAndWait(Ext4Helper.Locators.ext4Button("Save").findElement(metricWindow));
+        waitForText("QC Plots");
+    }
+
     public enum MetricType
     {
         Precursor,
@@ -60,145 +215,6 @@ public class ConfigureMetricsUIPage extends PortalBodyPanel
             this.formLabel = formLabel + ":";
             this.isSelect = isSelect;
         }
-    }
-
-    public ConfigureMetricsUIPage(BaseWebDriverTest test)
-    {
-        super(test.getDriver());
-    }
-
-    public ConfigureMetricsUIPage setLeveyJennings(String metric, @Nullable String lowerBound, @Nullable String upperBound)
-    {
-        selectOptionByText(Locator.name(metric), "Levey-Jennings (+/- standard deviations)");
-        if (lowerBound != null)
-            setFormElement(Locator.name(metric + "-lower"), lowerBound);
-        if (upperBound != null)
-            setFormElement(Locator.name(metric + "-upper"), upperBound);
-        return this;
-    }
-
-    public ConfigureMetricsUIPage disableMetric(String metric)
-    {
-        selectOptionByText(Locator.name(metric), "Disabled, completely hide the metric");
-        return this;
-    }
-
-    public ConfigureMetricsUIPage setFixedDeviationFromMean(QCPlotsWebPart.MetricType metric, @Nullable String lowerBound, @Nullable String upperBound)
-    {
-        selectOptionByText(Locator.name(metric.toString()), "Fixed deviation from mean");
-        if (lowerBound != null)
-            setFormElement(Locator.name(metric + "-lower"), lowerBound);
-        if (upperBound != null)
-            setFormElement(Locator.name(metric + "-upper"), upperBound);
-        return this;
-    }
-
-    public ConfigureMetricsUIPage setFixedValueCutOff(QCPlotsWebPart.MetricType metric, @Nullable String lowerBound, @Nullable String upperBound)
-    {
-        selectOptionByText(Locator.name(metric.toString()), "Fixed value cutoff");
-        if (lowerBound != null)
-            setFormElement(Locator.name(metric + "-lower"), lowerBound);
-        if (upperBound != null)
-            setFormElement(Locator.name(metric + "-upper"), upperBound);
-        return this;
-    }
-
-    public ConfigureMetricsUIPage setShowMetricNoOutlier(QCPlotsWebPart.MetricType metric)
-    {
-        selectOptionByText(Locator.name(metric.toString()), "Show metric in plots, but don't identify outliers");
-        return this;
-    }
-
-    public String getLowerBound(String metric)
-    {
-        return Locator.name(metric + "-lower").findElement(getDriver()).getText();
-    }
-    public String getUpperBound(String metric)
-    {
-        return Locator.name(metric + "-upper").findElement(getDriver()).getText();
-    }
-
-    public void verifyNoDataForMetric(String metricName)
-    {
-        Assert.assertEquals("Data should not be present for this metric - " + metricName, getText(Locator.id(metricName)), "No data in this folder");
-    }
-
-    public void clickSave()
-    {
-        clickAndWait(Locator.buttonContainingText("Save"));
-    }
-
-    public String clickSaveExpectingError()
-    {
-        Locator.buttonContainingText("Save").findElement(getDriver()).click();
-        Locator.XPathLocator errorMsgId = Locator.id("qcMetricsError");
-        waitForElement(errorMsgId);
-        waitFor(() -> !errorMsgId.findElement(getDriver()).getText().isEmpty() , WAIT_FOR_PAGE);
-        return errorMsgId.findElement(getDriver()).getText();
-    }
-
-    public void addNewCustomMetric(Map<CustomMetricProperties, String> metricProperties)
-    {
-        click(Locator.tagWithText("button", "Add New Custom Metric"));
-        waitForElement(Ext4Helper.Locators.window("Add New Metric"));
-        Window<?> metricWindow = new Window.WindowFinder(getDriver()).withTitle("Add New Metric").waitFor();
-        editCustomMetricValues(metricWindow, metricProperties);
-    }
-
-    public void addNewTraceMetric(Map<TraceMetricProperties, String> traceProperties)
-    {
-        click(Locator.tagWithText("button", "Add New Trace Metric"));
-        waitForElement(Ext4Helper.Locators.window("Add New Trace Metric"));
-        Window<?> metricWindow = new Window.WindowFinder(getDriver()).withTitle("Add New Trace Metric").waitFor();
-        editTraceMetricValues(metricWindow, traceProperties);
-    }
-
-    public void editMetric(String metric, Map<CustomMetricProperties, String> metricProperties)
-    {
-        waitAndClick(Locator.linkWithText(metric));
-        waitForElement(Ext4Helper.Locators.window("Edit Metric"));
-        Window<?> metricWindow = new Window.WindowFinder(getDriver()).withTitle("Edit Metric").waitFor();
-        editCustomMetricValues(metricWindow, metricProperties);
-    }
-
-    private void editCustomMetricValues(Window<?> metricWindow, Map<CustomMetricProperties, String> metricProperties)
-    {
-        metricProperties.forEach((prop, val) -> {
-            if(!prop.isSelect)
-            {
-                setFormElement(Locator.name(prop.name()), val);
-            }
-            else
-            {
-                String label = prop.formLabel;
-                //adding waits does not help here, however it passes in catch block
-                try
-                {
-                    _ext4Helper.selectComboBoxItem(label, val);
-                }
-                catch (NoSuchElementException e)
-                {
-                    _ext4Helper.selectComboBoxItem(label, val);
-                }
-            }
-        });
-        clickAndWait(Ext4Helper.Locators.ext4Button("Save").findElement(metricWindow));
-    }
-
-    private void editTraceMetricValues(Window<?> metricWindow, Map<TraceMetricProperties, String> metricProperties)
-    {
-        metricProperties.forEach((prop, val) -> {
-            if(!prop.isSelect)
-            {
-                setFormElement(Locator.name(prop.name()), val);
-            }
-            else
-            {
-                _ext4Helper.selectComboBoxItem(prop.formLabel, val);
-            }
-        });
-        clickAndWait(Ext4Helper.Locators.ext4Button("Save").findElement(metricWindow));
-        waitForText("QC Plots");
     }
 
 }

--- a/test/src/org/labkey/test/tests/panoramapremium/TargetedMSQCPremiumTest.java
+++ b/test/src/org/labkey/test/tests/panoramapremium/TargetedMSQCPremiumTest.java
@@ -83,18 +83,18 @@ public class TargetedMSQCPremiumTest extends TargetedMSPremiumTest
     @Test
     public void testConfigureQCMetrics()
     {
-        String metric = QCPlotsWebPart.MetricType.TOTAL_PEAK.toString();
+        QCPlotsWebPart.MetricType metric = QCPlotsWebPart.MetricType.TOTAL_PEAK;
         ConfigureMetricsUIPage configureUI = goToConfigureMetricsUI();
         configureUI.disableMetric(metric);
         configureUI.clickSave();
 
         PanoramaDashboard qcDashboard = new PanoramaDashboard(this);
         QCPlotsWebPart qcPlotsWebPart = qcDashboard.getQcPlotsWebPart();
-        verifyMetricNotPresent(qcPlotsWebPart, metric);
+        verifyMetricNotPresent(qcPlotsWebPart, metric.toString());
 
         //re-enabling peak area metric
         goToConfigureMetricsUI();
-        configureUI.setLeveyJennings(metric, null, null);
+        configureUI.setLeveyJennings(metric.toString(), null, null);
         clickAndWait(Locator.buttonContainingText("Save"));
         impersonate(USER);
         log("Verifying Configure QC Metrics Menu option not present for non admin");


### PR DESCRIPTION
#### Rationale
Adding wait before selecting the metric type while configuring them.

Example of error [Teamcity error ](https://teamcity.labkey.org/buildConfiguration/LabKey_247Release_External_Panorama_PanoramaBSqlserver/3168036?hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildChangesSection=true&expandBuildDeploymentsSection=false&expandBuildTestsSection=true)

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
