### PR TITLE
Fix pipeline job failure when moving Skyline documents in folders with non-ASCII characters

### DIFF
--- a/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
+++ b/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
@@ -405,7 +405,7 @@ public class SkylineDocumentParser implements AutoCloseable
             {
                 result = ExperimentService.get().createData(container, SkylineBinaryParser.DATA_TYPE);
                 result.setName(skydFile.getName());
-                result.setDataFileURI(skydFile.toURI());
+                result.setDataFileURI(skydFile.toPath().toUri());
                 result.save(user);
             }
             return result;


### PR DESCRIPTION
#### Rationale
Non-ASCII characters were not getting percent encoded in the dataFileUrl set on the ExpData associated with .skyd files. 
As a result, in folder paths that contain non-ASCII characters,  two rows were being created in ExpData for a .skyd file.  One with un-encoded characters and a second with a fully percent-encoded dataFileUrl.  
Example:
- file:///data/labkey/files/00Developer/vsharma/Issues/FilePathRootTest%20Project%20**☃~!@$&()_+%7B%7D-=%5B%5D,.%23äöüÅ**/Source%20Folder/@files/MRMer/MRMer.skyd
- file:///data/labkey/files/00Developer/vsharma/Issues/FilePathRootTest%20Project%20%E2%98%83~!@$&()_+%7B%7D-=%5B%5D,.%23%C3%A4%C3%B6%C3%BC%C3%85/Source%20Folder/@files/MRMer/MRMer.skyd

This was causing a pipeline job error when moving a Skyline document across folders.  It also caused the test added in https://github.com/LabKey/MacCossLabModules/pull/502 to fail, due to the pipeline job error, when running on TeamCity.

NOTE: Path.toUri() has platform specific behavior, it seems.  On my Windows machine, Path.toUri() does not percent-encode special characters. As a result, File.toURI() and Path.toUri () end up producing the same percent-encoded values.  That is why the move pipeline job and test succeed locally, but fail on TeamCity where File.toURI() and Path.toUri() produce different percent encoding.

#### Related Pull Requests
- https://github.com/LabKey/MacCossLabModules/pull/502
- https://github.com/LabKey/platform/pull/6292

#### Changes
- Use Path.toUri() instead of File.toURI() when setting the dataFileUrl on ExpData for a skyd file
