### PR TITLE
Let users set and view nicknames for instruments instead of serial numbers

### DIFF
--- a/resources/queries/targetedms/InstrumentSummaryByFolder.sql
+++ b/resources/queries/targetedms/InstrumentSummaryByFolder.sql
@@ -1,11 +1,13 @@
 SELECT
-       COUNT(ReplicateId.RunId) AS SkylineDocumentCount,
+       COUNT(DISTINCT ReplicateId.RunId) AS SkylineDocumentCount,
        COUNT(DISTINCT ReplicateId) AS ReplicateCount,
        MIN(AcquiredTime) AS FirstAcquisition,
        MAX(AcquiredTime) AS LastAcquisition,
        ReplicateId.RunId.Container,
-       InstrumentSerialNumber
+       InstrumentSerialNumber,
+       InstrumentNickname
 FROM targetedms.SampleFile
 GROUP BY
          ReplicateId.RunId.Container,
-         InstrumentSerialNumber
+         InstrumentSerialNumber,
+         InstrumentNickname

--- a/resources/queries/targetedms/InstrumentSummaryByFolder.sql
+++ b/resources/queries/targetedms/InstrumentSummaryByFolder.sql
@@ -4,10 +4,8 @@ SELECT
        MIN(AcquiredTime) AS FirstAcquisition,
        MAX(AcquiredTime) AS LastAcquisition,
        ReplicateId.RunId.Container,
-       InstrumentSerialNumber,
        InstrumentNickname
 FROM targetedms.SampleFile
 GROUP BY
          ReplicateId.RunId.Container,
-         InstrumentSerialNumber,
          InstrumentNickname

--- a/resources/queries/targetedms/QCInstrumentSummary.sql
+++ b/resources/queries/targetedms/QCInstrumentSummary.sql
@@ -1,4 +1,5 @@
 SELECT
+    sf.InstrumentNickname AS Nickname,
     sf.InstrumentId.model AS InstrumentName,
     sf.InstrumentSerialNumber AS SerialNumber,
     MIN(sf.AcquiredTime) AS StartDate,
@@ -9,6 +10,7 @@ SELECT
 FROM targetedms.SampleFile sf
 INNER JOIN replicate rep ON sf.replicateId = rep.Id
 GROUP BY
+         sf.InstrumentNickname,
          sf.InstrumentSerialNumber,
          sf.InstrumentId.model,
          rep.runId

--- a/resources/queries/targetedms/samplefile/.qview.xml
+++ b/resources/queries/targetedms/samplefile/.qview.xml
@@ -9,8 +9,7 @@
                 <property name="columnTitle" value="Skyline Document"/>
             </properties>
         </column>
-        <column name="InstrumentId" />
-        <column name="InstrumentSerialNumber" />
+        <column name="InstrumentNickname" />
         <column name="ModifiedTime" />
     </columns>
     <sorts>

--- a/resources/schemas/dbscripts/postgresql/targetedms-25.003-25.004.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-25.003-25.004.sql
@@ -1,0 +1,18 @@
+CREATE TABLE targetedms.InstrumentNickname
+(
+    Id              BIGSERIAL NOT NULL,
+
+    Container       entityid NOT NULL,
+    Created         TIMESTAMP,
+    CreatedBy       USERID,
+    Modified        TIMESTAMP,
+    ModifiedBy      USERID,
+
+    SerialNumber    VARCHAR(200),
+    Model           VARCHAR(300),
+    Nickname        VARCHAR(200),
+
+    CONSTRAINT PK_InstrumentNickname PRIMARY KEY (Id)
+);
+CREATE INDEX IDX_InstrumentNickname_Container ON targetedms.InstrumentNickname(Container);
+

--- a/resources/schemas/dbscripts/sqlserver/targetedms-25.003-25.004.sql
+++ b/resources/schemas/dbscripts/sqlserver/targetedms-25.003-25.004.sql
@@ -3,14 +3,14 @@ CREATE TABLE targetedms.InstrumentNickname
     Id              BIGINT IDENTITY(1, 1) NOT NULL,
 
     Container       entityid NOT NULL,
-    Created         TIMESTAMP,
+    Created         DATETIME,
     CreatedBy       USERID,
-    Modified        TIMESTAMP,
+    Modified        DATETIME,
     ModifiedBy      USERID,
 
-    SerialNumber    VARCHAR(200),
-    Model           VARCHAR(300),
-    Nickname    VARCHAR(200),
+    SerialNumber    NVARCHAR(200),
+    Model           NVARCHAR(300),
+    Nickname        NVARCHAR(200),
 
     CONSTRAINT PK_InstrumentNickname PRIMARY KEY (Id)
 );

--- a/resources/schemas/dbscripts/sqlserver/targetedms-25.003-25.004.sql
+++ b/resources/schemas/dbscripts/sqlserver/targetedms-25.003-25.004.sql
@@ -1,0 +1,18 @@
+CREATE TABLE targetedms.InstrumentNickname
+(
+    Id              BIGINT IDENTITY(1, 1) NOT NULL,
+
+    Container       entityid NOT NULL,
+    Created         TIMESTAMP,
+    CreatedBy       USERID,
+    Modified        TIMESTAMP,
+    ModifiedBy      USERID,
+
+    SerialNumber    VARCHAR(200),
+    Model           VARCHAR(300),
+    Nickname    VARCHAR(200),
+
+    CONSTRAINT PK_InstrumentNickname PRIMARY KEY (Id)
+);
+CREATE INDEX IDX_InstrumentNickname_Container ON targetedms.InstrumentNickname(Container);
+

--- a/resources/schemas/targetedms.xml
+++ b/resources/schemas/targetedms.xml
@@ -1920,4 +1920,17 @@
             <column columnName="Container"/>
         </columns>
     </table>
+    <table tableName="InstrumentNickname" tableDbType="TABLE">
+        <columns>
+            <column columnName="Id"/>
+            <column columnName="Created"/>
+            <column columnName="CreatedBy"/>
+            <column columnName="Modified"/>
+            <column columnName="ModifiedBy"/>
+            <column columnName="Container"/>
+            <column columnName="SerialNumber"/>
+            <column columnName="Model"/>
+            <column columnName="Nickname"/>
+        </columns>
+    </table>
 </tables>

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -113,10 +113,13 @@ import org.labkey.api.protein.PeptideCharacteristic;
 import org.labkey.api.protein.ProteinService;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.DetailsURL;
+import org.labkey.api.query.DuplicateKeyException;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.FilteredTable;
+import org.labkey.api.query.InvalidKeyException;
 import org.labkey.api.query.QueryParam;
 import org.labkey.api.query.QuerySettings;
+import org.labkey.api.query.QueryUpdateServiceException;
 import org.labkey.api.query.QueryView;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.reports.ReportService;
@@ -4580,7 +4583,7 @@ public class TargetedMSController extends SpringActionController
         }
 
         @Override
-        public boolean handlePost(InstrumentForm form, BindException errors)
+        public boolean handlePost(InstrumentForm form, BindException errors) throws SQLException, BatchValidationException, QueryUpdateServiceException, InvalidKeyException, DuplicateKeyException
         {
             Container targetContainer = ContainerManager.getForId(form.getTargetContainerId());
             if (targetContainer == null || !targetContainer.hasPermission(getUser(), UpdatePermission.class))
@@ -4607,7 +4610,7 @@ public class TargetedMSController extends SpringActionController
             }
             if (StringUtils.isEmpty(form.getName()) && name.getId() > 0)
             {
-                TargetedMSManager.get().deleteNickname(name);
+                TargetedMSManager.get().deleteNickname(name, getUser());
             }
             else
             {

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -1083,7 +1083,6 @@ public class TargetedMSController extends SpringActionController
         TableInfo sampleFileTable = schema.getTableOrThrow(TargetedMSSchema.TABLE_SAMPLE_FILE);
         List<String> instruments = new TableSelector(sampleFileTable, Collections.singleton("InstrumentNickname")).getArrayList(String.class);
         properties.put("fileCount", instruments.size());
-        ;
         properties.put("distinctInstruments", instruments.stream().filter(Objects::nonNull).distinct().sorted().toList());
 
         // # precursors tracked, count of distinct precursors. Include peptides and small molecules
@@ -4593,34 +4592,45 @@ public class TargetedMSController extends SpringActionController
                 throw new UnauthorizedException();
             }
 
-            InstrumentNickname name;
-            if (form.getId() > 0)
+            try (var t = TargetedMSSchema.getSchema().getScope().ensureTransaction())
             {
-                name = TargetedMSManager.get().getNickname(form.getId(), getUser());
-                if (name == null)
+                InstrumentNickname name;
+                if (form.getId() > 0)
                 {
-                    throw new NotFoundException();
+                    name = TargetedMSManager.get().getNickname(form.getId(), getUser());
+                    if (name == null)
+                    {
+                        throw new NotFoundException();
+                    }
+                    if (!name.getContainer().hasPermission(getUser(), UpdatePermission.class))
+                    {
+                        // Insert a different record instead
+                        name.setId(0);
+                    }
+                    else if (!name.getContainer().equals(targetContainer))
+                    {
+                        // Moving from one container to another. Handle this by deleting the old and inserting a new
+                        TargetedMSManager.get().deleteNickname(name, getUser());
+                        name.setId(0);
+                    }
                 }
-                if (!name.getContainer().hasPermission(getUser(), UpdatePermission.class))
+                else
                 {
-                    throw new UnauthorizedException();
+                    name = new InstrumentNickname();
                 }
-            }
-            else
-            {
-                name = new InstrumentNickname();
-            }
-            if (StringUtils.isEmpty(form.getName()) && name.getId() > 0)
-            {
-                TargetedMSManager.get().deleteNickname(name, getUser());
-            }
-            else
-            {
-                name.setNickname(form.getName());
-                name.setModel(form.getModel());
-                name.setSerialNumber(form.getSerialNumber());
-                name.setContainer(targetContainer);
-                TargetedMSManager.get().saveNickname(name, getUser());
+                if (StringUtils.isEmpty(form.getName()) && name.getId() > 0)
+                {
+                    TargetedMSManager.get().deleteNickname(name, getUser());
+                }
+                else
+                {
+                    name.setNickname(form.getName());
+                    name.setModel(form.getModel());
+                    name.setSerialNumber(form.getSerialNumber());
+                    name.setContainer(targetContainer);
+                    TargetedMSManager.get().saveNickname(name, getUser());
+                }
+                t.commit();
             }
 
             return true;

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.keypoint.PngEncoder;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.batik.dom.GenericDOMImplementation;
 import org.apache.batik.svggen.SVGGeneratorContext;
 import org.apache.batik.svggen.SVGGraphics2D;
@@ -166,6 +168,7 @@ import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.PopupMenu;
 import org.labkey.api.view.Portal;
 import org.labkey.api.view.RedirectException;
+import org.labkey.api.view.UnauthorizedException;
 import org.labkey.api.view.VBox;
 import org.labkey.api.view.ViewBackgroundInfo;
 import org.labkey.api.view.ViewContext;
@@ -186,6 +189,7 @@ import org.labkey.targetedms.model.AutoQCPingData;
 import org.labkey.targetedms.model.GuideSet;
 import org.labkey.targetedms.model.GuideSetKey;
 import org.labkey.targetedms.model.GuideSetStats;
+import org.labkey.targetedms.model.InstrumentNickname;
 import org.labkey.targetedms.model.PeptideOutliers;
 import org.labkey.targetedms.model.PrecursorChromInfoLitePlus;
 import org.labkey.targetedms.model.QCPlotFragment;
@@ -1020,7 +1024,7 @@ public class TargetedMSController extends SpringActionController
             List<Map<String, Object>> containers = new ArrayList<>();
 
             // include the QC Summary properties for the current container
-            containers.add(getContainerQCSummaryProperties(getContainer(), getContainer(), false));
+            containers.add(getContainerQCSummaryProperties(getContainer(), getContainer(), false, getUser()));
 
             // include the QC Summary properties for the direct subfolders, of type QC, that the user has read permission
             if (form.isIncludeSubfolders())
@@ -1040,7 +1044,7 @@ public class TargetedMSController extends SpringActionController
                     folderType = TargetedMSManager.getFolderType(bestContainer);
                     if (bestContainer.hasPermission(getUser(), ReadPermission.class) && folderType == TargetedMSService.FolderType.QC)
                     {
-                        containers.add(getContainerQCSummaryProperties(bestContainer, container, true));
+                        containers.add(getContainerQCSummaryProperties(bestContainer, container, true, getUser()));
                     }
                 }
             }
