### PR TITLE
Issue 52643: Panorama QC metric pages loading slowly

### DIFF
--- a/resources/views/configureQCMetric.html
+++ b/resources/views/configureQCMetric.html
@@ -3,7 +3,7 @@
     in each folder.
 </p>
 
-<div id="qcMetricsTable"></div>
+<div id="qcMetricsTable">Loading...</div>
 <div id="qcMetricsError"></div>
 <script type="text/javascript" nonce="<%=scriptNonce%>">
 

--- a/src/org/labkey/targetedms/view/paretoPlot.jsp
+++ b/src/org/labkey/targetedms/view/paretoPlot.jsp
@@ -33,6 +33,7 @@
         dependencies.add("targetedms/css/ParetoPlot.css");
         dependencies.add("targetedms/js/BaseQCPlotPanel.js");
         dependencies.add("targetedms/js/ParetoPlotPanel.js");
+        dependencies.add("targetedms/js/QCMetricConfigLoader.js");
     }
 %>
 <%

--- a/src/org/labkey/targetedms/view/qcSummary.jsp
+++ b/src/org/labkey/targetedms/view/qcSummary.jsp
@@ -29,6 +29,7 @@
         dependencies.add("targetedms/js/BaseQCPlotPanel.js");
         dependencies.add("targetedms/css/QCSummary.css");
         dependencies.add("targetedms/js/QCSummaryPanel.js");
+        dependencies.add("targetedms/js/QCMetricConfigLoader.js");
     }
 %>
 <%
@@ -37,7 +38,7 @@
     Integer sampleLimit = (Integer)HttpView.currentModel();
 %>
 
-<div style="min-height: 160px;" id="<%=h(qcSummaryId)%>" ></div>
+<div style="min-height: 175px;" id="<%=h(qcSummaryId)%>" ></div>
 
 <script type="text/javascript" nonce="<%=getScriptNonce()%>">
     Ext4.onReady(function()

--- a/src/org/labkey/targetedms/view/qcTrendPlotReport.jsp
+++ b/src/org/labkey/targetedms/view/qcTrendPlotReport.jsp
@@ -47,6 +47,7 @@
         dependencies.add("targetedms/js/QCTrendPlotPanel.js");
         dependencies.add("targetedms/js/QCPlotHoverPanel.js");
         dependencies.add("targetedms/js/PlotTypeCheckCombo.js");
+        dependencies.add("targetedms/js/QCMetricConfigLoader.js");
     }
 %>
 <%

--- a/test/src/org/labkey/test/pages/panoramapremium/ConfigureMetricsUIPage.java
+++ b/test/src/org/labkey/test/pages/panoramapremium/ConfigureMetricsUIPage.java
@@ -74,7 +74,7 @@ public class ConfigureMetricsUIPage extends PortalBodyPanel
 
     public void waitForMetricToAppear(QCPlotsWebPart.MetricType metric)
     {
-        longWait().until(ExpectedConditions.visibilityOf(Locator.name(metric.toString()).findElement(getDriver())));
+        waitForElement(Locator.name(metric.toString()), WAIT_FOR_PAGE);
     }
 
     public String getLowerBound(String metric)
@@ -89,7 +89,7 @@ public class ConfigureMetricsUIPage extends PortalBodyPanel
 
     public void verifyNoDataForMetric(String metricName)
     {
-        Assert.assertEquals("Data should not be present for this metric - " + metricName, getText(Locator.id(metricName)), "No data in this folder");
+        Assert.assertEquals("Data should not be present for this metric - " + metricName, "No data in this folder", getText(Locator.id(metricName)));
     }
 
     public void clickSave()

