### PR TITLE
Optimize chrom import - don't check transition mz if matched on TextId

### DIFF
--- a/src/org/labkey/targetedms/parser/SkylineBinaryParser.java
+++ b/src/org/labkey/targetedms/parser/SkylineBinaryParser.java
@@ -261,15 +261,12 @@ public class SkylineBinaryParser
         return _cacheFiles != null ? _cacheFiles.length : 0;
     }
 
-    public boolean matchTransitions(ChromGroupHeaderInfo header, List<? extends GeneralTransition> transitions, Double explicitRt, double tolerance)
+    /**
+     * Returns the number of transitions from the Precursor in the Skyline document that have a matching
+     * chromatogram in the ChromGroupHeaderInfo.
+     */
+    public int countTransitionMatches(ChromGroupHeaderInfo header, List<? extends GeneralTransition> transitions, double tolerance)
     {
-        if (explicitRt != null)
-        {
-            // We have retention time info, use that in the match
-            if (header.excludesTime(explicitRt))
-                return false;
-        }
-
         var numChromTransitions = header.getNumTransitions();
         ChromTransition[] chromTransitions;
 
@@ -281,20 +278,19 @@ public class SkylineBinaryParser
         {
             throw new RuntimeException(e);
         }
-
+        int matchCount = 0;
         for (GeneralTransition transition : transitions)
         {
             for (int i = 0; i < numChromTransitions; i++)
             {
-                // Do we need to look through all the transitions from the .skyd file?
                 if (header.toSignedMz(transition.getMz()).compareTolerant(chromTransitions[i].getProduct(header), tolerance) == 0)
                 {
-                    return true;
+                    matchCount++;
+                    break;
                 }
             }
         }
-
-        return false;
+        return matchCount;
     }
 
     public static byte[] uncompressStoredBytes(byte[] bytes, Integer uncompressedSize, int numPoints, int numTransitions) throws DataFormatException

--- a/src/org/labkey/targetedms/parser/SkylineBinaryParser.java
+++ b/src/org/labkey/targetedms/parser/SkylineBinaryParser.java
@@ -15,12 +15,10 @@
  */
 package org.labkey.targetedms.parser;
 
-import com.google.protobuf.CodedInputStream;
 import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.exp.api.DataType;
-import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass;
 import org.labkey.targetedms.parser.skyd.CacheFormat;
 import org.labkey.targetedms.parser.skyd.CacheFormatVersion;
@@ -263,15 +261,13 @@ public class SkylineBinaryParser
         return _cacheFiles != null ? _cacheFiles.length : 0;
     }
 
-    public int matchTransitions(ChromGroupHeaderInfo header, List<? extends GeneralTransition> transitions, Double explicitRt, double tolerance, boolean multiMatch)
+    public boolean matchTransitions(ChromGroupHeaderInfo header, List<? extends GeneralTransition> transitions, Double explicitRt, double tolerance)
     {
-        int match = 0;
-
         if (explicitRt != null)
         {
             // We have retention time info, use that in the match
             if (header.excludesTime(explicitRt))
-                return match;
+                return false;
         }
 
         var numChromTransitions = header.getNumTransitions();
@@ -290,39 +286,15 @@ public class SkylineBinaryParser
         {
             for (int i = 0; i < numChromTransitions; i++)
             {
-                // Do we need to look through all of the transitions from the .skyd file?
+                // Do we need to look through all the transitions from the .skyd file?
                 if (header.toSignedMz(transition.getMz()).compareTolerant(chromTransitions[i].getProduct(header), tolerance) == 0)
                 {
-                    if (explicitRt == null)
-                    {
-                        match++;
-                        if (!multiMatch)
-                        {
-                            break;  // only one match per transition
-                        }
-                    }
-                    else
-                    {
-                        match = multiMatch ? match + 1 : 1; // Examine all RT values even if we're not multimatch
-                    }
+                    return true;
                 }
             }
         }
 
-        return match;
-    }
-
-    public byte[] readChromatogramBytes(ChromGroupHeaderInfo header) throws DataFormatException, IOException
-    {
-        // Get the compressed bytes
-        ByteBuffer buffer = ByteBuffer.allocate(header.getCompressedSize());
-        getChannel().position(header.getLocationPoints()).read(buffer);
-        buffer.position(0);
-        byte[] result = new byte[header.getCompressedSize()];
-        buffer.get(result);
-        // Make sure it uncompresses successfully so that we don't import bad content into the database
-        uncompress(result, header.getUncompressedSize());
-        return result;
+        return false;
     }
 
     public static byte[] uncompressStoredBytes(byte[] bytes, Integer uncompressedSize, int numPoints, int numTransitions) throws DataFormatException

