### PR TITLE
Test updates for Firefox 128

### DIFF
--- a/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
@@ -26,6 +26,7 @@ import org.labkey.test.components.ext4.Window;
 import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
+import org.labkey.test.util.selenium.ScrollUtils;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -46,6 +47,7 @@ import java.util.stream.Collectors;
 import static org.junit.Assert.assertEquals;
 import static org.labkey.test.BaseWebDriverTest.WAIT_FOR_JAVASCRIPT;
 import static org.labkey.test.components.ext4.Window.Window;
+import static org.labkey.test.util.selenium.ScrollUtils.Alignment.center;
 
 public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
 {
@@ -432,7 +434,7 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
         getWrapper().shortWait().ignoring(StaleElementReferenceException.class).withMessage("Exclusion pop-up for Acquired Date = " + acquiredDate)
                 .until(input -> {
                     WebElement point = getPointByAcquiredDate(acquiredDate);
-                    getWrapper().scrollToMiddle(point);
+                    ScrollUtils.scrollIntoView(point, center, center);
                     getWrapper().mouseOverWithoutScrolling(point);
                     return getWrapper().isElementPresent(Locator.tagWithClass("div", "x4-form-display-field")
                             .containing(acquiredDate.substring(0, 16))); // drop seconds part (e.g. "2013-08-12 04:54") for trailing mean/CV

--- a/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
@@ -434,7 +434,8 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
                     WebElement point = getPointByAcquiredDate(acquiredDate);
                     getWrapper().scrollToMiddle(point);
                     getWrapper().mouseOverWithoutScrolling(point);
-                    return getWrapper().isElementPresent(Locator.tagWithClass("div", "x4-form-display-field").withText(acquiredDate));
+                    return getWrapper().isElementPresent(Locator.tagWithClass("div", "x4-form-display-field")
+                            .containing(acquiredDate.substring(0, 16))); // drop seconds part (e.g. "2013-08-12 04:54") for trailing mean/CV
                 });
         return elementCache().hopscotchBubble.findElement(getDriver());
     }

--- a/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
@@ -30,7 +30,6 @@ import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
-import org.openqa.selenium.interactions.MoveTargetOutOfBoundsException;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
@@ -430,10 +429,11 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
 
     public WebElement openExclusionBubble(String acquiredDate)
     {
-        getWrapper().shortWait().ignoring(StaleElementReferenceException.class, MoveTargetOutOfBoundsException.class)
-                .withMessage("Exclusion pop-up for Acquired Date = " + acquiredDate)
+        getWrapper().shortWait().ignoring(StaleElementReferenceException.class).withMessage("Exclusion pop-up for Acquired Date = " + acquiredDate)
                 .until(input -> {
-                    getWrapper().mouseOver(getPointByAcquiredDate(acquiredDate));
+                    WebElement point = getPointByAcquiredDate(acquiredDate);
+                    getWrapper().scrollToMiddle(point);
+                    getWrapper().mouseOverWithoutScrolling(point);
                     return getWrapper().isElementPresent(Locator.tagWithClass("div", "x4-form-display-field").withText(acquiredDate));
                 });
         return elementCache().hopscotchBubble.findElement(getDriver());
@@ -476,7 +476,7 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
             xEndOffset = (Integer.parseInt(endPoint.getAttribute("width")) / 2) - 1;
         }
 
-        getWrapper().scrollIntoView(startPoint);
+        getWrapper().scrollIntoView(startPoint, true);
 
         Actions builder = new Actions(getWrapper().getDriver());
 

