### PR TITLE
51889: Include SampleFileId targetedms.PTMPercentsGroupedPrepivot

### DIFF
--- a/resources/queries/targetedms/PTMPercentsGroupedPrepivot.sql
+++ b/resources/queries/targetedms/PTMPercentsGroupedPrepivot.sql
@@ -56,6 +56,7 @@ SELECT
        p1.Sequence @hidden,
        PreviousAA @hidden,
        NextAA @hidden,
+       p1.SampleFileId,
        p1.SampleFileId.SampleName,
        p1.AminoAcid,
        p1.SiteLocation,


### PR DESCRIPTION
#### Rationale
By including `SampleFileId` in the `SELECT` list we can simplify other custom queries that build on `targetedms.PTMPercentsGroupedPrepivot`

#### Changes
* Include `SampleFileId`