--- a/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
+++ b/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
@@ -3234,52 +3234,82 @@ public class SkylineDocumentParser implements AutoCloseable
                     chromsToMatchByTransitionMz.add(chrom);
                 }
             }
-
-            if (!chromsToMatchByTransitionMz.isEmpty())
-            {
-                ChromGroupHeaderInfo[] chromArray = new ChromGroupHeaderInfo[_binaryParser.getCacheFileSize()];
-                for (ChromGroupHeaderInfo chromInfo : chromsToMatchByTransitionMz)
-                {
-                    boolean foundMatch = _binaryParser.matchTransitions(chromInfo, transitions, explicitRT, tolerance);
-
-                    int fileIndex = chromInfo.getFileIndex();
-
-                    if (foundMatch)
-                    {
-                        if (chromArray[fileIndex] != null)
-                        {
-                            // If more than one value was found, ensure that there
-                            // is only one precursor match per file.
-                            // Use the entry with the m/z closest to the target
-                            ChromGroupHeaderInfo currentChromForFileIndex = chromArray[fileIndex];
-                            // Use the entry with the m/z closest to the target
-                            if (Math.abs(precursor.getMz() - chromInfo.getPrecursorMz()) <
-                                    Math.abs(precursor.getMz() - currentChromForFileIndex.getPrecursorMz()))
-                            {
-                                chromArray[fileIndex] = chromInfo;
-                            }
-                        }
-                        else
-                        {
-                            chromArray[fileIndex] = chromInfo;
-                        }
-                    }
-                }
-
-                // Now that we've found the best matches, add them to the list
-                for (ChromGroupHeaderInfo info : chromArray)
-                {
-                    if (info != null)
-                    {
-                        result.add(info);
-                    }
-                }
-            }
-
-            return result;
+            return findChromatogramsWithMostTransitions(precursor.getMz(), transitions, chromsToMatchByTransitionMz);
         }
 
         return Collections.emptyList();
+    }
+
+
+    /**
+     * Within each replicate, if there is more than one ChromGroupHeaderInfo, find the header infos with the most matching
+     * transitions, and, if there are multiple headers with the same number of matching transitions, then find the ones
+     * that have the closest match to the precursor m/z.
+     */
+    private List<ChromGroupHeaderInfo> findChromatogramsWithMostTransitions(
+            double precursorMz, List<? extends GeneralTransition> transitions, List<ChromGroupHeaderInfo> headerInfos)
+    {
+        Map<String, List<ChromGroupHeaderInfo>> byFile = headerInfos.stream()
+                .collect(Collectors.groupingBy(headerInfo -> _binaryParser.getFilePath(headerInfo)));
+
+        List<ChromGroupHeaderInfo> result = new ArrayList<>();
+
+        for (SkylineReplicate skylineReplicate : _replicateList)
+        {
+            List<ChromGroupHeaderInfo> candidates = new ArrayList<>();
+
+            for (SampleFile sampleFile : skylineReplicate.getSampleFileList())
+            {
+                List<ChromGroupHeaderInfo> listInFile = byFile.get(sampleFile.getFilePath());
+                if (listInFile != null)
+                {
+                    candidates.addAll(listInFile);
+                }
+            }
+
+            if (candidates.size() <= 1)
+            {
+                result.addAll(candidates);
+                continue;
+            }
+
+            int[] transitionCounts = new int[candidates.size()];
+            int maxTransitionCount = 0;
+            for (int i = 0; i < candidates.size(); i++)
+            {
+                int transitionCount = _binaryParser.countTransitionMatches(candidates.get(i), transitions, _matchTolerance);
+                transitionCounts[i] = transitionCount;
+                maxTransitionCount = Math.max(transitionCount, maxTransitionCount);
+            }
+            List<ChromGroupHeaderInfo> candidatesWithMostTransitions = new ArrayList<ChromGroupHeaderInfo>();
+            for (int i = 0; i < candidates.size(); i++)
+            {
+                if (transitionCounts[i] == maxTransitionCount)
+                {
+                    candidatesWithMostTransitions.add(candidates.get(i));
+                }
+            }
+            if (candidatesWithMostTransitions.size() <= 1)
+            {
+                result.addAll(candidatesWithMostTransitions);
+                continue;
+            }
+
+            // If multiple chromGroups tied for the number of matching transitions, then break the tie using
+            // precursor m/z distance
+            double minMzDelta = candidatesWithMostTransitions.stream()
+                    .mapToDouble(headerInfo -> Math.abs(precursorMz - headerInfo.getPrecursorMz()))
+                    .min().getAsDouble();
+            for (ChromGroupHeaderInfo headerInfo : candidatesWithMostTransitions)
+            {
+                if (Math.abs(precursorMz - headerInfo.getPrecursorMz()) == minMzDelta)
+                {
+                    result.add(headerInfo);
+                }
+            }
+        }
+
+        return result;
     }
 
     public int getPeptideGroupCount()

