### PR TITLE
Remove unnecessary QueryWebPart renders

### DIFF
--- a/resources/views/msProject.html
+++ b/resources/views/msProject.html
@@ -14,7 +14,6 @@
     if (!LABKEY.user.isAdmin) {
         config.filterArray = [LABKEY.Filter.create('researcher', LABKEY.user.id, LABKEY.Filter.Types.EQUAL)];
     }
-    let wp = new LABKEY.QueryWebPart(config);
-    wp.render();
+    new LABKEY.QueryWebPart(config);
     })();
 </script>

--- a/resources/views/msProjectDetails.html
+++ b/resources/views/msProjectDetails.html
@@ -79,7 +79,7 @@
 
         // query web part to show payment method and other invoice details - custom query
         let webpart = <%=webpartContext%>;
-        let wp = new LABKEY.QueryWebPart({
+        new LABKEY.QueryWebPart({
             renderTo: 'payment-methods',
             frame: 'portal',
             title: 'Payment Methods',
@@ -88,7 +88,6 @@
             filterArray: [LABKEY.Filter.create('project', project, LABKEY.Filter.Types.EQUAL)],
             containerFilter: LABKEY.Query.containerFilter.currentAndSubfolders
         });
-        wp.render();
 
         // add payment method link
         const addPaymentMethodEl = document.getElementById('add-payment-method-link');


### PR DESCRIPTION
#### Rationale
If `renderTo` is defined in a QueryWebPart config, it is automatically rendered. Calling `render()` explicitly will request the data again and re-render the grid. This is inefficient at best but I suspect this re-render is behind some intermittent failures we've been seeing on TeamCity.
I'm cleaning up all that I could find.

#### Related Pull Requests
* N/A

#### Changes
* Remove unnecessary QueryWebPart renders