@@ -1050,7 +1054,7 @@ public class TargetedMSController extends SpringActionController
         }
     }
 
-    private Map<String, Object> getContainerQCSummaryProperties(Container container, Container instrumentContainer, boolean isSubfolder)
+    private Map<String, Object> getContainerQCSummaryProperties(Container container, Container instrumentContainer, boolean isSubfolder, User user)
     {
         Map<String, Object> properties = new HashMap<>();
         SQLFragment sql;
@@ -1070,11 +1074,12 @@ public class TargetedMSController extends SpringActionController
         properties.put("lastImportDate", valueMap.get("lastImportDate"));
 
         // # sample files, count of rows in targetedms.SampleFile
-        sql = new SQLFragment("SELECT COUNT(s.Id) FROM ").append(TargetedMSManager.getTableInfoSampleFile(), "s");
-        sql.append(" JOIN ").append(TargetedMSManager.getTableInfoReplicate(), "re").append(" ON s.ReplicateId = re.Id");
-        sql.append(" JOIN ").append(TargetedMSManager.getTableInfoRuns(), "r").append(" ON re.RunId = r.Id");
-        sql.append(" WHERE r.Container = ?").add(container.getId());
-        properties.put("fileCount", new SqlSelector(TargetedMSSchema.getSchema(), sql).getObject(Integer.class));
+        TargetedMSSchema schema = new TargetedMSSchema(user, container);
+        TableInfo sampleFileTable = schema.getTableOrThrow(TargetedMSSchema.TABLE_SAMPLE_FILE);
+        List<String> instruments = new TableSelector(sampleFileTable, Collections.singleton("InstrumentNickname")).getArrayList(String.class);
+        properties.put("fileCount", instruments.size());
+        ;
+        properties.put("distinctInstruments", instruments.stream().filter(Objects::nonNull).distinct().sorted().toList());
 
         // # precursors tracked, count of distinct precursors. Include peptides and small molecules
         sql = new SQLFragment("SELECT DISTINCT COALESCE(p.ModifiedSequence, ");
@@ -1098,7 +1103,6 @@ public class TargetedMSController extends SpringActionController
             autoQCPingMap.put("isRecent", lastModified.getTime() >= timeoutMinutesAgo);
         }
         properties.put("autoQCPing", autoQCPingMap);
-        TargetedMSSchema schema = new TargetedMSSchema(getUser(), container);
         properties.put("metricCount", TargetedMSManager.getEnabledQCMetricConfigurations(schema).size());
 
         return properties;
@@ -3225,7 +3229,7 @@ public class TargetedMSController extends SpringActionController
 
             idx++;
         }
