### PR TITLE
Improvements to MAM reports and Excel exports

### DIFF
--- a/resources/queries/targetedms/PTMPercents.sql
+++ b/resources/queries/targetedms/PTMPercents.sql
@@ -8,8 +8,7 @@ SELECT
   PreviousAA @hidden,
   NextAA @hidden,
   SampleFileId.ReplicateId.Name AS ReplicateName,
-  -- Explicitly cast for SQLServer to avoid trying to add as numeric types
-  SUBSTRING(Sequence, IndexAA + 1, 1) || CAST(StartIndex + IndexAA + 1 AS VARCHAR) AS SiteLocation,
+  SiteLocation,
   SUBSTRING(Sequence, IndexAA + 1, 1) AS AminoAcid,
   StartIndex + IndexAA + 1 AS Location,
   PeptideGroupId
@@ -23,5 +22,6 @@ GROUP BY
   StartIndex,
   PeptideGroupId,
   IndexAA,
-  StructuralModId
+  StructuralModId,
+  SiteLocation
 PIVOT PercentModified BY ReplicateName

--- a/resources/queries/targetedms/PTMPercentsPrepivot.query.xml
+++ b/resources/queries/targetedms/PTMPercentsPrepivot.query.xml
@@ -6,6 +6,11 @@
                     <column columnName="ModifiedAreaProportion">
                         <formatString>0.00%</formatString>
                     </column>
+                    <column columnName="SiteLocation">
+                        <displayColumnFactory>
+                            <className>org.labkey.targetedms.query.SiteLocationDisplayColumnFactory</className>
+                        </displayColumnFactory>
+                    </column>
                 </columns>
             </table>
         </tables>

--- a/resources/queries/targetedms/PeptideIds.query.xml
+++ b/resources/queries/targetedms/PeptideIds.query.xml
@@ -3,6 +3,9 @@
         <tables xmlns="http://labkey.org/data/xml">
             <table tableName="PeptideIds" tableDbType="TABLE">
                 <columns>
+                    <column columnName="RetentionTime">
+                        <formatString>0.0</formatString>
+                    </column>
                     <column columnName="Modification">
                         <textAlign>left</textAlign>
                     </column>

--- a/resources/queries/targetedms/PeptideIds.query.xml
+++ b/resources/queries/targetedms/PeptideIds.query.xml
@@ -39,6 +39,11 @@
                             <className>org.labkey.targetedms.query.CrossLinkedPeptideDisplayColumn$PeptideLocationFactory</className>
                         </displayColumnFactory>
                     </column>
+                    <column columnName="PeptideIdentity">
+                        <displayColumnFactory>
+                            <className>org.labkey.targetedms.query.CrossLinkedPeptideDisplayColumn$PeptideIdentityFactory</className>
+                        </displayColumnFactory>
+                    </column>
                     <column columnName="BondLocation">
                         <columnTitle>Disulfide Bond Connection</columnTitle>
                         <displayColumnFactory>

--- a/resources/queries/targetedms/PeptideIds.sql
+++ b/resources/queries/targetedms/PeptideIds.sql
@@ -6,7 +6,9 @@ SELECT
    PrecursorId.NeutralMass AS ExpectedPeptideMass,
    -- Concatenate the empty string so that the protein DisplayColumn doesn't get propagated too
    PrecursorId.PeptideId.PeptideGroupId.Label || '' AS Chain,
-   CAST(PrecursorId.PeptideId.StartIndex + 1 AS VARCHAR) || '-' || CAST(PrecursorId.PeptideId.EndIndex AS VARCHAR) AS PeptideLocation,
+   CAST(PrecursorId.PeptideId.StartIndex + 1 AS VARCHAR) || '-' ||
+        -- Subtract one from the index if it was a c-term clipping of lysine, shortening the sequence
+        CAST(PrecursorId.PeptideId.EndIndex - (CASE WHEN LOCATE('C-Term Lys Clipping', Modification) >= 0 THEN 1 ELSE 0 END) AS VARCHAR) AS PeptideLocation,
    -- Value is calculated in Java in CrossLinkedPeptideDisplayColumn
    CAST(NULL AS VARCHAR) AS BondLocation,
    PrecursorId.PeptideId.Sequence @hidden,
@@ -15,18 +17,22 @@ SELECT
    PrecursorId.PeptideId.PeptideModifiedSequence AS PeptideModifiedSequence,
    PrecursorId.PeptideId AS Id @hidden,
    PrecursorId.PeptideId.PeptideGroupId.RunId AS RunId @hidden,
-   -- Show the modifications and their locations
-   (SELECT GROUP_CONCAT((StructuralModId.Name ||
-                         -- For now omit AA index info for anything but the first crosslinked peptide
-                         CASE WHEN psm.PeptideIndex = 0 THEN (' @ ' ||
-                         SUBSTRING(p.Sequence, IndexAA + 1, 1) ||
-                         CAST(IndexAA + p.StartIndex + 1 AS VARCHAR)) ELSE '' END),
-       (', ' || CHR(10)))
-   FROM targetedms.PeptideStructuralModification psm INNER JOIN targetedms.Peptide p ON psm.PeptideId = p.Id WHERE psm.PeptideId = pci.PrecursorId.PeptideId) AS Modification,
+   mods.Modification,
    SUM(TotalArea) AS TotalArea
 
 FROM
-     targetedms.precursorchrominfo pci
+     targetedms.precursorchrominfo pci LEFT OUTER JOIN
+         -- Show the modifications and their locations
+         (SELECT GROUP_CONCAT((StructuralModId.Name ||
+             -- For now omit AA index info for anything but the first crosslinked peptide
+                               CASE WHEN psm.PeptideIndex = 0 THEN (' @ ' ||
+                                                                    SUBSTRING(p.Sequence, IndexAA + 1, 1) ||
+                                                                    CAST(IndexAA + p.StartIndex + 1 AS VARCHAR)) ELSE '' END),
+                              (', ' || CHR(10))) AS Modification,
+          psm.PeptideId
+          FROM targetedms.PeptideStructuralModification psm INNER JOIN targetedms.Peptide p ON psm.PeptideId = p.Id
+          GROUP BY psm.PeptideId)
+mods ON mods.PeptideId = pci.PrecursorId.PeptideId
 GROUP BY
    PrecursorId.PeptideId.PeptideModifiedSequence,
    PrecursorId.NeutralMass,
@@ -38,4 +44,5 @@ GROUP BY
    PrecursorId.PeptideId.NextAA,
    PrecursorId.PeptideId.PreviousAA,
    PrecursorId.PeptideId.StartIndex,
-   PrecursorId.PeptideId.EndIndex
+   PrecursorId.PeptideId.EndIndex,
+   Modification

--- a/resources/queries/targetedms/PeptideIds.sql
+++ b/resources/queries/targetedms/PeptideIds.sql
@@ -9,6 +9,9 @@ SELECT
    CAST(PrecursorId.PeptideId.StartIndex + 1 AS VARCHAR) || '-' ||
         -- Subtract one from the index if it was a c-term clipping of lysine, shortening the sequence
         CAST(PrecursorId.PeptideId.EndIndex - (CASE WHEN LOCATE('C-Term Lys Clipping', Modification) >= 0 THEN 1 ELSE 0 END) AS VARCHAR) AS PeptideLocation,
+   CAST(PrecursorId.PeptideId.StartIndex + 1 AS VARCHAR) || '-' ||
+        -- Subtract one from the index if it was a c-term clipping of lysine, shortening the sequence
+        CAST(PrecursorId.PeptideId.EndIndex - (CASE WHEN LOCATE('C-Term Lys Clipping', Modification) >= 0 THEN 1 ELSE 0 END) AS VARCHAR) AS PeptideIdentity,
    -- Value is calculated in Java in CrossLinkedPeptideDisplayColumn
    CAST(NULL AS VARCHAR) AS BondLocation,
    PrecursorId.PeptideId.Sequence @hidden,

--- a/resources/queries/targetedms/PeptideIds/.qview.xml
+++ b/resources/queries/targetedms/PeptideIds/.qview.xml
@@ -1,4 +1,15 @@
 <customView xmlns="http://labkey.org/data/xml/queryCustomView">
+    <columns>
+        <column name="RetentionTime" />
+        <column name="MinObservedPeptideMass" />
+        <column name="MaxObservedPeptideMass" />
+        <column name="ExpectedPeptideMass" />
+        <column name="Chain" />
+        <column name="PeptideIdentity" />
+        <column name="BondLocation" />
+        <column name="PeptideModifiedSequence" />
+        <column name="Modification" />
+    </columns>
     <sorts>
         <sort column="RetentionTime" />
     </sorts>

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -2523,7 +2523,7 @@ public class TargetedMSController extends SpringActionController
 
         public HtmlString getModifiedPeptideHtml()
         {
-            return new ModifiedPeptideHtmlMaker().getPrecursorHtml(getPrecursor(), getRun().getId(), _targetedMSSchema);
+            return new ModifiedPeptideHtmlMaker().getPrecursorHtml(getPrecursor(), getRun().getId(), _targetedMSSchema).first;
         }
 
         public PeptideSettings.IsotopeLabel getIsotopeLabel()
@@ -3228,7 +3228,7 @@ public class TargetedMSController extends SpringActionController
 
             idx++;
         }
