### PR TITLE
Ticket 50070: Slow query on the Early Stage PTM report

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSSchema.java
+++ b/src/org/labkey/targetedms/TargetedMSSchema.java
@@ -1592,6 +1592,7 @@ public class TargetedMSSchema extends UserSchema
                 result.getMutableColumnOrThrow("DataId").setFk(QueryForeignKey.from(_expSchema, cf).to(ExpSchema.TableType.Data.name(), null, null));
                 result.getMutableColumnOrThrow("Owner").setFk(new UserIdQueryForeignKey(this, true));
                 result.getMutableColumnOrThrow("SkydDataId").setFk(QueryForeignKey.from(_expSchema, cf).to(ExpSchema.TableType.Data.name(), null, null));
+                result.getMutableColumnOrThrow("ExperimentRunLSID").setFk(QueryForeignKey.from(_expSchema, cf).to("Runs", "LSID", null));
             }
             TargetedMSTable.fixupLookups(result);
             return result;


### PR DESCRIPTION
#### Rationale
This query (and the pivot queries that build on it) can be very slow. In my testing this change is 10x faster.

#### Changes
* Use a CTE so that the database doesn't need to fetch the same underlying data multiple times
* Wire up a lookup for convenience