### PR TITLE
Migrate <permissionClasses> -> <requiresPermissions>

### DIFF
--- a/resources/views/configureQCGroups.view.xml
+++ b/resources/views/configureQCGroups.view.xml
@@ -1,5 +1,5 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Include or Exclude Precursors">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.UpdatePermission"/>
-    </permissionClasses>
+    </requiresPermissions>
 </view>

--- a/resources/views/configureQCMetric.view.xml
+++ b/resources/views/configureQCMetric.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Configure QC Metrics">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.AdminPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="internal/jQuery"/>
         <dependency path="Ext4"/>

--- a/resources/views/subscribeOutlierNotifications.view.xml
+++ b/resources/views/subscribeOutlierNotifications.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Panorama QC Notifications">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="internal/jQuery"/>
     </dependencies>


### PR DESCRIPTION
#### Rationale
We recommend `<requiresPermissions>` since it matches the other elements and action annotations; use what we document so we propagate the recommended element. `<permissionsClasses>` remains a valid synonym.