-        if(unsupportedLibraries.size() > 0)
+        if(!unsupportedLibraries.isEmpty())
         {
             HtmlView view = new HtmlView(DIV("Annotated spectra cannot be displayed from the following unsupported "
                             + (unsupportedLibraries.size() == 1 ? "library" : "libraries") + ": ",
@@ -3240,7 +3240,7 @@ public class TargetedMSController extends SpringActionController
             view.setTitle("Unsupported Spectrum " + (unsupportedLibraries.size() == 1 ? "Library" : "Libraries"));
             vbox.addView(view);
         }
-        if(specLibErrors.size() > 0)
+        if(!specLibErrors.isEmpty())
         {
             HtmlView view = new HtmlView(DOM.LK.ERRORS(specLibErrors.stream().map(e -> new LabKeyError(e.getMessage())).collect(Collectors.toList())));
             view.setTitle("Spectrum Library Errors");

--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -76,6 +76,7 @@ import org.labkey.targetedms.parser.SpectrumFilter;
 import org.labkey.targetedms.parser.skyaudit.SkylineAuditLogParser;
 import org.labkey.targetedms.passport.PassportController;
 import org.labkey.targetedms.pipeline.TargetedMSPipelineProvider;
+import org.labkey.targetedms.query.CrossLinkedPeptideDisplayColumn;
 import org.labkey.targetedms.query.PrecursorManager;
 import org.labkey.targetedms.query.SkylineListSchema;
 import org.labkey.targetedms.search.ModificationSearchWebPart;
@@ -705,7 +706,8 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
             PrecursorManager.TestCase.class,
             CrossLinkedPeptideInfo.TestCase.class,
             Protein.TestCase.class,
-            SpectrumFilter.TestCase.class
+            SpectrumFilter.TestCase.class,
+            CrossLinkedPeptideDisplayColumn.TestCase.class
         );
     }
 

--- a/src/org/labkey/targetedms/TargetedMSSchema.java
+++ b/src/org/labkey/targetedms/TargetedMSSchema.java
@@ -47,7 +47,6 @@ import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.query.ExpRunTable;
 import org.labkey.api.exp.query.ExpSchema;
 import org.labkey.api.module.Module;
-import org.labkey.api.query.CrosstabView;
 import org.labkey.api.query.CustomView;
 import org.labkey.api.query.DefaultQueryUpdateService;
 import org.labkey.api.query.DefaultSchema;
@@ -69,9 +68,7 @@ import org.labkey.api.query.UserIdQueryForeignKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
-import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.Permission;
-import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.targetedms.RepresentativeDataState;
 import org.labkey.api.targetedms.RunRepresentativeDataState;
 import org.labkey.api.util.ContainerContext;
@@ -111,7 +108,9 @@ import org.labkey.targetedms.query.QCTraceMetricValuesTable;
 import org.labkey.targetedms.query.RepresentativeStateDisplayColumn;
 import org.labkey.targetedms.query.SampleFileTable;
 import org.labkey.targetedms.query.SkylineAuditTable;
+import org.labkey.targetedms.query.TargetedMSCrosstabView;
 import org.labkey.targetedms.query.TargetedMSForeignKey;
+import org.labkey.targetedms.query.TargetedMSQueryView;
 import org.labkey.targetedms.query.TargetedMSTable;
 import org.labkey.targetedms.view.FontAwesomeLinkColumn;
 import org.springframework.validation.BindException;
@@ -1505,7 +1504,6 @@ public class TargetedMSSchema extends UserSchema
         if (TABLE_TRANSITION_ANNOTATION.equalsIgnoreCase(name) || TABLE_TRANSITION_OPTIMIZATION.equalsIgnoreCase(name))
         {
             TargetedMSTable result = new TargetedMSTable(getSchema().getTable(name), this, cf, ContainerJoinType.TransitionFK);
-            TargetedMSSchema targetedMSSchema = this;
             result.getMutableColumnOrThrow("TransitionId").setFk(new TargetedMSForeignKey(this, TABLE_TRANSITION, cf));
             result.addWrapColumn("MoleculeTransition", result.getRealTable().getColumn("TransitionId")).
                     setFk(new TargetedMSForeignKey(this, TABLE_MOLECULE_TRANSITION, cf));
@@ -1608,16 +1606,16 @@ public class TargetedMSSchema extends UserSchema
                 TABLE_INSTRUMENT_RATE.equalsIgnoreCase(name) ||
                 TABLE_INSTRUMENT_USAGE_PAYMENT.equalsIgnoreCase(name))
         {
-            var result = new FilteredTable<TargetedMSSchema>(getSchema().getTable(name), this, cf)
+            var result = new FilteredTable<>(getSchema().getTable(name), this, cf)
             {
                 @Override
                 public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
                 {
-                    return getContainer().hasPermission(user,perm);
+                    return getContainer().hasPermission(user, perm);
                 }
 
                 @Override
-                public @Nullable QueryUpdateService getUpdateService()
+                public @NotNull QueryUpdateService getUpdateService()
                 {
                     return new DefaultQueryUpdateService(this, getRealTable());
                 }
@@ -1668,7 +1666,7 @@ public class TargetedMSSchema extends UserSchema
         String queryName = settings.getQueryName();
         if (queryName != null && ("PTMPercentsGrouped".equalsIgnoreCase(queryName) || queryName.toLowerCase().startsWith(QUERY_PTM_PERCENTS_GROUPED_PREFIX.toLowerCase())))
         {
-            return new CrosstabView(TargetedMSSchema.this, settings, errors)
+            return new TargetedMSCrosstabView(TargetedMSSchema.this, settings, errors)
             {
                 @Override
                 protected DataRegion createDataRegion()
@@ -1705,7 +1703,16 @@ public class TargetedMSSchema extends UserSchema
             };
         }
 
-        return super.createView(context, settings, errors);
+        QueryDefinition qdef = settings.getQueryDef(this);
+        if (qdef != null)
+        {
+            TableInfo tableInfo = qdef.getTable(this, new ArrayList<>(), true);
+            if (tableInfo instanceof CrosstabTableInfo cti && cti.isCrosstab())
+
+                return new TargetedMSCrosstabView(this, settings, errors);
+        }
+
+        return new TargetedMSQueryView(this, settings, errors);
     }
 
     @Override

--- a/src/org/labkey/targetedms/query/CrossLinkedPeptideDisplayColumn.java
+++ b/src/org/labkey/targetedms/query/CrossLinkedPeptideDisplayColumn.java
@@ -41,6 +41,18 @@ public class CrossLinkedPeptideDisplayColumn extends DataColumn
     }
 
     @Override
+    public boolean isSortable()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isFilterable()
+    {
+        return false;
+    }
+
+    @Override
     public Object getValue(RenderContext ctx)
     {
         Object defaultValue = super.getValue(ctx);

--- a/src/org/labkey/targetedms/query/CrossLinkedPeptideDisplayColumn.java
+++ b/src/org/labkey/targetedms/query/CrossLinkedPeptideDisplayColumn.java
@@ -1,21 +1,24 @@
 package org.labkey.targetedms.query;
 
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+import org.junit.Test;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.DataColumn;
 import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.DisplayColumnFactory;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.query.FieldKey;
-import org.labkey.targetedms.parser.PeptideGroup;
 import org.labkey.targetedms.parser.Protein;
 import org.labkey.targetedms.view.CrossLinkedPeptideInfo;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.BiFunction;
 
 /**
  * Renders the cross-linked peptide info in a few different variants. For unlinked peptides, passes through the primary
@@ -25,13 +28,18 @@ public class CrossLinkedPeptideDisplayColumn extends DataColumn
 {
     // Cache the proteins for a given run to avoid many redundant queries
     private final Map<Long, List<Protein>> _proteins = new HashMap<>();
-    private final BiFunction<Protein, CrossLinkedPeptideInfo.PeptideSequence, String> _formatter;
+    private final Formatter _formatter;
 
-    public CrossLinkedPeptideDisplayColumn(ColumnInfo col, BiFunction<Protein, CrossLinkedPeptideInfo.PeptideSequence, String> formatter)
+    private CrossLinkedPeptideDisplayColumn(ColumnInfo col, Formatter formatter)
     {
         super(col);
         setNoWrap(true);
         _formatter = formatter;
+    }
+
+    interface Formatter
+    {
+        String format(CrossLinkedPeptideInfo.Match match, CrossLinkedPeptideInfo.PeptideSequence sequence, String modification);
     }
 
     @Override
@@ -58,30 +66,40 @@ public class CrossLinkedPeptideDisplayColumn extends DataColumn
         Object defaultValue = super.getValue(ctx);
 
         String modifiedSequence = ctx.get(getModifiedSequenceFieldKey(), String.class);
+        String modification = ctx.get(getModificationFieldKey(), String.class);
         if (modifiedSequence != null)
         {
             CrossLinkedPeptideInfo i = new CrossLinkedPeptideInfo(modifiedSequence);
-            if (i.isCrosslinked())
-            {
-                List<Protein> proteins = getProteinsFromRun(ctx);
-
-                StringBuilder result = new StringBuilder();
-                String separator = "";
-
-                for (CrossLinkedPeptideInfo.PeptideSequence sequence : i.getAllSequences())
-                {
-                    Protein protein = sequence.findMatch(proteins);
-                    if (protein != null)
-                    {
-                        result.append(separator);
-                        separator = "\n";
-                        result.append(_formatter.apply(protein, sequence));
-                    }
-                }
-                return result.toString();
-            }
+            List<Protein> proteins = getProteinsFromRun(ctx);
+            List<CrossLinkedPeptideInfo.PeptideSequence> sequences = i.getAllSequences();
+            return render(sequences, proteins, modification);
         }
         return defaultValue;
+    }
+
+    protected @NotNull String render(List<CrossLinkedPeptideInfo.PeptideSequence> sequences, List<Protein> proteins, String modification)
+    {
+        StringBuilder result = new StringBuilder();
+        String outerSeparator = "";
+
+        for (CrossLinkedPeptideInfo.PeptideSequence sequence : sequences)
+        {
+            List<CrossLinkedPeptideInfo.Match> matches = sequence.findMatches(proteins);
+            if (!matches.isEmpty())
+            {
+                result.append(outerSeparator);
+                outerSeparator = "\n";
+
+                String innerSeparator = "";
+                for (CrossLinkedPeptideInfo.Match match : matches)
+                {
+                    result.append(innerSeparator);
+                    innerSeparator = "; ";
+                    result.append(_formatter.format(match, sequence, modification));
+                }
+            }
+        }
+        return result.toString();
     }
 
     private List<Protein> getProteinsFromRun(RenderContext ctx)
@@ -99,6 +117,11 @@ public class CrossLinkedPeptideDisplayColumn extends DataColumn
         return FieldKey.fromString(getColumnInfo().getFieldKey().getParent(), "PeptideModifiedSequence");
     }
 
+    private FieldKey getModificationFieldKey()
+    {
+        return FieldKey.fromString(getColumnInfo().getFieldKey().getParent(), "Modification");
+    }
+
     private FieldKey getRunIdFieldKey()
     {
         return FieldKey.fromString(getColumnInfo().getFieldKey().getParent(), "RunId");
@@ -109,6 +132,7 @@ public class CrossLinkedPeptideDisplayColumn extends DataColumn
     {
         super.addQueryFieldKeys(keys);
         keys.add(getModifiedSequenceFieldKey());
+        keys.add(getModificationFieldKey());
         keys.add(getRunIdFieldKey());
     }
 
@@ -117,7 +141,7 @@ public class CrossLinkedPeptideDisplayColumn extends DataColumn
         @Override
         public DisplayColumn createRenderer(ColumnInfo colInfo)
         {
-            return new CrossLinkedPeptideDisplayColumn(colInfo, (protein, sequence) -> protein.getLabel() == null ? protein.getName() : protein.getLabel());
+            return new CrossLinkedPeptideDisplayColumn(colInfo, (match, sequence, modification) -> match.protein().getLabel() == null ? match.protein().getName() : match.protein().getLabel());
         }
     }
 
@@ -126,12 +150,55 @@ public class CrossLinkedPeptideDisplayColumn extends DataColumn
         @Override
         public DisplayColumn createRenderer(ColumnInfo colInfo)
         {
-            return new CrossLinkedPeptideDisplayColumn(colInfo, (peptideGroup, sequence) ->
+            return new CrossLinkedPeptideDisplayColumn(colInfo, (match, sequence, modification) ->
+                (match.index() + 1) + "-" + (match.index() + getPeptideLength(sequence.getUnmodified(), modification)));
+        }
+    }
+
+    private static int getPeptideLength(String unmodifiedSequence, String modification)
+    {
+        // If this is a clipped peptide, it's actual length is one shorter than its amino acid sequence
+        if (modification != null && modification.toLowerCase().contains("c-term lys clipping"))
+        {
+            return unmodifiedSequence.length() - 1;
+        }
+        return unmodifiedSequence.length();
+    }
+
+    public static class PeptideIdentityFactory implements DisplayColumnFactory
+    {
+        @Override
+        public DisplayColumn createRenderer(ColumnInfo colInfo)
+        {
+            return new CrossLinkedPeptideDisplayColumn(colInfo, (match, sequence, modification) ->
             {
-                int startIndex = peptideGroup.getSequence().indexOf(sequence.getUnmodified());
-                return (startIndex + 1) + "-" + (startIndex + sequence.getUnmodified().length());
+                String label = match.protein().getLabel();
+                String suffix = getChainAbbreviation(label);
+                return (match.index() + 1) + "-" + (match.index() + getPeptideLength(sequence.getUnmodified(), modification)) + suffix;
             });
         }
+    }
+
+    public static @NotNull String getChainAbbreviation(String label)
+    {
+        String result = "";
+        if (label != null)
+        {
+            label = label.toLowerCase();
+            if (label.endsWith("_hc"))
+            {
+                result = "HC";
+            }
+            if (label.endsWith("_hcstar"))
+            {
+                result = "HC*";
+            }
+            if (label.endsWith("_lc"))
+            {
+                result = "LC";
+            }
+        }
+        return result;
     }
 
     public static class BondLocationFactory implements DisplayColumnFactory
@@ -139,21 +206,123 @@ public class CrossLinkedPeptideDisplayColumn extends DataColumn
         @Override
         public DisplayColumn createRenderer(ColumnInfo colInfo)
         {
-            return new CrossLinkedPeptideDisplayColumn(colInfo, (peptideGroup, sequence) ->
+            return new CrossLinkedPeptideDisplayColumn(colInfo, null)
             {
-                StringBuilder result = new StringBuilder();
-                String separator = "";
-                for (int linkIndex : sequence.getLinkIndices())
+                @Override
+                protected @NotNull String render(List<CrossLinkedPeptideInfo.PeptideSequence> sequences, List<Protein> proteins, String modification)
                 {
-                    result.append(separator);
-                    separator = ", ";
-                    int startIndex = peptideGroup.getSequence().indexOf(sequence.getUnmodified());
-                    result.append(sequence.getUnmodified().charAt(linkIndex));
-                    result.append(startIndex + linkIndex + 1);
+                    List<List<String>> allBonds = new ArrayList<>();
+
+                    for (CrossLinkedPeptideInfo.PeptideSequence sequence : sequences)
+                    {
+                        List<CrossLinkedPeptideInfo.Match> matches = sequence.findMatches(proteins);
+                        List<String> bonds = new ArrayList<>();
+                        for (CrossLinkedPeptideInfo.Match match : matches)
+                        {
+                            for (int linkIndex : sequence.getLinkIndices())
+                            {
+                                bonds.add(Character.toString(sequence.getUnmodified().charAt(linkIndex)) + (match.index() + linkIndex + 1) + getChainAbbreviation(match.protein().getLabel()));
+                            }
+                        }
+                        allBonds.add(bonds);
+                    }
+
+                    List<String> combinations = generateCombinations(allBonds);
+
+                    return StringUtils.join(combinations, "/\n");
                 }
-                return result.toString();
-            });
+            };
         }
     }
 
+    private static void generateCombinationsRecursive(List<List<String>> inputLists, List<String> results, int depth, StringBuilder currentCombination)
+    {
+        // Base case: if we have reached the end of the input lists, add the combination to results
+        if (depth == inputLists.size())
+        {
+            results.add(currentCombination.toString());
+            return;
+        }
+
+        // Iterate over the current list at this depth
+        for (String value : inputLists.get(depth))
+        {
+            int oldLength = currentCombination.length();
+            if (oldLength != 0)
+            {
+                currentCombination.append("-");
+            }
+            currentCombination.append(value); // Append the current value to the combination
+            generateCombinationsRecursive(inputLists, results, depth + 1, currentCombination); // Recursively go to the next depth
+            currentCombination.setLength(oldLength); // Undo the append operation for backtracking
+        }
+    }
+
+    public static List<String> generateCombinations(List<List<String>> inputLists)
+    {
+        List<String> results = new ArrayList<>();
+        if (inputLists == null || inputLists.isEmpty())
+        {
+            return results;
+        }
+
+        // Helper method to recursively generate combinations
+        generateCombinationsRecursive(inputLists, results, 0, new StringBuilder());
+        return results;
+    }
+
+
+    public static class TestCase
+    {
+        @Test
+        public void testGenerateCombinationsThreeDoubles()
+        {
+            List<List<String>> inputLists = new ArrayList<>();
+            inputLists.add(List.of("A", "B"));
+            inputLists.add(List.of("1", "2"));
+            inputLists.add(List.of("X", "Y"));
+
+            List<String> expected = List.of(
+                    "A-1-X", "A-1-Y",
+                    "A-2-X", "A-2-Y",
+                    "B-1-X", "B-1-Y",
+                    "B-2-X", "B-2-Y"
+            );
+
+            List<String> actual = generateCombinations(inputLists);
+            Assert.assertEquals(expected, actual);
+        }
+
+        @Test
+        public void testGenerateCombinationsTwoDoubles()
+        {
+            List<List<String>> inputLists = new ArrayList<>();
+            inputLists.add(List.of("A", "B"));
+            inputLists.add(List.of("1", "2"));
+
+            List<String> expected = List.of(
+                    "A-1", "A-2",
+                    "B-1", "B-2"
+            );
+
+            List<String> actual = generateCombinations(inputLists);
+            Assert.assertEquals(expected, actual);
+        }
+
+        @Test
+        public void testGenerateCombinationsMixed()
+        {
+            List<List<String>> inputLists = new ArrayList<>();
+            inputLists.add(List.of("A", "B"));
+            inputLists.add(List.of("1"));
+
+            List<String> expected = List.of(
+                    "A-1", "B-1"
+            );
+
+            List<String> actual = generateCombinations(inputLists);
+            Assert.assertEquals(expected, actual);
+        }
+
+    }
 }

--- a/src/org/labkey/targetedms/query/ModifiedSequenceDisplayColumn.java
+++ b/src/org/labkey/targetedms/query/ModifiedSequenceDisplayColumn.java
@@ -17,9 +17,18 @@ package org.labkey.targetedms.query;
 
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.logging.log4j.Logger;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.Font;
+import org.apache.poi.ss.usermodel.IndexedColors;
+import org.apache.poi.ss.usermodel.RichTextString;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.DisplayColumnFactory;
+import org.labkey.api.data.ExcelColumn;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.util.HtmlString;
@@ -33,7 +42,10 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -45,6 +57,7 @@ public abstract class ModifiedSequenceDisplayColumn extends IconColumn
     private final ModifiedPeptideHtmlMaker _htmlMaker;
     String _iconPath;
     HtmlString _cellData;
+    List<List<ModifiedPeptideHtmlMaker.SequencePart>> _parsedParts;
 
     boolean _exportAsStrippedHtml = false;
 
@@ -310,7 +323,9 @@ public abstract class ModifiedSequenceDisplayColumn extends IconColumn
                     }
                 }
 
-                _cellData = getHtmlMaker().getPeptideHtml(peptideId, peptideGroupId, sequence, peptideModifiedSequence, runId, previousAA, nextAA, _useParens, strModIndices);
+                var rendered = getHtmlMaker().getPeptideHtml(peptideId, peptideGroupId, sequence, peptideModifiedSequence, runId, previousAA, nextAA, _useParens, strModIndices);
+                _cellData = rendered.first;
+                _parsedParts = rendered.second;
                 _iconPath = IconFactory.getPeptideIconPath(peptideId, runId, decoy, standardType);
             }
         }
@@ -356,19 +371,112 @@ public abstract class ModifiedSequenceDisplayColumn extends IconColumn
 
             String precursorModifiedSequence = (String)getValue(ctx);
 
-            if(precursorId == null || peptideId == null || isotopeLabelId == null || precursorModifiedSequence == null || sequence == null || runId == null)
+            if (precursorId == null || peptideId == null || isotopeLabelId == null || precursorModifiedSequence == null || sequence == null || runId == null)
             {
                 _cellData = HtmlString.of(precursorModifiedSequence);
             }
             else
             {
-                _cellData = getHtmlMaker().getPrecursorHtml(peptideId,
+                var rendered = getHtmlMaker().getPrecursorHtml(peptideId,
                         peptideGroupId,
                         isotopeLabelId,
                         precursorModifiedSequence,
                         runId);
+                _cellData = rendered.first;
+                _parsedParts = rendered.second;
                 _iconPath = IconFactory.getPrecursorIconPath(precursorId, runId, decoy);
             }
+        }
+    }
+
+    @Override
+    public ExcelColumn createExcelColumn(Map<ExcelColumn.ExcelFormatDescriptor, CellStyle> formatters, Workbook workbook)
+    {
+        return new ExcelColumnImpl(this, formatters, workbook);
+    }
+
+    private class ExcelColumnImpl extends ExcelColumn
+    {
+        private CellStyle _wrappedStyle;
+        private Font _crosslinkedFont;
+        private Font _modifiedFont;
+
+        ExcelColumnImpl(ModifiedSequenceDisplayColumn col, Map<ExcelColumn.ExcelFormatDescriptor, CellStyle> formatters, Workbook workbook)
+        {
+            super(col, formatters, workbook);
+        }
+
+        @Override
+        public void writeCell(Sheet sheet, int column, int row, RenderContext ctx)
+        {
+            ModifiedSequenceDisplayColumn.this.initialize(ctx);
+
+            StringBuilder builder = new StringBuilder();
+            Map<Integer, Font> highlights = new HashMap<>();
+            int i = 0;
+            String separator = "";
+            for (List<ModifiedPeptideHtmlMaker.SequencePart> parts : _parsedParts)
+            {
+                i += separator.length();
+                builder.append(separator);
+                separator = "\n";
+                for (ModifiedPeptideHtmlMaker.SequencePart part : parts)
+                {
+                    String s = part.sequence();
+                    builder.append(s);
+                    for (int j = 0; j < s.length(); j++)
+                    {
+                        if (part.crossLinked())
+                        {
+                            if (_crosslinkedFont == null)
+                            {
+                                _crosslinkedFont = _workbook.createFont();
+                                _crosslinkedFont.setColor(IndexedColors.GREEN.getIndex());
+                                _crosslinkedFont.setBold(true);
+                            }
+                            highlights.put(i, _crosslinkedFont);
+                        }
+                        else if (part.modified())
+                        {
+                            if (_modifiedFont == null)
+                            {
+                                _modifiedFont = _workbook.createFont();
+                                _modifiedFont.setColor(IndexedColors.RED.getIndex());
+                                _modifiedFont.setBold(true);
+                            }
+                            highlights.put(i, _modifiedFont);
+                        }
+                        i++;
+                    }
+                }
+            }
+
+            Row rowObject = getRow(sheet, row);
+            Cell cell = rowObject.getCell(column, Row.MissingCellPolicy.CREATE_NULL_AS_BLANK);
+
+            cell.setCellValue(builder.toString());
+            RichTextString richText = cell.getRichStringCellValue();
+
+            for (Map.Entry<Integer, Font> entry : highlights.entrySet())
+            {
+                richText.applyFont(entry.getKey(), entry.getKey() + 1, entry.getValue());
+            }
+
+            if (_parsedParts.size() > 1)
+            {
+                // We have multiple cross-linked peptides so we need a taller row to show them on separate lines within
+                // the same cell
+                if (_wrappedStyle == null)
+                {
+                    _wrappedStyle = _workbook.createCellStyle();
+                    _wrappedStyle.setWrapText(true);
+                }
+                cell.setCellStyle(_wrappedStyle);
+                rowObject.setHeightInPoints(_parsedParts.size() * sheet.getDefaultRowHeightInPoints());
+            }
+
+            // Set the rich text string to the cell
+            cell.setCellValue(richText);
         }
     }
 }

--- a/src/org/labkey/targetedms/query/ModifiedSequenceDisplayColumn.java
+++ b/src/org/labkey/targetedms/query/ModifiedSequenceDisplayColumn.java
@@ -25,7 +25,6 @@ import org.apache.poi.ss.usermodel.RichTextString;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
-import org.apache.poi.xssf.usermodel.XSSFRichTextString;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.DisplayColumnFactory;
@@ -156,6 +155,7 @@ public abstract class ModifiedSequenceDisplayColumn extends IconColumn
         {
         }
 
+        @SuppressWarnings("unused") // Used by query XML metadata
         public PeptideDisplayColumnFactory(MultiValuedMap<String, String> map)
         {
             _showNextAndPrevious = getBooleanProperty(map, "showNextAndPrevious", _showNextAndPrevious);
@@ -473,7 +473,11 @@ public abstract class ModifiedSequenceDisplayColumn extends IconColumn
                     _wrappedStyle.setWrapText(true);
                 }
                 cell.setCellStyle(_wrappedStyle);
-                rowObject.setHeightInPoints(_parsedParts.size() * sheet.getDefaultRowHeightInPoints());
+                float minHeight = sheet.getDefaultRowHeightInPoints() * _parsedParts.size();
+                if (rowObject.getHeightInPoints() < minHeight)
+                {
+                    rowObject.setHeightInPoints(minHeight);
+                }
             }
 
             // Set the rich text string to the cell

--- a/src/org/labkey/targetedms/query/ModifiedSequenceDisplayColumn.java
+++ b/src/org/labkey/targetedms/query/ModifiedSequenceDisplayColumn.java
@@ -25,6 +25,7 @@ import org.apache.poi.ss.usermodel.RichTextString;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFRichTextString;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.DisplayColumnFactory;

--- a/src/org/labkey/targetedms/query/SiteLocationDisplayColumnFactory.java
+++ b/src/org/labkey/targetedms/query/SiteLocationDisplayColumnFactory.java
@@ -20,6 +20,7 @@ import org.labkey.api.query.FieldKey;
 import java.util.Map;
 import java.util.Set;
 
+/** For Excel export, output a chain abbreviation, a three-letter abbreviation for the amino acid, and the index as a superscript */
 public class SiteLocationDisplayColumnFactory implements DisplayColumnFactory
 {
     @Override

--- a/src/org/labkey/targetedms/query/SiteLocationDisplayColumnFactory.java
+++ b/src/org/labkey/targetedms/query/SiteLocationDisplayColumnFactory.java
@@ -1,0 +1,152 @@
+package org.labkey.targetedms.query;
+
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.Font;
+import org.apache.poi.ss.usermodel.RichTextString;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.streaming.SXSSFSheet;
+import org.apache.poi.xssf.usermodel.XSSFFont;
+import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.DataColumn;
+import org.labkey.api.data.DisplayColumn;
+import org.labkey.api.data.DisplayColumnFactory;
+import org.labkey.api.data.ExcelColumn;
+import org.labkey.api.data.RenderContext;
+import org.labkey.api.query.FieldKey;
+
+import java.util.Map;
+import java.util.Set;
+
+public class SiteLocationDisplayColumnFactory implements DisplayColumnFactory
+{
+    @Override
+    public DisplayColumn createRenderer(ColumnInfo colInfo)
+    {
+        return new SiteLocationDisplayColumn(colInfo);
+    }
+
+    private static class ExcelColumnImpl extends ExcelColumn
+    {
+        private final SiteLocationDisplayColumn _col;
+        private XSSFFont _superscriptFont;
+
+        public ExcelColumnImpl(SiteLocationDisplayColumn col, Map<ExcelFormatDescriptor, CellStyle> formatters, Workbook workbook)
+        {
+            super(col, formatters, workbook);
+            _col = col;
+        }
+
+        @Override
+        public void writeCell(Sheet sheet, int column, int row, RenderContext ctx)
+        {
+            Object o = _col.getExcelCompatibleValue(ctx);
+
+            if (o instanceof String s && s.length() >= 2 &&
+                    (s.charAt(0) >= 'A' && s.charAt(0) <= 'Z') &&
+                    (s.charAt(1) >= '0' && s.charAt(1) <= '9'))
+            {
+                String aa = s.substring(0, 1);
+                aa = switch (aa)
+                {
+                    case "G" ->	"Gly";
+                    case "A" ->	"Ala";
+                    case "V" ->	"Val";
+                    case "L" ->	"Leu";
+                    case "I" ->	"Ile";
+                    case "T" ->	"Thr";
+                    case "S" ->	"Ser";
+                    case "M" ->	"Met";
+                    case "C" ->	"Cys";
+                    case "P" ->	"Pro";
+                    case "F" ->	"Phe";
+                    case "Y" ->	"Tyr";
+                    case "W" ->	"Trp";
+                    case "H" ->	"His";
+                    case "K" ->	"Lys";
+                    case "R" ->	"Arg";
+                    case "D" ->	"Asp";
+                    case "E" ->	"Glu";
+                    case "N" ->	"Asn";
+                    case "Q" ->	"Gln";
+                    default -> aa;
+                };
+
+                String chain = _col.getChainLabel(ctx);
+                String chainPrefix = "";
+                if (chain != null)
+                {
+                    chain = chain.toLowerCase();
+                    if (chain.endsWith("_hc"))
+                    {
+                        chainPrefix = "HC ";
+                    }
+                    if (chain.endsWith("_hcstar"))
+                    {
+                        chainPrefix = "HC* ";
+                    }
+                    if (chain.endsWith("_lc"))
+                    {
+                        chainPrefix = "LC ";
+                    }
+                }
+
+                String offset = s.substring(1);
+                String value = chainPrefix + aa + offset;
+
+                Row rowObject = getRow(sheet, row);
+                Cell cell = rowObject.getCell(column, Row.MissingCellPolicy.CREATE_NULL_AS_BLANK);
+                cell.setCellValue(value);
+
+                if (sheet instanceof SXSSFSheet)
+                {
+                    RichTextString richText = cell.getRichStringCellValue();
+                    if (_superscriptFont == null)
+                    {
+                        _superscriptFont = (XSSFFont) _workbook.createFont();
+                        _superscriptFont.setTypeOffset(Font.SS_SUPER);
+                    }
+                    richText.applyFont(chainPrefix.length() + aa.length(), value.length(), _superscriptFont);
+                    cell.setCellValue(richText);
+                }
+            }
+            else
+            {
+                super.writeCell(sheet, column, row, ctx);
+            }
+        }
+    }
+
+    private static class SiteLocationDisplayColumn extends DataColumn
+    {
+        public SiteLocationDisplayColumn(ColumnInfo colInfo)
+        {
+            super(colInfo);
+        }
+
+        @Override
+        public ExcelColumn createExcelColumn(Map<ExcelColumn.ExcelFormatDescriptor, CellStyle> formatters, Workbook workbook)
+        {
+            return new ExcelColumnImpl(this, formatters, workbook);
+        }
+
+        private String getChainLabel(RenderContext ctx)
+        {
+            return ctx.get(getChainLabelFieldKey(), String.class);
+        }
+
+        private FieldKey getChainLabelFieldKey()
+        {
+            return new FieldKey(getBoundColumn().getFieldKey().getParent(), "PeptideGroupId").append("Label");
+        }
+
+        @Override
+        public void addQueryFieldKeys(Set<FieldKey> keys)
+        {
+            super.addQueryFieldKeys(keys);
+            keys.add(getChainLabelFieldKey());
+        }
+    }
+}

--- a/src/org/labkey/targetedms/query/SiteLocationDisplayColumnFactory.java
+++ b/src/org/labkey/targetedms/query/SiteLocationDisplayColumnFactory.java
@@ -75,22 +75,10 @@ public class SiteLocationDisplayColumnFactory implements DisplayColumnFactory
                 };
 
                 String chain = _col.getChainLabel(ctx);
-                String chainPrefix = "";
-                if (chain != null)
+                String chainPrefix = CrossLinkedPeptideDisplayColumn.getChainAbbreviation(chain);
+                if (!chainPrefix.isEmpty())
                 {
-                    chain = chain.toLowerCase();
-                    if (chain.endsWith("_hc"))
-                    {
-                        chainPrefix = "HC ";
-                    }
-                    if (chain.endsWith("_hcstar"))
-                    {
-                        chainPrefix = "HC* ";
-                    }
-                    if (chain.endsWith("_lc"))
-                    {
-                        chainPrefix = "LC ";
-                    }
+                    chainPrefix = chainPrefix + " ";
                 }
 
                 String offset = s.substring(1);

--- a/src/org/labkey/targetedms/query/TargetedMSCrosstabView.java
+++ b/src/org/labkey/targetedms/query/TargetedMSCrosstabView.java
@@ -1,0 +1,34 @@
+package org.labkey.targetedms.query;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.data.ExcelWriter;
+import org.labkey.api.query.CrosstabView;
+import org.labkey.api.query.QuerySettings;
+import org.labkey.api.query.QueryView;
+import org.labkey.targetedms.TargetedMSSchema;
+import org.springframework.validation.BindException;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Ensures that the Excel export uses shared strings to support rich text formatting, as the expense of memory use during export
+ */
+public class TargetedMSCrosstabView extends CrosstabView
+{
+    public TargetedMSCrosstabView(TargetedMSSchema schema, @NotNull QuerySettings settings, BindException errors)
+    {
+        super(schema, settings, errors);
+    }
+
+    @Override
+    public ExcelWriter getExcelWriter(ExcelWriter.ExcelDocumentType docType, @Nullable Map<String, String> renameColumnMap) throws IOException
+    {
+        if (docType == ExcelWriter.ExcelDocumentType.xlsx)
+        {
+            docType = ExcelWriter.ExcelDocumentType.xlsxSharedStrings;
+        }
+        return super.getExcelWriter(docType, renameColumnMap);
+    }
+}

--- a/src/org/labkey/targetedms/query/TargetedMSQueryView.java
+++ b/src/org/labkey/targetedms/query/TargetedMSQueryView.java
@@ -1,0 +1,33 @@
+package org.labkey.targetedms.query;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.data.ExcelWriter;
+import org.labkey.api.query.QuerySettings;
+import org.labkey.api.query.QueryView;
+import org.labkey.targetedms.TargetedMSSchema;
+import org.springframework.validation.BindException;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class TargetedMSQueryView extends QueryView
+{
+    public TargetedMSQueryView(TargetedMSSchema schema, @NotNull QuerySettings settings, BindException errors)
+    {
+        super(schema, settings, errors);
+    }
+
+    /**
+     * Ensures that the Excel export uses shared strings to support rich text formatting, as the expense of memory use during export
+     */
+    @Override
+    public ExcelWriter getExcelWriter(ExcelWriter.ExcelDocumentType docType, @Nullable Map<String, String> renameColumnMap) throws IOException
+    {
+        if (docType == ExcelWriter.ExcelDocumentType.xlsx)
+        {
+            docType = ExcelWriter.ExcelDocumentType.xlsxSharedStrings;
+        }
+        return super.getExcelWriter(docType, renameColumnMap);
+    }
+}

--- a/src/org/labkey/targetedms/view/CrossLinkedPeptideInfo.java
+++ b/src/org/labkey/targetedms/view/CrossLinkedPeptideInfo.java
@@ -1,5 +1,6 @@
 package org.labkey.targetedms.view;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
@@ -123,6 +124,9 @@ public class CrossLinkedPeptideInfo
         return new PeptideSequence(0);
     }
 
+    /** @param index 0-based index for the match within the protein's sequence */
+    public record Match(Protein protein, int index) {}
+
     public class PeptideSequence
     {
         private final int _index;
@@ -167,17 +171,33 @@ public class CrossLinkedPeptideInfo
         }
 
         @Nullable
-        public Protein findMatch(List<Protein> proteins)
+        public Match findMatch(List<Protein> proteins)
         {
+            return findMatches(proteins).stream().findFirst().orElse(null);
+        }
+
+        @NotNull
+        public List<Match> findMatches(List<Protein> proteins)
+        {
+            List<Match> result = new ArrayList<>();
             for (Protein protein : proteins)
             {
                 String proteinSequence = protein.getSequence();
-                if (proteinSequence != null && proteinSequence.contains(getUnmodified()))
+                if (proteinSequence != null)
                 {
-                    return protein;
+                    int index = -1;
+                    do
+                    {
+                        index = proteinSequence.indexOf(getUnmodified(), index + 1);
+                        if (index >= 0)
+                        {
+                            result.add(new Match(protein, index));
+                        }
+                    }
+                    while (index > 0);
                 }
             }
-            return null;
+            return result;
         }
 
         public int getPeptideIndex()

--- a/src/org/labkey/targetedms/view/DocumentView.java
+++ b/src/org/labkey/targetedms/view/DocumentView.java
@@ -15,11 +15,16 @@
 
 package org.labkey.targetedms.view;
 
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.data.ExcelWriter;
 import org.labkey.api.data.NestableQueryView;
 import org.labkey.api.data.Sort;
 import org.labkey.api.query.QueryNestingOption;
 import org.labkey.api.view.ViewContext;
 import org.labkey.targetedms.TargetedMSSchema;
+
+import java.io.IOException;
+import java.util.Map;
 
 /**
  * User: binalpatel
@@ -41,5 +46,15 @@ public abstract class DocumentView extends NestableQueryView
     protected Sort getBaseSort()
     {
         return new Sort("Id");
+    }
+
+    @Override
+    public ExcelWriter getExcelWriter(ExcelWriter.ExcelDocumentType docType, @Nullable Map<String, String> renameColumnMap) throws IOException
+    {
+        if (docType == ExcelWriter.ExcelDocumentType.xlsx)
+        {
+            docType = ExcelWriter.ExcelDocumentType.xlsxSharedStrings;
+        }
+        return super.getExcelWriter(docType, renameColumnMap);
     }
 }

--- a/src/org/labkey/targetedms/view/ModifiedPeptideHtmlMaker.java
+++ b/src/org/labkey/targetedms/view/ModifiedPeptideHtmlMaker.java
@@ -223,11 +223,11 @@ public class ModifiedPeptideHtmlMaker
             nextAA = null;
             if (runId != null)
             {
-                Protein matchingProtein = extraSequence.findMatch(getProteins(runId));
+                CrossLinkedPeptideInfo.Match matchingProtein = extraSequence.findMatch(getProteins(runId));
                 if (matchingProtein != null)
                 {
-                    String proteinSequence = matchingProtein.getSequence();
-                    int startIndex = proteinSequence.indexOf(extraSequence.getUnmodified());
+                    String proteinSequence = matchingProtein.protein().getSequence();
+                    int startIndex = matchingProtein.index();
                     int endIndex = startIndex + extraSequence.getUnmodified().length();
 
                     // Stay consistent with primary sequence for showing or hiding previous and next amino acids

--- a/src/org/labkey/targetedms/view/ModifiedPeptideHtmlMaker.java
+++ b/src/org/labkey/targetedms/view/ModifiedPeptideHtmlMaker.java
@@ -17,8 +17,8 @@ package org.labkey.targetedms.view;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.util.DOM;
 import org.labkey.api.util.HtmlString;
-import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.targetedms.TargetedMSSchema;
 import org.labkey.targetedms.chart.ChartColors;
@@ -30,6 +30,7 @@ import org.labkey.targetedms.query.ModificationManager;
 import org.labkey.targetedms.query.PeptideGroupManager;
 import org.labkey.targetedms.query.PeptideManager;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -37,12 +38,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
+
+import static org.labkey.api.util.DOM.at;
 
 /**
  * User: vsharma
- * Date: 4/29/12
- * Time: 7:33 PM
  */
 public class ModifiedPeptideHtmlMaker
 {
@@ -68,28 +70,28 @@ public class ModifiedPeptideHtmlMaker
         _firstIsotopeLabelIdInDocMap = new HashMap<>();
     }
 
-    public HtmlString getPrecursorHtml(Precursor precursor, Long runId, TargetedMSSchema schema)
+    public Pair<HtmlString, List<List<SequencePart>>> getPrecursorHtml(Precursor precursor, Long runId, TargetedMSSchema schema)
     {
         Peptide peptide = PeptideManager.getPeptide(schema.getContainer(), precursor.getGeneralMoleculeId());
         return getPrecursorHtml(peptide, precursor, runId);
     }
 
-    public HtmlString getPrecursorHtml(Peptide peptide, Precursor precursor, Long runId)
+    public Pair<HtmlString, List<List<SequencePart>>> getPrecursorHtml(Peptide peptide, Precursor precursor, Long runId)
     {
         return getPrecursorHtml(peptide.getId(), peptide.getPeptideGroupId(), precursor.getIsotopeLabelId(), precursor.getModifiedSequence(), runId);
     }
 
-    public HtmlString getPrecursorHtml(long peptideId, Long peptideGroupId, long isotopeLabelId, String precursorModifiedSequence, Long runId)
+    public Pair<HtmlString, List<List<SequencePart>>> getPrecursorHtml(long peptideId, Long peptideGroupId, long isotopeLabelId, String precursorModifiedSequence, Long runId)
     {
         return getHtml(peptideId, peptideGroupId, isotopeLabelId, precursorModifiedSequence, runId, null, null, false, null);
     }
 
     public HtmlString getPeptideHtml(Peptide peptide, Long runId)
     {
-        return getPeptideHtml(peptide.getId(), peptide.getPeptideGroupId(), peptide.getSequence(), peptide.getPeptideModifiedSequence(), runId, null, null, false, null);
+        return getPeptideHtml(peptide.getId(), peptide.getPeptideGroupId(), peptide.getSequence(), peptide.getPeptideModifiedSequence(), runId, null, null, false, null).first;
     }
 
-    public HtmlString getPeptideHtml(long peptideId, Long peptideGroupId, String sequence, String peptideModifiedSequence, Long runId, @Nullable String previousAA, @Nullable String nextAA, boolean useParens, @Nullable Set<Pair<Integer, Integer>> strModIndices)
+    public Pair<HtmlString, List<List<SequencePart>>> getPeptideHtml(long peptideId, Long peptideGroupId, String sequence, String peptideModifiedSequence, Long runId, @Nullable String previousAA, @Nullable String nextAA, boolean useParens, @Nullable Set<Pair<Integer, Integer>> strModIndices)
     {
         String altSequence = peptideModifiedSequence;
         if (StringUtils.isBlank(altSequence))
@@ -125,7 +127,7 @@ public class ModifiedPeptideHtmlMaker
      *                      value of the pair is the index of the cross-linked peptide (0 for non-cross linked
      *                      peptides), and the second value is the index of the AA
      */
-    private HtmlString getHtml(long peptideId, @Nullable Long peptideGroupId, @Nullable Long isotopeLabelId, String altSequence, Long runId, @Nullable String previousAA, @Nullable String nextAA, boolean useParens, @Nullable Set<Pair<Integer, Integer>> strModIndices)
+    private Pair<HtmlString, List<List<SequencePart>>> getHtml(long peptideId, @Nullable Long peptideGroupId, @Nullable Long isotopeLabelId, String altSequence, Long runId, @Nullable String previousAA, @Nullable String nextAA, boolean useParens, @Nullable Set<Pair<Integer, Integer>> strModIndices)
     {
         Long firstIsotopeLabelIdInDoc = null;
         if(runId != null)
@@ -153,21 +155,42 @@ public class ModifiedPeptideHtmlMaker
             isotopeModIndices = ModificationManager.getIsotopeModIndexes(peptideId, isotopeLabelId, runId);
         }
 
-        StringBuilder result = new StringBuilder();
-        result.append("<div style=\"display: inline-block;\" title='").append(PageFlowUtil.filter(altSequence)).append("'>");
-        String labelModColor = "black";
+        String labelModColor;
         StringBuilder error = new StringBuilder();
-        if(isotopeLabelId != null)
+        if (isotopeLabelId != null)
         {
-            if(isotopeLabelId >= firstIsotopeLabelIdInDoc)
+            if (isotopeLabelId >= firstIsotopeLabelIdInDoc)
             {
                 labelModColor = toHex(ChartColors.getIsotopeColor(isotopeLabelId - firstIsotopeLabelIdInDoc).getRGB());
             }
             else
             {
                 error.append("Error getting color for isotope label.");
+                labelModColor = "black";
             }
         }
+        else
+        {
+            labelModColor = "black";
+        }
+
+        List<List<SequencePart>> allParts = getCrossLinkedSequenceParts(altSequence, peptideGroupId, runId, strModIndices, isotopeModIndices, useParens, previousAA, nextAA, showPreviousNext);
+
+        AtomicBoolean separator = new AtomicBoolean(false);
+
+        return Pair.of(DOM.createHtmlFragment(
+                DOM.DIV(at(DOM.Attribute.style, "display:inline-block;", DOM.Attribute.title, altSequence),
+                        allParts.stream().map(parts ->
+                                DOM.createHtmlFragment(
+                                        separator.getAndSet(true) ? DOM.BR() : null,
+                                        renderSequenceHtml(parts, labelModColor))),
+                        error.isEmpty() ? DOM.DIV(at(DOM.Attribute.style, "color:red;"), error.toString()) : null)),
+            allParts);
+    }
+
+    private List<List<SequencePart>> getCrossLinkedSequenceParts(String altSequence, Long peptideGroupId, Long runId, Set<Pair<Integer, Integer>> strModIndices, Set<Integer> isotopeModIndices, boolean useParens, String previousAA, String nextAA, boolean showPreviousNext)
+    {
+        List<List<SequencePart>> result = new ArrayList<>();
 
         CrossLinkedPeptideInfo crossLink = new CrossLinkedPeptideInfo(altSequence);
 
@@ -191,14 +214,13 @@ public class ModifiedPeptideHtmlMaker
             }
         }
 
