### PR TITLE
Fix case sensitive-check for 24.x->25.x upgrade sequence

### DIFF
--- a/resources/schemas/dbscripts/postgresql/targetedms-25.001-25.002.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-25.001-25.002.sql
@@ -2,7 +2,7 @@
 -- script from 24.11
 CREATE FUNCTION targetedms.ensureColumns() RETURNS void AS $$
 BEGIN
-  IF NOT EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'QCMetricConfiguration' AND COLUMN_NAME = 'MinTimeValue') THEN
+  IF NOT EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'qcmetricconfiguration' AND COLUMN_NAME = 'mintimevalue') THEN
     EXECUTE 'ALTER TABLE targetedms.QCMetricConfiguration RENAME COLUMN TimeValue To MinTimeValue';
     EXECUTE 'ALTER TABLE targetedms.QCMetricConfiguration ADD COLUMN MaxTimeValue REAL';
     EXECUTE 'ALTER TABLE targetedms.QCMetricConfiguration ADD COLUMN TimeValueOption VARCHAR(10)';


### PR DESCRIPTION
#### Rationale
Our conditional upgrade script for 24.11 servers isn't check for the right casing for a table and column name

#### Changes
* Postgres considers these identifiers to be lower case because they weren't quoted when they were created