--- a/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
@@ -30,6 +30,7 @@ import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.interactions.MoveTargetOutOfBoundsException;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
@@ -429,7 +430,8 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
 
     public WebElement openExclusionBubble(String acquiredDate)
     {
-        getWrapper().shortWait().ignoring(StaleElementReferenceException.class).withMessage("Exclusion pop-up for Acquired Date = " + acquiredDate)
+        getWrapper().shortWait().ignoring(StaleElementReferenceException.class, MoveTargetOutOfBoundsException.class)
+                .withMessage("Exclusion pop-up for Acquired Date = " + acquiredDate)
                 .until(input -> {
                     getWrapper().mouseOver(getPointByAcquiredDate(acquiredDate));
                     return getWrapper().isElementPresent(Locator.tagWithClass("div", "x4-form-display-field").withText(acquiredDate));

--- a/test/src/org/labkey/test/tests/panoramapremium/TargetedMSQCPremiumTest.java
+++ b/test/src/org/labkey/test/tests/panoramapremium/TargetedMSQCPremiumTest.java
@@ -229,8 +229,7 @@ public class TargetedMSQCPremiumTest extends TargetedMSPremiumTest
         String pressurePlotSVGText = qcPlotsWebPart.getSVGPlotText("precursorPlot0");
         assertFalse("Pressure trace plot is not present", pressurePlotSVGText.isEmpty());
         assertTrue("Y axis label is not correct or present", pressurePlotSVGText.contains(yAxisLabel));
-        mouseOver(qcPlotsWebPart.getPointByAcquiredDate("2009-11-03 19:37:28"));
-        waitForElement(qcPlotsWebPart.getBubble());
+        qcPlotsWebPart.openExclusionBubble("2009-11-03 19:37:28");
         String pressureTracehoverText = waitForElementToBeVisible(qcPlotsWebPart.getBubbleContent()).getText();
         Assertions.assertThat(pressureTracehoverText).as("Tooltip value").contains("7.363");
 

--- a/test/src/org/labkey/test/tests/panoramapremium/TargetedMSiRTMetricsTest.java
+++ b/test/src/org/labkey/test/tests/panoramapremium/TargetedMSiRTMetricsTest.java
@@ -91,8 +91,7 @@ public class TargetedMSiRTMetricsTest extends TargetedMSPremiumTest
         String acquiredDate = "2014-03-17 06:46:14";
         qcPlotsWebPart.setMetricType(QCPlotsWebPart.MetricType.IRTCORRELATION);
         checker().verifyEquals("Incorrect plot displayed for iRT Correlation metric", Arrays.asList("iRT Correlation"), qcPlotsWebPart.getPlotTitles());
-        mouseOver(qcPlotsWebPart.getPointByAcquiredDate(acquiredDate));
-        waitForElement(qcPlotsWebPart.getBubble());
+        qcPlotsWebPart.openExclusionBubble(acquiredDate);
         String ticAreaHoverText = waitForElement(qcPlotsWebPart.getBubbleContent()).getText();
         checker().withScreenshot("IRTCorrelation").verifyTrue("Incorrect iRT Correlation value calculated", ticAreaHoverText.contains("0.999"));
         qcPlotsWebPart.closeBubble();
@@ -101,8 +100,7 @@ public class TargetedMSiRTMetricsTest extends TargetedMSPremiumTest
         acquiredDate = "2014-03-16 05:21:58";
         qcPlotsWebPart.setMetricType(QCPlotsWebPart.MetricType.IRTINTERCEPT);
         checker().verifyEquals("Incorrect plot displayed for iRT Intercept metric", Arrays.asList("iRT Intercept"), qcPlotsWebPart.getPlotTitles());
-        mouseOver(qcPlotsWebPart.getPointByAcquiredDate(acquiredDate));
-        waitForElement(qcPlotsWebPart.getBubble());
+        qcPlotsWebPart.openExclusionBubble(acquiredDate);
         ticAreaHoverText = waitForElement(qcPlotsWebPart.getBubbleContent()).getText();
         checker().withScreenshot("IRTIntercept").verifyTrue("Incorrect  iRT Intercept value calculated", ticAreaHoverText.contains("34.2"));
         qcPlotsWebPart.closeBubble();
@@ -111,7 +109,7 @@ public class TargetedMSiRTMetricsTest extends TargetedMSPremiumTest
         acquiredDate = "2014-03-17 06:46:14";
         qcPlotsWebPart.setMetricType(QCPlotsWebPart.MetricType.IRTSLOPE);
         checker().verifyEquals("Incorrect plot displayed for iRT Slope metric", Arrays.asList("iRT Slope"), qcPlotsWebPart.getPlotTitles());
-        mouseOver(qcPlotsWebPart.getPointByAcquiredDate(acquiredDate));
+        qcPlotsWebPart.openExclusionBubble(acquiredDate);
         waitForElement(qcPlotsWebPart.getBubble());
         ticAreaHoverText = waitForElement(qcPlotsWebPart.getBubbleContent()).getText();
         checker().withScreenshot("IRTSlope").verifyTrue("Incorrect iRT Slope value calculated", ticAreaHoverText.contains("0.646"));

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentTest.java
@@ -45,7 +45,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -767,11 +766,11 @@ public class TargetedMSExperimentTest extends TargetedMSTest
                 "M+2 758.0285",
                 "x25 657.6403",
                 "a22 786.8611",
-                "z\u20222",  "272.1843", // z.2
-                "z\u202213", "387.5359", // z.13
-                "z\u202212", "355.1850", // z.12
-                "z\u20329",  "251.4732", // z'9
-                "z\u20321",  "54.0409" // z'1
+                "z\u20222",  "272.1843", // z•2
+                "z\u202213", "387.5359", // z•13
+                "z\u202212", "355.1850", // z•12
+                "z\u20329",  "251.4732", // z′9
+                "z\u20321",  "54.0409" // z′1
         );
         assertTextPresentInThisOrder(new TextSearcher(nestedTableText), expectedIons.toArray(new String[0]));
 
@@ -784,14 +783,14 @@ public class TargetedMSExperimentTest extends TargetedMSTest
                 "z\u20222 - 272.1843+", "z\u202213 - 387.5359+++", "z\u202212 - 355.1850+++",
                 "z\u20329 - 251.4732+++", "z\u20321 - 54.0409+++");
 
-        List<WebElement> svgElements = Locator.css("svg g text").findElements(getDriver());
+        List<WebElement> svgElements = Locator.css("svg g text").waitForElements(getDriver(), WAIT_FOR_JAVASCRIPT);
         Set<String> svgTexts = new HashSet<>();
         for (WebElement el: svgElements)
         {
             svgTexts.add(el.getText());
         }
-        List<String> missing = expectedLegendTexts.stream().filter(l -> !svgTexts.contains(l)).collect(Collectors.toList());
+        List<String> missing = expectedLegendTexts.stream().filter(l -> !svgTexts.contains(l)).toList();
 
-        assertTrue("Missing legend items in chromatogram plot - " + missing, missing.size() == 0);
+        assertTrue("Missing legend items in chromatogram plot - " + missing, missing.isEmpty());
     }
 }

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSProteinGroupingTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSProteinGroupingTest.java
@@ -67,7 +67,7 @@ public class TargetedMSProteinGroupingTest extends TargetedMSTest
         checker().verifyEquals("Incorrect number of peptides imported", 1, peptideTable.getDataRowCount());
         CustomizeView customizeView = peptideTable.openCustomizeGrid();
         customizeView.addColumn("PeptideGroupId");