-        renderSequence(crossLink.getBaseSequence(), filterModIndices(strModIndices, 0), isotopeModIndices, result, labelModColor, useParens, previousAA, nextAA, cdrIndices);
+        result.add(renderSequence(crossLink.getBaseSequence(), filterModIndices(strModIndices, 0), isotopeModIndices, useParens, previousAA, nextAA, cdrIndices));
 
         // If we have cross-linking info, show those peptides too
         for (CrossLinkedPeptideInfo.PeptideSequence extraSequence : crossLink.getExtraSequences())
         {
             previousAA = null;
             nextAA = null;
-            result.append("<br />\n");
             if (runId != null)
             {
                 Protein matchingProtein = extraSequence.findMatch(getProteins(runId));
@@ -207,7 +229,7 @@ public class ModifiedPeptideHtmlMaker
                     String proteinSequence = matchingProtein.getSequence();
                     int startIndex = proteinSequence.indexOf(extraSequence.getUnmodified());
                     int endIndex = startIndex + extraSequence.getUnmodified().length();
-                    
+
                     // Stay consistent with primary sequence for showing or hiding previous and next amino acids
                     if (showPreviousNext)
                     {
@@ -230,16 +252,9 @@ public class ModifiedPeptideHtmlMaker
                     }
                 }
             }
