### PR TITLE
Ticket 52856: Switch PTM reporting to pivot by replicate name

### DIFF
--- a/resources/queries/targetedms/PTMPercents.sql
+++ b/resources/queries/targetedms/PTMPercents.sql
@@ -7,7 +7,7 @@ SELECT
   Sequence @hidden,
   PreviousAA @hidden,
   NextAA @hidden,
-  SampleFileId.SampleName,
+  SampleFileId.ReplicateId.Name AS ReplicateName,
   -- Explicitly cast for SQLServer to avoid trying to add as numeric types
   SUBSTRING(Sequence, IndexAA + 1, 1) || CAST(StartIndex + IndexAA + 1 AS VARCHAR) AS SiteLocation,
   SUBSTRING(Sequence, IndexAA + 1, 1) AS AminoAcid,
@@ -15,7 +15,7 @@ SELECT
   PeptideGroupId
 FROM PTMPercentsPrepivot
 GROUP BY
-  SampleFileId.SampleName,
+  SampleFileId.ReplicateId.Name,
   Sequence,
   PreviousAA,
   NextAA,
@@ -24,4 +24,4 @@ GROUP BY
   PeptideGroupId,
   IndexAA,
   StructuralModId
-PIVOT PercentModified BY SampleName
+PIVOT PercentModified BY ReplicateName

--- a/resources/queries/targetedms/PTMPercentsGrouped.sql
+++ b/resources/queries/targetedms/PTMPercentsGrouped.sql
@@ -9,7 +9,7 @@ SELECT
     MIN(Id) AS Id @hidden,
     PreviousAA @hidden,
     NextAA @hidden,
-    SampleName,
+    ReplicateName,
 
     MAX(MaxPercentModified) AS MaxPercentModified,
     SUM(PercentModified) AS PercentModified,
@@ -20,7 +20,7 @@ SELECT
 FROM
     PTMPercentsGroupedPrepivot
 GROUP BY
-    SampleName,
+    ReplicateName,
     Sequence,
     PreviousAA,
     NextAA,
@@ -30,4 +30,4 @@ GROUP BY
     Location,
     SiteLocation,
     Modification
-PIVOT PercentModified, TotalPercentModified BY SampleName
+PIVOT PercentModified, TotalPercentModified BY ReplicateName

--- a/resources/queries/targetedms/PTMPercentsGroupedPrepivot.sql
+++ b/resources/queries/targetedms/PTMPercentsGroupedPrepivot.sql
@@ -57,7 +57,7 @@ SELECT
        PreviousAA @hidden,
        NextAA @hidden,
        p1.SampleFileId,
-       p1.SampleFileId.SampleName,
+       p1.SampleFileId.ReplicateId.Name AS ReplicateName,
        p1.AminoAcid,
        p1.SiteLocation,
        p1.Location,

--- a/resources/views/configureQCMetric.html
+++ b/resources/views/configureQCMetric.html
@@ -264,8 +264,7 @@
                     }
                 }, this);
 
-                var rowsToUpsert = false;
-                var commands = [];
+                const commands = [];
 
                 if (recordsToInsert.length > 0) {
                     commands.push({
@@ -274,7 +273,6 @@
                         command: 'insert',
                         rows: recordsToInsert
                     });
-                    rowsToUpsert = true;
                 }
 
                 if (recordsToUpdate.length > 0) {
@@ -284,7 +282,6 @@
                         command: 'update',
                         rows: recordsToUpdate
                     });
-                    rowsToUpsert = true;
                 }
 
                 if (recordsToDelete.length > 0) {
@@ -294,10 +291,10 @@
                         command: 'delete',
                         rows: recordsToDelete
                     });
-                    rowsToUpsert = true;
                 }
 
