### PR TITLE
TargetedMSSampleManagerIntegrationTest update to check for LKSM and LIMS product configuration cases

### DIFF
--- a/test/src/org/labkey/test/tests/panoramapremium/TargetedMSSampleManagerIntegrationTest.java
+++ b/test/src/org/labkey/test/tests/panoramapremium/TargetedMSSampleManagerIntegrationTest.java
@@ -1,5 +1,6 @@
 package org.labkey.test.tests.panoramapremium;
 
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -100,31 +101,31 @@ public class TargetedMSSampleManagerIntegrationTest extends TargetedMSPremiumTes
 
         log("Clicking the replicate column link to verify the navigation");
         clickAndWait(Locator.linkWithText("Q_Exactive_08_09_2013_JGB_02").index(0));
-        checker().verifyTrue("Sample link did not navigate to sample manager application",
-                getCurrentRelativeURL(false).contains(WebTestHelper.buildRelativeUrl("targetedms", getProjectName() + "/" + TargetedMS_SubFolder, "showSampleFile")));
+        Assertions.assertThat(getCurrentRelativeURL()).as("Sample link did not navigate to sample manager application")
+                .contains(WebTestHelper.buildRelativeUrl("targetedms", getProjectName() + "/" + TargetedMS_SubFolder, "showSampleFile"));
         goBack();
 
         log("Navigating to SM app");
         assertElementPresent(Locator.linkWithText(s2));
         assertElementPresent(Locator.linkWithText(s3));
         clickAndWait(Locator.linkWithText(s1));
-        checker().fatal().verifyTrue("Sample link did not navigate to Sample Manager application",
-                getCurrentRelativeURL(false).contains(WebTestHelper.buildRelativeUrl("SampleManager", getProjectName() + "/" + Sample_Manager_Subfolder, "app")));
+        Assertions.assertThat(getCurrentRelativeURL()).as("Sample link did not navigate to Sample Manager application")
+                .contains(WebTestHelper.buildRelativeUrl("SampleManager", getProjectName() + "/" + Sample_Manager_Subfolder, "app"));
 
         log("Navigating back to labkey server");
         waitForElementToBeVisible(Locator.linkWithText("Assays"));
         click(Locator.linkWithText("Assays"));
         waitAndClick(Locator.linkContainingText("Skyline Documents"));
         waitAndClickAndWait(Locator.linkWithText(SProCoP_FILE_ANNOTATED));
-        checker().fatal().verifyTrue("Did not navigate back to labkey server",
-                getCurrentRelativeURL(false).contains(WebTestHelper.buildRelativeUrl("targetedms", getProjectName() + "/" + TargetedMS_SubFolder, "showPrecursorList")));
+        Assertions.assertThat(getCurrentRelativeURL()).as("Did not navigate back to labkey server")
+                .contains(WebTestHelper.buildRelativeUrl("targetedms", getProjectName() + "/" + TargetedMS_SubFolder, "showPrecursorList"));
 
         log("Change to the LIMS configuration to verify the navigation");
         setProductConfigurationViaApi(ProductKey.labkeyLims);
         clickAndWait(Locator.linkWithText("6 replicates"));
         clickAndWait(Locator.linkWithText(s1));
-        checker().fatal().verifyTrue("Sample link did not navigate to LIMS application",
-                getCurrentRelativeURL(false).contains(WebTestHelper.buildRelativeUrl("LIMS", getProjectName() + "/" + Sample_Manager_Subfolder, "app")));
+        Assertions.assertThat(getCurrentRelativeURL()).as("Sample link did not navigate to LIMS application")
+                .contains(WebTestHelper.buildRelativeUrl("LIMS", getProjectName() + "/" + Sample_Manager_Subfolder, "app"));
 
         log("Disabling the SM to verify the navigation");
         goToProjectHome();
@@ -134,8 +135,8 @@ public class TargetedMSSampleManagerIntegrationTest extends TargetedMSPremiumTes
         navigateToFolder(getProjectName(), TargetedMS_SubFolder);
         waitAndClickAndWait(Locator.linkContainingText("replicates"));
         clickAndWait(Locator.linkWithText(s1));
-        checker().fatal().verifyTrue("Sample link navigated to sample manager application when disabled at folder level",
-                getCurrentRelativeURL(false).contains(WebTestHelper.buildRelativeUrl("experiment", getProjectName() + "/" + Sample_Manager_Subfolder, "showMaterial")));
+        Assertions.assertThat(getCurrentRelativeURL()).as("Sample link navigated to sample manager application when disabled at folder level")
+                .contains(WebTestHelper.buildRelativeUrl("experiment", getProjectName() + "/" + Sample_Manager_Subfolder, "showMaterial"));
 
     }
 

