### PR TITLE
Keep track of trace metric index per sample file for unnamed traces

### DIFF
--- a/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
+++ b/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
@@ -3113,7 +3113,7 @@ public class SkylineDocumentParser implements AutoCloseable
         {
             return Collections.emptyList();
         }
-        int traceMetricIndex = 1;
+        Map<String, Integer> traceMetricIndices = new HashMap<>();
         for (ChromGroupHeaderInfo chromatogram : _binaryParser.getChromatograms())
         {
             // Sample-scoped chromatograms have a magic precursor MZ value
@@ -3147,7 +3147,8 @@ public class SkylineDocumentParser implements AutoCloseable
                     {
                         if (chromatogramGroupId.getQcTraceName() == null && chromatogram.getFlagValues().contains(ChromGroupHeaderInfo.FlagValues.extracted_qc_trace))
                         {
-                            info.setTextId("QC Trace " + traceMetricIndex++);
+                            int traceMetricIndex = traceMetricIndices.merge(path, 1, Integer::sum);
+                            info.setTextId("QC Trace " + traceMetricIndex);
                         }
                         else
                         {


### PR DESCRIPTION
#### Rationale
Trace metric index for unnamed traces should be incremented per sample file. Otherwise, we end up with as many unique trace names as there are sample files (times the number of unnamed traces in each sample file). 
