### PR TITLE
Cache transition MZ during precursor import

### DIFF
--- a/src/org/labkey/targetedms/parser/SignedMz.java
+++ b/src/org/labkey/targetedms/parser/SignedMz.java
@@ -22,16 +22,16 @@ import org.jetbrains.annotations.NotNull;
  */
 public class SignedMz implements Comparable<SignedMz>
 {
-    private final Double _mz;
+    private final double _mz;
     private final boolean _isNegative;
 
-    public SignedMz(Double mz, boolean isNegative)
+    public SignedMz(double mz, boolean isNegative)
     {
         _mz = mz;
         _isNegative = isNegative;
     }
 
-    public Double getMz()
+    public double getMz()
     {
         return _mz;
     }
@@ -41,35 +41,19 @@ public class SignedMz implements Comparable<SignedMz>
         return _isNegative;
     }
 
-    public boolean hasValue()
-    {
-        return _mz != null;
-    }
-
     @Override
     public int compareTo(@NotNull SignedMz other)
     {
-        if (hasValue() != other.hasValue())
-        {
-            return hasValue() ? 1 : -1;
-        }
         if (isNegative() != other.isNegative())
         {
             return isNegative() ? -1 : 1;
         }
         // Same sign
-        if (hasValue())
-            return _mz.compareTo(other.getMz());
-
-        return 0; // Both empty
+        return Double.compare(_mz, other.getMz());
     }
 
     public int compareTolerant(SignedMz other, double tolerance)
     {
-        if (hasValue() != other.hasValue())
-        {
-            return hasValue() ? 1 : -1;
-        }
         if (isNegative() != other.isNegative())
         {
             return isNegative() ? -1 : 1; // Not interested in tolerance when signs disagree
@@ -77,6 +61,6 @@ public class SignedMz implements Comparable<SignedMz>
         // Same sign
         if (Math.abs(_mz - other.getMz()) <= tolerance)
             return 0;
-        return _mz.compareTo(other.getMz());
+        return Double.compare(_mz, other.getMz());
     }
 }

--- a/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
+++ b/src/org/labkey/targetedms/parser/SkylineDocumentParser.java
@@ -2292,6 +2292,7 @@ public class SkylineDocumentParser implements AutoCloseable
             }
         }
 
+        Map<ChromGroupHeaderInfo, SignedMz[]> cachedTransitions = new HashMap<>();
         List<? extends GeneralTransition> transitionsList = precursor.getTransitionsList();
         for (GeneralTransition transition: transitionsList)
         {
@@ -2305,9 +2306,14 @@ public class SkylineDocumentParser implements AutoCloseable
                     int matchIndex = -1;
                     // Figure out which index into the list of transitions we're inserting.
                     double deltaNearestMz = Double.MAX_VALUE;
-                    SignedMz[] transitions = Arrays.stream(_binaryParser.getTransitions(c))
-                            .map(t->t.getProduct(c))
-                            .toArray(SignedMz[]::new);
+                    SignedMz[] transitions = cachedTransitions.get(c);
+                    if (transitions == null)
+                    {
+                        transitions = Arrays.stream(_binaryParser.getTransitions(c))
+                                .map(t->t.getProduct(c))
+                                .toArray(SignedMz[]::new);
+                        cachedTransitions.put(c, transitions);
+                    }
                     double transitionMz = transition.getMz();
                     if (transChromInfo.isOptimizationPeak())
                     {
@@ -2332,7 +2338,7 @@ public class SkylineDocumentParser implements AutoCloseable
                         incrementMissingChromatograms(filePath,
                                 "Unable to find a matching chromatogram for file path " + filePath +
                                 ". SKYD file may be out of sync with primary Skyline document. Transition " + transition +
-                                ", " + precursor + ", " +precursor.getCharge());
+                                ", " + precursor + ", " + precursor.getCharge());
                     }
                     else
                     {


### PR DESCRIPTION
#### Rationale
Grabbing transition chromatograms can be slow, especially on networked file systems.

#### Changes
* Avoid reloading transition-level data repeatedly by caching within the current precursor