--- a/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
+++ b/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
@@ -3182,18 +3182,12 @@ public class SkylineDocumentParser implements AutoCloseable
         // Add precursor matches to a list, if they match at least 1 transition
         // in this group, and are potentially the maximal transition match.
 
-        // Using only the maximum works well for the case where there are 2
-        // precursors in the same document that match a single entry.
-        // TODO: But it messes up when there are 2 sets of transitions for
-        //       the same precursor covering different numbers of transitions.
-        //       Skyline never creates this case, but it has been reported
-        // int maxTranMatch = 1;
-
         if (_binaryParser != null && _binaryParser.getChromatograms() != null)
         {
             // ChromatogramCache.TryLoadChromInfo() in Skyline code:
             // Filter the list of chromatograms based on our precursor mZ
-            int i = findEntry(precursor.getSignedMz(), tolerance, _binaryParser.getChromatograms(), 0, _binaryParser.getChromatograms().length - 1);
+            ChromGroupHeaderInfo[] chromHeaders = _binaryParser.getChromatograms();
+            int i = findEntry(precursor.getSignedMz(), tolerance, chromHeaders, 0, chromHeaders.length - 1);
             if (i == -1)
             {
                 return Collections.emptyList();
@@ -3201,100 +3195,88 @@ public class SkylineDocumentParser implements AutoCloseable
 
             Double explicitRT = molecule.getExplicitRetentionTime();
 
+            List<ChromGroupHeaderInfo> result = new ArrayList<>();
+
             // Add entries to a list until they no longer match
-            List<ChromGroupHeaderInfo> listChromatograms = new ArrayList<>();
-            while (i < _binaryParser.getChromatograms().length &&
-                    matchMz(precursor.getSignedMz(), _binaryParser.getChromatograms()[i].getPrecursor(), tolerance))
+            List<ChromGroupHeaderInfo> chromsToMatchByTransitionMz = new ArrayList<>();
+            while (i < chromHeaders.length &&
+                    matchMz(precursor.getSignedMz(), chromHeaders[i].getPrecursor(), tolerance))
             {
-                ChromGroupHeaderInfo chrom = _binaryParser.getChromatograms()[i++];
+                ChromGroupHeaderInfo chrom = chromHeaders[i++];
                 // Sequence matching for extracted chromatogram data added in v1.5
                 ChromatogramGroupId chromTextId = _binaryParser.getTextId(chrom);
-                if (chromTextId != null) 
+                if (chromTextId != null)
                 {
-                    if (!molecule.targetMatches(chromTextId.getTarget()))
-                        continue;
-                    try
+                    // If we match based on textId, consider it a chromatogram worth storing
+                    if (molecule.targetMatches(chromTextId.getTarget()))
                     {
-                        SpectrumFilter spectrumFilter = SpectrumFilter.fromByteArray(precursor.getSpectrumFilter());
-                        if (!Objects.equals(spectrumFilter, chromTextId.getSpectrumFilter())) 
+                        try
                         {
-                            continue;
+                            SpectrumFilter spectrumFilter = SpectrumFilter.fromByteArray(precursor.getSpectrumFilter());
+                            if (Objects.equals(spectrumFilter, chromTextId.getSpectrumFilter()))
+                            {
+                                result.add(chrom);
+                            }
                         }
-                    }
-                    catch (InvalidProtocolBufferException e)
-                    {
-                        _log.warn("Error parsing spectrum filter {}", e);
-                        return Collections.emptyList();
+                        catch (InvalidProtocolBufferException e)
+                        {
+                            _log.warn("Error parsing spectrum filter", e);
+                            return Collections.emptyList();
+                        }
+                        continue;
                     }
                 }
 
                 // If explicit retention time info is available, use that to discard obvious mismatches
                 if (explicitRT == null || !chrom.excludesTime(explicitRT))
                 {
-                    listChromatograms.add(chrom);
+                    // See if we can find a match based on transition mz instead for SRM-style data
+                    chromsToMatchByTransitionMz.add(chrom);
                 }
             }
 
-            // MeasuredResults.TryLoadChromatogram in Skyline code:
-            // Since we are reading and returning chromatograms for all replicates we need to maintain
-            // the number of maximum transition matches for each replicate.
-            // MeasuredResults.TryLoadChromatogram in Skyline reads and returns chromatograms for a single replicate.
-            int[] maxTranMatches = new int[_binaryParser.getCacheFileSize()];
-
-            ChromGroupHeaderInfo[] chromArray = new ChromGroupHeaderInfo[_binaryParser.getCacheFileSize()];
-
-            for (ChromGroupHeaderInfo chromInfo : listChromatograms)
+            if (!chromsToMatchByTransitionMz.isEmpty())
             {
-                // If the chromatogram set has an optimization function then the number
-                // of matching chromatograms per transition is a reflection of better
-                // matching.  Otherwise, we only expect one match per transition.
-                // TODO - do we need this on the Java side?
-                boolean multiMatch = false;//chromatogram.OptimizationFunction != null;
-
-                int tranMatch = _binaryParser.matchTransitions(chromInfo, transitions, explicitRT, tolerance, multiMatch);
-
-                int fileIndex = chromInfo.getFileIndex();
-                int maxTranMatch = maxTranMatches[fileIndex];
-
-                if (tranMatch >= maxTranMatch)
+                ChromGroupHeaderInfo[] chromArray = new ChromGroupHeaderInfo[_binaryParser.getCacheFileSize()];
+                for (ChromGroupHeaderInfo chromInfo : chromsToMatchByTransitionMz)
                 {
-                    // If new maximum, clear anything collected at the previous maximum
-                    if (tranMatch > maxTranMatch)
-                    {
-                        chromArray[fileIndex] = null;
-                    }
+                    boolean foundMatch = _binaryParser.matchTransitions(chromInfo, transitions, explicitRT, tolerance);
 
-                    maxTranMatches[fileIndex] = tranMatch;
+                    int fileIndex = chromInfo.getFileIndex();
 
-                    if(chromArray[fileIndex] != null)
+                    if (foundMatch)
                     {
-                        // If more than one value was found, ensure that there
-                        // is only one precursor match per file.
-                        // Use the entry with the m/z closest to the target
-                        ChromGroupHeaderInfo currentChromForFileIndex = chromArray[fileIndex];
-                        // Use the entry with the m/z closest to the target
-                        if (Math.abs(precursor.getMz() - chromInfo.getPrecursorMz()) <
-                                Math.abs(precursor.getMz() - currentChromForFileIndex.getPrecursorMz()))
+                        if (chromArray[fileIndex] != null)
+                        {
+                            // If more than one value was found, ensure that there
+                            // is only one precursor match per file.
+                            // Use the entry with the m/z closest to the target
+                            ChromGroupHeaderInfo currentChromForFileIndex = chromArray[fileIndex];
+                            // Use the entry with the m/z closest to the target
+                            if (Math.abs(precursor.getMz() - chromInfo.getPrecursorMz()) <
+                                    Math.abs(precursor.getMz() - currentChromForFileIndex.getPrecursorMz()))
+                            {
+                                chromArray[fileIndex] = chromInfo;
+                            }
+                        }
+                        else
                         {
                             chromArray[fileIndex] = chromInfo;
                         }
                     }
-                    else
+                }
+
+                // Now that we've found the best matches, add them to the list
+                for (ChromGroupHeaderInfo info : chromArray)
+                {
+                    if (info != null)
                     {
-                        chromArray[fileIndex] = chromInfo;
+                        result.add(info);
                     }
                 }
             }
 
-            List<ChromGroupHeaderInfo> finalList = new ArrayList<>();
-            for (ChromGroupHeaderInfo info : chromArray)
-            {
-                if (info != null)
-                {
-                    finalList.add(info);
-                }
-            }
-            return finalList;
+            return result;
         }
 
         return Collections.emptyList();

--- a/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
+++ b/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
@@ -3179,9 +3179,6 @@ public class SkylineDocumentParser implements AutoCloseable
             GeneralPrecursor<?> precursor,
             double tolerance)
     {
-        // Add precursor matches to a list, if they match at least 1 transition
-        // in this group, and are potentially the maximal transition match.
-
         if (_binaryParser != null && _binaryParser.getChromatograms() != null)
         {
             // ChromatogramCache.TryLoadChromInfo() in Skyline code:
@@ -3198,43 +3195,42 @@ public class SkylineDocumentParser implements AutoCloseable
             List<ChromGroupHeaderInfo> result = new ArrayList<>();
 
             // Add entries to a list until they no longer match
-            List<ChromGroupHeaderInfo> chromsToMatchByTransitionMz = new ArrayList<>();
             while (i < chromHeaders.length &&
                     matchMz(precursor.getSignedMz(), chromHeaders[i].getPrecursor(), tolerance))
             {
                 ChromGroupHeaderInfo chrom = chromHeaders[i++];
+                // If explicit retention time info is available, use that to discard obvious mismatches
+                if (explicitRT != null && chrom.excludesTime(explicitRT))
+                {
+                    continue;
+                }
+
                 // Sequence matching for extracted chromatogram data added in v1.5
                 ChromatogramGroupId chromTextId = _binaryParser.getTextId(chrom);
                 if (chromTextId != null)
                 {
                     // If we match based on textId, consider it a chromatogram worth storing
-                    if (molecule.targetMatches(chromTextId.getTarget()))
+                    if (!molecule.targetMatches(chromTextId.getTarget()))
                     {
-                        try
+                        continue;
+                    }
+                    try
+                    {
+                        SpectrumFilter spectrumFilter = SpectrumFilter.fromByteArray(precursor.getSpectrumFilter());
+                        if (!Objects.equals(spectrumFilter, chromTextId.getSpectrumFilter()))
                         {
-                            SpectrumFilter spectrumFilter = SpectrumFilter.fromByteArray(precursor.getSpectrumFilter());
-                            if (Objects.equals(spectrumFilter, chromTextId.getSpectrumFilter()))
-                            {
-                                result.add(chrom);
-                            }
+                            continue;
                         }
-                        catch (InvalidProtocolBufferException e)
-                        {
-                            _log.warn("Error parsing spectrum filter", e);
-                            return Collections.emptyList();
-                        }
+                    }
+                    catch (InvalidProtocolBufferException e)
+                    {
+                        _log.warn("Error parsing spectrum filter", e);
                         continue;
                     }
                 }
-
-                // If explicit retention time info is available, use that to discard obvious mismatches
-                if (explicitRT == null || !chrom.excludesTime(explicitRT))
-                {
-                    // See if we can find a match based on transition mz instead for SRM-style data
-                    chromsToMatchByTransitionMz.add(chrom);
-                }
+                result.add(chrom);
             }
-            return findChromatogramsWithMostTransitions(precursor.getMz(), transitions, chromsToMatchByTransitionMz);
+            return findChromatogramsWithMostTransitions(precursor.getMz(), transitions, result);
         }
 
         return Collections.emptyList();


### PR DESCRIPTION
#### Rationale
We're spending a lot of time pulling transition chromatogram headers during import on very large documents.

#### Changes
Only do the time consuming work of counting the number of transition matches if more than one chromatogram group was found for a particular Replicate.