-            renderSequence(extraSequence, filterModIndices(strModIndices, extraSequence.getPeptideIndex()), isotopeModIndices, result, labelModColor, useParens, previousAA, nextAA, Collections.emptySet());
+            result.add(renderSequence(extraSequence, filterModIndices(strModIndices, extraSequence.getPeptideIndex()), isotopeModIndices, useParens, previousAA, nextAA, Collections.emptySet()));
         }
-
-        result.append("</div>");
-
-        if (!error.isEmpty())
-        {
-            result.append("<div style='color:red;'>").append(PageFlowUtil.filter(error.toString())).append("</div>");
-        }
-        return HtmlString.unsafe(result.toString());
+        return result;
     }
 
     private Set<Integer> filterModIndices(Set<Pair<Integer, Integer>> strModIndices, int peptideIndex)
@@ -247,20 +262,51 @@ public class ModifiedPeptideHtmlMaker
         return strModIndices.stream().filter(x -> x.first == peptideIndex).map(x -> x.second).collect(Collectors.toSet());
     }
 
-    private void renderSequence(CrossLinkedPeptideInfo.PeptideSequence sequenceInfo, Set<Integer> strModIndices, Set<Integer> isotopeModIndices, StringBuilder result, String labelModColor, boolean useParens, @Nullable String previousAA, @Nullable String nextAA, Set<Integer> cdrIndices)
+    public record SequencePart(String sequence, boolean modified, boolean isotopeModified, boolean crossLinked, boolean cdr) {}
+
+    private HtmlString renderSequenceHtml(List<SequencePart> parts, String labelModColor)
     {
+        return DOM.createHtmlFragment(
+            parts.stream().map(part -> {
+                if (part.modified || part.isotopeModified || part.crossLinked || part.cdr)
+                {
+                    StringBuilder style = new StringBuilder();
+                    if (part.modified || part.isotopeModified || part.crossLinked)
+                    {
+                        style.append("font-weight:bold;");
+                    }
+                    if (part.isotopeModified)
+                    {
+                        style.append("color:").append(labelModColor).append(";");
+                    }
+                    else if (part.crossLinked)
+                    {
+                        style.append("color:").append("green").append(";");
+                    }
+                    if (part.modified)
+                    {
+                        style.append("text-decoration:underline;");
+                    }
+                    if (part.cdr)
+                    {
+                        style.append("background-color:lightgrey;");
+                    }
+                    return DOM.SPAN(at(DOM.Attribute.style, style), part.sequence);
+                }
+                return part.sequence;
+            }));
+    }
+
+    private List<SequencePart> renderSequence(CrossLinkedPeptideInfo.PeptideSequence sequenceInfo, Set<Integer> strModIndices, Set<Integer> isotopeModIndices, boolean useParens, @Nullable String previousAA, @Nullable String nextAA, Set<Integer> cdrIndices)
+    {
+        List<SequencePart> parts = new ArrayList<>();
+
         if (previousAA != null)
         {
-            if (useParens)
-            {
-                result.append("(");
-            }
-            result.append(PageFlowUtil.filter(previousAA));
-            result.append(useParens ? ")" : ".");
+            parts.add(new SequencePart(useParens ? "(" + previousAA + ")" : previousAA, false, false, false, false));
         }
 
         String sequence = sequenceInfo.getUnmodified();
-
         for(int i = 0; i < sequence.length(); i++)
         {
             boolean isStrModified = strModIndices != null && strModIndices.contains(i);
@@ -268,47 +314,15 @@ public class ModifiedPeptideHtmlMaker
             boolean isCrossLinked = sequenceInfo.isCrossLinked(i);
             boolean isCDR = cdrIndices.contains(i);
 
-            if (isIsotopeModified || isStrModified || isCrossLinked || isCDR)
-            {
-                StringBuilder style = new StringBuilder("style='");
-                if (isIsotopeModified || isStrModified || isCrossLinked)
-                {
-                    style.append("font-weight:bold;");
-                }
-                if (isIsotopeModified)
-                {
-                    style.append("color:").append(labelModColor).append(";");
-                }
-                else if (isCrossLinked)
-                {
-                    style.append("color:").append("green").append(";");
-                }
-                if (isStrModified)
-                {
-                    style.append("text-decoration:underline;");
-                }
-                if (isCDR)
-                {
-                    style.append("background-color:lightgrey;");
-                }
-                style.append("'");
-                result.append("<span ").append(style).append(">").append(sequence.charAt(i)).append("</span>");
-            }
-            else
-            {
-                result.append(PageFlowUtil.filter(sequence.charAt(i)));
-            }
+            parts.add(new SequencePart(String.valueOf(sequence.charAt(i)), isStrModified, isIsotopeModified, isCrossLinked, isCDR));
         }
 
         if (nextAA != null)
         {
-            result.append(useParens ? "(" : ".");
-            result.append(PageFlowUtil.filter(nextAA));
-            if (useParens)
-            {
-                result.append(")");
-            }
+            parts.add(new SequencePart(useParens ? "(" + nextAA + ")" : nextAA, false, false, false, false));
         }
+
+        return parts;
     }
 
     public String toHex(int rgb)

