### PR TITLE
Mark modules that support both databases

### DIFF
--- a/module.properties
+++ b/module.properties
@@ -1,1 +1,2 @@
 ModuleClass: org.labkey.targetedms.TargetedMSModule
+SupportedDatabases: mssql, pgsql


### PR DESCRIPTION
#### Rationale
Need to explicitly declare support for SQL Server since we're about to change the default to PostgreSQL-only