--- a/test/src/org/labkey/test/tests/panoramapremium/TargetedMSSampleManagerIntegrationTest.java
+++ b/test/src/org/labkey/test/tests/panoramapremium/TargetedMSSampleManagerIntegrationTest.java
@@ -1,8 +1,10 @@
 package org.labkey.test.tests.panoramapremium;
 
+import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.labkey.remoteapi.CommandException;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.WebTestHelper;
@@ -12,6 +14,7 @@ import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.SampleTypeHelper;
 import org.labkey.test.util.exp.SampleTypeAPIHelper;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -23,11 +26,12 @@ public class TargetedMSSampleManagerIntegrationTest extends TargetedMSPremiumTes
     protected static final String TargetedMS_SubFolder = "TargetedMS Subfolder";
     protected static final String Sample_Manager_Subfolder = "Sample Manager Subfolder";
     private static final String sampleType = "TargetedMS_Linked_Sample_Type";
+    private static ProductKey _previousProduct = null;
 
     @BeforeClass
     public static void initProject()
     {
-        TargetedMSSampleManagerIntegrationTest init = (TargetedMSSampleManagerIntegrationTest) getCurrentTest();
+        TargetedMSSampleManagerIntegrationTest init = getCurrentTest();
         init.doInit();
     }
 
@@ -53,9 +57,25 @@ public class TargetedMSSampleManagerIntegrationTest extends TargetedMSPremiumTes
         createSampleType(sampleType);
     }
 
