### PR TITLE
Option to copy SKYD file to temp directory during import

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -48,6 +48,7 @@ import org.labkey.api.query.QueryView;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.ApplicationAdminPermission;
 import org.labkey.api.settings.AdminConsole;
+import org.labkey.api.settings.OptionalFeatureService;
 import org.labkey.api.targetedms.TargetedMSService;
 import org.labkey.api.usageMetrics.UsageMetricsService;
 import org.labkey.api.util.PageFlowUtil;
@@ -126,6 +127,8 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
     public static final String PEPTIDE_TAB_NAME = "Peptides";
     public static final String PROTEIN_TAB_NAME = "Proteins";
     public static final String MOLECULE_TAB_NAME = "Molecules";
+
+    public static final String USE_TEMP_DIR_FOR_SKYD_IMPORT = "UseTempDirForSkydImport";
 
     public static final String[] EXPERIMENT_FOLDER_WEB_PARTS = new String[] {MSSearchWebpart.NAME,
                                                                            TARGETED_MS_RUNS_WEBPART_NAME};
@@ -214,6 +217,10 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
         MAX_PRECURSORS_PROPERTY.setShowDescriptionInline(true);
         addModuleProperty(MAX_PRECURSORS_PROPERTY);
 
+        AdminConsole.addOptionalFeatureFlag(new AdminConsole.OptionalFeatureFlag(USE_TEMP_DIR_FOR_SKYD_IMPORT,
+                "Stage SKYD files to a temporary local file for import purposes",
+                "When using a non-local file system, the latency for random access requests can be significantly slower than first copying to local storage",
+                false, false, OptionalFeatureService.FeatureType.Optional));
     }
 
     @Override

--- a/src/org/labkey/targetedms/parser/SkylineBinaryParser.java
+++ b/src/org/labkey/targetedms/parser/SkylineBinaryParser.java
@@ -19,6 +19,9 @@ import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.exp.api.DataType;
+import org.labkey.api.settings.OptionalFeatureService;
+import org.labkey.api.util.FileUtil;
+import org.labkey.targetedms.TargetedMSModule;
 import org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass;
 import org.labkey.targetedms.parser.skyd.CacheFormat;
 import org.labkey.targetedms.parser.skyd.CacheFormatVersion;
@@ -44,15 +47,12 @@ import java.util.zip.Inflater;
 
 /**
  * Parses the .skyd binary file format, for chromatogram data.
- *
  * Based on ChromatogramCache.cs and ChromHeaderInfo.cs from Skyline
- * 
- * User: jeckels
- * Date: Apr 13, 2012
  */
 public class SkylineBinaryParser
 {
     private final File _file;
+    private final boolean _deleteFileOnClose;
     private final Logger _log;
     private FileChannel _channel;
     private RandomAccessFile _randomAccessFile;
@@ -71,10 +71,24 @@ public class SkylineBinaryParser
 
     private CachedFile[] _cacheFiles;
 
-    public SkylineBinaryParser(File file, Logger log)
+    public SkylineBinaryParser(File file, Logger log) throws IOException
     {
-        _file = file;
         _log = log;
+
+        if (OptionalFeatureService.get().isFeatureEnabled(TargetedMSModule.USE_TEMP_DIR_FOR_SKYD_IMPORT))
+        {
+            _deleteFileOnClose = true;
+            _file = FileUtil.createTempFile(file.getName(), ".skyd");
+            _file.deleteOnExit();
+            _log.info("Copying SKYD to temp directory for import purposes");
+            FileUtil.copyFile(file, _file);
+            _log.info("Copying complete");
+        }
+        else
+        {
+            _file = file;
+            _deleteFileOnClose = false;
+        }
     }
 
     public ChromGroupHeaderInfo[] getChromatograms()
@@ -97,6 +111,18 @@ public class SkylineBinaryParser
         // using a FileChannel there is a known Java issue on Windows that prevents the mapped file from being deleted,
         // http://bugs.java.com/bugdatabase/view_bug.do?bug_id=4715154 and http://bugs.java.com/bugdatabase/view_bug.do?bug_id=4469299
         System.gc();
+
+        if (_deleteFileOnClose && _file != null)
+        {
+            if (!_file.delete())
+            {
+                _log.warn("Failed to delete temp copy of SKYD file: " + _file.getAbsolutePath());
+            }
+            else
+            {
+                _log.info("Deleted temp copy of SKYD file");
+            }
+        }
     }
 
     public void parse() throws IOException


### PR DESCRIPTION
#### Rationale
Importing very large Skyline documents can be slow when the files live on a remote file system. We can improve latency by copying the SKYD file to a local temp directory before doing lots of random access I/O on it.

#### Changes
* Optional feature to control behavior
* Copy to local file before importing, delete after completion