-                if (rowsToUpsert) {
+                if (commands.length > 0) {
+                    jQuery('#qcMetricsError').text("Saving...");
                     LABKEY.Query.saveRows({
                         commands: commands,
                         method: 'POST',

--- a/src/org/labkey/targetedms/TargetedMSSchema.java
+++ b/src/org/labkey/targetedms/TargetedMSSchema.java
@@ -1863,7 +1863,7 @@ public class TargetedMSSchema extends UserSchema
             long runId = Long.parseLong(runIdString);
             QueryDefinition queryDef = Objects.requireNonNull(getQueryDef(baseQueryName));
             QueryDefinition result = QueryService.get().createQueryDef(getUser(), getContainer(), getSchemaPath(), queryName);
-            result.setSql(queryDef.getSql() + " IN (SELECT sf.SampleName FROM targetedms.SampleFile sf WHERE sf.ReplicateId.RunId = " + runId + ")");
+            result.setSql(queryDef.getSql() + " IN (SELECT r.Name FROM targetedms.Replicate r WHERE r.RunId = " + runId + ")");
             result.setMetadataXml(queryDef.getMetadataXml());
             return result;
         }

--- a/src/org/labkey/targetedms/query/PTMPercentsGroupedCustomizer.java
+++ b/src/org/labkey/targetedms/query/PTMPercentsGroupedCustomizer.java
@@ -183,7 +183,7 @@ public class PTMPercentsGroupedCustomizer extends PTMPercentsCustomizer
     /** Key is the sample name and run ID, value is a pair of boolean (stressed or not) and description, both annotation-based */
     public static Map<Pair<String, Long>, Pair<Boolean, String>> getSampleMetadata(Container container)
     {
-        SQLFragment sql = new SQLFragment("SELECT DISTINCT sf.SampleName, r.RunId, raStressed.Value AS Stressed, COALESCE(raDescription.Value, sf.SampleName) AS Description FROM ");
+        SQLFragment sql = new SQLFragment("SELECT DISTINCT r.Name, r.RunId, raStressed.Value AS Stressed, COALESCE(raDescription.Value, sf.SampleName) AS Description FROM ");
         sql.append(TargetedMSManager.getTableInfoSampleFile(), "sf");
         sql.append(" INNER JOIN ");
         sql.append(TargetedMSManager.getTableInfoReplicate(), "r");
@@ -200,11 +200,11 @@ public class PTMPercentsGroupedCustomizer extends PTMPercentsCustomizer
         sql.append(" ON r.Id = raDescription.ReplicateId AND raDescription.Name = 'Sample Description'");
         Map<Pair<String, Long>, Pair<Boolean, String>> result = new HashMap<>();
         new SqlSelector(TargetedMSManager.getSchema(), sql).forEach(rs -> {
-            String sampleName = rs.getString("SampleName");
+            String replicateName = rs.getString("Name");
             Long runId = rs.getLong("RunId");
             Boolean stressed = "Stressed".equalsIgnoreCase(rs.getString("Stressed"));
             String description = rs.getString("Description");
-            result.put(Pair.of(sampleName, runId), Pair.of(stressed, description));
+            result.put(Pair.of(replicateName, runId), Pair.of(stressed, description));
         });
         return result;
     }

--- a/src/org/labkey/targetedms/query/PTMPercentsGroupedCustomizer.java
+++ b/src/org/labkey/targetedms/query/PTMPercentsGroupedCustomizer.java
@@ -180,14 +180,11 @@ public class PTMPercentsGroupedCustomizer extends PTMPercentsCustomizer
         return -1;
     }
 
-    /** Key is the sample name and run ID, value is a pair of boolean (stressed or not) and description, both annotation-based */
+    /** Key is the replicate name and run ID, value is a pair of boolean (stressed or not) and description, both annotation-based */
     public static Map<Pair<String, Long>, Pair<Boolean, String>> getSampleMetadata(Container container)
     {
-        SQLFragment sql = new SQLFragment("SELECT DISTINCT r.Name, r.RunId, raStressed.Value AS Stressed, COALESCE(raDescription.Value, sf.SampleName) AS Description FROM ");
-        sql.append(TargetedMSManager.getTableInfoSampleFile(), "sf");
-        sql.append(" INNER JOIN ");
+        SQLFragment sql = new SQLFragment("SELECT DISTINCT r.Name, r.RunId, raStressed.Value AS Stressed, COALESCE(raDescription.Value, r.Name) AS Description FROM ");
         sql.append(TargetedMSManager.getTableInfoReplicate(), "r");
-        sql.append(" ON r.Id = sf.ReplicateId ");
         sql.append(" INNER JOIN ");
         sql.append(TargetedMSManager.getTableInfoRuns(), "run");
         sql.append(" ON r.RunId = run.Id AND run.Container = ?");

--- a/src/org/labkey/targetedms/query/SamplePivotCustomizer.java
+++ b/src/org/labkey/targetedms/query/SamplePivotCustomizer.java
@@ -26,7 +26,7 @@ import java.util.Set;
 /**
  * Customizes the set of columns available on a pivot query that operates on samples, hiding all of the pivot values
  * that aren't part of the run that's being filtered on. This lets you view a single document's worth of data
- * without seeing empty columns for all of the other samples in the same container.
+ * without seeing empty columns for all the other samples in the same container.
  */
 public class SamplePivotCustomizer implements TableCustomizer
 {

--- a/test/src/org/labkey/test/pages/panoramapremium/ConfigureMetricsUIPage.java
+++ b/test/src/org/labkey/test/pages/panoramapremium/ConfigureMetricsUIPage.java
@@ -102,7 +102,11 @@ public class ConfigureMetricsUIPage extends PortalBodyPanel
         Locator.buttonContainingText("Save").findElement(getDriver()).click();
         Locator.XPathLocator errorMsgId = Locator.id("qcMetricsError");
         waitForElement(errorMsgId);
-        waitFor(() -> !errorMsgId.findElement(getDriver()).getText().isEmpty(), WAIT_FOR_PAGE);
+        waitFor(() ->
+        {
+            String errorText = errorMsgId.findElement(getDriver()).getText();
+            return !errorText.isEmpty() && !errorText.equals("Saving...");
+        }, WAIT_FOR_PAGE);
         return errorMsgId.findElement(getDriver()).getText();
     }
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSEarlyStagePTMReportTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSEarlyStagePTMReportTest.java
@@ -44,7 +44,7 @@ public class TargetedMSEarlyStagePTMReportTest extends TargetedMSTest
         log("Verifying the table headers");
         Assert.assertEquals("Incorrect column headers", Arrays.asList("Chain", "Site Location", "Sequence", "Modification", "Max Percent Modified",
                 "Percent Modified", "Total Percent Modified", "Percent Modified", "Total Percent Modified"), reportTable.getColumnLabels());
-        Assert.assertEquals("Incorrect Sample Names displayed as headers", "Sample1 Sc_WCL-250ng-5ngNIST_rKCTi_3hRP-20cm_DE30_QE_2",
+        Assert.assertEquals("Incorrect Sample Names displayed as headers", "QE_1 QE_2",
                 Locator.xpath("//table/thead[2]/tr").findElement(reportTable).getText());
 
         int vtnRowIndex = 1;

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSEarlyStagePTMReportTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSEarlyStagePTMReportTest.java
@@ -44,7 +44,7 @@ public class TargetedMSEarlyStagePTMReportTest extends TargetedMSTest
         log("Verifying the table headers");
         Assert.assertEquals("Incorrect column headers", Arrays.asList("Chain", "Site Location", "Sequence", "Modification", "Max Percent Modified",
                 "Percent Modified", "Total Percent Modified", "Percent Modified", "Total Percent Modified"), reportTable.getColumnLabels());
-        Assert.assertEquals("Incorrect Sample Names displayed as headers", "QE_1 QE_2",
+        Assert.assertEquals("Incorrect Sample Names displayed as headers", "Sample1 QE_2",
                 Locator.xpath("//table/thead[2]/tr").findElement(reportTable).getText());
 
         int vtnRowIndex = 1;

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSEarlyStagePTMReportTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSEarlyStagePTMReportTest.java
@@ -52,11 +52,11 @@ public class TargetedMSEarlyStagePTMReportTest extends TargetedMSTest
 
         log("Verifying the modified percentage for sequence with CDR Range and stressed or not stressed updates");
         Assert.assertEquals("Incorrect percentages for (K)VTNMDPADTATYYCAR(D) sequence", Arrays.asList("(K)VTNMDPADTATYYCAR(D)", "11.3%", "11.3%", "11.1%", "11.1%"),
-                reportTable.getRowDataAsText(vtnRowIndex, "Sequence", "Sc_WCL-250ng-5ngNIST_rKCTi_3hRP-20cm_DE30_QE_1::PercentModified", "Sc_WCL-250ng-5ngNIST_rKCTi_3hRP-20cm_DE30_QE_1::TotalPercentModified",
-                        "Sc_WCL-250ng-5ngNIST_rKCTi_3hRP-20cm_DE30_QE_2::PercentModified", "Sc_WCL-250ng-5ngNIST_rKCTi_3hRP-20cm_DE30_QE_2::TotalPercentModified"));
+                reportTable.getRowDataAsText(vtnRowIndex, "Sequence", "QE_1::PercentModified", "QE_1::TotalPercentModified",
+                        "QE_2::PercentModified", "QE_2::TotalPercentModified"));
         Assert.assertEquals("Incorrect percentages for (R)WQQGNVFSCSVMHEALHNHYTQK(S) sequence", Arrays.asList("(R)WQQGNVFSCSVMHEALHNHYTQK(S)", "22.1%", "22.1%", "24.1%", "24.1%"),
-                reportTable.getRowDataAsText(wqqRowIndex, "Sequence", "Sc_WCL-250ng-5ngNIST_rKCTi_3hRP-20cm_DE30_QE_1::PercentModified", "Sc_WCL-250ng-5ngNIST_rKCTi_3hRP-20cm_DE30_QE_1::TotalPercentModified",
-                        "Sc_WCL-250ng-5ngNIST_rKCTi_3hRP-20cm_DE30_QE_2::PercentModified", "Sc_WCL-250ng-5ngNIST_rKCTi_3hRP-20cm_DE30_QE_2::TotalPercentModified"));
+                reportTable.getRowDataAsText(wqqRowIndex, "Sequence", "QE_1::PercentModified", "QE_1::TotalPercentModified",
+                        "QE_2::PercentModified", "QE_2::TotalPercentModified"));
 
         log("Verifying the cell colors:Green, Yellow and Red");
         Assert.assertEquals("Incorrect risk category color for - Green", "rgb(137, 202, 83)",

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSMAMTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSMAMTest.java
@@ -29,7 +29,7 @@ public class TargetedMSMAMTest extends TargetedMSTest
     @BeforeClass
     public static void setupProject()
     {
-        TargetedMSMAMTest init = (TargetedMSMAMTest) getCurrentTest();
+        TargetedMSMAMTest init = getCurrentTest();
         init.setupFolder(FolderType.ExperimentMAM);
         init.importData(SKY_FILE, 1);
         init.importData(CROSS_LINKED_SKY_FILE, 2);
@@ -50,7 +50,8 @@ public class TargetedMSMAMTest extends TargetedMSTest
         assertElementPresent("Wrong modification count", Locator.xpath("//td[contains(text(), 'Carbamidomethyl Cysteine')]"), 9);
         assertTextPresentInThisOrder("(K)HDLDLICR(A)", "(K)YLECSALTQR(G)", "(R)YVDIAIPCNNK(G)");
         assertTextPresentInThisOrder("C245", "C157", "C163");
-        assertTextPresent("A_D110907_SiRT_HELA_11_nsMRM_150selected_2_30min-5-35", "A_D110907_SiRT_HELA_11_nsMRM_150selected_1_30min-5-35");
+
+        assertTextPresent("Chromatograms");
 
         clickAndWait(Locator.linkContainingText("Peptide Map"));
         assertTextPresentInThisOrder("11.3", "14.1", "14.8");


### PR DESCRIPTION
#### Rationale
Usually sample names and replicate names match up. But it's possible for a multiple replicates to have the same sample name, which causes them to be collapsed in the PTM reports.

#### Changes
* Switch to pivoting by replicate name