-        customizeView.clickViewGrid();
+        customizeView.applyCustomView();
         peptideTable = new DataRegionTable.DataRegionFinder(getDriver()).withName("Peptides").waitFor();
         checker().verifyEquals("Incorrect group for the protein", group, peptideTable.getDataAsText(0, "PeptideGroupId"));
     }

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -228,8 +228,7 @@ public class TargetedMSQCTest extends TargetedMSTest
         PanoramaDashboard qcDashboard = new PanoramaDashboard(this);
         QCPlotsWebPart qcPlotsWebPart = qcDashboard.getQcPlotsWebPart();
         scrollIntoView(Locator.tagWithText("span","FFVAPFPEVFGK ++, 692.8686"));
-        mouseOver(qcPlotsWebPart.getPointByAcquiredDate(date));
-        waitForElement(qcPlotsWebPart.getBubble());
+        qcPlotsWebPart.openExclusionBubble(date);
         clickAndWait(Locator.linkWithText("view chromatogram"));
         assertTrue("Navigated to incorrect replicate", isTextPresent(replicate));
         assertTrue("Plot is not highlighted", Locator.tagWithAttribute("div", "alt", "Chromatogram " + replicate).findElement(getDriver()).getAttribute("style").contains(" solid beige"));
@@ -690,8 +689,7 @@ public class TargetedMSQCTest extends TargetedMSTest
         log("Verifying tic_area information in hover plot");
         qcPlotsWebPart.setMetricType(QCPlotsWebPart.MetricType.TICAREA);
         qcPlotsWebPart.waitForPlots(1);
-        mouseOver(qcPlotsWebPart.getPointByAcquiredDate(acquiredDate));
-        waitForElement(qcPlotsWebPart.getBubble());
+        qcPlotsWebPart.openExclusionBubble(acquiredDate);
         String ticAreahoverText = waitForElement(qcPlotsWebPart.getBubbleContent()).getText();
         assertTrue("Wrong header present", ticAreahoverText.contains("Total Ion Chromatogram Area"));
         assertTrue("Wrong Link present", ticAreahoverText.contains("VIEW DOCUMENT"));

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSTrailingMeanAndCVTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSTrailingMeanAndCVTest.java
@@ -91,7 +91,7 @@ public class TargetedMSTrailingMeanAndCVTest extends TargetedMSTest
 
         log("Verifying tooltips");
         qcPlotsWebPart.waitForPlots(7);
