### PR TITLE
Complete migration from srcURL and returnURL to returnUrl

### DIFF
--- a/resources/views/configureQCMetric.html
+++ b/resources/views/configureQCMetric.html
@@ -102,11 +102,11 @@
             });
         }
 
-        function getReturnURL() {
-            var returnURL = LABKEY.ActionURL.getParameter('returnUrl');
+        function getReturnUrl() {
+            var returnUrl = LABKEY.ActionURL.getParameter('returnUrl');
 
-            if(returnURL) {
-                return returnURL;
+            if(returnUrl) {
+                return returnUrl;
             }
             else {
                 return LABKEY.ActionURL.buildURL('project', 'start');
@@ -162,7 +162,7 @@
             },
 
             resetQCMetrics: function(){
-                window.location = getReturnURL();
+                window.location = getReturnUrl();
             },
 
             showCustomMetricWindow: function (op, clickedMetric) {
@@ -302,12 +302,12 @@
                         commands: commands,
                         method: 'POST',
                         success: function (data) {
-                            window.location = getReturnURL();
+                            window.location = getReturnUrl();
                         },
                         failure: LABKEY.Utils.getCallbackWrapper(LABKEY.internal.ConfigureQCMetrics.onError, this, true)
                     });
                 } else {
-                    window.location = getReturnURL();
+                    window.location = getReturnUrl();
                 }
 
             },

--- a/resources/views/subscribeOutlierNotifications.html
+++ b/resources/views/subscribeOutlierNotifications.html
@@ -48,11 +48,11 @@
             }
         }
 
