### PR TITLE
Add ManageVersion property to all module.properties files

### DIFF
--- a/module.properties
+++ b/module.properties
@@ -1,2 +1,3 @@
 ModuleClass: org.labkey.targetedms.TargetedMSModule
 SupportedDatabases: mssql, pgsql
+ManageVersion: true


### PR DESCRIPTION
#### Rationale
We want every LabKey-managed module to specify the `ManageVersion` property. https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=47369