--- a/src/org/labkey/targetedms/view/PrecursorHtmlMaker.java
+++ b/src/org/labkey/targetedms/view/PrecursorHtmlMaker.java
@@ -44,7 +44,7 @@ public class PrecursorHtmlMaker
         }
 
         return DOM.createHtmlFragment(
-                new ModifiedPeptideHtmlMaker().getPrecursorHtml(peptide, precursor, runId),
+                new ModifiedPeptideHtmlMaker().getPrecursorHtml(peptide, precursor, runId).first,
                 DOM.SPAN(body));
     }
 
@@ -52,7 +52,7 @@ public class PrecursorHtmlMaker
                                              long runId, TargetedMSSchema schema)
     {
         return DOM.createHtmlFragment(
-                modifiedPeptideHtmlMaker.getPrecursorHtml(precursor, runId, schema),
+                modifiedPeptideHtmlMaker.getPrecursorHtml(precursor, runId, schema).first,
                 DOM.SPAN(LabelFactory.getChargeLabel(precursor.getCharge())));
     }
 }

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSMAMTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSMAMTest.java
@@ -56,8 +56,8 @@ public class TargetedMSMAMTest extends TargetedMSTest
         clickAndWait(Locator.linkContainingText("Peptide Map"));
         assertTextPresentInThisOrder("11.3", "14.1", "14.8");
         assertTextPresentInThisOrder("1501.75", "1078.50", "1547.71");