-        if(unsupportedLibraries.size() > 0)
+        if(!unsupportedLibraries.isEmpty())
         {
             HtmlView view = new HtmlView(DIV("Annotated spectra cannot be displayed from the following unsupported "
                             + (unsupportedLibraries.size() == 1 ? "library" : "libraries") + ": ",
@@ -3237,7 +3241,7 @@ public class TargetedMSController extends SpringActionController
             view.setTitle("Unsupported Spectrum " + (unsupportedLibraries.size() == 1 ? "Library" : "Libraries"));
             vbox.addView(view);
         }
-        if(specLibErrors.size() > 0)
+        if(!specLibErrors.isEmpty())
         {
             HtmlView view = new HtmlView(DOM.LK.ERRORS(specLibErrors.stream().map(e -> new LabKeyError(e.getMessage())).collect(Collectors.toList())));
             view.setTitle("Spectrum Library Errors");
@@ -4510,7 +4514,21 @@ public class TargetedMSController extends SpringActionController
 
     public static class InstrumentForm extends QueryViewAction.QueryExportForm
     {
+        private long _id;
+        private String _name;
+        private String _model;
         private String _serialNumber;
+        private String _targetContainerId;
+
+        public String getModel()
+        {
+            return _model;
+        }
+
+        public void setModel(String model)
+        {
+            _model = model;
+        }
 
         public String getSerialNumber()
         {
@@ -4520,6 +4538,93 @@ public class TargetedMSController extends SpringActionController
         public void setSerialNumber(String serialNumber)
         {
             _serialNumber = serialNumber;
+        }
+
+        public String getTargetContainerId()
+        {
+            return _targetContainerId;
+        }
+
+        public void setTargetContainerId(String targetContainerId)
+        {
+            _targetContainerId = targetContainerId;
+        }
+
+        public String getName()
+        {
+            return _name;
+        }
+
+        public void setName(String name)
+        {
+            _name = name;
+        }
+
+        public long getId()
+        {
+            return _id;
+        }
+
+        public void setId(long id)
+        {
+            _id = id;
+        }
+    }
+
+    @RequiresPermission(UpdatePermission.class)
+    public static class SaveInstrumentNameAction extends FormHandlerAction<InstrumentForm>
+    {
+        @Override
+        public void validateCommand(InstrumentForm target, Errors errors)
+        {
+        }
+
+        @Override
+        public boolean handlePost(InstrumentForm form, BindException errors)
+        {
+            Container targetContainer = ContainerManager.getForId(form.getTargetContainerId());
+            if (targetContainer == null || !targetContainer.hasPermission(getUser(), UpdatePermission.class))
+            {
+                throw new UnauthorizedException();
+            }
+
+            InstrumentNickname name;
+            if (form.getId() > 0)
+            {
+                name = TargetedMSManager.get().getNickname(form.getId(), getUser());
+                if (name == null)
+                {
+                    throw new NotFoundException();
+                }
+                if (!name.getContainer().hasPermission(getUser(), UpdatePermission.class))
+                {
+                    throw new UnauthorizedException();
+                }
+            }
+            else
+            {
+                name = new InstrumentNickname();
+            }
+            if (StringUtils.isEmpty(form.getName()) && name.getId() > 0)
+            {
+                TargetedMSManager.get().deleteNickname(name);
+            }
+            else
+            {
+                name.setNickname(form.getName());
+                name.setModel(form.getModel());
+                name.setSerialNumber(form.getSerialNumber());
+                name.setContainer(targetContainer);
+                TargetedMSManager.get().saveNickname(name, getUser());
+            }
+
+            return true;
+        }
+
+        @Override
+        public URLHelper getSuccessURL(InstrumentForm form)
+        {
+            return StringUtils.isBlank(form.getName()) ? getContainer().getStartURL(getUser()) : new ActionURL(ShowInstrumentAction.class, getContainer()).addParameter("name", form.getName());
         }
     }
 
@@ -4538,7 +4643,7 @@ public class TargetedMSController extends SpringActionController
         @Override
         public void addNavTrail(NavTree root)
         {
-            root.addChild("Instrument " + (_form == null ? "" : _form.getSerialNumber()));
+            root.addChild("Instrument " + (_form == null ? "" : _form.getName()));
         }
 
         @Override
@@ -4550,7 +4655,7 @@ public class TargetedMSController extends SpringActionController
                 Sort sort = new Sort();
                 sort.appendSortColumn(FieldKey.fromParts("AcquiredTime"), Sort.SortDirection.DESC, false);
                 settings.setBaseSort(sort);
-                settings.setBaseFilter(new SimpleFilter(FieldKey.fromParts("InstrumentSerialNumber"), form.getSerialNumber()));
+                settings.setBaseFilter(new SimpleFilter(FieldKey.fromParts("InstrumentNickname"), form.getName()));
                 settings.setContainerFilterName(ContainerFilter.Type.AllFolders.name());
                 TargetedMSSchema schema = new TargetedMSSchema(getUser(), getContainer());
                 return schema.createView(getViewContext(), settings, errors);
@@ -4558,7 +4663,7 @@ public class TargetedMSController extends SpringActionController
             if (FOLDER_SUMMARY.equalsIgnoreCase(dataRegion))
             {
                 QuerySettings settings = new QuerySettings(getViewContext(), FOLDER_SUMMARY, "InstrumentSummaryByFolder");
-                settings.setBaseFilter(new SimpleFilter(FieldKey.fromParts("InstrumentSerialNumber"), form.getSerialNumber()));
+                settings.setBaseFilter(new SimpleFilter(FieldKey.fromParts("InstrumentNickname"), form.getName()));
                 settings.setContainerFilterName(ContainerFilter.Type.AllFolders.name());
                 TargetedMSSchema schema = new TargetedMSSchema(getUser(), getContainer());
                 return schema.createView(getViewContext(), settings, errors);
@@ -4567,23 +4672,44 @@ public class TargetedMSController extends SpringActionController
         }
 
         @Override
-        public ModelAndView getView(InstrumentForm form, BindException errors) throws Exception
+        public ModelAndView getView(InstrumentForm form, BindException errors)
         {
-            if (form.getSerialNumber() == null)
+            if (form.getName() == null)
             {
-                throw new NotFoundException("No instrument serial number specified");
+                throw new NotFoundException("No instrument specified");
             }
             _form = form;
 
+            TargetedMSSchema schema = new TargetedMSSchema(getUser(), getContainer());
+            List<InstrumentNickname> names = TargetedMSManager.get().getNickname(form.getName(), schema);
+
+            if (names.isEmpty())
+            {
+                throw new NotFoundException("No matching instruments found");
+            }
+
+            VBox result = new VBox();
+
+            for (InstrumentNickname name : names)
+            {
+                var nameView = new JspView<>("/org/labkey/targetedms/view/nickname.jsp", name);
+                nameView.setTitle("Instrument Info");
+                nameView.setFrame(WebPartView.FrameType.PORTAL);
+                result.addView(nameView);
+            }
+
             QueryView folderSummaryView = createQueryView(form, errors, false, FOLDER_SUMMARY);
-            folderSummaryView.setTitle("Data in this Server");
+            folderSummaryView.setTitle("Summary by Folder");
             folderSummaryView.setFrame(WebPartView.FrameType.PORTAL);
 
             QueryView sampleFileView = createQueryView(form, errors, false, TargetedMSSchema.TABLE_SAMPLE_FILE);
-            sampleFileView.setTitle("Data from this Instrument");
+            sampleFileView.setTitle("Samples from " + form.getName());
             sampleFileView.setFrame(WebPartView.FrameType.PORTAL);
 
-            return new VBox(folderSummaryView, sampleFileView);
+            result.addView(folderSummaryView);
+            result.addView(sampleFileView);
+
+            return result;
         }
     }
 
@@ -5322,7 +5448,7 @@ public class TargetedMSController extends SpringActionController
         {
             int seqId = selectedProtein.getSequenceId();
             List<PeptideCharacteristic> combinedPeptideCharacteristics = new ArrayList<>(PeptideManager.getCombinedPeptideCharacteristics(group.getId(), replicateId));
-            List<PeptideCharacteristic> modifiedPeptideCharacteristics = new ArrayList<>(PeptideManager.getModifiedPeptideCharacteristics(group.getId(), replicateId));;
+            List<PeptideCharacteristic> modifiedPeptideCharacteristics = new ArrayList<>(PeptideManager.getModifiedPeptideCharacteristics(group.getId(), replicateId));
 
             List<Replicate> replicates = ReplicateManager.getReplicatesForRun(run.getRunId());
             List<org.labkey.api.protein.Replicate> msReplicates = new ArrayList<>();
@@ -5606,7 +5732,7 @@ public class TargetedMSController extends SpringActionController
         public ModelAndView getView(ConflictUIForm form, BindException errors)
         {
             List<ConflictProtein> conflictProteinList = ConflictResultsManager.getConflictedProteins(getContainer());
-            if(conflictProteinList.size() == 0)
+            if(conflictProteinList.isEmpty())
             {
                 errors.reject(ERROR_MSG, "Library folder "+getContainer().getPath()+" does not contain any conflicting proteins.");
                 return new SimpleErrorView(errors, true);
@@ -5805,7 +5931,7 @@ public class TargetedMSController extends SpringActionController
         public ModelAndView getView(ConflictUIForm form, BindException errors)
         {
             List<ConflictPrecursor> conflictPrecursorList = ConflictResultsManager.getConflictedPrecursors(getContainer());
-            if(conflictPrecursorList.size() == 0)
+            if(conflictPrecursorList.isEmpty())
             {
                 errors.reject(ERROR_MSG, "Library folder "+getContainer().getPath()+" does not contain any conflicting data.");
                 return new SimpleErrorView(errors, true);
@@ -6340,19 +6466,11 @@ public class TargetedMSController extends SpringActionController
     // ------------------------------------------------------------------------
     // Actions to export chromatogram libraries
     // ------------------------------------------------------------------------
+    @Setter
+    @Getter
     public static class DownloadForm
     {
         int revision;
-
-        public int getRevision()
-        {
-            return revision;
-        }
-
-        public void setRevision(int revision)
-        {
-            this.revision = revision;
-        }
     }
     @RequiresPermission(ReadPermission.class)
     public static class DownloadChromLibraryAction extends SimpleViewAction<DownloadForm>
@@ -6362,7 +6480,7 @@ public class TargetedMSController extends SpringActionController
         {
             // Check if the folder has any representative data
             List<Long> representativeRunIds = TargetedMSManager.getCurrentRepresentativeRunIds(getContainer());
-            if(representativeRunIds.size() == 0)
+            if(representativeRunIds.isEmpty())
             {
                 //errors.reject(ERROR_MSG, "Folder "+getContainer().getPath()+" does not contain any representative data.");
                 //return new SimpleErrorView(errors, true);
@@ -7288,6 +7406,8 @@ public class TargetedMSController extends SpringActionController
     /*
      * BEGIN RENAME CODE BLOCK
      */
+    @Setter
+    @Getter
     public static class RunForm extends ReturnUrlForm
     {
         public enum PARAMS
@@ -7297,26 +7417,6 @@ public class TargetedMSController extends SpringActionController
 
         int run = 0;
         String columns;
-
-        public void setRun(int run)
-        {
-            this.run = run;
-        }
-
-        public int getRun()
-        {
-            return run;
-        }
-
-        public String getColumns()
-        {
-            return columns;
-        }
-
-        public void setColumns(String columns)
-        {
-            this.columns = columns;
-        }
 
         @Override
         public ActionURL getReturnActionURL()
@@ -7353,19 +7453,11 @@ public class TargetedMSController extends SpringActionController
         return url;
     }
 
+    @Setter
+    @Getter
     public static class RenameForm extends RunForm
     {
         private String description;
-
-        public String getDescription()
-        {
-            return description;
-        }
-
-        public void setDescription(String description)
-        {
-            this.description = description;
-        }
     }
 
     @RequiresPermission(UpdatePermission.class)

--- a/src/org/labkey/targetedms/TargetedMSListener.java
+++ b/src/org/labkey/targetedms/TargetedMSListener.java
@@ -70,6 +70,7 @@ public class TargetedMSListener implements ContainerManager.ContainerListener
         LibSpectrumReader.clearLibCache(c);
 
         new SqlExecutor(TargetedMSManager.getSchema()).execute("DELETE FROM " + TargetedMSManager.getTableInfoQCEmailNotifications() + " WHERE Container = ?", c);
+        new SqlExecutor(TargetedMSManager.getSchema()).execute("DELETE FROM " + TargetedMSManager.getTableInfoInstrumentNickname() + " WHERE Container = ?", c);
     }
 
     @Override

--- a/src/org/labkey/targetedms/TargetedMSManager.java
+++ b/src/org/labkey/targetedms/TargetedMSManager.java
@@ -1157,27 +1157,31 @@ public class TargetedMSManager
         return name;
     }
 
+    private record NicknameKey(String serialNumber, String model) {}
+
     /** @return the matches in order of closest to furthest match, injecting a virtual option if the list is empty */
     public List<InstrumentNickname> getNickname(String name, TargetedMSSchema schema)
     {
         TableInfo info = schema.getTableOrThrow(TABLE_INSTRUMENT_NICKNAME, new ContainerFilter.CurrentPlusProjectAndShared(schema.getContainer(), schema.getUser()));
         List<InstrumentNickname> matches = new TableSelector(info, new SimpleFilter(FieldKey.fromParts("Nickname"), name), null).getArrayList(InstrumentNickname.class);
 
-        List<InstrumentNickname> result = new ArrayList<>();
+        Map<NicknameKey, InstrumentNickname> dedupeAcrossContainers = new HashMap<>();
         // Closest is from the current container
-        addNameMatch(result, matches, schema.getContainer());
+        addNameMatch(dedupeAcrossContainers, matches, schema.getContainer());
         // Next closest is from the project
         @Nullable Container project = schema.getContainer().getProject();
         if (project != null && !project.equals(schema.getContainer()))
         {
-            addNameMatch(result, matches, schema.getContainer().getProject());
+            addNameMatch(dedupeAcrossContainers, matches, schema.getContainer().getProject());
         }
         Container shared = ContainerManager.getSharedContainer();
         // Furthest is from /Shared
         if (!schema.getContainer().equals(shared))
         {
-            addNameMatch(result, matches, shared);
+            addNameMatch(dedupeAcrossContainers, matches, shared);
         }
+
+        List<InstrumentNickname> result = new ArrayList<>(dedupeAcrossContainers.values());
         
         if (matches.isEmpty())
         {
@@ -1211,13 +1215,14 @@ public class TargetedMSManager
         return result;
     }
 
-    private void addNameMatch(List<InstrumentNickname> result, List<InstrumentNickname> matches, Container container)
+    private void addNameMatch(Map<NicknameKey, InstrumentNickname> result, List<InstrumentNickname> matches, Container container)
     {
         for (InstrumentNickname match : matches)
         {
             if (match.getContainer().equals(container))
             {
-                result.add(match);
+                NicknameKey key = new NicknameKey(match.getSerialNumber(), match.getModel());
+                result.putIfAbsent(key, match);
             }
         }
     }

--- a/src/org/labkey/targetedms/TargetedMSManager.java
+++ b/src/org/labkey/targetedms/TargetedMSManager.java
@@ -43,6 +43,7 @@ import org.labkey.api.data.Table;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.data.dialect.SqlDialect;
+import org.labkey.api.data.dialect.StandardDialectStringHandler;
 import org.labkey.api.data.statistics.MathStat;
 import org.labkey.api.data.statistics.StatsService;
 import org.labkey.api.exp.AbstractFileXarSource;
@@ -73,6 +74,8 @@ import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.DeletePermission;
+import org.labkey.api.security.permissions.ReadPermission;
+import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.targetedms.ITargetedMSRun;
 import org.labkey.api.targetedms.RepresentativeDataState;
 import org.labkey.api.targetedms.RunRepresentativeDataState;
@@ -91,6 +94,7 @@ import org.labkey.targetedms.model.GuideSetKey;
 import org.labkey.targetedms.model.GuideSetStats;
 import org.labkey.api.targetedms.model.QCMetricConfiguration;
 import org.labkey.api.targetedms.model.QCMetricStatus;
+import org.labkey.targetedms.model.InstrumentNickname;
 import org.labkey.targetedms.model.QCTraceMetricValues;
 import org.labkey.targetedms.model.RawMetricDataSet;
 import org.labkey.targetedms.model.passport.IKeyword;
@@ -136,6 +140,7 @@ import static org.labkey.api.targetedms.TargetedMSService.FOLDER_TYPE_PROP_NAME;
 import static org.labkey.api.targetedms.TargetedMSService.FolderType.Library;
 import static org.labkey.api.targetedms.TargetedMSService.FolderType.LibraryProtein;
 import static org.labkey.api.targetedms.TargetedMSService.MODULE_NAME;
+import static org.labkey.targetedms.TargetedMSSchema.TABLE_INSTRUMENT_NICKNAME;
 
 public class TargetedMSManager
 {
@@ -456,6 +461,11 @@ public class TargetedMSManager
     public static TableInfo getTableInfoFoldChange()
     {
         return getSchema().getTable(TargetedMSSchema.TABLE_FOLD_CHANGE);
+    }
+
+    public static TableInfo getTableInfoInstrumentNickname()
+    {
+        return getSchema().getTable(TABLE_INSTRUMENT_NICKNAME);
     }
 
     public static TableInfo getTableInfoiRTPeptide()
@@ -1128,6 +1138,81 @@ public class TargetedMSManager
         for (ExpRun run : experimentRunsToDelete)
         {
             run.delete(user);
+        }
+    }
+
+    public InstrumentNickname getNickname(long id, User user)
+    {
+        InstrumentNickname name = new TableSelector(getTableInfoInstrumentNickname()).getObject(id, InstrumentNickname.class);
+        if (name == null || !name.getContainer().hasPermission(user, ReadPermission.class))
+        {
+            throw new NotFoundException();
+        }
+        return name;
+    }
+
+    /** @return the matches in order of closest to furthest match, injecting a virtual option if the list is empty */
+    public List<InstrumentNickname> getNickname(String name, TargetedMSSchema schema)
+    {
+        TableInfo info = schema.getTableOrThrow(TABLE_INSTRUMENT_NICKNAME, new ContainerFilter.CurrentPlusProjectAndShared(schema.getContainer(), schema.getUser()));
+        List<InstrumentNickname> matches = new TableSelector(info, new SimpleFilter(FieldKey.fromParts("Nickname"), name), null).getArrayList(InstrumentNickname.class);
+
+        List<InstrumentNickname> result = new ArrayList<>();
+        // Closest is from the current container
+        addNameMatch(result, matches, schema.getContainer());
+        // Next closest is from the project
+        @Nullable Container project = schema.getContainer().getProject();
+        if (project != null && !project.equals(schema.getContainer()))
+        {
+            addNameMatch(result, matches, schema.getContainer().getProject());
+        }
+        Container shared = ContainerManager.getSharedContainer();
+        // Furthest is from /Shared
+        if (!schema.getContainer().equals(shared))
+        {
+            addNameMatch(result, matches, shared);
+        }
+        
+        if (matches.isEmpty())
+        {
+            String sql = "SELECT DISTINCT InstrumentNickname, " +
+                    "InstrumentId.Model AS Model, " +
+                    "InstrumentSerialNumber AS SerialNumber " +
+                    "FROM targetedms.SampleFile WHERE InstrumentNickname = " +
+                    new StandardDialectStringHandler().quoteStringLiteral(name) +
+                    " ORDER By InstrumentNickname, InstrumentId.Model, InstrumentSerialNumber";
+            TableSelector selector = QueryService.get().selector(schema, sql);
+            result = selector.getArrayList(InstrumentNickname.class);
+            Container targetContainer;
+            if (shared.hasPermission(schema.getUser(), UpdatePermission.class))
+            {
+                targetContainer = shared;
+            }
+            else if (project != null && project.hasPermission(schema.getUser(), UpdatePermission.class))
+            {
+                targetContainer = project;
+            }
+            else
+            {
+                targetContainer = schema.getContainer();
+            }
+            for (InstrumentNickname instrumentNickname : result)
+            {
+                instrumentNickname.setContainer(targetContainer);
+            }
+        }
+
+        return result;
+    }
+
+    private void addNameMatch(List<InstrumentNickname> result, List<InstrumentNickname> matches, Container container)
+    {
+        for (InstrumentNickname match : matches)
+        {
+            if (match.getContainer().equals(container))
+            {
+                result.add(match);
+            }
         }
     }
 
@@ -2850,5 +2935,22 @@ public class TargetedMSManager
     public void clearCachedEnabledQCMetrics(Container container)
     {
         getSchema().getScope().addCommitTask(() -> _metricCache.remove(container), DbScope.CommitTaskOption.IMMEDIATE, DbScope.CommitTaskOption.POSTCOMMIT, DbScope.CommitTaskOption.POSTROLLBACK);
+    }
+
+    public void deleteNickname(InstrumentNickname name)
+    {
+        Table.delete(getTableInfoInstrumentNickname(), name.getId());
+    }
+
+    public void saveNickname(InstrumentNickname name, User user)
+    {
+        if (name.getId() > 0)
+        {
+            Table.update(user, getTableInfoInstrumentNickname(), name, name.getId());
+        }
+        else
+        {
+            Table.insert(user, getTableInfoInstrumentNickname(), name);
+        }
     }
 }

--- a/src/org/labkey/targetedms/TargetedMSManager.java
+++ b/src/org/labkey/targetedms/TargetedMSManager.java
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.cache.Cache;
 import org.labkey.api.cache.CacheManager;
+import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
@@ -65,11 +66,15 @@ import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.pipeline.PipelineValidationException;
 import org.labkey.api.query.BatchValidationException;
+import org.labkey.api.query.DuplicateKeyException;
 import org.labkey.api.query.FieldKey;
+import org.labkey.api.query.InvalidKeyException;
 import org.labkey.api.query.QueryDefinition;
 import org.labkey.api.query.QueryException;
 import org.labkey.api.query.QuerySchema;
 import org.labkey.api.query.QueryService;
+import org.labkey.api.query.QueryUpdateService;
+import org.labkey.api.query.QueryUpdateServiceException;
 import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
@@ -117,6 +122,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.sql.SQLException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -2937,20 +2943,37 @@ public class TargetedMSManager
         getSchema().getScope().addCommitTask(() -> _metricCache.remove(container), DbScope.CommitTaskOption.IMMEDIATE, DbScope.CommitTaskOption.POSTCOMMIT, DbScope.CommitTaskOption.POSTROLLBACK);
     }
 
-    public void deleteNickname(InstrumentNickname name)
+    @NotNull
+    private QueryUpdateService getNicknameUpdateService(User user, Container container)
     {
-        Table.delete(getTableInfoInstrumentNickname(), name.getId());
+        TargetedMSSchema schema = new TargetedMSSchema(user, container);
+        TableInfo table = schema.getTableOrThrow(TABLE_INSTRUMENT_NICKNAME);
+        return Objects.requireNonNull(table.getUpdateService());
     }
 
-    public void saveNickname(InstrumentNickname name, User user)
+    public void deleteNickname(InstrumentNickname name, User user) throws SQLException, BatchValidationException, QueryUpdateServiceException, InvalidKeyException
     {
+        getNicknameUpdateService(user, name.getContainer()).
+                deleteRows(user, name.getContainer(), Arrays.asList(new CaseInsensitiveHashMap<>(Map.of("id", name.getId()))), null, null);
+    }
+
+    public void saveNickname(InstrumentNickname name, User user) throws SQLException, BatchValidationException, QueryUpdateServiceException, InvalidKeyException, DuplicateKeyException
+    {
+        Map<String, Object> row = new CaseInsensitiveHashMap<>();
+        row.put("nickname", name.getNickname());
+        row.put("serialNumber", name.getSerialNumber());
+        row.put("model", name.getModel());
+        BatchValidationException errors = new BatchValidationException();
         if (name.getId() > 0)
         {
-            Table.update(user, getTableInfoInstrumentNickname(), name, name.getId());
+            row.put("id", name.getId());
+            getNicknameUpdateService(user, name.getContainer()).
+                    updateRows(user, name.getContainer(), Arrays.asList(row), Arrays.asList(row), errors, null, null);
         }
         else
         {
-            Table.insert(user, getTableInfoInstrumentNickname(), name);
+            getNicknameUpdateService(user, name.getContainer()).
+                    insertRows(user, name.getContainer(), Arrays.asList(row), errors, null, null);
         }
     }
 }

--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -233,7 +233,7 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
     @Override
     public Double getSchemaVersion()
     {
-        return 25.003;
+        return 25.004;
     }
 
     @Override

--- a/src/org/labkey/targetedms/TargetedMSSchema.java
+++ b/src/org/labkey/targetedms/TargetedMSSchema.java
@@ -158,6 +158,7 @@ public class TargetedMSSchema extends UserSchema
     public static final String TABLE_MOLECULE_GROUP = "MoleculeGroup";
     public static final String TABLE_PEPTIDE_GROUP_ANNOTATION = "PeptideGroupAnnotation";
     public static final String TABLE_INSTRUMENT = "Instrument";
+    public static final String TABLE_INSTRUMENT_NICKNAME = "InstrumentNickname";
     public static final String TABLE_ISOTOPE_ENRICHMENT = "IsotopeEnrichment";
     public static final String TABLE_ISOLATION_SCHEME = "IsolationScheme";
     public static final String TABLE_ISOLATION_WINDOW = "IsolationWindow";
@@ -1607,18 +1608,20 @@ public class TargetedMSSchema extends UserSchema
                 TABLE_INSTRUMENT_SCHEDULE.equalsIgnoreCase(name) ||
                 TABLE_RATE_TYPE.equalsIgnoreCase(name) ||
                 TABLE_INSTRUMENT_RATE.equalsIgnoreCase(name) ||
-                TABLE_INSTRUMENT_USAGE_PAYMENT.equalsIgnoreCase(name))
+                TABLE_INSTRUMENT_USAGE_PAYMENT.equalsIgnoreCase(name) ||
+
+                TABLE_INSTRUMENT_NICKNAME.equalsIgnoreCase(name))
         {
-            var result = new FilteredTable<TargetedMSSchema>(getSchema().getTable(name), this, cf)
+            var result = new FilteredTable<>(getSchema().getTable(name), this, cf)
             {
                 @Override
                 public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
                 {
-                    return getContainer().hasPermission(user,perm);
+                    return getContainer().hasPermission(user, perm);
                 }
 
-                @Override
-                public @Nullable QueryUpdateService getUpdateService()
+                @Override @NotNull
+                public QueryUpdateService getUpdateService()
                 {
                     return new DefaultQueryUpdateService(this, getRealTable());
                 }
@@ -1749,6 +1752,7 @@ public class TargetedMSSchema extends UserSchema
         hs.add(TABLE_REPLICATE);
         hs.add(TABLE_REPLICATE_ANNOTATION);
         hs.add(TABLE_INSTRUMENT);
+        hs.add(TABLE_INSTRUMENT_NICKNAME);
         hs.add(TABLE_ISOTOPE_ENRICHMENT);
         hs.add(TABLE_GENERAL_MOLECULE_CHROM_INFO);
         hs.add(TABLE_GENERAL_MOLECULE_ANNOTATION);

--- a/src/org/labkey/targetedms/TargetedMSSchema.java
+++ b/src/org/labkey/targetedms/TargetedMSSchema.java
@@ -46,6 +46,7 @@ import org.labkey.api.data.WrappedColumn;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.query.ExpRunTable;
 import org.labkey.api.exp.query.ExpSchema;
+import org.labkey.api.gwt.client.AuditBehaviorType;
 import org.labkey.api.module.Module;
 import org.labkey.api.query.CrosstabView;
 import org.labkey.api.query.CustomView;
@@ -1609,7 +1610,6 @@ public class TargetedMSSchema extends UserSchema
                 TABLE_RATE_TYPE.equalsIgnoreCase(name) ||
                 TABLE_INSTRUMENT_RATE.equalsIgnoreCase(name) ||
                 TABLE_INSTRUMENT_USAGE_PAYMENT.equalsIgnoreCase(name) ||
-
                 TABLE_INSTRUMENT_NICKNAME.equalsIgnoreCase(name))
         {
             var result = new FilteredTable<>(getSchema().getTable(name), this, cf)
@@ -1627,6 +1627,10 @@ public class TargetedMSSchema extends UserSchema
                 }
             };
             result.wrapAllColumns(true);
+            if (TABLE_INSTRUMENT_NICKNAME.equalsIgnoreCase(name))
+            {
+                result.setAuditBehavior(AuditBehaviorType.DETAILED);
+            }
             TargetedMSTable.fixupLookups(result);
             return result;
         }

--- a/src/org/labkey/targetedms/chart/ComparisonChartMaker.java
+++ b/src/org/labkey/targetedms/chart/ComparisonChartMaker.java
@@ -16,6 +16,7 @@
 package org.labkey.targetedms.chart;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.Nullable;
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.LegendItem;
@@ -145,13 +146,18 @@ public class ComparisonChartMaker
     {
         if (molecule == null)
         {
+            if (peptideGroup == null)
+            {
+                throw new NotFoundException("Could not resolve molecule or group");
+            }
+
             return Pair.of(peptideGroup.getLabel(), ComparisonDataset.ChartType.MOLECULE_COMPARISON);
         }
         return Pair.of(molecule.getCustomIonName(), ComparisonDataset.ChartType.REPLICATE_COMPARISON);
     }
 
     public JFreeChart makeRetentionTimesChart(long replicateId, PeptideGroup peptideGroup,
-                                          Molecule molecule, MoleculePrecursor precursor,
+                                          Molecule molecule, @Nullable MoleculePrecursor precursor,
                                           String groupByAnnotation, String filterByAnnotation, String value, boolean cvValues,
                                           User user, Container container)
     {
@@ -332,7 +338,7 @@ public class ComparisonChartMaker
     }
 
     private List<PrecursorChromInfoLitePlus> getInputData(PeptideGroup peptideGroup, long replicateId, Peptide peptide,
-                                                          Precursor precursor, ComparisonDataset.ChartType chartType,
+                                                          @Nullable Precursor precursor, ComparisonDataset.ChartType chartType,
                                                           User user, Container container)
     {
         List<PrecursorChromInfoLitePlus> pciPlusList;
@@ -353,7 +359,7 @@ public class ComparisonChartMaker
     }
 
     private List<PrecursorChromInfoLitePlus> getInputData(PeptideGroup peptideGroup, long replicateId, Molecule molecule,
-                                                          MoleculePrecursor precursor, ComparisonDataset.ChartType chartType,
+                                                          @Nullable MoleculePrecursor precursor, ComparisonDataset.ChartType chartType,
                                                           User user, Container container)
     {
         List<PrecursorChromInfoLitePlus> pciPlusList;

--- a/src/org/labkey/targetedms/model/InstrumentNickname.java
+++ b/src/org/labkey/targetedms/model/InstrumentNickname.java
@@ -1,0 +1,62 @@
+package org.labkey.targetedms.model;
+
+import org.labkey.api.data.Container;
+
+public class InstrumentNickname
+{
+    private long _id;
+    private String _nickname;
+    private String _model;
+    private String _serialNumber;
+    private Container _container;
+
+    public long getId()
+    {
+        return _id;
+    }
+
+    public void setId(long id)
+    {
+        _id = id;
+    }
+
+    public String getNickname()
+    {
+        return _nickname;
+    }
+
+    public void setNickname(String nickname)
+    {
+        _nickname = nickname;
+    }
+
+    public String getModel()
+    {
+        return _model;
+    }
+
+    public void setModel(String model)
+    {
+        _model = model;
+    }
+
+    public String getSerialNumber()
+    {
+        return _serialNumber;
+    }
+
+    public void setSerialNumber(String serialNumber)
+    {
+        _serialNumber = serialNumber;
+    }
+
+    public Container getContainer()
+    {
+        return _container;
+    }
+
+    public void setContainer(Container container)
+    {
+        _container = container;
+    }
+}

--- a/src/org/labkey/targetedms/query/SampleFileTable.java
+++ b/src/org/labkey/targetedms/query/SampleFileTable.java
@@ -117,9 +117,10 @@ public class SampleFileTable extends TargetedMSTable
         ExprColumn excludedColumn = new ExprColumn(this, "Excluded", excludedSQL, JdbcType.BOOLEAN);
         addColumn(excludedColumn);
 
-        SQLFragment nicknameSql = new SQLFragment("(SELECT MIN(COALESCE(Nickname, ");
-        nicknameSql.append(getSqlDialect().concatenate("i.Model", "' - '", ExprColumn.STR_TABLE_ALIAS + ".InstrumentSerialNumber"));
-        nicknameSql.append(", ").append(ExprColumn.STR_TABLE_ALIAS).append(".InstrumentSerialNumber, i.Model)) FROM (SELECT * FROM ");
+        SQLFragment nicknameSql = new SQLFragment("COALESCE(");
+
+        // Find a nickname if we have one
+        nicknameSql.append("(SELECT MIN(Nickname) FROM ((SELECT * FROM ");
         nicknameSql.append(TargetedMSManager.getTableInfoInstrument(), "i");
         nicknameSql.append(" WHERE i.Id = ");
         nicknameSql.append(ExprColumn.STR_TABLE_ALIAS).append(".InstrumentId) i LEFT OUTER JOIN ");
@@ -128,7 +129,17 @@ public class SampleFileTable extends TargetedMSTable
         nicknameSql.append(ExprColumn.STR_TABLE_ALIAS).append(".InstrumentSerialNumber");
         nicknameSql.append(" OR (f.SerialNumber IS NULL AND ");
         nicknameSql.append(ExprColumn.STR_TABLE_ALIAS).append(".InstrumentSerialNumber");
-        nicknameSql.append(" IS NULL)) AND (f.Model = i.Model OR (f.Model IS NULL AND i.Model IS NULL)))");
+        nicknameSql.append(" IS NULL)) AND (f.Model = i.Model OR (f.Model IS NULL AND i.Model IS NULL)))), ");
+
+        // Alternatively, use the default name for the instrument (model - serial number)
+        nicknameSql.append("(SELECT COALESCE(");
+        nicknameSql.append(getSqlDialect().concatenate("x.Model", "' - '", ExprColumn.STR_TABLE_ALIAS + ".InstrumentSerialNumber"));
+        nicknameSql.append(", ").append(ExprColumn.STR_TABLE_ALIAS).append(".InstrumentSerialNumber, x.Model)");
+        nicknameSql.append(" FROM (SELECT Model FROM ");
+        nicknameSql.append(TargetedMSManager.getTableInfoInstrument(), "i");
+        nicknameSql.append(" WHERE i.Id = ");
+        nicknameSql.append(ExprColumn.STR_TABLE_ALIAS).append(".InstrumentId) x)");
+        nicknameSql.append(") ");
         ExprColumn nicknameCol = new ExprColumn(this, "InstrumentNickname", nicknameSql, JdbcType.VARCHAR);
         addColumn(nicknameCol);
 

--- a/src/org/labkey/targetedms/query/SampleFileTable.java
+++ b/src/org/labkey/targetedms/query/SampleFileTable.java
@@ -123,7 +123,8 @@ public class SampleFileTable extends TargetedMSTable
         SQLFragment nicknameSql = new SQLFragment("COALESCE(");
 
         // Find a nickname if we have one
-        SQLFragment nicknameToLimitSql = new SQLFragment("SELECT Nickname FROM (SELECT *, CASE WHEN Container = ? THEN 3 WHEN Container = ? THEN 2 ELSE 1 END AS ContainerSort FROM (SELECT * FROM ");
+        SQLFragment nicknameToLimitSql = new SQLFragment("SELECT Nickname FROM (SELECT Nickname, CASE WHEN Container = ? THEN 3 WHEN Container = ? THEN 2 ELSE 1 END AS ContainerSort FROM \n");
+        nicknameToLimitSql.append("(SELECT i.* FROM ");
         nicknameSql.add(ContainerManager.getSharedContainer());
         nicknameSql.add(schema.getContainer().getProject());
         nicknameToLimitSql.append(TargetedMSManager.getTableInfoInstrument(), "i");

--- a/src/org/labkey/targetedms/query/SampleFileTable.java
+++ b/src/org/labkey/targetedms/query/SampleFileTable.java
@@ -117,6 +117,21 @@ public class SampleFileTable extends TargetedMSTable
         ExprColumn excludedColumn = new ExprColumn(this, "Excluded", excludedSQL, JdbcType.BOOLEAN);
         addColumn(excludedColumn);
 
+        SQLFragment nicknameSql = new SQLFragment("(SELECT MIN(COALESCE(Nickname, ");
+        nicknameSql.append(getSqlDialect().concatenate("i.Model", "' - '", ExprColumn.STR_TABLE_ALIAS + ".InstrumentSerialNumber"));
+        nicknameSql.append(", ").append(ExprColumn.STR_TABLE_ALIAS).append(".InstrumentSerialNumber, i.Model)) FROM (SELECT * FROM ");
+        nicknameSql.append(TargetedMSManager.getTableInfoInstrument(), "i");
+        nicknameSql.append(" WHERE i.Id = ");
+        nicknameSql.append(ExprColumn.STR_TABLE_ALIAS).append(".InstrumentId) i LEFT OUTER JOIN ");
+        nicknameSql.append(schema.getTableOrThrow(TargetedMSSchema.TABLE_INSTRUMENT_NICKNAME, ContainerFilter.Type.CurrentPlusProjectAndShared.create(schema)), "f");
+        nicknameSql.append(" ON (f.SerialNumber = ");
+        nicknameSql.append(ExprColumn.STR_TABLE_ALIAS).append(".InstrumentSerialNumber");
+        nicknameSql.append(" OR (f.SerialNumber IS NULL AND ");
+        nicknameSql.append(ExprColumn.STR_TABLE_ALIAS).append(".InstrumentSerialNumber");
+        nicknameSql.append(" IS NULL)) AND (f.Model = i.Model OR (f.Model IS NULL AND i.Model IS NULL)))");
+        ExprColumn nicknameCol = new ExprColumn(this, "InstrumentNickname", nicknameSql, JdbcType.VARCHAR);
+        addColumn(nicknameCol);
+
         // Special handling for a sample identifier annotation. Inject it even if this folder doesn't have it configured
 
         AnnotatedTargetedMSTable.AnnotationSettingForTyping idSetting = new AnnotatedTargetedMSTable.AnnotationSettingForTyping("SampleIdentifier",
@@ -221,8 +236,8 @@ public class SampleFileTable extends TargetedMSTable
         downloadCol.setTextAlign("left");
         downloadCol.setDisplayColumnFactory(DownloadLinkColumn::new);
 
-        DetailsURL instrumentURL = new DetailsURL(new ActionURL(TargetedMSController.ShowInstrumentAction.class, getContainer()), Collections.singletonMap("serialNumber", "InstrumentSerialNumber"));
-        getMutableColumn("InstrumentSerialNumber").setURL(instrumentURL);
+        DetailsURL instrumentURL = new DetailsURL(new ActionURL(TargetedMSController.ShowInstrumentAction.class, getContainer()), Collections.singletonMap("name", "InstrumentNickname"));
+        getMutableColumnOrThrow("InstrumentNickname").setURL(instrumentURL);
     }
 
     @Override
@@ -247,7 +262,7 @@ public class SampleFileTable extends TargetedMSTable
                     FieldKey.fromParts("File"),
                     FieldKey.fromParts("Download"),
                     FieldKey.fromParts("AcquiredTime"),
-                    FieldKey.fromParts("InstrumentSerialNumber")
+                    FieldKey.fromParts("InstrumentNickname")
             ));
 
             // Find the columns that have values for the run of interest, and include them in the set of columns in the default
@@ -259,7 +274,6 @@ public class SampleFileTable extends TargetedMSTable
             aggregates.add(new Aggregate(FieldKey.fromParts("ReplicateId", "SampleType"), Aggregate.BaseType.MAX));
             aggregates.add(new Aggregate(FieldKey.fromParts("ReplicateId", "AnalyteConcentration"), Aggregate.BaseType.MAX));
             aggregates.add(new Aggregate(FieldKey.fromParts("ReplicateId", "SampleDilutionFactor"), Aggregate.BaseType.MAX));
-            aggregates.add(new Aggregate(FieldKey.fromParts("InstrumentId"), Aggregate.BaseType.MAX));
 
             // Also search for values for any replicate annotations being used in this container
             for (AnnotatedTargetedMSTable.AnnotationSettingForTyping annotation : getUserSchema().getAnnotationSettings("replicate", ContainerFilter.current(getUserSchema())))

--- a/src/org/labkey/targetedms/query/SampleFileTable.java
+++ b/src/org/labkey/targetedms/query/SampleFileTable.java
@@ -123,16 +123,24 @@ public class SampleFileTable extends TargetedMSTable
         SQLFragment nicknameSql = new SQLFragment("COALESCE(");
 
         // Find a nickname if we have one
-        nicknameSql.append("(SELECT MIN(Nickname) FROM ((SELECT * FROM ");
-        nicknameSql.append(TargetedMSManager.getTableInfoInstrument(), "i");
-        nicknameSql.append(" WHERE i.Id = ");
-        nicknameSql.append(ExprColumn.STR_TABLE_ALIAS).append(".InstrumentId) i LEFT OUTER JOIN ");
-        nicknameSql.append(schema.getTableOrThrow(TargetedMSSchema.TABLE_INSTRUMENT_NICKNAME, ContainerFilter.Type.CurrentPlusProjectAndShared.create(schema)), "f");
-        nicknameSql.append(" ON (f.SerialNumber = ");
-        nicknameSql.append(ExprColumn.STR_TABLE_ALIAS).append(".InstrumentSerialNumber");
-        nicknameSql.append(" OR (f.SerialNumber IS NULL AND ");
-        nicknameSql.append(ExprColumn.STR_TABLE_ALIAS).append(".InstrumentSerialNumber");
-        nicknameSql.append(" IS NULL)) AND (f.Model = i.Model OR (f.Model IS NULL AND i.Model IS NULL)))), ");
+        SQLFragment nicknameToLimitSql = new SQLFragment("SELECT Nickname FROM (SELECT *, CASE WHEN Container = ? THEN 3 WHEN Container = ? THEN 2 ELSE 1 END AS ContainerSort FROM (SELECT * FROM ");
+        nicknameSql.add(ContainerManager.getSharedContainer());
+        nicknameSql.add(schema.getContainer().getProject());
+        nicknameToLimitSql.append(TargetedMSManager.getTableInfoInstrument(), "i");
+        nicknameToLimitSql.append(" WHERE i.Id = ");
+        nicknameToLimitSql.append(ExprColumn.STR_TABLE_ALIAS).append(".InstrumentId) i LEFT OUTER JOIN ");
+        nicknameToLimitSql.append(schema.getTableOrThrow(TargetedMSSchema.TABLE_INSTRUMENT_NICKNAME, ContainerFilter.Type.CurrentPlusProjectAndShared.create(schema)), "f");
+        nicknameToLimitSql.append(" ON (f.SerialNumber = ");
+        nicknameToLimitSql.append(ExprColumn.STR_TABLE_ALIAS).append(".InstrumentSerialNumber");
+        nicknameToLimitSql.append(" OR (f.SerialNumber IS NULL AND ");
+        nicknameToLimitSql.append(ExprColumn.STR_TABLE_ALIAS).append(".InstrumentSerialNumber");
+        nicknameToLimitSql.append(" IS NULL)) AND (f.Model = i.Model OR (f.Model IS NULL AND i.Model IS NULL))) x ORDER BY ContainerSort\n");
+
+        getSqlDialect().limitRows(nicknameToLimitSql, 1);
+
+        nicknameSql.append("(");
+        nicknameSql.append(nicknameToLimitSql);
+        nicknameSql.append("),\n");
 
         // Alternatively, use the default name for the instrument (model - serial number)
         nicknameSql.append("(SELECT COALESCE(");
@@ -143,7 +151,7 @@ public class SampleFileTable extends TargetedMSTable
         nicknameSql.append(" WHERE i.Id = ");
         nicknameSql.append(ExprColumn.STR_TABLE_ALIAS).append(".InstrumentId) x)");
         nicknameSql.append(") ");
-        ExprColumn nicknameCol = new ExprColumn(this, "InstrumentNickname", nicknameSql, JdbcType.VARCHAR);
+        ExprColumn nicknameCol = new ExprColumn(this, "InstrumentNickname", nicknameSql, JdbcType.VARCHAR, getColumn("InstrumentSerialNumber"), getColumn("InstrumentId"));
         addColumn(nicknameCol);
 
         // Special handling for a sample identifier annotation. Inject it even if this folder doesn't have it configured

--- a/src/org/labkey/targetedms/view/nickname.jsp
+++ b/src/org/labkey/targetedms/view/nickname.jsp
@@ -33,16 +33,16 @@
     Container shared = ContainerManager.getSharedContainer();
     if (shared.hasPermission(getUser(), UpdatePermission.class))
     {
-        targetContainers.put(shared.getId(), shared.getPath());
+        targetContainers.put(shared.getId(), "Server-wide");
     }
     Container project = getContainer().getProject();
     if (project != null && project.hasPermission(getUser(), UpdatePermission.class))
     {
-        targetContainers.put(project.getId(), project.getPath());
+        targetContainers.putIfAbsent(project.getId(), "In this project, " + project.getName());
     }
     if (getContainer().hasPermission(getUser(), UpdatePermission.class))
     {
-        targetContainers.put(getContainer().getId(), getContainer().getPath());
+        targetContainers.putIfAbsent(getContainer().getId(), "In this folder, " + getContainer().getPath());
     }
     %>
 
@@ -65,7 +65,7 @@
             </tr>
             <% if (!targetContainers.isEmpty()) { %>
             <tr class="form-group">
-                <td class="lk-form-label"><label for="targetContainerId<%= name.getId()%>">Save in</label></td>
+                <td class="lk-form-label"><label for="targetContainerId<%= name.getId()%>">Use nickname</label></td>
                 <td>
                     <select name="targetContainerId" id="targetContainerId<%= name.getId()%>">
                         <labkey:options value="<%= name.getContainer().getId() %>" map="<%= targetContainers %>"/>

--- a/src/org/labkey/targetedms/view/nickname.jsp
+++ b/src/org/labkey/targetedms/view/nickname.jsp
@@ -1,0 +1,79 @@
+<%
+/*
+ * Copyright (c) 2013-2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+%>
+<%@ page import="org.labkey.api.view.HttpView" %>
+<%@ page import="org.labkey.api.view.JspView" %>
+<%@ page import="org.labkey.targetedms.TargetedMSController" %>
+<%@ page import="org.labkey.targetedms.model.InstrumentNickname" %>
+<%@ page import="org.labkey.api.security.permissions.UpdatePermission" %>
+<%@ page import="org.labkey.api.data.Container" %>
+<%@ page import="org.labkey.api.data.ContainerManager" %>
+<%@ page import="java.util.Map" %>
+<%@ page import="java.util.LinkedHashMap" %>
+<%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
+<%@ page extends="org.labkey.api.jsp.JspBase" %>
+<%
+    JspView<InstrumentNickname> currentView = HttpView.currentView();
+    InstrumentNickname name = currentView.getModelBean();
+    Map<String, String> targetContainers = new LinkedHashMap<>();
+    Container shared = ContainerManager.getSharedContainer();
+    if (shared.hasPermission(getUser(), UpdatePermission.class))
+    {
+        targetContainers.put(shared.getId(), shared.getPath());
+    }
+    Container project = getContainer().getProject();
+    if (project != null && project.hasPermission(getUser(), UpdatePermission.class))
+    {
+        targetContainers.put(project.getId(), project.getPath());
+    }
+    if (getContainer().hasPermission(getUser(), UpdatePermission.class))
+    {
+        targetContainers.put(getContainer().getId(), getContainer().getPath());
+    }
+    %>
+
+    <labkey:form action="<%=urlFor(TargetedMSController.SaveInstrumentNameAction.class)%>" method="post" layout="horizontal">
+        <labkey:input type="hidden" name="id" value="<%=name.getId()%>"/>
+        <labkey:input type="hidden" name="model" value="<%=name.getModel()%>"/>
+        <labkey:input type="hidden" name="serialNumber" value="<%=name.getSerialNumber()%>"/>
+        <table>
+            <tr class="form-group">
+                <td class="lk-form-label">Model</td>
+                <td><%= h(name.getModel()) %></td>
+            </tr>
+            <tr class="form-group">
+                <td class="lk-form-label">Serial Number</td>
+                <td><%= h(name.getSerialNumber()) %></td>
+            </tr>
+            <tr class="form-group">
+                <td class="lk-form-label"><label for="nickname<%= name.getId()%>">Nickname</label></td>
+                <td><% if (targetContainers.isEmpty()) { %><%= h(name.getNickname()) %><% } else { %><labkey:input type="text" id="nickname<%= name.getId()%>" name="name" value="<%= name.getNickname() %>" size="40" /><% } %></td>
+            </tr>
+            <% if (!targetContainers.isEmpty()) { %>
+            <tr class="form-group">
+                <td class="lk-form-label"><label for="targetContainerId<%= name.getId()%>">Save in</label></td>
+                <td>
+                    <select name="targetContainerId" id="targetContainerId<%= name.getId()%>">
+                        <labkey:options value="<%= name.getContainer().getId() %>" map="<%= targetContainers %>"/>
+                    </select>
+                    <%= button("Save").submit(true) %>
+                </td>
+            </tr>
+            <% } %>
+        </table>
+    </labkey:form>
+

--- a/src/org/labkey/targetedms/view/nickname.jsp
+++ b/src/org/labkey/targetedms/view/nickname.jsp
@@ -63,6 +63,14 @@
                 <td class="lk-form-label"><label for="nickname<%= name.getId()%>">Nickname</label></td>
                 <td><% if (targetContainers.isEmpty()) { %><%= h(name.getNickname()) %><% } else { %><labkey:input type="text" id="nickname<%= name.getId()%>" name="name" value="<%= name.getNickname() %>" size="40" /><% } %></td>
             </tr>
+            <% if (!targetContainers.containsKey(name.getContainer().getId())) { %>
+            <tr class="form-group">
+                <td class="lk-form-label">Currently saved in</td>
+                <td>
+                    <%= h(name.getContainer().getPath()) %>
+                </td>
+            </tr>
+            <% } %>
             <% if (!targetContainers.isEmpty()) { %>
             <tr class="form-group">
                 <td class="lk-form-label"><label for="targetContainerId<%= name.getId()%>">Use nickname</label></td>

--- a/src/org/labkey/targetedms/view/nickname.jsp
+++ b/src/org/labkey/targetedms/view/nickname.jsp
@@ -46,10 +46,14 @@
     }
     %>
 
+<%-- Always render the form, but conditionally render its elements--%>
     <labkey:form action="<%=urlFor(TargetedMSController.SaveInstrumentNameAction.class)%>" method="post" layout="horizontal">
+    <% if (!targetContainers.isEmpty()) { %>
         <labkey:input type="hidden" name="id" value="<%=name.getId()%>"/>
         <labkey:input type="hidden" name="model" value="<%=name.getModel()%>"/>
         <labkey:input type="hidden" name="serialNumber" value="<%=name.getSerialNumber()%>"/>
+    <% } %>
+
         <table>
             <tr class="form-group">
                 <td class="lk-form-label">Model</td>
@@ -61,7 +65,7 @@
             </tr>
             <tr class="form-group">
                 <td class="lk-form-label"><label for="nickname<%= name.getId()%>">Nickname</label></td>
-                <td><% if (targetContainers.isEmpty()) { %><%= h(name.getNickname()) %><% } else { %><labkey:input type="text" id="nickname<%= name.getId()%>" name="name" value="<%= name.getNickname() %>" size="40" /><% } %></td>
+                <td><% if (targetContainers.isEmpty()) { %><%= h(name.getNickname()) %><% } else { %><labkey:input type="text" name="name" value="<%= name.getNickname() %>" size="40" /><% } %></td>
             </tr>
             <% if (!targetContainers.containsKey(name.getContainer().getId())) { %>
             <tr class="form-group">

--- a/src/org/labkey/targetedms/view/renameRun.jsp
+++ b/src/org/labkey/targetedms/view/renameRun.jsp
@@ -22,7 +22,8 @@
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
-    RenameBean bean = ((JspView<RenameBean>) HttpView.currentView()).getModelBean();
+    JspView<RenameBean> currentView = HttpView.currentView();
+    RenameBean bean = currentView.getModelBean();
 %>
 <labkey:form action="<%=urlFor(RenameRunAction.class)%>" method="post" layout="horizontal">
 <%=generateReturnUrlFormField(bean.returnUrl)%>

--- a/test/src/org/labkey/test/tests/panoramapremium/TargetedMSIsotopologueTest.java
+++ b/test/src/org/labkey/test/tests/panoramapremium/TargetedMSIsotopologueTest.java
@@ -16,12 +16,10 @@ import static org.junit.Assert.assertTrue;
 @BaseWebDriverTest.ClassTimeout(minutes = 3)
 public class TargetedMSIsotopologueTest extends TargetedMSPremiumTest
 {
-    protected static final String ISOTOPOLOGUE_FILE_ANNOTATED = "PRM_7x5mix_A40010_QEHF_examples_v3.sky.zip";
-
     @BeforeClass
     public static void initProject()
     {
-        TargetedMSIsotopologueTest init = (TargetedMSIsotopologueTest) getCurrentTest();
+        TargetedMSIsotopologueTest init = getCurrentTest();
         init.doInit();
     }
 

--- a/test/src/org/labkey/test/tests/panoramapremium/TargetedMSQCPremiumTest.java
+++ b/test/src/org/labkey/test/tests/panoramapremium/TargetedMSQCPremiumTest.java
@@ -202,10 +202,9 @@ public class TargetedMSQCPremiumTest extends TargetedMSPremiumTest
         timeValueOptions.put("Last", "Last");
         timeValueOptions.put("Min", "Min");
         timeValueOptions.put("Max", "Max");
-        String skyFile = "SampleFileChromInfo.sky.zip";
 
         setUpFolder(projectName, FolderType.QC);
-        importData(skyFile);
+        importData(SAMPLE_FILE_CHROM_INFO);
 
         addNewTimeTraceMetrics(metrics.get("First"), timeValueOptions.get("First"), traceName);
         addNewTimeTraceMetrics(metrics.get("Min"), timeValueOptions.get("Min"), "ColumnPressure (channel 4)");
@@ -225,13 +224,13 @@ public class TargetedMSQCPremiumTest extends TargetedMSPremiumTest
         log("Delete run and verify trace metric values are deleted");
         clickTab("Runs");
         TargetedMSRunsTable runsTable = new TargetedMSRunsTable(this);
-        runsTable.deleteRun(skyFile);
+        runsTable.deleteRun(SAMPLE_FILE_CHROM_INFO);
         goToSchemaBrowser();
         traceValuesTable = viewQueryData("targetedms", "QCTraceMetricValues");
         assertEquals("Values in QCTraceMetricValues are not deleted on deleting run", 0, traceValuesTable.getDataRowCount());
 
         log("Reimport run and verify QCTraceMetricValues has values after import");
-        importData(skyFile, 2);
+        importData(SAMPLE_FILE_CHROM_INFO, 2);
         goToSchemaBrowser();
         traceValuesTable = viewQueryData("targetedms", "QCTraceMetricValues");
         assertTrue("Trace values after import are not present", traceValuesTable.getDataRowCount() > 0);

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentalQCLinkTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentalQCLinkTest.java
@@ -21,7 +21,6 @@ import java.util.List;
 @BaseWebDriverTest.ClassTimeout(minutes = 4)
 public class TargetedMSExperimentalQCLinkTest extends TargetedMSTest
 {
-    private static final String SKY_FILE_EXPERIMENT = "SProCoPTutorial.zip";
     private static final String SKY_FILE_QC = "SProCoPTutorial-QCFolderData.zip";
     private static final String QC_FOLDER_1 = "Test Project QC Folder 1";
     private static final String QC_FOLDER_2 = "Test Project QC Folder 2";
@@ -30,14 +29,14 @@ public class TargetedMSExperimentalQCLinkTest extends TargetedMSTest
     @BeforeClass
     public static void initProject()
     {
-        TargetedMSExperimentalQCLinkTest init = (TargetedMSExperimentalQCLinkTest) getCurrentTest();
+        TargetedMSExperimentalQCLinkTest init = getCurrentTest();
         init.doInit();
     }
 
     private void doInit()
     {
         setupFolder(FolderType.Experiment);
-        importData(SKY_FILE_EXPERIMENT);
+        importData(SProCoP_FILE);
 
         log("Creating one test QC folder with same data");
         setUpFolder(QC_FOLDER_1, FolderType.QC);
@@ -98,7 +97,7 @@ public class TargetedMSExperimentalQCLinkTest extends TargetedMSTest
     @Test
     public void testLinkExperimentalQC()
     {
-        String expRange = "Skyline File: " + SKY_FILE_EXPERIMENT + ", " +
+        String expRange = "Skyline File: " + SProCoP_FILE + ", " +
                 "Start: 2013-08-09 11:39:00, " +
                 "End: 2013-08-27 14:45:49, " +
                 "Mean: 14.669, Std Dev: 0.501, " +
@@ -139,8 +138,8 @@ public class TargetedMSExperimentalQCLinkTest extends TargetedMSTest
 
         log("Verify experiment toolbar is present");
         checker().verifyTrue("Experiment date range toolbar is not present",
-                isElementPresent(Locator.linkContainingText(SKY_FILE_EXPERIMENT)));
-        clickAndWait(Locator.linkContainingText(SKY_FILE_EXPERIMENT));
+                isElementPresent(Locator.linkContainingText(SProCoP_FILE)));
+        clickAndWait(Locator.linkContainingText(SProCoP_FILE));
         checker().verifyEquals("Did not navigate to experimental folder", getProjectName(), getCurrentContainer());
         goBack();
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSInstrumentNicknameTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSInstrumentNicknameTest.java
@@ -221,7 +221,7 @@ public class TargetedMSInstrumentNicknameTest extends TargetedMSTest
         // We should also get links to the QC folders with data from the same instrument
         assertElementPresent(Locator.linkWithText(getProjectName()));
         assertElementPresent(Locator.linkWithText(QC_SUB_FOLDER));
-        assertElementPresent(Locator.linkWithText(QC_SUB_FOLDER));
+        assertElementPresent(Locator.linkWithText(QC_SUB_SUB_FOLDER));
     }
 
     @Test

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSInstrumentNicknameTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSInstrumentNicknameTest.java
@@ -128,12 +128,6 @@ public class TargetedMSInstrumentNicknameTest extends TargetedMSTest
         importData(SAMPLE_FILE_CHROM_INFO, 2, false, true);
     }
 
-    @Before
-    public void preTest()
-    {
-        goToProjectHome();
-    }
-
     @Test
     public void testSubfolders()
     {

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSInstrumentNicknameTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSInstrumentNicknameTest.java
@@ -229,9 +229,9 @@ public class TargetedMSInstrumentNicknameTest extends TargetedMSTest
     {
         goToProjectHome();
         clickFolder(NON_QC_SUB_FOLDER);
-        click(Locator.linkWithText(SAMPLE_FILE_CHROM_INFO));
-        click(Locator.linkWithText("2 replicates"));
-        click(Locator.linkWithText(QTRAP));
+        clickAndWait(Locator.linkWithText(SAMPLE_FILE_CHROM_INFO));
+        clickAndWait(Locator.linkWithText("2 replicates"));
+        clickAndWait(Locator.linkWithText(QTRAP));
 
         String postImpersonationUrl = getDriver().getCurrentUrl();
         // Check we don't let readers save

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSInstrumentNicknameTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSInstrumentNicknameTest.java
@@ -250,8 +250,8 @@ public class TargetedMSInstrumentNicknameTest extends TargetedMSTest
         setFormElement(Locator.input("name"), NICKNAME_3);
         clickButton("Save");
 
-        click(Locator.linkWithText(SAMPLE_FILE_CHROM_INFO));
-        click(Locator.linkWithText("2 replicates"));
+        clickAndWait(Locator.linkWithText(SAMPLE_FILE_CHROM_INFO));
+        clickAndWait(Locator.linkWithText("2 replicates"));
         assertElementPresent(Locator.linkWithText(NICKNAME_3));
         stopImpersonating();
     }

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSInstrumentNicknameTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSInstrumentNicknameTest.java
@@ -152,7 +152,7 @@ public class TargetedMSInstrumentNicknameTest extends TargetedMSTest
         setFormElement(Locator.input("name"), NICKNAME_1);
         clickButton("Save");
         goToProjectHome();
-        waitAndClick(qExactiveWithSerialLinkLocator);
+        waitAndClickAndWait(qExactiveWithSerialLinkLocator);
         setFormElement(Locator.input("name"), NICKNAME_1);
         clickButton("Save");
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSInstrumentNicknameTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSInstrumentNicknameTest.java
@@ -214,8 +214,8 @@ public class TargetedMSInstrumentNicknameTest extends TargetedMSTest
 
         // Now try a non-QC folder, which should be inheriting the first nickname but not the second
         clickFolder(NON_QC_SUB_FOLDER);
-        click(Locator.linkWithText(ISOTOPOLOGUE_FILE_ANNOTATED));
-        click(Locator.linkWithText("6 replicates"));
+        clickAndWait(Locator.linkWithText(ISOTOPOLOGUE_FILE_ANNOTATED));
+        clickAndWait(Locator.linkWithText("6 replicates"));
         assertElementPresent(nickname1LinkLocator);
         assertElementPresent(qExactiveWithSerialLinkLocator);
         // We should also get links to the QC folders with data from the same instrument

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSInstrumentNicknameTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSInstrumentNicknameTest.java
@@ -166,7 +166,7 @@ public class TargetedMSInstrumentNicknameTest extends TargetedMSTest
         assertElementNotPresent(qExactiveLinkLocator);
         assertElementNotPresent(qExactiveWithSerialLinkLocator);
 
-        click(nickname1LinkLocator);
+        clickAndWait(nickname1LinkLocator);
         // We should see both model/serial numbers on the same page
         assertTextPresent(Q_EXACTIVE, 4);  // Twice on the page itself, twice in hidden form elements
         assertTextPresent(Q_EXACTIVE_SERIAL_ONLY, 2); // Once on the page itself, once in hidden form elements

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSInstrumentNicknameTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSInstrumentNicknameTest.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 2016-2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.labkey.test.tests.targetedms;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.labkey.remoteapi.CommandException;
+import org.labkey.remoteapi.Connection;
+import org.labkey.remoteapi.query.DeleteRowsCommand;
+import org.labkey.remoteapi.query.Filter;
+import org.labkey.remoteapi.query.SelectRowsCommand;
+import org.labkey.test.Locator;
+import org.labkey.test.TestTimeoutException;
+import org.labkey.test.util.ApiPermissionsHelper;
+import org.labkey.test.util.PermissionsHelper;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@Category({})
+public class TargetedMSInstrumentNicknameTest extends TargetedMSTest
+{
+    private static final String QC_SUB_FOLDER = "QC Subfolder";
+    private static final String QC_SUB_SUB_FOLDER = "QC SubSubfolder";
+    private static final String NON_QC_SUB_FOLDER = "NonQC Subfolder 3";
+    public static final String Q_EXACTIVE = "Q Exactive";
+    public static final String Q_EXACTIVE_SERIAL_ONLY = "Exactive Series slot #2384";
+    public static final String Q_EXACTIVE_WITH_SERIAL = Q_EXACTIVE + " - " + Q_EXACTIVE_SERIAL_ONLY;
+    public static final String QTRAP = "4000 QTRAP - U02630409";
+    public static final String AUTOMATED_TEST_NICKNAME_PREFIX = "AutomatedTestNickname";
+    public static final String NICKNAME_1 = AUTOMATED_TEST_NICKNAME_PREFIX + "1" + TRICKY_CHARACTERS;
+    public static final String NICKNAME_2 = AUTOMATED_TEST_NICKNAME_PREFIX + "2" + TRICKY_CHARACTERS;
+    public static final String NICKNAME_3 = AUTOMATED_TEST_NICKNAME_PREFIX + "3" + TRICKY_CHARACTERS;
+    public static final String REPLICATE_NAME_WITHOUT_SERIAL = "QEHF_7x5_TRAP_PRM_30minG_ES800_200fmolOC_25Oct19_R2";
+    public static final String FILE_PATH_WITHOUT_SERIAL = "C:\\Xcalibur\\data\\Bhavin\\2018\\October\\QEHF_QC_24Oct2018\\QEHF_7x5_TRAP_PRM_30minG_ES800_TRAP_200fmolOC_25Oct2018_R2.raw";
+    public static final String REPLICATE_NAME_WITH_SERIAL = "QEHF_7x5_TRAP_PRM_30minG_ES800_200fmolOC_21Apr18_R2";
+    public static final String FILE_PATH_WITH_SERIAL = "Z:\\QEHF_RawData\\Bhavin\\2018\\April\\SystemSuitability_7x5_Validation_16Apr2018\\QEHF_SysSuitStd_35AQUA_7x5_TRAP_PRM_30minG_ES800_400fmolOC_3axAdj17A_21Apr18_R2.raw";
+
+    @Override
+    protected String getProjectName()
+    {
+        return getClass().getSimpleName() + " Project";
+    }
+
+    @BeforeClass
+    public static void initProject()
+    {
+        TargetedMSInstrumentNicknameTest init = getCurrentTest();
+        init.setupProjectWithSubfolders();
+        init.importInitialData();
+    }
+
+    @Override
+    protected void doCleanup(boolean afterTest) throws TestTimeoutException
+    {
+        super.doCleanup(afterTest);
+
+        // Clean out the nicknames set in /Shared
+        var command = new SelectRowsCommand("targetedms", "InstrumentNickname");
+        command.setFilters(List.of(new Filter("Nickname", AUTOMATED_TEST_NICKNAME_PREFIX, Filter.Operator.STARTS_WITH)));
+        try
+        {
+            Connection connection = createDefaultConnection();
+            var response = command.execute(connection, "/Shared");
+            if (!response.getRows().isEmpty())
+            {
+                var deleteCommand = new DeleteRowsCommand("targetedms", "InstrumentNickname");
+                deleteCommand.setRows(response.getRows());
+                deleteCommand.execute(connection, "/Shared");
+            }
+        }
+        catch (IOException | CommandException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void setupProjectWithSubfolders()
+    {
+        setupFolder(FolderType.QC);
+
+        setupSubfolder(getProjectName(), QC_SUB_FOLDER, FolderType.QC);
+        setupSubfolder(getProjectName(), NON_QC_SUB_FOLDER, FolderType.Experiment);
+
+        clickFolder(QC_SUB_FOLDER);
+        setupSubfolder(getProjectName(), QC_SUB_FOLDER, QC_SUB_SUB_FOLDER, FolderType.QC);
+
+        _userHelper.createUser(USER);
+
+        // give user reader permissions to all but FOLDER_1
+        ApiPermissionsHelper permissionsHelper = new ApiPermissionsHelper(this);
+        permissionsHelper.addMemberToRole(USER, "Reader", PermissionsHelper.MemberType.user, getProjectName());
+        permissionsHelper.addMemberToRole(USER, "Editor", PermissionsHelper.MemberType.user, getProjectName() + "/" + NON_QC_SUB_FOLDER);
+    }
+
+    private void importInitialData()
+    {
+        goToProjectHome();
+        importData(ISOTOPOLOGUE_FILE_ANNOTATED, 1, false, false);
+
+        // Import the same file into a subfolders to test scoping
+        clickFolder(QC_SUB_FOLDER);
+        importData(ISOTOPOLOGUE_FILE_ANNOTATED, 1, false, false);
+
+        clickFolder(QC_SUB_SUB_FOLDER);
+        importData(ISOTOPOLOGUE_FILE_ANNOTATED, 1, false, false);
+
+        clickFolder(NON_QC_SUB_FOLDER);
+        importData(ISOTOPOLOGUE_FILE_ANNOTATED, 1, false, false);
+        // Only do DB maintenance on the last import in the sequence
+        importData(SAMPLE_FILE_CHROM_INFO, 2, false, true);
+    }
+
+    @Before
+    public void preTest()
+    {
+        goToProjectHome();
+    }
+
+    @Test
+    public void testSubfolders()
+    {
+        goToProjectHome();
+        Locator qExactiveLinkLocator = Locator.linkWithText(Q_EXACTIVE);
+        Locator qExactiveWithSerialLinkLocator = Locator.linkWithText(Q_EXACTIVE_WITH_SERIAL);
+        Locator nickname1LinkLocator = Locator.linkWithText(NICKNAME_1);
+        Locator nickname2LinkLocator = Locator.linkWithText(NICKNAME_2);
+
+        // Default display should show both variants of the model/serial number
+        waitForElement(qExactiveLinkLocator);
+        assertElementPresent(qExactiveWithSerialLinkLocator);
+
+        // Give a nickname that collapses them, saving in the default scope (server-side)
+        click(qExactiveLinkLocator);
+        setFormElement(Locator.input("name"), NICKNAME_1);
+        clickButton("Save");
+        goToProjectHome();
+        waitAndClick(qExactiveWithSerialLinkLocator);
+        setFormElement(Locator.input("name"), NICKNAME_1);
+        clickButton("Save");
+
+        // Be sure that the new nickname is shown and the model/serial number aren't
+        waitForElement(nickname1LinkLocator);
+        assertElementNotPresent(qExactiveLinkLocator);
+        assertElementNotPresent(qExactiveWithSerialLinkLocator);
+
+        clickFolder(QC_SUB_FOLDER);
+        waitForElement(nickname1LinkLocator);
+        assertElementNotPresent(qExactiveLinkLocator);
+        assertElementNotPresent(qExactiveWithSerialLinkLocator);
+
+        click(nickname1LinkLocator);
+        // We should see both model/serial numbers on the same page
+        assertTextPresent(Q_EXACTIVE, 4);  // Twice on the page itself, twice in hidden form elements
+        assertTextPresent(Q_EXACTIVE_SERIAL_ONLY, 2); // Once on the page itself, once in hidden form elements
+        assertTextPresent(
+                getProjectName() + "/" + QC_SUB_FOLDER + "/" + QC_SUB_SUB_FOLDER,
+                getProjectName() + "/" + NON_QC_SUB_FOLDER,
+
+                // Check for a sample without a serial number
+                REPLICATE_NAME_WITHOUT_SERIAL, FILE_PATH_WITHOUT_SERIAL,
+
+                // And one with a serial number
+                REPLICATE_NAME_WITH_SERIAL, FILE_PATH_WITH_SERIAL
+        );
+
+        // Rename the nickname for the one with the serial number to make sure they split
+        setFormElement(Locator.input("name"), NICKNAME_2);
+        clickButton("Save");
+
+        assertTextPresent(Q_EXACTIVE_SERIAL_ONLY, 2);  // Once visible on the page, once in a hidden form element
+        assertTextPresent(REPLICATE_NAME_WITH_SERIAL, FILE_PATH_WITH_SERIAL);
+
+        String postImpersonationUrl = getDriver().getCurrentUrl();
+        impersonateRole("Reader");
+        assertTextPresent(Q_EXACTIVE_SERIAL_ONLY, 1);  // Just the visible element, no form and hidden inputs for readers
+        stopImpersonating();
+        beginAt(postImpersonationUrl);
+
+        // Now resave, scoped to the folder
+        Locator.XPathLocator targetContainerLocator = Locator.name("targetContainerId");
+        selectOptionByTextContaining(targetContainerLocator.findElement(getDriver()), "In this folder");
+        clickButton("Save");
+
+        goToDashboard();
+        // We should see the current folder showing both nicknames
+        waitForElement(nickname1LinkLocator);
+        waitForElement(nickname2LinkLocator);
+        // We should also see the subfolder showing the nickname for one and the serial number for the other
+        waitForElement(qExactiveWithSerialLinkLocator);
+
+        // The subfolder should only see one of the nicknames
+        clickFolder(QC_SUB_SUB_FOLDER);
+        waitForElement(nickname1LinkLocator);
+        assertElementPresent(qExactiveWithSerialLinkLocator);
+        assertElementNotPresent(nickname2LinkLocator);
+
+        // Now try a non-QC folder, which should be inheriting the first nickname but not the second
+        clickFolder(NON_QC_SUB_FOLDER);
+        click(Locator.linkWithText(ISOTOPOLOGUE_FILE_ANNOTATED));
+        click(Locator.linkWithText("6 replicates"));
+        assertElementPresent(nickname1LinkLocator);
+        assertElementPresent(qExactiveWithSerialLinkLocator);
+        // We should also get links to the QC folders with data from the same instrument
+        assertElementPresent(Locator.linkWithText(getProjectName()));
+        assertElementPresent(Locator.linkWithText(QC_SUB_FOLDER));
+        assertElementPresent(Locator.linkWithText(QC_SUB_FOLDER));
+    }
+
+    @Test
+    public void testNonSiteAdmin()
+    {
+        goToProjectHome();
+        clickFolder(NON_QC_SUB_FOLDER);
+        click(Locator.linkWithText(SAMPLE_FILE_CHROM_INFO));
+        click(Locator.linkWithText("2 replicates"));
+        click(Locator.linkWithText(QTRAP));
+
+        String postImpersonationUrl = getDriver().getCurrentUrl();
+        // Check we don't let readers save
+        impersonateRole("Reader");
+        assertTextPresent("Currently saved in");
+        assertElementNotPresent(Locator.lkButton("Save"));
+        stopImpersonating();
+        beginAt(postImpersonationUrl);
+
+        Locator.XPathLocator targetContainerLocator = Locator.name("targetContainerId");
+        // Impersonate a user who can only edit in subfolder
+        impersonate(USER);
+        // Ensure they can't save in /Shared or project
+        assertEquals("Wrong number of places to save the nickname", 1, targetContainerLocator.findElement(getDriver()).findElements(Locator.tag("option")).size());
+        selectOptionByTextContaining(targetContainerLocator.findElement(getDriver()), "In this folder");
+        setFormElement(Locator.input("name"), NICKNAME_3);
+        clickButton("Save");
+
+        click(Locator.linkWithText(SAMPLE_FILE_CHROM_INFO));
+        click(Locator.linkWithText("2 replicates"));
+        assertElementPresent(Locator.linkWithText(NICKNAME_3));
+        stopImpersonating();
+    }
+}

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSInstrumentNicknameTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSInstrumentNicknameTest.java
@@ -148,7 +148,7 @@ public class TargetedMSInstrumentNicknameTest extends TargetedMSTest
         assertElementPresent(qExactiveWithSerialLinkLocator);
 
         // Give a nickname that collapses them, saving in the default scope (server-side)
-        click(qExactiveLinkLocator);
+        clickAndWait(qExactiveLinkLocator);
         setFormElement(Locator.input("name"), NICKNAME_1);
         clickButton("Save");
         goToProjectHome();

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCSummaryTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCSummaryTest.java
@@ -76,7 +76,7 @@ public class TargetedMSQCSummaryTest extends TargetedMSTest
     @BeforeClass
     public static void initProject()
     {
-        TargetedMSQCSummaryTest init = (TargetedMSQCSummaryTest)getCurrentTest();
+        TargetedMSQCSummaryTest init = getCurrentTest();
         init.setupProjectWithSubfolders();
         init.importInitialData();
     }
@@ -96,13 +96,14 @@ public class TargetedMSQCSummaryTest extends TargetedMSTest
     private void importInitialData()
     {
         goToProjectHome();
-        importData(SProCoP_FILE);
+        importData(SProCoP_FILE, 1, false, false);
 
         clickFolder(FOLDER_2);
-        importData(QC_1_FILE);
+        importData(QC_1_FILE, 1, false, false);
 
         clickFolder(FOLDER_2A);
-        importData(QC_2_FILE);
+        // Do DB maintenance after the last of the initial imports
+        importData(QC_2_FILE, 1, false, true);
     }
 
     private void setAutoQCPingTimeOut(String timeOutLength)
@@ -321,7 +322,7 @@ public class TargetedMSQCSummaryTest extends TargetedMSTest
         for(String classValue : iconClassValues)
         {
             log("Validate that the autoQC icon has a value of '" + classValue + "' in its class property.");
-            assertTrue("AutoQC icon not as expected. Class did not contain '" + classValue + "'. Class: '" + tmpString + "'", tmpString.toLowerCase().contains(classValue));
+            assertTrue("AutoQC icon not as expected. Class did not contain '" + classValue + "'. Class: '" + tmpString + "'", tmpString != null && tmpString.toLowerCase().contains(classValue));
         }
 
         log("Validate bubble text is '" + bubbleText + "'");
@@ -363,7 +364,7 @@ public class TargetedMSQCSummaryTest extends TargetedMSTest
                 if (!waitFor(() -> textSearcher.getMissingTexts(perBubbleTexts).isEmpty(), 10000))
                 {
                     String actualText = textSearcher.getLastSearchedText();
-                    fail("The bubble text for the file detail not as expected. Bubble text: '" + actualText + "' Missing: '" + String.join(",", perBubbleTexts.stream().filter(s -> !actualText.contains(s)).collect(Collectors.toList())) + "'");
+                    fail("The bubble text for the file detail not as expected. Bubble text: '" + actualText + "' Missing: '" + perBubbleTexts.stream().filter(s -> !actualText.contains(s)).collect(Collectors.joining(",")) + "'");
                 }
             }
             qcSummaryWebPart.closeBubble();
@@ -423,9 +424,9 @@ public class TargetedMSQCSummaryTest extends TargetedMSTest
         }
     }
 
-    public class AutoQCPing extends PostCommand<CommandResponse>
+    public static class AutoQCPing extends PostCommand<CommandResponse>
     {
-        private String _softwareVersion;
+        private final String _softwareVersion;
 
         public AutoQCPing()
         {

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSTest.java
@@ -58,6 +58,8 @@ public abstract class TargetedMSTest extends BaseWebDriverTest
     protected static final String QC_3_FILE = "QC_3.sky.zip";
     protected static final String QC_4_FILE = "QC_4.sky.zip";
     protected static final String SKY_FILE_SMALLMOL_PEP = "smallmol_plus_peptides.sky.zip";
+    protected static final String ISOTOPOLOGUE_FILE_ANNOTATED = "PRM_7x5mix_A40010_QEHF_examples_v3.sky.zip";
+    protected static final String SAMPLE_FILE_CHROM_INFO = "SampleFileChromInfo.sky.zip";
     protected static final String USER = "qcuser@targetedms.test";
     private static ConfiguresSite siteConfigurer;
 
@@ -219,6 +221,12 @@ public abstract class TargetedMSTest extends BaseWebDriverTest
     @LogMethod
     protected void importData(@LoggedParam String file, int jobCount, boolean expectError)
     {
+        importData(file, jobCount, expectError, true);
+    }
+
+    @LogMethod
+    protected void importData(@LoggedParam String file, int jobCount, boolean expectError, boolean doDbMaintenance)
+    {
         Locator.XPathLocator importButtonLoc = Locator.lkButton("Process and Import Data");
         WebElement importButton = importButtonLoc.findElementOrNull(getDriver());
         if (null == importButton)
@@ -234,7 +242,10 @@ public abstract class TargetedMSTest extends BaseWebDriverTest
         waitForText("Skyline document import");
         waitForPipelineJobsToComplete(jobCount, file, expectError);
 
-        runDbMaintenance();
+        if (doDbMaintenance)
+        {
+            runDbMaintenance();
+        }
     }
 
     private void runDbMaintenance()

--- a/webapp/TargetedMS/js/QCSummaryPanel.js
+++ b/webapp/TargetedMS/js/QCSummaryPanel.js
@@ -21,13 +21,32 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
             text: 'Loading...'
         })
 
-        LABKEY.targetedms.QCMetricConfigLoader.getMetrics(this.initPanel, this);
+        this.qcPlotPanel.queryQCInstruments(this.getQCSummary, this);
         this.numSampleFileStats = config ? config.sampleLimit : 3;
     },
 
-    initPanel : function(metrics) {
-        this.metricPropArr = metrics;
-        this.qcPlotPanel.queryQCInstruments(this.getQCSummary, this);
+    formatInstruments: function(container) {
+        if (container.distinctInstruments) {
+            if (container.distinctInstruments.length > 1) {
+                container.instrument = ' for multiple instruments: <ul>';
+                for (let index = 0; index < container.distinctInstruments.length; index++) {
+                    container.instrument += '<li>' + this.formatInstrument(container.distinctInstruments[index], container.path) + '</li>';
+                }
+                container.instrument += '</ul> We recommend that each instrument use its own QC folder.';
+            }
+            else if (container.distinctInstruments.length === 1 && container.distinctInstruments[0]) {
+                container.instrument = ' for ' + this.formatInstrument(container.distinctInstruments[0], container.path);
+            }
+        }
+    },
+
+    formatInstrument: function(name, containerPath) {
+        let result = Ext4.util.Format.htmlEncode(name ? name : 'unknown instrument');
+        if (name)
+            result = '<a href="' +
+                    LABKEY.ActionURL.buildURL('targetedms', 'showInstrument', containerPath, {name: name}) +
+                    '">' + result + '</a>'
+        return result;
     },
 
     getQCSummary: function () {
@@ -57,25 +76,14 @@ Ext4.define('LABKEY.targetedms.QCSummary', {
                 container.showName = hasChildren;
                 container.isParent = true;
                 container.parentOnly = containers.length === 1;
-                if (this.qcPlotPanel.qcIntrumentsArr) {
-                    if (this.qcPlotPanel.qcIntrumentsArr.length > 1) {
-                        container.instrument = ' for multiple instruments: <ul>';
-                        for (let index = 0; index < this.qcPlotPanel.qcIntrumentsArr.length; index++) {
-                            let currentInstrument = this.qcPlotPanel.qcIntrumentsArr[index];
-                            container.instrument += '<li>' + Ext4.util.Format.htmlEncode(currentInstrument ? currentInstrument : 'unknown instrument') + '</li>';
-                        }
-                        container.instrument += '</ul> We recommend that each instrument use its own QC folder.';
-                    }
-                    else if (this.qcPlotPanel.qcIntrumentsArr.length === 1 && this.qcPlotPanel.qcIntrumentsArr[0]) {
-                        container.instrument = ' for ' + Ext4.util.Format.htmlEncode(this.qcPlotPanel.qcIntrumentsArr[0]);
-                    }
-                }
+                this.formatInstruments(container);
                 this.add(this.getContainerSummaryView(container, hasChildren, width));
 
                 // Add the set of child containers in an hbox layout
                 if (hasChildren) {
                     for (var i = 1; i < containers.length; i++) {
                         container = containers[i];
+                        this.formatInstruments(container);
                         container.showName = true;
                         container.parentOnly = false;
                         container.isParent = false;


### PR DESCRIPTION
#### Rationale
Panorama shows instrument model and serial number when it's available in the Skyline document. However, users often refer to them by other names, like "QE1" and "QE2" for the first and second Q Exactive instruments acquired by a lab. We can improve usability by letting users assign nicknames.

#### Changes
* For users with editor or higher access, let them set a nickname on the instrument details page
* Show the nickname (or the model/serial number when no nickname is set) whenever we're referring to an instrument
* Use Shared/Project/Current scoping so nicknames only need to be set once in any common deployment scenario
