### PR TITLE
Issue 50861: Pass around properly encoded WebDav URLs

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -276,6 +276,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -6299,11 +6300,11 @@ public class TargetedMSController extends SpringActionController
 
             if ("skyp".equalsIgnoreCase(form.getView()))
             {
-                String url = data.getWebDavURL(FileContentService.PathType.full);
+                URI url = data.getWebDavURL(FileContentService.PathType.full);
                 if (url != null)
                 {
                     String lineSeparator = "\r\n";
-                    StringBuilder text = new StringBuilder(url);
+                    StringBuilder text = new StringBuilder(url.toString());
                     if (run.getDocumentSize() != null)
                     {
                         text.append(lineSeparator).append("FileSize:").append(run.getDocumentSize()); // Size of the .sky.zip in bytes

--- a/src/org/labkey/targetedms/query/SampleFileTable.java
+++ b/src/org/labkey/targetedms/query/SampleFileTable.java
@@ -68,6 +68,7 @@ import org.labkey.targetedms.parser.SampleFile;
 
 import java.io.IOException;
 import java.io.Writer;
+import java.net.URI;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -368,12 +369,12 @@ public class SampleFileTable extends TargetedMSTable
                         Long dataSize = downloadInfo.getSize();
                         String size = dataSize != null ? FileUtils.byteCountToDisplaySize(dataSize) : "";
                         ExpData expData = downloadInfo.getExpData();
-                        String url = expData.getWebDavURL(FileContentService.PathType.full);
+                        String url = expData.getWebDavURL(FileContentService.PathType.full).toString();
                         if(!downloadInfo.isFile())
                         {
                             int idx = url.lastIndexOf('/');
                             url = idx != -1 ? url.substring(0, idx) : url;
-                            url = url + "?method=zip&depth=-1&file=" + expData.getName() + "&zipName=" + expData.getName();
+                            url = url + "?method=zip&depth=-1&file=" + PageFlowUtil.encode(expData.getName()) + "&zipName=" + PageFlowUtil.encode(expData.getName());
                         }
 
                         out.write(PageFlowUtil.iconLink("fa fa-download", null).href(url).toString());


### PR DESCRIPTION
#### Rationale
We are inconsistently encoding URIs in Strings and passing them around. Many codepaths end up double-encoding and then selectively decoding specific characters.

We can do better by using `URI` on the server and properly encoding throughout.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5961

#### Changes
- Switch to `URI` to make it clear what's being passed around
- Return encoded values in JSON and other responses