-        assertTextPresentInThisOrder("NU205", "NU205", "1433Z");
-        assertTextPresentInThisOrder("70-84", "325-333", "28-41");
+        assertTextPresentInThisOrder("NU205", "NU205", "1433Z", "UCRI; RL35");
+        assertTextPresentInThisOrder("70-84", "325-333", "28-41", "190-196; 26-32");
         assertTextPresentInThisOrder("(K)ASTEGVAIQGQQGTR(L)", "(K)AQYEDIANR(S)", "(K)SVTEQGAELSNEER(N)");
         assertTextPresentInThisOrder("Carbamidomethyl Cysteine @ C157", "Carbamidomethyl Cysteine @ C245", "Carbamidomethyl Cysteine @ C94");
     }
@@ -74,7 +74,8 @@ public class TargetedMSMAMTest extends TargetedMSTest
 
         clickAndWait(Locator.linkContainingText("Peptide Map"));
         assertTextPresentInThisOrder("364-366", "367-369", "364-367");
-        assertTextPresentInThisOrder("Q364, N366", "T369", "D364");
+        // Disulfide bonds
+        assertTextPresentInThisOrder("Q364-T369-D364/\nN366-T369-D364", "V121-S345-Q142/\nQ124-S345-Q142");
         assertTextPresentInThisOrder("(A)LKPLALV(D)", "(G)AVVQDPA(Y)", "(F)YGEATSR(E)");
     }
 }

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSPeptideLibraryTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSPeptideLibraryTest.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.test.tests.targetedms;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -262,6 +263,11 @@ public class TargetedMSPeptideLibraryTest extends TargetedMSTest
         for(int i = 0; i < expectedConflictCount; i++)
         {
             String conflict = getTableCellText(table, i, 2);
+            if (conflict != null)
+            {
+                // Strip out whitespace
+                conflict = conflict.replaceAll("\\s", "");
+            }
             assertTrue("Unexpected row in conflicts table " + conflict, expectedConflicts.contains(conflict));
         }
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSPeptideLibraryTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSPeptideLibraryTest.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.test.tests.targetedms;
 
