### PR TITLE
Issue 50927: Custom dates broken in peptide heat map view

### DIFF
--- a/resources/views/peptideSummary.html
+++ b/resources/views/peptideSummary.html
@@ -311,15 +311,27 @@
 
     function customDateRange() {
         $('#fom-loading').show();
-        if (document.getElementById("ps-start-date").value) {
-            startDate = formatDate(document.getElementById("ps-start-date").value);
+        const startDateVal = document.getElementById('ps-start-date').value;
+        const endDateVal = document.getElementById('ps-end-date').value;
+
+        if (!startDateVal || !endDateVal) {
+            alert('Please select both start and end dates.');
+            $('#fom-loading').hide();
+            return;
         }
-        if (document.getElementById("ps-end-date").value) {
-            endDate = formatDate(document.getElementById("ps-end-date").value);
+
+        if (startDateVal) {
+            startDate = formatDate(startDateVal);
         }
-        if (document.getElementById("ps-start-date").value && document.getElementById("ps-end-date").value) {
+        if (endDateVal) {
+            endDate = formatDate(endDateVal);
+        }
+        if (startDateVal && endDateVal) {
             persistDateRange(-1);
             getData();
+        }
+        else {
+            $('#fom-loading').hide();
         }
     }
 

--- a/resources/views/peptideSummary.html
+++ b/resources/views/peptideSummary.html
@@ -320,19 +320,11 @@
             return;
         }
 
-        if (startDateVal) {
-            startDate = formatDate(startDateVal);
-        }
-        if (endDateVal) {
-            endDate = formatDate(endDateVal);
-        }
-        if (startDateVal && endDateVal) {
-            persistDateRange(-1);
-            getData();
-        }
-        else {
-            $('#fom-loading').hide();
-        }
+        startDate = formatDate(startDateVal);
+        endDate = formatDate(endDateVal);
+
+        persistDateRange(-1);
+        getData();
     }
 
     function formatDate(d, includeTime) {


### PR DESCRIPTION
#### Rationale
Selecting custom range from the date range dropdown and clicking apply without filling in any date info leaves the loading spinner indefinitely spinning.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
