### PR TITLE
Fix skydDataId on TargetedMSRun

### DIFF
--- a/api-src/org/labkey/api/targetedms/TargetedMSService.java
+++ b/api-src/org/labkey/api/targetedms/TargetedMSService.java
@@ -22,6 +22,7 @@ import org.labkey.api.data.TableCustomizer;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.ExperimentRunType;
 import org.labkey.api.exp.XarFormatException;
+import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.pipeline.PipelineValidationException;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
@@ -72,6 +73,9 @@ public interface TargetedMSService
     ITargetedMSRun getRunByFileName(String fileName, Container container);
     List<ITargetedMSRun> getRuns(Container container);
     ITargetedMSRun getRunByLsid(String lsid, Container container);
+
+    boolean updateSkydDataId(ITargetedMSRun run, ExpData newSkydData, User user);
+
     List<? extends SkylineAnnotation> getReplicateAnnotations(Container container);
     void registerSkylineDocumentImportListener(SkylineDocumentImportListener skyLineDocumentImportListener);
     List<SkylineDocumentImportListener> getSkylineDocumentImportListener();

--- a/src/org/labkey/targetedms/TargetedMSManager.java
+++ b/src/org/labkey/targetedms/TargetedMSManager.java
@@ -865,10 +865,16 @@ public class TargetedMSManager
 
     public static boolean updateSkydDataId(ITargetedMSRun run, ExpData newSkydData, User user)
     {
-        if (!(run instanceof TargetedMSRun) || newSkydData == null)
+        if (!(run instanceof TargetedMSRun))
         {
-            return false;
+            throw new IllegalArgumentException("Invalid run type. Expected TargetedMSRun but received " +
+                    (run != null ? run.getClass().getName() : "null"));
         }
+        if (newSkydData == null)
+        {
+            throw new IllegalArgumentException("Cannot update with null newSkydData. A valid ExpData object is required");
+        }
+
         TargetedMSRun targetedRun = (TargetedMSRun) run;
 
         ExpRun expRun = ExperimentService.get().getExpRun(targetedRun.getExperimentRunLSID());

--- a/src/org/labkey/targetedms/TargetedMSManager.java
+++ b/src/org/labkey/targetedms/TargetedMSManager.java
@@ -73,6 +73,7 @@ import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.DeletePermission;
+import org.labkey.api.targetedms.ITargetedMSRun;
 import org.labkey.api.targetedms.RepresentativeDataState;
 import org.labkey.api.targetedms.RunRepresentativeDataState;
 import org.labkey.api.targetedms.TargetedMSService;
@@ -123,6 +124,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -859,6 +861,24 @@ public class TargetedMSManager
             return runs[0];
         }
         throw new IllegalArgumentException("More than one TargetedMS runs found for LSID "+lsid);
+    }
+
+    public static boolean updateSkydDataId(ITargetedMSRun run, ExpData newSkydData, User user)
+    {
+        if (!(run instanceof TargetedMSRun))
+        {
+            return false;
+        }
+        TargetedMSRun targetedRun = (TargetedMSRun) run;
+
+        ExpRun expRun = ExperimentService.get().getExpRun(targetedRun.getExperimentRunLSID());
+        if (expRun == null) return false;
+
+        if (!Objects.equals(newSkydData.getRunId(), expRun.getRowId())) return false;
+
+        targetedRun.setSkydDataId(newSkydData.getRowId());
+        TargetedMSManager.updateRun(targetedRun, user);
+        return true;
     }
 
     public static List<Long> getRunIdsByInstrument(String serialNumber)

--- a/src/org/labkey/targetedms/TargetedMSManager.java
+++ b/src/org/labkey/targetedms/TargetedMSManager.java
@@ -865,7 +865,7 @@ public class TargetedMSManager
 
     public static boolean updateSkydDataId(ITargetedMSRun run, ExpData newSkydData, User user)
     {
-        if (!(run instanceof TargetedMSRun))
+        if (!(run instanceof TargetedMSRun) || newSkydData == null)
         {
             return false;
         }

--- a/src/org/labkey/targetedms/TargetedMSServiceImpl.java
+++ b/src/org/labkey/targetedms/TargetedMSServiceImpl.java
@@ -22,6 +22,7 @@ import org.labkey.api.data.TableCustomizer;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.ExperimentRunType;
 import org.labkey.api.exp.XarFormatException;
+import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.pipeline.PipelineValidationException;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
@@ -273,6 +274,11 @@ public class TargetedMSServiceImpl implements TargetedMSService
     public ITargetedMSRun getRunByLsid(String lsid, Container container)
     {
         return TargetedMSManager.getRunByLsid(lsid, container);
+    }
+
+    public boolean updateSkydDataId(ITargetedMSRun run, ExpData newSkydData, User user)
+    {
+        return TargetedMSManager.updateSkydDataId(run, newSkydData, user);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
When a sky.zip file or its exploded folder are moved, post-import, so that the relative locations of sky.zip and its corresponding .skyd file are non-standard, two ExpData rows are created for the skyd file in the Panorama Public copy pipeline job.
- The first ExpData (linked to the ExpRun) is created during XAR import.
- The second ExpData (not linked to the ExpRun) is created in the `SkylineDocumentParser.parseChromatograms()` method.
Normally, while running the copy pipeline job, `SkylineDocumentParser.parseChromatograms()` does not have to create a new ExpData, since an ExpData with the expected path already exists.

Having 2 ExpDatas causes:
- The skydDataId in TargetedMSRun references an ExpData not linked to the ExpRun. It refers to a file in the 'export' directory which gets deleted after folder import. 
- FK violations during cleanup (`CopyExperimentFinalTask.cleanupExportDirectory()`) prevents deletion of ExpData corresponding to the skydDataId

#### Related Pull Requests
- https://github.com/LabKey/MacCossLabModules/pull/526

#### Changes
- Added a method in TargetedMSService to update the skydDataId