-import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -81,10 +80,10 @@ public class TargetedMSPeptideLibraryTest extends TargetedMSTest
 
         // Verify one precursor from some of the proteins in the library.  All are from SKY_FILE1 at this point.
         Map<String, Pair<String, String>> precursorMap = new HashMap<>();
-        precursorMap.put("AHHNALER",           new Pair(SKY_FILE1, "MAX"));
-        precursorMap.put("ALDFAVGEYNK[+8.0]",  new Pair(SKY_FILE1, "QPrEST_CystC_HPRR5000001"));
-        precursorMap.put("QFVYLESDYSK[+8.0]",  new Pair(SKY_FILE1, "HPRR1440042"));
-        precursorMap.put("ADVTPADFSEWSK",      new Pair(SKY_FILE1, "iRT-C18 Standard Peptides"));
+        precursorMap.put("AHHNALER",           Pair.of(SKY_FILE1, "MAX"));
+        precursorMap.put("ALDFAVGEYNK[+8.0]",  Pair.of(SKY_FILE1, "QPrEST_CystC_HPRR5000001"));
+        precursorMap.put("QFVYLESDYSK[+8.0]",  Pair.of(SKY_FILE1, "HPRR1440042"));
+        precursorMap.put("ADVTPADFSEWSK",      Pair.of(SKY_FILE1, "iRT-C18 Standard Peptides"));
         // The precursors below are only in SKY_FILE1 so will not result in a conflict. We can leave them out otherwise the test takes too long to run.
         // precursorMap.put("DPDYQPPAK",          new Pair(SKY_FILE1, "CTCF"));
         // precursorMap.put("EDSSLLNPAAK",        new Pair(SKY_FILE1, "TAF11"));