-        mouseOver(qcPlotsWebPart.getPointByAcquiredDate("2013-08-12 04:54:55"));
+        qcPlotsWebPart.openExclusionBubble("2013-08-12 04:54:55");
         String toolTipText = waitForElement(qcPlotsWebPart.getBubbleContent()).getText();
         Assert.assertEquals("Invalid tooltip", "Peptide:\n" +
                 "ATEEQLK ++, 409.7163\n" +
@@ -112,7 +112,7 @@ public class TargetedMSTrailingMeanAndCVTest extends TargetedMSTest
         dashboard = new PanoramaDashboard(this);
         qcPlotsWebPart = dashboard.getQcPlotsWebPart();
         qcPlotsWebPart.setQCPlotTypes(QCPlotsWebPart.QCPlotType.TrailingMean);
-        mouseOver(qcPlotsWebPart.getPointByAcquiredDate("2013-08-14 00:44:46"));
+        qcPlotsWebPart.openExclusionBubble("2013-08-14 00:44:46");
         toolTipText = waitForElement(qcPlotsWebPart.getBubbleContent()).getText();
         Assert.assertEquals("Invalid tooltip of the point in guide set", "Peptide:\n" +
                 "ATEEQLK ++, 409.7163\n" +
@@ -156,7 +156,7 @@ public class TargetedMSTrailingMeanAndCVTest extends TargetedMSTest
         qcPlotsWebPart.setTrailingLast(trailingLast);
         log("Verifying tooltips");
         qcPlotsWebPart.waitForPlots(7);
-        mouseOver(qcPlotsWebPart.getPointByAcquiredDate("2013-08-12 04:54:55"));
+        qcPlotsWebPart.openExclusionBubble("2013-08-12 04:54:55");
         String toolTipText = waitForElement(qcPlotsWebPart.getBubbleContent()).getText();
         Assert.assertEquals("Invalid tooltip", "Peptide:\n" +
                 "ATEEQLK ++, 409.7163\n" +
@@ -177,7 +177,7 @@ public class TargetedMSTrailingMeanAndCVTest extends TargetedMSTest
         dashboard = new PanoramaDashboard(this);
         qcPlotsWebPart = dashboard.getQcPlotsWebPart();
         qcPlotsWebPart.setQCPlotTypes(QCPlotsWebPart.QCPlotType.TrailingCV);
-        mouseOver(qcPlotsWebPart.getPointByAcquiredDate("2013-08-21 09:07:36"));
+        qcPlotsWebPart.openExclusionBubble("2013-08-21 09:07:36");
         toolTipText = waitForElement(qcPlotsWebPart.getBubbleContent()).getText();
         Assert.assertEquals("Invalid tooltip of the point in guide set", "Peptide:\n" +
                 "ATEEQLK ++, 409.7163\n" +


### PR DESCRIPTION
#### Rationale
`CustomizeView.clickViewGrid` doesn't wait for the data region to update. `applyCustomView` should be used in most cases.

`scrollIntoView` doesn't seem to scroll svg points correctly, causing `mouseOver` to throw `MoveTargetOutOfBoundsException` when attempting to activate a tooltip.
```
org.openqa.selenium.interactions.MoveTargetOutOfBoundsException: Move target (366, 892) is out of bounds of viewport dimensions (1280, 891)
[...]
  at app//org.labkey.test.WebDriverWrapper.mouseOver(WebDriverWrapper.java:2943)
  at app//org.labkey.test.components.targetedms.QCPlotsWebPart.lambda$16(QCPlotsWebPart.java:434)
  at app//org.openqa.selenium.support.ui.FluentWait.until(FluentWait.java:203)
  at app//org.labkey.test.components.targetedms.QCPlotsWebPart.openExclusionBubble(QCPlotsWebPart.java:433)
  at app//org.labkey.test.tests.targetedms.TargetedMSQCTest.verifyExclusionButtonSelection(TargetedMSQCTest.java:974)
  at app//org.labkey.test.tests.targetedms.TargetedMSQCTest.testQCPlotExclusions(TargetedMSQCTest.java:858)
```

#### Related Pull Requests
* N/A

#### Changes
* Wait for data region update after adding columns
* Scroll SVG point to the middle in `openExclusionBubble`