### PR TITLE
Fix crawler failure in TargetedMSCalibrationCurveTest

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -114,8 +114,10 @@ import org.labkey.api.query.DetailsURL;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.FilteredTable;
 import org.labkey.api.query.QueryParam;
+import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QuerySettings;
 import org.labkey.api.query.QueryView;
+import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.reports.ReportService;
 import org.labkey.api.reports.model.ViewCategory;
@@ -7814,10 +7816,31 @@ public class TargetedMSController extends SpringActionController
         }
     }
 
+    public static WebPartView<?> getFiguresOfMeritView(User user, Container container, long generalMoleculeId, boolean minimize)
+    {
+        UserSchema schema = QueryService.get().getUserSchema(user, container, TargetedMSSchema.SCHEMA_NAME);
+        TableInfo tableInfo = schema.getTable(TargetedMSSchema.TABLE_MOLECULE_INFO);
+        if (tableInfo == null)
+        {
+            throw new NotFoundException("Query " + TargetedMSSchema.SCHEMA_NAME + "." + TargetedMSSchema.TABLE_MOLECULE_INFO + " not found.");
+        }
+
+        SimpleFilter filter = new SimpleFilter(FieldKey.fromString("GeneralMoleculeId"), generalMoleculeId, CompareType.EQUAL);
+        FiguresOfMeritView.MoleculeInfo moleculeInfo = new TableSelector(tableInfo, filter, null).getObject(FiguresOfMeritView.MoleculeInfo.class);
+        if (moleculeInfo == null)
+        {
+            HtmlView htmlView = new HtmlView(HtmlString.of("No figures of merit available due to lack of quantitative data"));
+            htmlView.setTitle("Figures of Merit");
+            htmlView.setFrame(WebPartView.FrameType.PORTAL);
+            return htmlView;
+        }
+        return new FiguresOfMeritView(moleculeInfo, schema, minimize);
+    }
+
     @RequiresPermission(ReadPermission.class)
     public static class ShowFiguresOfMeritAction extends SimpleViewAction<GeneralMoleculeForm>
     {
-        private FiguresOfMeritView _figuresOfMeritView;
+        private HttpView<?> _figuresOfMeritView;
 
         @Override
         public void validate(GeneralMoleculeForm form, BindException errors)
@@ -7830,20 +7853,20 @@ public class TargetedMSController extends SpringActionController
         @Override
         public ModelAndView getView(GeneralMoleculeForm form, BindException errors)
         {
-            _figuresOfMeritView = new FiguresOfMeritView(getUser(), getContainer(), form.getGeneralMoleculeId().longValue(), false);
+            _figuresOfMeritView = getFiguresOfMeritView(getUser(), getContainer(), form.getGeneralMoleculeId().longValue(), false);
             return _figuresOfMeritView;
         }
 
         @Override
         public void addNavTrail(NavTree root)
         {
-            if (_figuresOfMeritView != null && _figuresOfMeritView.getModelBean() != null)
+            if (_figuresOfMeritView != null && _figuresOfMeritView.getModelBean() instanceof FiguresOfMeritView.MoleculeInfo info)
             {
-                TargetedMSRun run = _figuresOfMeritView.getModelBean().getRun();
+                TargetedMSRun run = info.getRun();
                 root.addChild("Targeted MS Runs", getShowListURL(getContainer()));
                 root.addChild(run.getDescription(), getShowCalibrationCurvesURL(getContainer(), run.getId()));
 
-                GeneralMolecule<?, ?> molecule = _figuresOfMeritView.getModelBean().getGeneralMolecule();
+                GeneralMolecule<?, ?> molecule = info.getGeneralMolecule();
                 if (molecule != null)
                 {
                     root.addChild("Figures of Merit: " + molecule.getTextId());
@@ -7918,7 +7941,7 @@ public class TargetedMSController extends SpringActionController
         public ModelAndView getView(CalibrationCurveForm calibrationCurveForm, BindException errors)
         {
             CalibrationCurveChart chart = _curvePlotView.getChart();
-            GeneralMolecule molecule = chart.getMolecule();
+            GeneralMolecule<?, ?> molecule = chart.getMolecule();
             if (molecule == null)
             {
                 throw new NotFoundException("Could not find molecule");
@@ -7944,8 +7967,7 @@ public class TargetedMSController extends SpringActionController
                 detailsUrl = new ActionURL(ShowMoleculeAction.class, getContainer());
             }
 
-            FiguresOfMeritView fomView = new FiguresOfMeritView(getUser(), getContainer(), molecule.getId(), true);
-            fomView.setTitleHref(new ActionURL(ShowFiguresOfMeritAction.class, getContainer()).addParameter("GeneralMoleculeId", molecule.getId()));
+            HttpView<?> fomView = getFiguresOfMeritView(getUser(), getContainer(), molecule.getId(), true);
 
             JspView<SummaryChartBean> summaryChartView = new JspView<>("/org/labkey/targetedms/view/summaryChartsView.jsp", summaryChartBean);
             summaryChartView.setTitle("Summary Charts");

--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -480,7 +480,7 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
                         }
                         catch (NumberFormatException ignored) {}
                     }
-                    return new FiguresOfMeritView(portalCtx.getUser(), portalCtx.getContainer(), id, true);
+                    return TargetedMSController.getFiguresOfMeritView(portalCtx.getUser(), portalCtx.getContainer(), id, true);
                 }
 
                 @Override

--- a/src/org/labkey/targetedms/view/FiguresOfMeritView.java
+++ b/src/org/labkey/targetedms/view/FiguresOfMeritView.java
@@ -1,16 +1,14 @@
 package org.labkey.targetedms.view;
 
-import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.SimpleFilter;
-import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.query.FieldKey;
-import org.labkey.api.query.QueryService;
 import org.labkey.api.query.UserSchema;
-import org.labkey.api.security.User;
+import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.JspView;
 import org.labkey.api.view.NotFoundException;
+import org.labkey.targetedms.TargetedMSController;
 import org.labkey.targetedms.TargetedMSManager;
 import org.labkey.targetedms.TargetedMSRun;
 import org.labkey.targetedms.TargetedMSSchema;
@@ -21,25 +19,15 @@ import org.labkey.targetedms.query.PeptideManager;
 
 public class FiguresOfMeritView extends JspView<FiguresOfMeritView.MoleculeInfo>
 {
-    public FiguresOfMeritView(User user, Container container, long generalMoleculeId, boolean minimize)
+    public FiguresOfMeritView(MoleculeInfo moleculeInfo, UserSchema schema, boolean minimize)
     {
         super("/org/labkey/targetedms/view/figuresOfMerit.jsp");
+
+        Container container = schema.getContainer();
+        long generalMoleculeId = moleculeInfo._generalMoleculeId;
+
         setTitle("Figures of Merit");
-
-        UserSchema schema = QueryService.get().getUserSchema(user, container, TargetedMSSchema.SCHEMA_NAME);
-        TableInfo tableInfo = schema.getTable(TargetedMSSchema.TABLE_MOLECULE_INFO);
-        if (tableInfo == null)
-        {
-            throw new NotFoundException("Query " + TargetedMSSchema.SCHEMA_NAME + "." + TargetedMSSchema.TABLE_MOLECULE_INFO + " not found.");
-        }
-
-        SimpleFilter filter = new SimpleFilter(FieldKey.fromString("GeneralMoleculeId"), generalMoleculeId, CompareType.EQUAL);
-        MoleculeInfo moleculeInfo = new TableSelector(tableInfo, filter, null).getObject(MoleculeInfo.class);
-
-        if (moleculeInfo == null)
-        {
-            throw new NotFoundException("GeneralMoleculeId " + generalMoleculeId + " not found");
-        }
+        setTitleHref(new ActionURL(TargetedMSController.ShowFiguresOfMeritAction.class, container).addParameter("GeneralMoleculeId", generalMoleculeId));
         setModelBean(moleculeInfo);
         moleculeInfo.setMinimize(minimize);
 
@@ -62,8 +50,8 @@ public class FiguresOfMeritView extends JspView<FiguresOfMeritView.MoleculeInfo>
 
     public static class MoleculeInfo
     {
-        Long _runId;
-        Long _generalMoleculeId;
+        long _runId;
+        long _generalMoleculeId;
         String _peptideName;
         String _moleculeName;
         String _fileName;
@@ -74,22 +62,22 @@ public class FiguresOfMeritView extends JspView<FiguresOfMeritView.MoleculeInfo>
         TargetedMSRun _run;
         private boolean _minimize;
 
-        public Long getRunId()
+        public long getRunId()
         {
             return _runId;
         }
 
-        public void setRunId(Long runId)
+        public void setRunId(long runId)
         {
             _runId = runId;
         }
 
-        public Long getGeneralMoleculeId()
+        public long getGeneralMoleculeId()
         {
             return _generalMoleculeId;
         }
 
-        public void setGeneralMoleculeId(Long moleculeId)
+        public void setGeneralMoleculeId(long moleculeId)
         {
             _generalMoleculeId = moleculeId;
         }

--- a/test/src/org/labkey/test/tests/targetedms/AbstractQuantificationTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/AbstractQuantificationTest.java
@@ -52,7 +52,7 @@ public class AbstractQuantificationTest extends TargetedMSTest
     @BeforeClass
     public static void setupProject()
     {
-        AbstractQuantificationTest init = (AbstractQuantificationTest) getCurrentTest();
+        AbstractQuantificationTest init = getCurrentTest();
 
         init.setupFolder(FolderType.Experiment);
     }
@@ -85,7 +85,7 @@ public class AbstractQuantificationTest extends TargetedMSTest
             }
 
             // No data
-            if (distinctGroups.size() < 1)
+            if (distinctGroups.isEmpty())
             {
                 assertTextPresent("No data of this type");
                 return;
@@ -321,7 +321,7 @@ public class AbstractQuantificationTest extends TargetedMSTest
                 assertNotEquals(msg, -1, rowIndex);
                 String actualErrorMessage = calibrationCurvesTable.getDataAsText(rowIndex, "Error Message");
                 String expectedErrorMessage = (String) expectedRow.get("ErrorMessage");
-                if (expectedErrorMessage != null && expectedErrorMessage.length() > 0)
+                if (expectedErrorMessage != null && !expectedErrorMessage.isEmpty())
                 {
                     assertNotEquals("", actualErrorMessage);
                     rowWithoutData = rowIndex;
@@ -441,12 +441,13 @@ public class AbstractQuantificationTest extends TargetedMSTest
 
     private void testCalculatedConcentrations(String scenario) throws Exception
     {
-        String query = "SELECT COALESCE(generalmoleculechrominfo.PeptideId.Sequence, \n" +
-                "generalmoleculechrominfo.MoleculeId.Molecule) AS Peptide, \n" +
-                "generalmoleculechrominfo.SampleFileId.ReplicateId.Name AS Replicate, \n" +
-                "generalmoleculechrominfo.CalculatedConcentration, \n" +
-                "generalmoleculechrominfo.SampleFileId.ReplicateId.RunId.FileName\n" +
-                "FROM generalmoleculechrominfo";
+        String query = """
+                SELECT COALESCE(generalmoleculechrominfo.PeptideId.Sequence,
+                generalmoleculechrominfo.MoleculeId.Molecule) AS Peptide,
+                generalmoleculechrominfo.SampleFileId.ReplicateId.Name AS Replicate,
+                generalmoleculechrominfo.CalculatedConcentration,
+                generalmoleculechrominfo.SampleFileId.ReplicateId.RunId.FileName
+                FROM generalmoleculechrominfo""";
         ExecuteSqlCommand sc = new ExecuteSqlCommand("targetedms");
         sc.setSql(query);
         SelectRowsResponse resp = sc.execute(createDefaultConnection(), getProjectName() + "/" + scenario);
@@ -488,7 +489,7 @@ public class AbstractQuantificationTest extends TargetedMSTest
 
     private Double parseOptionalDouble(String value)
     {
-        if (value == null || "".equals(value) || "#N/A".equals(value))
+        if (value == null || value.isEmpty() || "#N/A".equals(value))
         {
             return null;
         }
@@ -501,9 +502,9 @@ public class AbstractQuantificationTest extends TargetedMSTest
         {
             return null;
         }
-        if (value instanceof String)
+        if (value instanceof String s)
         {
-            return parseOptionalDouble((String) value);
+            return parseOptionalDouble(s);
         }
         return (Double) value;
     }
@@ -516,7 +517,7 @@ public class AbstractQuantificationTest extends TargetedMSTest
         return null == value || "#N/A".equals(value);
     }
 
-    protected class FiguresOfMerit
+    protected static class FiguresOfMerit
     {
         String loq;
         String uloq;
@@ -525,8 +526,6 @@ public class AbstractQuantificationTest extends TargetedMSTest
         String lod;
         String calc;
         String name;
-
-        private FiguresOfMerit(){}
 
         public FiguresOfMerit(@NotNull String molName)
         {


### PR DESCRIPTION
#### Rationale
When there is no quantitative data available for a molecule, we don't have anything to show for figures of merit. Tell the user that instead of giving a 404.

#### Changes
* Switch to showing a normal page saying there's no data instead of throwing `NotFoundException`