@@ -135,8 +134,6 @@ public class TargetedMSPeptideLibraryTest extends TargetedMSTest
             precursorTable.getPagingWidget().setPageSize(250, true);
         }
 
-        List<String> colNames = precursorTable.getColumnNames();
-        String x = colNames.get(0);
         assertEquals("Unexpected number of rows in the precursors table (library view)", libraryPrecursorCount, precursorTable.getDataRowCount());
 
         for(Map.Entry<String, Pair<String, String>> entry: precursorMap.entrySet())
@@ -175,9 +172,9 @@ public class TargetedMSPeptideLibraryTest extends TargetedMSTest
         // Verify one precursor from some of the proteins in the library.
         // From SKY_FILE1
         Map<String, Pair<String, String>> precursorMap = new HashMap<>();
-        precursorMap.put("AHHNALER",           new Pair(SKY_FILE1, "MAX")); // Conflicted in SKY_FILE2
-        precursorMap.put("ALDFAVGEYNK[+8.0]",  new Pair(SKY_FILE1, "QPrEST_CystC_HPRR5000001")); // Conflicted in SKY_FILE2
-        precursorMap.put("QFVYLESDYSK[+8.0]",  new Pair(SKY_FILE1, "HPRR1440042")); // Conflicted in SKY_FILE2
+        precursorMap.put("AHHNALER",           Pair.of(SKY_FILE1, "MAX")); // Conflicted in SKY_FILE2
+        precursorMap.put("ALDFAVGEYNK[+8.0]",  Pair.of(SKY_FILE1, "QPrEST_CystC_HPRR5000001")); // Conflicted in SKY_FILE2
+        precursorMap.put("QFVYLESDYSK[+8.0]",  Pair.of(SKY_FILE1, "HPRR1440042")); // Conflicted in SKY_FILE2
 
 
         // The precursors below are only in SKY_FILE2 so will not result in a conflict. We can leave them out otherwise the test takes too long to run.
@@ -187,14 +184,14 @@ public class TargetedMSPeptideLibraryTest extends TargetedMSTest
         // precursorMap.put("AGTLDLSLTVQGK",      new Pair(SKY_FILE2, "HPRR350065"));
         // precursorMap.put("AHSSHLK",            new Pair(SKY_FILE2, "TP53"));
 
-        precursorMap.put("ADVTPADFSEWSK",      new Pair(SKY_FILE2, "iRT-C18 Standard Peptides")); // iRT peptide should always be from the new file
+        precursorMap.put("ADVTPADFSEWSK",      Pair.of(SKY_FILE2, "iRT-C18 Standard Peptides")); // iRT peptide should always be from the new file
 
         // SKY_FILE2 has both the heavy and light versions of QFVYLESDYSK.
         // heavy version (QFVYLESDYSK[+8.0]) is conflicted as it also in SKY_FILE1
         // There are two entries for the peptide QFVYLESDYSK in the library at this point
         // QFVYLESDYSK -> QFVYLESDYSK[+8.0] -> heavy precursor from SKY_FILE1
         // QFVYLESDYSK -> QFVYLESDYSK       -> light precursor from SKY_FILE2
-        precursorMap.put("QFVYLESDYSK",        new Pair(SKY_FILE2, "HPRR1440042"));
+        precursorMap.put("QFVYLESDYSK",        Pair.of(SKY_FILE2, "HPRR1440042"));
 
         verifyLibraryPrecursors(precursorMap, libraryPrecursorCount,
                 124 // total precursor count includes all the precursors from all the documents in the folder
@@ -292,15 +289,15 @@ public class TargetedMSPeptideLibraryTest extends TargetedMSTest
         Map<String, Pair<String, String>> precursorMap = new HashMap<>();
 
         // After resolving conflicts
-        precursorMap.put("AHHNALER",           new Pair(SKY_FILE2, "MAX"));         // Now from SKY_FILE2
-        precursorMap.put("MSDNDDIEVESDADK",    new Pair(SKY_FILE2, "MAX"));         // Now from SKY_FILE2
+        precursorMap.put("AHHNALER",           Pair.of(SKY_FILE2, "MAX"));         // Now from SKY_FILE2
+        precursorMap.put("MSDNDDIEVESDADK",    Pair.of(SKY_FILE2, "MAX"));         // Now from SKY_FILE2
         // Both heavy and light precursors of the peptides ALDFAVGEYNK and QFVYLESDYSK are now from SKY_FILE2
-        precursorMap.put("ALDFAVGEYNK[+8.0]",  new Pair(SKY_FILE2, "HPRR5000001")); // Now from SKY_FILE2
-        precursorMap.put("ALDFAVGEYNK",        new Pair(SKY_FILE2, "HPRR5000001"));
-        precursorMap.put("QFVYLESDYSK[+8.0]",  new Pair(SKY_FILE2, "HPRR1440042")); // Now from SKY_FILE2
-        precursorMap.put("QFVYLESDYSK",        new Pair(SKY_FILE2, "HPRR1440042"));
+        precursorMap.put("ALDFAVGEYNK[+8.0]",  Pair.of(SKY_FILE2, "HPRR5000001")); // Now from SKY_FILE2
+        precursorMap.put("ALDFAVGEYNK",        Pair.of(SKY_FILE2, "HPRR5000001"));
+        precursorMap.put("QFVYLESDYSK[+8.0]",  Pair.of(SKY_FILE2, "HPRR1440042")); // Now from SKY_FILE2
+        precursorMap.put("QFVYLESDYSK",        Pair.of(SKY_FILE2, "HPRR1440042"));
 
-        precursorMap.put("ADVTPADFSEWSK",      new Pair(SKY_FILE2, "iRT-C18 Standard Peptides")); // iRT peptide should always be from the new file
+        precursorMap.put("ADVTPADFSEWSK",      Pair.of(SKY_FILE2, "iRT-C18 Standard Peptides")); // iRT peptide should always be from the new file
 
         verifyLibraryPrecursors(precursorMap, libraryPrecursorCount,
                 124 // total precursor count includes all the precursors from all the documents in the folder
@@ -321,10 +318,10 @@ public class TargetedMSPeptideLibraryTest extends TargetedMSTest
 
         // All are from SKY_FILE1 after deleting SKY_FILE2.
         Map<String, Pair<String, String>> precursorMap = new HashMap<>();
-        precursorMap.put("AHHNALER",           new Pair(SKY_FILE1, "MAX"));
-        precursorMap.put("ALDFAVGEYNK[+8.0]",  new Pair(SKY_FILE1, "QPrEST_CystC_HPRR5000001"));
-        precursorMap.put("QFVYLESDYSK[+8.0]",  new Pair(SKY_FILE1, "HPRR1440042"));
-        precursorMap.put("ADVTPADFSEWSK",      new Pair(SKY_FILE1, "iRT-C18 Standard Peptides"));
+        precursorMap.put("AHHNALER",           Pair.of(SKY_FILE1, "MAX"));
+        precursorMap.put("ALDFAVGEYNK[+8.0]",  Pair.of(SKY_FILE1, "QPrEST_CystC_HPRR5000001"));
+        precursorMap.put("QFVYLESDYSK[+8.0]",  Pair.of(SKY_FILE1, "HPRR1440042"));
+        precursorMap.put("ADVTPADFSEWSK",      Pair.of(SKY_FILE1, "iRT-C18 Standard Peptides"));
 
         verifyLibraryPrecursors(precursorMap, libraryPrecursorCount,
                 libraryPrecursorCount // total precursor count is the same as the library precursor count since there is only one document in the folder


### PR DESCRIPTION
#### Rationale
Users have requested improvements to the MAM reports. This includes showing more details when a peptide sequence is repeated across protein sequences and showing more cross-linking possibilities. They also want to see richer formatting in Excel exports, especially around modified peptide sequences.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6627

#### Changes
* Refactor modified peptide rendering to support both Excel and HTML output
* Use rich text formatting to highlight modified peptides in Excel exports
* Overrides to force shared strings in Excel exports, required for rich text support
* Show all indices for peptides repeated across proteins in the same Skyline file in Peptide Map
* Smaller formatting updates for Peptide Map report
* Make better use of HtmlString and DOM builder