-        function getReturnURL() {
-            var returnURL = LABKEY.ActionURL.getParameter('returnUrl');
+        function getReturnUrl() {
+            var returnUrl = LABKEY.ActionURL.getParameter('returnUrl');
 
-            if(returnURL) {
-                return returnURL;
+            if(returnUrl) {
+                return returnUrl;
             }
             else {
                 return LABKEY.ActionURL.buildURL('project', 'start');
@@ -77,7 +77,7 @@
             },
 
             onCancel: function () {
-                window.location = getReturnURL();
+                window.location = getReturnUrl();
             },
 
             onSave: function () {
@@ -110,7 +110,7 @@
                            commands: commands,
                            method: 'POST',
                            success: function () {
-                               window.location = getReturnURL();
+                               window.location = getReturnUrl();
                            },
                            failure: LABKEY.Utils.getCallbackWrapper(LABKEY.internal.SubscribeQCNotification.onError, this, true)
                        });

--- a/resources/web/PanoramaPremium/window/AddNewMetricWindow.js
+++ b/resources/web/PanoramaPremium/window/AddNewMetricWindow.js
@@ -579,11 +579,11 @@ Ext4.define('Panorama.Window.AddCustomMetricWindow', {
 
     },
 
-    getReturnURL: function () {
-        var returnURL = LABKEY.ActionURL.getParameter('returnUrl');
+    getReturnUrl: function () {
+        var returnUrl = LABKEY.ActionURL.getParameter('returnUrl');
 
-        if(returnURL) {
-            return returnURL;
+        if(returnUrl) {
+            return returnUrl;
         }
         else {
             return LABKEY.ActionURL.buildURL('project', 'start');

--- a/resources/web/PanoramaPremium/window/AddNewTraceMetricWindow.js
+++ b/resources/web/PanoramaPremium/window/AddNewTraceMetricWindow.js
@@ -450,11 +450,11 @@ Ext4.define('Panorama.Window.AddTraceMetricWindow', {
         }, this);
     },
 
-    getReturnURL: function () {
-        var returnURL = LABKEY.ActionURL.getParameter('returnUrl');
+    getReturnUrl: function () {
+        var returnUrl = LABKEY.ActionURL.getParameter('returnUrl');
 
-        if (returnURL) {
-            return returnURL;
+        if (returnUrl) {
+            return returnUrl;
         }
         else {
             return LABKEY.ActionURL.buildURL('project', 'start');

--- a/src/org/labkey/panoramapremium/View/QCSummaryMenuCustomizer.java
+++ b/src/org/labkey/panoramapremium/View/QCSummaryMenuCustomizer.java
@@ -6,8 +6,6 @@ import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.NavTreeCustomizer;
 import org.labkey.api.view.ViewContext;
-import org.labkey.panoramapremium.PanoramaPremiumController;
-import org.labkey.targetedms.TargetedMSController;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -31,7 +29,7 @@ public class QCSummaryMenuCustomizer implements NavTreeCustomizer
         if(viewContext.getContainer().hasPermission(viewContext.getUser(), AdminPermission.class))
         {
             List<NavTree> navTrees = new ArrayList<>();
-            ActionURL url = new ActionURL("targetedms", actionName, viewContext.getContainer()).addReturnURL(viewContext.getActionURL());
+            ActionURL url = new ActionURL("targetedms", actionName, viewContext.getContainer()).addReturnUrl(viewContext.getActionURL());
             navTrees.add(new NavTree(menuLabel, url));
 
             return navTrees;

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -7352,11 +7352,11 @@ public class TargetedMSController extends SpringActionController
         }
     }
 
-    public static ActionURL getRenameRunURL(Container c, TargetedMSRun run, ActionURL returnURL)
+    public static ActionURL getRenameRunURL(Container c, TargetedMSRun run, ActionURL returnUrl)
     {
         ActionURL url = new ActionURL(RenameRunAction.class, c);
         url.addParameter("run", run.getRunId() );
-        url.addReturnURL(returnURL);
+        url.addReturnUrl(returnUrl);
         return url;
     }
 
@@ -7379,7 +7379,7 @@ public class TargetedMSController extends SpringActionController
     public class RenameRunAction extends FormViewAction<RenameForm>
     {
         private TargetedMSRun _run;
-        private URLHelper _returnURL;
+        private URLHelper _returnUrl;
 
         @Override
         public void validateCommand(RenameForm target, Errors errors)
@@ -7390,16 +7390,16 @@ public class TargetedMSController extends SpringActionController
         public ModelAndView getView(RenameForm form, boolean reshow, BindException errors)
         {
             _run = validateRun(form.getRun());
-            _returnURL = form.getReturnURLHelper(getShowRunURL(getContainer(), form.getRun()));
+            _returnUrl = form.getReturnUrlHelper(getShowRunURL(getContainer(), form.getRun()));
 
             String description = form.getDescription();
-            if (description == null || description.length() == 0)
+            if (description == null || description.isEmpty())
                 description = _run.getDescription();
 
             RenameBean bean = new RenameBean();
             bean.run = _run;
             bean.description = description;
-            bean.returnURL = _returnURL;
+            bean.returnUrl = _returnUrl;
 
             getPageConfig().setFocusId("description");
 
@@ -7419,13 +7419,13 @@ public class TargetedMSController extends SpringActionController
         @Override
         public URLHelper getSuccessURL(RenameForm form)
         {
-            return form.getReturnURLHelper();
+            return form.getReturnUrlHelper();
         }
 
         @Override
         public void addNavTrail(NavTree root)
         {
-            addRunNavTrail(root, _run, _returnURL, "Rename Run", getPageConfig(), null);
+            addRunNavTrail(root, _run, _returnUrl, "Rename Run", getPageConfig(), null);
         }
     }
 
@@ -7434,7 +7434,7 @@ public class TargetedMSController extends SpringActionController
     {
         public TargetedMSRun run;
         public String description;
-        public URLHelper returnURL;
+        public URLHelper returnUrl;
     }
 
     private void addRunNavTrail(NavTree root, TargetedMSRun run, URLHelper runURL, String title, PageConfig page, String helpTopic)

--- a/src/org/labkey/targetedms/TargetedMSFolderType.java
+++ b/src/org/labkey/targetedms/TargetedMSFolderType.java
@@ -89,7 +89,7 @@ public class TargetedMSFolderType extends MultiPortalFolderType
                     {
                         ActionURL fileRootsUrl = new ActionURL("admin", "fileRootsStandAlone", c)
                                 .addParameter("folderSetup", true)
-                                .addReturnURL(setupUrl);
+                                .addReturnUrl(setupUrl);
                         extraSteps.add(new NavTree("Change File Root", fileRootsUrl));
                     }
                     extraSteps.add(new NavTree(TargetedMSController.CONFIGURE_TARGETED_MS_FOLDER, setupUrl));

--- a/src/org/labkey/targetedms/query/QCFolderDisplayColumnFactory.java
+++ b/src/org/labkey/targetedms/query/QCFolderDisplayColumnFactory.java
@@ -56,7 +56,7 @@ public class QCFolderDisplayColumnFactory implements DisplayColumnFactory
                     {
                         url.addParameter("RunId", currentRunId.toString());
                     }
-                    url.addReturnURL(ctx.getViewContext().getActionURL());
+                    url.addReturnUrl(ctx.getViewContext().getActionURL());
                     sb.append("<div><a href=\"")
                             .append(PageFlowUtil.filter(url))
                             .append("\"")

--- a/src/org/labkey/targetedms/view/renameRun.jsp
+++ b/src/org/labkey/targetedms/view/renameRun.jsp
@@ -25,8 +25,8 @@
     RenameBean bean = ((JspView<RenameBean>) HttpView.currentView()).getModelBean();
 %>
 <labkey:form action="<%=urlFor(RenameRunAction.class)%>" method="post" layout="horizontal">
-<%=generateReturnUrlFormField(bean.returnURL)%>
+<%=generateReturnUrlFormField(bean.returnUrl)%>
     <labkey:input type="hidden" name="run" value="<%=bean.run.getRunId()%>"/>
     <labkey:input type="text" size="70" name="description" id="description" label="Name" value="<%=bean.description%>"/>
-    <%= button("Rename").submit(true) %> <%= button("Cancel").href(bean.returnURL) %>
+    <%= button("Rename").submit(true) %> <%= button("Cancel").href(bean.returnUrl) %>
 </labkey:form>


### PR DESCRIPTION
#### Rationale
In 2021 we made a major push to use `returnUrl` consistently instead of `srcURL` or `returnURL`. We can finish the job.

Issue 7580: inconsistent use of returnUrl parameter

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6407

#### Changes
- Change everything to `returnUrl` and get rid of code checking for old versions of the parameters