### PR TITLE
Ticket 50070: Speed up Early Stage PTM report, next round

### DIFF
--- a/resources/queries/targetedms/PTMPercents.sql
+++ b/resources/queries/targetedms/PTMPercents.sql
@@ -7,7 +7,7 @@ SELECT
   Sequence @hidden,
   PreviousAA @hidden,
   NextAA @hidden,
-  SampleName,
+  SampleFileId.SampleName,
   -- Explicitly cast for SQLServer to avoid trying to add as numeric types
   SUBSTRING(Sequence, IndexAA + 1, 1) || CAST(StartIndex + IndexAA + 1 AS VARCHAR) AS SiteLocation,
   SUBSTRING(Sequence, IndexAA + 1, 1) AS AminoAcid,
@@ -15,7 +15,7 @@ SELECT
   PeptideGroupId
 FROM PTMPercentsPrepivot
 GROUP BY
-  SampleName,
+  SampleFileId.SampleName,
   Sequence,
   PreviousAA,
   NextAA,

--- a/resources/queries/targetedms/PTMPercentsGrouped.sql
+++ b/resources/queries/targetedms/PTMPercentsGrouped.sql
@@ -1,7 +1,6 @@
 SELECT
     PeptideGroupId,
-    -- Explicitly cast for SQLServer to avoid trying to add as numeric types
-    AminoAcid || CAST(Location AS VARCHAR) AS SiteLocation,
+    SiteLocation,
     AminoAcid,
     Location,
     PeptideModifiedSequence,
@@ -29,5 +28,6 @@ GROUP BY
     PeptideGroupId,
     AminoAcid,
     Location,
+    SiteLocation,
     Modification
 PIVOT PercentModified, TotalPercentModified BY SampleName

--- a/resources/queries/targetedms/PTMPercentsPrepivot.sql
+++ b/resources/queries/targetedms/PTMPercentsPrepivot.sql
@@ -6,10 +6,11 @@ SELECT ci.ModifiedAreaProportion,
        ci.PeptideId.PreviousAA,
        ci.PeptideId.StartIndex,
        ci.SampleFileId,
-       ci.SampleFileId.SampleName,
        ci.PeptideId.PeptideGroupId,
        psm.IndexAA,
-       psm.StructuralModId
+       psm.StructuralModId,
+       -- Explicitly cast for SQLServer to avoid trying to add as numeric types
+       (SUBSTRING(ci.PeptideId.Sequence, IndexAA + 1, 1)) || CAST(ci.PeptideId.StartIndex + IndexAA + 1 AS VARCHAR) AS SiteLocation
 FROM
      targetedms.GeneralMoleculeChromInfo ci LEFT JOIN
          targetedms.PeptideStructuralModification psm ON ci.PeptideId = psm.PeptideId LEFT JOIN


### PR DESCRIPTION
#### Rationale
The early stage PTM report is still slow for one of our installations.

#### Changes
* Introduce a second CTE to avoid rework
* Change grouping strategy slightly to reduce number of columns involved