-    @Test
-    public void testSampleTypeNavigation()
+    @After
+    public void resetProductConfiguration()
     {
+        try
+        {
+            if (_previousProduct != null)
+                setProductConfigurationViaApi(_previousProduct);
+        }
+        catch (Exception e)
+        {
+            log("Failed to reset the product configuration back to its original value:" + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testSampleTypeNavigation() throws IOException, CommandException
+    {
+        _previousProduct = setProductConfigurationViaApi(ProductKey.sampleManagerProfessional);
+
         String s1 = "AnnotatedSample1";
         String s2 = "ExtractedSampleId4";
         String s3 = "Q_Exactive_08_09_2013_JGB_87";
@@ -88,8 +108,8 @@ public class TargetedMSSampleManagerIntegrationTest extends TargetedMSPremiumTes
         assertElementPresent(Locator.linkWithText(s2));
         assertElementPresent(Locator.linkWithText(s3));
         clickAndWait(Locator.linkWithText(s1));
-        checker().verifyTrue("Sample link did not navigate to sample manager application",
-                getCurrentRelativeURL(false).contains(WebTestHelper.buildRelativeUrl("sampleManager", getProjectName() + "/" + Sample_Manager_Subfolder, "app")));
+        checker().verifyTrue("Sample link did not navigate to Sample Manager application",
+                getCurrentRelativeURL(false).contains(WebTestHelper.buildRelativeUrl("SampleManager", getProjectName() + "/" + Sample_Manager_Subfolder, "app")));
 
         log("Navigating back to labkey server");
         waitForElementToBeVisible(Locator.linkWithText("Assays"));
@@ -98,6 +118,13 @@ public class TargetedMSSampleManagerIntegrationTest extends TargetedMSPremiumTes
         waitAndClickAndWait(Locator.linkWithText(SProCoP_FILE_ANNOTATED));
         checker().verifyTrue("Did not navigate back to labkey server",
                 getCurrentRelativeURL(false).contains(WebTestHelper.buildRelativeUrl("targetedms", getProjectName() + "/" + TargetedMS_SubFolder, "showPrecursorList")));
+
+        log("Change to the LIMS configuration to verify the navigation");
+        setProductConfigurationViaApi(ProductKey.labkeyLims);
+        clickAndWait(Locator.linkWithText("6 replicates"));
+        clickAndWait(Locator.linkWithText(s1));
+        checker().verifyTrue("Sample link did not navigate to LIMS application",
+                getCurrentRelativeURL(false).contains(WebTestHelper.buildRelativeUrl("LIMS", getProjectName() + "/" + Sample_Manager_Subfolder, "app")));
 
         log("Disabling the SM to verify the navigation");
         goToProjectHome();

--- a/test/src/org/labkey/test/tests/panoramapremium/TargetedMSSampleManagerIntegrationTest.java
+++ b/test/src/org/labkey/test/tests/panoramapremium/TargetedMSSampleManagerIntegrationTest.java
@@ -108,7 +108,7 @@ public class TargetedMSSampleManagerIntegrationTest extends TargetedMSPremiumTes
         assertElementPresent(Locator.linkWithText(s2));
         assertElementPresent(Locator.linkWithText(s3));
         clickAndWait(Locator.linkWithText(s1));
-        checker().verifyTrue("Sample link did not navigate to Sample Manager application",
+        checker().fatal().verifyTrue("Sample link did not navigate to Sample Manager application",
                 getCurrentRelativeURL(false).contains(WebTestHelper.buildRelativeUrl("SampleManager", getProjectName() + "/" + Sample_Manager_Subfolder, "app")));
 
         log("Navigating back to labkey server");
@@ -116,14 +116,14 @@ public class TargetedMSSampleManagerIntegrationTest extends TargetedMSPremiumTes
         click(Locator.linkWithText("Assays"));
         waitAndClick(Locator.linkContainingText("Skyline Documents"));
         waitAndClickAndWait(Locator.linkWithText(SProCoP_FILE_ANNOTATED));
-        checker().verifyTrue("Did not navigate back to labkey server",
+        checker().fatal().verifyTrue("Did not navigate back to labkey server",
                 getCurrentRelativeURL(false).contains(WebTestHelper.buildRelativeUrl("targetedms", getProjectName() + "/" + TargetedMS_SubFolder, "showPrecursorList")));
 
         log("Change to the LIMS configuration to verify the navigation");
         setProductConfigurationViaApi(ProductKey.labkeyLims);
         clickAndWait(Locator.linkWithText("6 replicates"));
         clickAndWait(Locator.linkWithText(s1));
-        checker().verifyTrue("Sample link did not navigate to LIMS application",
+        checker().fatal().verifyTrue("Sample link did not navigate to LIMS application",
                 getCurrentRelativeURL(false).contains(WebTestHelper.buildRelativeUrl("LIMS", getProjectName() + "/" + Sample_Manager_Subfolder, "app")));
 
         log("Disabling the SM to verify the navigation");
@@ -134,7 +134,7 @@ public class TargetedMSSampleManagerIntegrationTest extends TargetedMSPremiumTes
         navigateToFolder(getProjectName(), TargetedMS_SubFolder);
         waitAndClickAndWait(Locator.linkContainingText("replicates"));
         clickAndWait(Locator.linkWithText(s1));
-        checker().verifyTrue("Sample link navigated to sample manager application when disabled at folder level",
+        checker().fatal().verifyTrue("Sample link navigated to sample manager application when disabled at folder level",
                 getCurrentRelativeURL(false).contains(WebTestHelper.buildRelativeUrl("experiment", getProjectName() + "/" + Sample_Manager_Subfolder, "showMaterial")));
 
     }

--- a/test/src/org/labkey/test/tests/panoramapremium/TargetedMSSampleManagerIntegrationTest.java
+++ b/test/src/org/labkey/test/tests/panoramapremium/TargetedMSSampleManagerIntegrationTest.java
@@ -120,13 +120,6 @@ public class TargetedMSSampleManagerIntegrationTest extends TargetedMSPremiumTes
         Assertions.assertThat(getCurrentRelativeURL()).as("Did not navigate back to labkey server")
                 .contains(WebTestHelper.buildRelativeUrl("targetedms", getProjectName() + "/" + TargetedMS_SubFolder, "showPrecursorList"));
 
-        log("Change to the LIMS configuration to verify the navigation");
-        setProductConfigurationViaApi(ProductKey.labkeyLims);
-        clickAndWait(Locator.linkWithText("6 replicates"));
-        clickAndWait(Locator.linkWithText(s1));
-        Assertions.assertThat(getCurrentRelativeURL()).as("Sample link did not navigate to LIMS application")
-                .contains(WebTestHelper.buildRelativeUrl("LIMS", getProjectName() + "/" + Sample_Manager_Subfolder, "app"));
-
         log("Disabling the SM to verify the navigation");
         goToProjectHome();
         navigateToFolder(getProjectName(), Sample_Manager_Subfolder);


### PR DESCRIPTION
#### Rationale
We recently made a change to how we determine the primary application Id for a container/project. This means that if a distribution has the LKSM and LIMS products registered and the container has the sampleManager module enabled but does not have the folder type set as LIMS or LKSM, the container will default to the "highest" product based on the site product configuration. 

This PR updates the related test to check for both the LKSM and LIMS cases in the TargetedMS integration.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6726
- https://github.com/LabKey/targetedms/pull/1079
- https://github.com/LabKey/limsModules/pull/1454
- https://github.com/LabKey/testAutomation/pull/2478

#### Changes
* update to check for LKSM and LIMS product configuration cases