--- a/webapp/TargetedMS/js/BaseQCPlotPanel.js
+++ b/webapp/TargetedMS/js/BaseQCPlotPanel.js
@@ -31,21 +31,20 @@ Ext4.define('LABKEY.targetedms.BaseQCPlotPanel', {
     },
 
     getPlotWebPartHeader: function(wp, title) {
-        var html = '<br/>' +
-                '<table class="labkey-wp ' + wp + '">' +
+        return '<br/>' +
+                '<table class="labkey-wp ' + Ext4.util.Format.htmlEncode(wp) + '">' +
                 ' <tr class="labkey-wp-header">' +
                 '     <th class="labkey-wp-title-left">' +
-                '        <span class="labkey-wp-title-text ' +  wp + '-title">'+ Ext4.util.Format.htmlEncode(title) + '</span>' +
+                '        <span class="labkey-wp-title-text ' + Ext4.util.Format.htmlEncode(wp) + '-title">' + Ext4.util.Format.htmlEncode(title) + '</span>' +
                 '     </th>' +
                 ' </tr>';
-        return html;
     },
 
     addPlotWebPartToPlotDiv: function (id, title, div, wp) {
         var html = this.getPlotWebPartHeader(wp, title);
             html += '<tr>' +
                     '     <td class="labkey-wp-body">' +
-                    '        <div id="' + id + '" class="chart-render-div"></div>' +
+                    '        <div id="' + Ext4.util.Format.htmlEncode(id) + '" class="chart-render-div"></div>' +
                     '     </td>' +
                     ' </tr>' +
                     '</table>';
@@ -57,7 +56,7 @@ Ext4.define('LABKEY.targetedms.BaseQCPlotPanel', {
 
         Ext4.each(ids, function(plotId){
             html += '<tr>' +
-                    '     <td><div id="' + plotId + '" class="chart-render-div"></div></td>' +
+                    '     <td><div id="' + Ext4.util.Format.htmlEncode(plotId) + '" class="chart-render-div"></div></td>' +
                     ' </tr>';
         });
         html += '</table>';
@@ -134,21 +133,6 @@ Ext4.define('LABKEY.targetedms.BaseQCPlotPanel', {
 
             plotDiv.unmask();
         }
-    },
-
-    queryInitialQcMetrics : function(successCallback,callbackScope) {
-        LABKEY.Ajax.request({
-            url: LABKEY.ActionURL.buildURL('targetedms', 'GetQCMetricConfigurations.api'),
-            method: 'GET',
-            success: function(response) {
-                this.metricPropArr = Ext4.JSON.decode(response.responseText).configurations;
-                successCallback.call(callbackScope);
-            },
-            failure: LABKEY.Utils.getCallbackWrapper(function(response) {
-                this.failureHandler(response);
-            }, null, true),
-            scope: this
-        });
     },
 
     queryQCInstruments: function(successCallback, callbackScope) {

--- a/webapp/TargetedMS/js/ParetoPlotPanel.js
+++ b/webapp/TargetedMS/js/ParetoPlotPanel.js
@@ -15,12 +15,13 @@ Ext4.define('LABKEY.targetedms.ParetoPlotPanel', {
     {
         this.callParent();
 
-        this.queryInitialQcMetrics(this.initPlot, this);
+        Ext4.get(this.plotDivId).mask("Loading...");
+
+        LABKEY.targetedms.QCMetricConfigLoader.getMetrics(this.initPlot, this);
     },
 
-    initPlot : function() {
-
-        Ext4.get(this.plotDivId).mask("Loading...");
+    initPlot : function(metrics) {
+        this.metricPropArr = metrics;
 
         LABKEY.Ajax.request({
             url: LABKEY.ActionURL.buildURL('targetedms', 'GetQCMetricOutliers.api'),

--- a/webapp/TargetedMS/js/QCMetricConfigLoader.js
+++ b/webapp/TargetedMS/js/QCMetricConfigLoader.js
@@ -1,0 +1,41 @@
+if (!LABKEY.targetedms) {
+    LABKEY.targetedms = {};
+}
+
+if (!LABKEY.targetedms.QCMetricConfigLoader) {
+    LABKEY.targetedms.QCMetricConfigLoader = {
+        initialQcMetrics: null,
+        initialQcMetricsCallbacks: [],
+        initialQcMetricsRequested: false,
+
+        getMetrics : function(successCallback, callbackScope) {
+            if (this.initialQcMetrics) {
+                successCallback.call(callbackScope, this.initialQcMetrics);
+            }
+            else {
+                this.initialQcMetricsCallbacks.push({callback: successCallback, scope: callbackScope});
+
+                if (!this.initialQcMetricsRequested) {
+                    this.initialQcMetricsRequested = true;
+                    LABKEY.Ajax.request({
+                        url: LABKEY.ActionURL.buildURL('targetedms', 'GetQCMetricConfigurations.api'),
+                        method: 'GET',
+                        success: function (response) {
+                            const configs = Ext4.JSON.decode(response.responseText).configurations;
+                            this.initialQcMetrics = configs;
+                            for (const c of this.initialQcMetricsCallbacks) {
+                                c.callback.call(c.scope, this.initialQcMetrics);
+                            }
+                            this.initialQcMetricsCallbacks = [];
+                        },
+                        failure: LABKEY.Utils.getCallbackWrapper(function (response) {
+                            this.failureHandler(response);
+                        }, null, true),
+                        scope: this
+                    });
+                }
+            }
+        },
+
+    }
+}

--- a/webapp/TargetedMS/js/QCSummaryPanel.js
+++ b/webapp/TargetedMS/js/QCSummaryPanel.js
@@ -16,11 +16,17 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
 
         this.callParent();
 
-        this.qcPlotPanel.queryInitialQcMetrics(this.initPanel, this);
+        this.add({
+            xtype: 'label',
+            text: 'Loading...'
+        })
+
+        LABKEY.targetedms.QCMetricConfigLoader.getMetrics(this.initPanel, this);
         this.numSampleFileStats = config ? config.sampleLimit : 3;
     },
 
-    initPanel : function() {
+    initPanel : function(metrics) {
+        this.metricPropArr = metrics;
         this.qcPlotPanel.queryQCInstruments(this.getQCSummary, this);
     },
 
@@ -32,6 +38,7 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
             },
             scope: this,
             success: LABKEY.Utils.getCallbackWrapper(function (response) {
+                this.removeAll();
                 var containers = response['containers'],
                         container,
                         childPanelItems = [],
@@ -49,7 +56,7 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
                 container = containers[0];
                 container.showName = hasChildren;
                 container.isParent = true;
-                container.parentOnly = containers.length == 1;
+                container.parentOnly = containers.length === 1;
                 if (this.qcPlotPanel.qcIntrumentsArr) {
                     if (this.qcPlotPanel.qcIntrumentsArr.length > 1) {
                         container.instrument = ' for multiple instruments: <ul>';

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -112,7 +112,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                     if (value === "true" || value === "false") {
                         value = value === "true";
                     }
-                    else if (value != undefined && value.length > 0 && !isNaN(Number(value))) {
+                    else if (value !== undefined && value.length > 0 && !isNaN(Number(value))) {
                         value = +value;
                     }
                     else if (key === 'plotTypes') { // convert string to array
@@ -121,15 +121,15 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                         value = value.split(',');
                     }
                     if(key === 'selectedAnnotations') {
-                        var annotations = {};
+                        const annotations = {};
 
-                        var a = value.split(',');
-                        for(var i = 0; i < a.length; i++)
+                        const a = value.split(',');
+                        for (let i = 0; i < a.length; i++)
                         {
-                            var b = a[i].split(":");
-                            var name = b[0];
-                            var val = b[1];
-                            var selected = annotations[name];
+                            const b = a[i].split(":");
+                            const name = b[0];
+                            const val = b[1];
+                            let selected = annotations[name];
                             if(!selected)
                             {
                                 selected = [];
@@ -213,6 +213,8 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         }
 
         this.getExpRunRangeDetails();
+        // We just finished loading the previously set options so clear any dirty state
+        this.havePlotOptionsChanged = false;
     },
 
     getExpRunRangeDetails: function() {
@@ -288,7 +290,6 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
 
     getFirstPlotOptionsToolbar: function() {
         if (!this.plotTypeOptionsToolbar) {
-            let items = [];
             this.plotTypeOptionsToolbar = Ext4.create('Ext.toolbar.Toolbar', {
                 ui: 'footer',
                 cls: 'levey-jennings-toolbar',
@@ -329,7 +330,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                 minValue: 2,
                 listeners: {
                     scope: this,
-                    change: function (cmp, newVal, oldVal) {
+                    change: function (cmp, newVal) {
                         this.trailingRuns = newVal;
                         this.havePlotOptionsChanged = true;
                         this.displayTrendPlot();
@@ -372,7 +373,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
             value: selectedPlotTypes,
             listeners: {
                 scope: this,
-                change: function(cmp, newVal, oldVal) {
+                change: function(cmp, newVal) {
                     var newValues = newVal;
                     this.plotTypes = newValues ? Ext4.isArray(newValues) ? newValues : [newValues] : [];
 
@@ -420,7 +421,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
 
             toolbarItems.push(this.getGroupedXCheckbox());
             toolbarItems.push({xtype: 'tbspacer'}, {xtype: 'tbseparator'}, {xtype: 'tbspacer'});
-            var location = toolbarItems.push(this.getSinglePlotCheckbox());
+            const location = toolbarItems.push(this.getSinglePlotCheckbox());
             toolbarItems.push({xtype: 'tbspacer'}, {xtype: 'tbseparator'}, {xtype: 'tbspacer'});
             toolbarItems.push(this.getShowExcludedCheckbox());
             toolbarItems.push({xtype: 'tbspacer'}, {xtype: 'tbseparator'}, {xtype: 'tbspacer'});

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -92,8 +92,9 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         if (this.minAcquiredTime == null || this.maxAcquiredTime == null)
             Ext4.get(this.plotDivId).update("<span class='labkey-error'>Unable to render report. Missing min and max AcquiredTime from data query.</span>");
         else {
+            Ext4.get(this.plotDivId).update("Loading...");
             // Load replicate annotations in the callback.
-            this.queryInitialQcMetrics(this.queryContainerReplicateAnnotations, this);
+            LABKEY.targetedms.QCMetricConfigLoader.getMetrics(this.queryContainerReplicateAnnotations, this);
         }
     },
 
@@ -154,7 +155,8 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         });
     },
 
-    queryContainerReplicateAnnotations : function() {
+    queryContainerReplicateAnnotations : function(metrics) {
+        this.metricPropArr = metrics;
         LABKEY.Ajax.request({
             url: LABKEY.ActionURL.buildURL('targetedms', 'GetContainerReplicateAnnotations.api'),
             method: 'GET',


### PR DESCRIPTION
#### Rationale
We can improve messaging when loading a QC folder, even if it's slow.

#### Changes
* Avoid double-loading the QC metric configurations by consolidating the requests
* Show `Loading...` to make slowness feel less like a broken page
* Improve HTML creation
* Avoid saving preferences immediately after loading them
* Minor code cleanup