### PR TITLE
Fix ExpRun's FilePathRoot after a run is moved to another folder.

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSDataHandler.java
+++ b/src/org/labkey/targetedms/TargetedMSDataHandler.java
@@ -32,6 +32,7 @@ import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.pipeline.PipelineService;
+import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.targetedms.RunRepresentativeDataState;
 import org.labkey.api.targetedms.TargetedMSService;
@@ -283,6 +284,26 @@ public class TargetedMSDataHandler extends AbstractExperimentDataHandler
             newData.setDataFileURI(destFile.toUri());
             newData.setContainer(targetContainer);
             newData.save(user);
+        }
+
+        // Fix ExpRun's FilePathRoot if it is still set to the file root of the source folder
+        ExpRun experimentRun = ExperimentService.get().getExpRun(newRunLSID);
+        if (experimentRun == null)
+        {
+            throw new ExperimentException("Unable to find exprun for lsid " + newRunLSID + ". Cannot set the filePathRoot.");
+        }
+        Path newFileRootPath = targetRoot.getRootFileLike().toNioPathForRead();
+        if (!newFileRootPath.equals(experimentRun.getFilePathRootPath()))
+        {
+            experimentRun.setFilePathRootPath(newFileRootPath);
+            try
+            {
+                experimentRun.save(user);
+            }
+            catch (BatchValidationException e)
+            {
+                throw new ExperimentException(e);
+            }
         }
 
         // Update the run


### PR DESCRIPTION
#### Rationale
When a Skyline document is moved to another folder, FilePathRoot on the moved ExpRun continues to point to the source container. 
- FilePathRoot gets set incorrectly in `XarReader`:
`vals.setFilePathRoot(FileUtil.getAbsolutePath(_xarSource.getRootPath()))`
- `getRootPath() `method in `MoveRunsXarSource` returns the root path in the source container. 
- Incorrect FilePathRoot causes the PanoramaPublic data copy pipeline to fail in `PanoramaPublicFileImporter.alignDataFileUrls()`

**Questions:**
- Would it be better to fix this in XarReader instead of the targetedms?  This draft PR has a potential fix: https://github.com/LabKey/platform/pull/6292
- Would it be better to fix the FilePathRoot in the panoramapublic module instead, so that it only impacts PanoramaWeb? 

Related issues and tickets:
- [Issue 33712: Moving an assay file does not update exp.ExperimentRun.filepathRoot](https://www.labkey.org/issues/home/Developer/issues/details.view?issueId=33712)
- [Issue 47189: Error moving Skyline documents across folders](https://www.labkey.org/issues/home/Developer/issues/details.view?issueId=47189)
- [Ticket 35288: Issue 33712 is not fixed - Move Run doesn't update exp.ExperimentRun.filePathRoot column](https://www.labkey.org/MacCoss/support%20tickets/issues-details.view?issueId=35288)

#### Related Pull Requests
- https://github.com/LabKey/MacCossLabModules/pull/502
- https://github.com/LabKey/platform/pull/6292 (Draft PR if better to fix in XarReader instead)

#### Changes
- Update FilePathRoot in TargetedMSDataHandler

