### PR TITLE
Correct the descriptions for the two different Proportion columns

### DIFF
--- a/resources/schemas/targetedms.xml
+++ b/resources/schemas/targetedms.xml
@@ -391,7 +391,7 @@
             <column columnName="PredictedRetentionTime" />
             <column columnName="ModifiedAreaProportion">
                 <formatString>##0.####%</formatString>
-                <description>(area of precursor in the sample) / (total area of all precursors for the same grouping in the sample)</description>
+                <description>(total area of all precursors associated with this peptide or molecule in the sample) / (total area of all precursors for the same grouping in the sample)</description>
             </column>
         </columns>
     </table>
@@ -587,7 +587,7 @@
             <column columnName="IonMobilityType"/>
             <column columnName="PrecursorModifiedAreaProportion">
                 <formatString>##0.####%</formatString>
-                <description>(sum area of precursors for this peptide in the same sample) / (total area of all precursors for the same grouping in the sample)</description>
+                <description>(area of precursor in the sample) / (total area of all precursors for the same grouping in the sample)</description>
             </column>
             <column columnName="TransitionChromatogramIndices"/>
             <column columnName="TotalAreaMs1" />


### PR DESCRIPTION
#### Rationale
The descriptions for `PrecursorChromInfo.PrecursorModifiedAreaProportion` and `GeneralMoleculeChromInfo.ModifiedAreaProportion` were effectively flipped

#### Changes
* Swap them and use more consistent terms