### PR TITLE
Minor auto-refactor code cleanup on a massive scale

### DIFF
--- a/api-src/org/labkey/api/targetedms/SkylineAnnotation.java
+++ b/api-src/org/labkey/api/targetedms/SkylineAnnotation.java
@@ -15,10 +15,6 @@
  */
 package org.labkey.api.targetedms;
 
-import org.labkey.api.data.Container;
-
-import java.util.Date;
-
 /**
  * User: vsharma
  * Date: 8/26/2015
@@ -26,6 +22,6 @@ import java.util.Date;
  */
 public interface SkylineAnnotation
 {
-    public String getName();
-    public String getValue();
+    String getName();
+    String getValue();
 }

--- a/api-src/org/labkey/api/targetedms/TargetedMSService.java
+++ b/api-src/org/labkey/api/targetedms/TargetedMSService.java
@@ -143,9 +143,6 @@ public interface TargetedMSService
     /**
      * Returns the name of a chromatogram library file according to the naming pattern used for creating
      * .clib files for a specific revision number in a given container.
-     * @param container
-     * @param revision
-     * @return
      */
     String getChromLibFileName(@NotNull Container container, int revision);
 
@@ -153,16 +150,12 @@ public interface TargetedMSService
      * Returns the revision number from the file name if the given file name matches the chromatogram library
      * naming pattern.  Example: chromlib_314_rev5.clib; revision number is 5.
      * Returns null if the given file name does not match the expected pattern.
-     * @param chromLibFileName
-     * @return
      */
     @Nullable
     Integer parseChromLibRevision(@NotNull String chromLibFileName);
 
     /**
      *
-     * @param sampleFileId
-     * @param container container that has the Skyline document that the sample file belongs to.
      * @return the replicate name associated with the given sampleFileId. Returns null if a database row with the given
      * sampleFileId does not exist, or if the Skyline document with the sample file is not in the given container.
      */

--- a/src/org/labkey/panoramapremium/PanoramaPremiumController.java
+++ b/src/org/labkey/panoramapremium/PanoramaPremiumController.java
@@ -118,7 +118,7 @@ public class PanoramaPremiumController extends SpringActionController
 
         //skip selected precursors that are already excluded
         selectedRowsKeys.forEach(id -> {
-            List<ExcludedPrecursor> prec = precursorsList.stream().filter(p -> p.getId() == id).collect(Collectors.toList());
+            List<ExcludedPrecursor> prec = precursorsList.stream().filter(p -> p.getId() == id).toList();
             ExcludedPrecursor precursor = prec.get(0);
             precursor.setIsPeptide(isPeptide);
 

--- a/src/org/labkey/panoramapremium/View/QCSummaryMenuCustomizer.java
+++ b/src/org/labkey/panoramapremium/View/QCSummaryMenuCustomizer.java
@@ -13,8 +13,8 @@ import java.util.List;
 
 public class QCSummaryMenuCustomizer implements NavTreeCustomizer
 {
-    private @NotNull String actionName;
-    private @NotNull String menuLabel;
+    private final @NotNull String actionName;
+    private final @NotNull String menuLabel;
 
     public QCSummaryMenuCustomizer(@NotNull String actionName, @NotNull String menuLabel)
     {

--- a/src/org/labkey/targetedms/IrtPeptide.java
+++ b/src/org/labkey/targetedms/IrtPeptide.java
@@ -113,7 +113,6 @@ public class IrtPeptide extends SkylineEntity implements Comparable<IrtPeptide>
 
     /**
      * Include a new import value in the weighted average iRT value for the peptide sequence.
-     * @param newObservation
      */
     public void reweighValue(double newObservation)
     {

--- a/src/org/labkey/targetedms/SkylineAuditLogManager.java
+++ b/src/org/labkey/targetedms/SkylineAuditLogManager.java
@@ -392,7 +392,7 @@ public class SkylineAuditLogManager
         {
             SimpleFilter runAuditLogFilter = new SimpleFilter(FieldKey.fromParts("VersionId"), pRunId);
 
-            if (deleteEntryIds.size() > 0)
+            if (!deleteEntryIds.isEmpty())
             {
                 SimpleFilter entryFilter = new SimpleFilter(
                         new SimpleFilter.InClause(FieldKey.fromParts("entryId"), deleteEntryIds, false)

--- a/src/org/labkey/targetedms/SkylinePort/Irt/IRetentionScoreCalculator.java
+++ b/src/org/labkey/targetedms/SkylinePort/Irt/IRetentionScoreCalculator.java
@@ -28,7 +28,7 @@ import java.util.ArrayList;
 
 public interface IRetentionScoreCalculator
 {
-    public String getName();
+    String getName();
 
 	Double ScoreSequence(String modifiedSequence);
 

--- a/src/org/labkey/targetedms/SkylinePort/Irt/IrtRegressionCalculator.java
+++ b/src/org/labkey/targetedms/SkylinePort/Irt/IrtRegressionCalculator.java
@@ -98,14 +98,14 @@ public class IrtRegressionCalculator
             }
         }
 
-        if (existingPeptideList.size() > 0)
+        if (!existingPeptideList.isEmpty())
         {
             pipelineLog.info("Attempting to calculate iRT regression line from shared peptides.");
             // Attempt to get a regression based on shared peptides
             CurrentCalculator calculator = new CurrentCalculator(standardPeptideList, existingPeptideList);
             ArrayList<MeasuredRetentionTime> peptidesTimes = retentionTimes.getPeptideRetentionTimes();
             //var peptidesTimes = retentionTimes.getPeptideRetentionTimes().toArray();
-            RetentionTimeRegression regression = RetentionTimeRegression.FindThreshold(MIN_IRT_TO_TIME_CORRELATION, RetentionTimeRegression.getThresholdPrecision(), peptidesTimes, new ArrayList<MeasuredRetentionTime>(), peptidesTimes, calculator, false);
+            RetentionTimeRegression regression = RetentionTimeRegression.FindThreshold(MIN_IRT_TO_TIME_CORRELATION, RetentionTimeRegression.getThresholdPrecision(), peptidesTimes, new ArrayList<>(), peptidesTimes, calculator, false);
 
             if (regression != null && regression.getPeptideTimes().size() >= MIN_IRT_TO_TIME_POINT_COUNT)
             {
@@ -142,10 +142,10 @@ public class IrtRegressionCalculator
 
     private final static class CurrentCalculator extends RetentionScoreCalculatorSpec
     {
-        private LinkedHashMap<String, Double> _dictStandards = new LinkedHashMap<>();
-        private LinkedHashMap<String, Double> _dictLibrary = new LinkedHashMap<>();
+        private final LinkedHashMap<String, Double> _dictStandards = new LinkedHashMap<>();
+        private final LinkedHashMap<String, Double> _dictLibrary = new LinkedHashMap<>();
 
-        private double _unknownScore;
+        private final double _unknownScore;
 
         public CurrentCalculator(Iterable<IrtPeptide> standardPeptides, Iterable<IrtPeptide> libraryPeptides)
         {

--- a/src/org/labkey/targetedms/SkylinePort/Irt/RegressionLine.java
+++ b/src/org/labkey/targetedms/SkylinePort/Irt/RegressionLine.java
@@ -80,8 +80,7 @@ public final class RegressionLine implements IRegressionFunction
      for a given x.
 
      @param x Value in x dimension
-     @return
-    */
+     */
     @Override
     public double GetY(double x)
     {
@@ -93,8 +92,7 @@ public final class RegressionLine implements IRegressionFunction
      for a given y.
 
      @param y Value in y dimension
-     @return
-    */
+     */
     public double GetX(double y)
     {
         return (y - getIntercept()) / getSlope();

--- a/src/org/labkey/targetedms/SkylinePort/Irt/RegressionLineElement.java
+++ b/src/org/labkey/targetedms/SkylinePort/Irt/RegressionLineElement.java
@@ -32,7 +32,7 @@ package org.labkey.targetedms.SkylinePort.Irt;
 */
 public final class RegressionLineElement implements IRegressionFunction
 {
-    private RegressionLine _regressionLine;
+    private final RegressionLine _regressionLine;
 
     public RegressionLine getRegressionLine()
     {

--- a/src/org/labkey/targetedms/SkylinePort/Irt/RetentionTimeRegression.java
+++ b/src/org/labkey/targetedms/SkylinePort/Irt/RetentionTimeRegression.java
@@ -306,10 +306,10 @@ public final class RetentionTimeRegression
     */
     public RetentionTimeStatistics CalcStatistics(ArrayList<MeasuredRetentionTime> peptidesTimes, java.util.Map<String, Double> scoreCache)
     {
-        java.util.ArrayList<String> listPeptides = new java.util.ArrayList<String>();
-        java.util.ArrayList<Double> listHydroScores = new java.util.ArrayList<Double>();
-        java.util.ArrayList<Double> listPredictions = new java.util.ArrayList<Double>();
-        java.util.ArrayList<Double> listRetentionTimes = new java.util.ArrayList<Double>();
+        java.util.ArrayList<String> listPeptides = new java.util.ArrayList<>();
+        java.util.ArrayList<Double> listHydroScores = new java.util.ArrayList<>();
+        java.util.ArrayList<Double> listPredictions = new java.util.ArrayList<>();
+        java.util.ArrayList<Double> listRetentionTimes = new java.util.ArrayList<>();
 
         boolean usableCalc = getCalculator().IsUsable();
 
@@ -500,7 +500,7 @@ public final class RetentionTimeRegression
         RetentionScoreCalculatorSpec s = null;
         RefObject<RetentionScoreCalculatorSpec> tempRef_s = new RefObject<>(s);
         RetentionTimeRegression tempVar = CalcRegression(name, calculators, measuredPeptides, null, false, statistics, tempRef_s);
-        s = tempRef_s.get();
+        tempRef_s.get();
         return tempVar;
     }
 
@@ -514,8 +514,7 @@ public final class RetentionTimeRegression
      @param allPeptides If true, do not let the calculator pick which peptides to use in the regression
      @param statistics Statistics from the regression of the best calculator
      @param calculatorSpec The best calculator
-     @return
-    */
+     */
     public static RetentionTimeRegression CalcRegression(String name, ArrayList<RetentionScoreCalculatorSpec> calculators, ArrayList<MeasuredRetentionTime> measuredPeptides, RetentionTimeScoreCache scoreCache, boolean allPeptides, RefObject<RetentionTimeStatistics> statistics, RefObject<RetentionScoreCalculatorSpec> calculatorSpec)
     {
         // Get a list of peptide names for use by the calculators to choose their regression peptides
@@ -545,7 +544,7 @@ public final class RetentionTimeRegression
         // An arraylist, indexed by calculator, of actual retention times for the peptides in peptideScoresByCalc
         List<ArrayList<Double>> listRTs = new ArrayList<>(calcs);
 
-        LinkedHashMap<String, Double> dictMeasuredPeptides = new LinkedHashMap<String, Double>();
+        LinkedHashMap<String, Double> dictMeasuredPeptides = new LinkedHashMap<>();
 
         for (MeasuredRetentionTime measured : measuredPeptides)
         {
@@ -575,7 +574,7 @@ public final class RetentionTimeRegression
 
             try
             {
-                listRTs.set(i, new ArrayList<Double>());
+                listRTs.set(i, new ArrayList<>());
                 calcPeptides.set(i, allPeptides ? listPeptides : calc.ChooseRegressionPeptides(listPeptides));
                 peptideScoresByCalc.set(i, RetentionTimeScoreCache.CalcScores(calc, calcPeptides.get(i), scoreCache));
             }
@@ -714,8 +713,8 @@ public final class RetentionTimeRegression
         RefObject<RetentionTimeStatistics> tempRef_statisticsRefined = new RefObject<>(statisticsRefined);
         RefObject<LinkedHashSet<Integer>> tempRef_outIndexes = new RefObject<>(outIndexes);
         RetentionTimeRegression tempVar = regressionInitial.FindThreshold(threshold, precision, 0, measuredPeptides.size(), standardPeptides, variablePeptides, statisticsAll, calculator, scoreCache, isCanceled, tempRef_statisticsRefined, tempRef_outIndexes);
-        statisticsRefined = tempRef_statisticsRefined.get();  // TPG: TODO Proper handling of the ref conversion
-        outIndexes = tempRef_outIndexes.get();
+        tempRef_statisticsRefined.get();
+        tempRef_outIndexes.get();
         return tempVar;
 
     }
@@ -840,7 +839,7 @@ public final class RetentionTimeRegression
         Collections.sort(listDeltas);
 
         // Remove points with the highest deltas above mid
-        outIndexes.set(new LinkedHashSet<Integer>());
+        outIndexes.set(new LinkedHashSet<>());
         int countOut = variablePeptides.size() - mid - 1;
         for (int i = 0; i < countOut; i++)
         {
@@ -859,9 +858,9 @@ public final class RetentionTimeRegression
         peptidesTimesTry.addAll(requiredPeptides);
 
         RetentionScoreCalculatorSpec s = null;
-        RefObject<RetentionScoreCalculatorSpec> tempRef_s = new RefObject<RetentionScoreCalculatorSpec>(s);
+        RefObject<RetentionScoreCalculatorSpec> tempRef_s = new RefObject<>(s);
         RetentionTimeRegression tempVar = CalcRegression(getName(), Lists.newArrayList(calculator), peptidesTimesTry, scoreCache, true, statisticsResult, tempRef_s);
-        s = tempRef_s.get();  // TPG TODO: By ref handled correctly?
+        tempRef_s.get();
         return tempVar;
     }
 

--- a/src/org/labkey/targetedms/SkylinePort/Irt/RetentionTimeScoreCache.java
+++ b/src/org/labkey/targetedms/SkylinePort/Irt/RetentionTimeScoreCache.java
@@ -63,7 +63,7 @@ public final class RetentionTimeScoreCache
         Map<String, Double> calcCache = _cache.get(calculator.getName());
         if(calcCache != null)
         {
-            LinkedHashMap<String, Double> newCalcCache = new LinkedHashMap<String, Double>();
+            LinkedHashMap<String, Double> newCalcCache = new LinkedHashMap<>();
 
             for (String key : calcCache.keySet())
             {
@@ -77,7 +77,7 @@ public final class RetentionTimeScoreCache
 
     public double CalcScore(IRetentionScoreCalculator calculator, String peptide)
     {
-        LinkedHashMap<String, Double> cacheCalc = null;
+        LinkedHashMap<String, Double> cacheCalc;
         cacheCalc = _cache.get(calculator.getName());
         return CalcScore(calculator, peptide, cacheCalc);
     }

--- a/src/org/labkey/targetedms/SkylinePort/Irt/RetentionTimeStatistics.java
+++ b/src/org/labkey/targetedms/SkylinePort/Irt/RetentionTimeStatistics.java
@@ -87,7 +87,7 @@ public final class RetentionTimeStatistics
 
 	public java.util.Map<String, Double> getScoreCache()
 	{
-		LinkedHashMap<String, Double> scoreCache = new LinkedHashMap<String, Double>();
+		LinkedHashMap<String, Double> scoreCache = new LinkedHashMap<>();
 		for (int i = 0; i < getPeptides().size(); i++)
 		{
 			String sequence = getPeptides().get(i);

--- a/src/org/labkey/targetedms/SkylinePort/Irt/Statistics.java
+++ b/src/org/labkey/targetedms/SkylinePort/Irt/Statistics.java
@@ -354,8 +354,7 @@ public class Statistics
 
 	 @param s1 First set of numbers
 	 @param s2 Second set of numbers
-	 @return
-	*/
+     */
 	public static double Covariance(Statistics s1, Statistics s2)
 	{
 		try
@@ -549,7 +548,7 @@ public class Statistics
 		double a = ATerm2(y, x);
 		double b = BTerm2(y, x);
 
-		java.util.ArrayList<Double> residuals = new java.util.ArrayList<Double>();
+		java.util.ArrayList<Double> residuals = new java.util.ArrayList<>();
 		for (int i = 0; i < x.getLength(); i++)
 		{
 			residuals.add(y._list[i] - (a*x._list[i] + b));

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -7840,7 +7840,7 @@ public class TargetedMSController extends SpringActionController
         public ApiResponse execute(ClustergrammerForm form, BindException errors) throws Exception
         {
             Map<String, Map<String, Double>> results = TargetedMSManager.getClustergrammerQuery(getUser(), getContainer(), form.getSelectedIds());
-            if (results.size() == 0)
+            if (results.isEmpty())
             {
                 errors.reject(ERROR_MSG, "No results for the selected file(s)");
                 return null;

--- a/src/org/labkey/targetedms/TargetedMSFolderType.java
+++ b/src/org/labkey/targetedms/TargetedMSFolderType.java
@@ -120,7 +120,7 @@ public class TargetedMSFolderType extends MultiPortalFolderType
 
         if (container.hasPermission(user, AdminPermission.class))
         {
-            if (Portal.getParts(container, RAW_FILES_TAB).size() == 0)
+            if (Portal.getParts(container, RAW_FILES_TAB).isEmpty())
             {
                 ActionURL url = new ActionURL(TargetedMSController.AddRawDataTabAction.class, container);
                 NavTree addRawData = new NavTree("Add Raw Data Tab", url);

--- a/src/org/labkey/targetedms/TargetedMSManager.java
+++ b/src/org/labkey/targetedms/TargetedMSManager.java
@@ -911,7 +911,7 @@ public class TargetedMSManager
 
     public static boolean updateSkydDataId(ITargetedMSRun run, ExpData newSkydData, User user)
     {
-        if (!(run instanceof TargetedMSRun))
+        if (!(run instanceof TargetedMSRun targetedRun))
         {
             throw new IllegalArgumentException("Invalid run type. Expected TargetedMSRun but received " +
                     (run != null ? run.getClass().getName() : "null"));
@@ -920,8 +920,6 @@ public class TargetedMSManager
         {
             throw new IllegalArgumentException("Cannot update with null newSkydData. A valid ExpData object is required");
         }
-
-        TargetedMSRun targetedRun = (TargetedMSRun) run;
 
         ExpRun expRun = ExperimentService.get().getExpRun(targetedRun.getExperimentRunLSID());
         if (expRun == null) return false;

--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -82,7 +82,6 @@ import org.labkey.targetedms.search.ModificationSearchWebPart;
 import org.labkey.targetedms.search.ProteinSearchWebPart;
 import org.labkey.targetedms.view.CalibrationCurveView;
 import org.labkey.targetedms.view.CrossLinkedPeptideInfo;
-import org.labkey.targetedms.view.FiguresOfMeritView;
 import org.labkey.targetedms.view.LibraryQueryViewWebPart;
 import org.labkey.targetedms.view.ReplicateSummaryWebPart;
 import org.labkey.targetedms.view.TargetedMSRunsWebPartView;

--- a/src/org/labkey/targetedms/TargetedMSRun.java
+++ b/src/org/labkey/targetedms/TargetedMSRun.java
@@ -313,6 +313,7 @@ public class TargetedMSRun implements Serializable, ITargetedMSRun
 
     public void setAuditLogEntriesCount(int auditLogEntriesCount){this._auditLogEntriesCount = auditLogEntriesCount;}
 
+    @Override
     public RunRepresentativeDataState getRepresentativeDataState()
     {
         return _representativeDataState;
@@ -416,7 +417,7 @@ public class TargetedMSRun implements Serializable, ITargetedMSRun
     {
         if (_fullScanSettings == null)
         {
-            _fullScanSettings = TargetedMSManager.get().getTransitionFullScanSettings(getId());
+            _fullScanSettings = TargetedMSManager.getTransitionFullScanSettings(getId());
         }
         return _fullScanSettings;
     }

--- a/src/org/labkey/targetedms/TargetedMSServiceImpl.java
+++ b/src/org/labkey/targetedms/TargetedMSServiceImpl.java
@@ -276,6 +276,7 @@ public class TargetedMSServiceImpl implements TargetedMSService
         return TargetedMSManager.getRunByLsid(lsid, container);
     }
 
+    @Override
     public boolean updateSkydDataId(ITargetedMSRun run, ExpData newSkydData, User user)
     {
         return TargetedMSManager.updateSkydDataId(run, newSkydData, user);

--- a/src/org/labkey/targetedms/calculations/NormalizationMethodAreas.java
+++ b/src/org/labkey/targetedms/calculations/NormalizationMethodAreas.java
@@ -42,12 +42,12 @@ import java.util.Optional;
  */
 public class NormalizationMethodAreas
 {
-    private TargetedMSRun _run;
-    private User _user;
-    private Container _container;
-    private ReplicateDataSet _replicateDataSet;
+    private final TargetedMSRun _run;
+    private final User _user;
+    private final Container _container;
+    private final ReplicateDataSet _replicateDataSet;
     private Collection<StandardEntry> _standardEntries;
-    private Map<NormalizationMethod, List<GeneralMoleculeResultDataSet>> _moleculeDataSets = new HashMap<>();
+    private final Map<NormalizationMethod, List<GeneralMoleculeResultDataSet<?, ?, ?>>> _moleculeDataSets = new HashMap<>();
 
     public NormalizationMethodAreas(TargetedMSRun run, User user, Container container, ReplicateDataSet replicateDataSet)
     {
@@ -59,14 +59,7 @@ public class NormalizationMethodAreas
 
     public NormalizationFactors getNormalizationFactors(NormalizationMethod normalizationMethod)
     {
-        return new NormalizationFactors()
-        {
-            @Override
-            public double getNormalizationFactor(long sampleFileId)
-            {
-                return 1.0 / getAreaForNormalization(normalizationMethod, sampleFileId);
-            }
-        };
+        return sampleFileId -> 1.0 / getAreaForNormalization(normalizationMethod, sampleFileId);
     }
 
     public boolean hasNormalizationFactors(NormalizationMethod normalizationMethod)
@@ -93,7 +86,7 @@ public class NormalizationMethodAreas
             {
                 Optional<PeptideSettings.IsotopeLabel> isotopeLabelOptional
                         = _replicateDataSet.listIsotopeLabels().stream().filter(label -> isotopeLabelName.equals(label.getName())).findFirst();
-                if (!isotopeLabelOptional.isPresent())
+                if (isotopeLabelOptional.isEmpty())
                 {
                     return 0;
                 }
@@ -101,21 +94,21 @@ public class NormalizationMethodAreas
             }
         }
         double total = 0;
-        for (GeneralMoleculeResultDataSet generalMoleculeResultDataSet : getMoleculeDataSets(normalizationMethod))
+        for (GeneralMoleculeResultDataSet<?, ?, ?> generalMoleculeResultDataSet : getMoleculeDataSets(normalizationMethod))
         {
             total += generalMoleculeResultDataSet.getTotalArea(sampleFileId, isotopeLabel);
         }
         return total;
     }
 
-    private List<GeneralMoleculeResultDataSet> getMoleculeDataSets(NormalizationMethod normalizationMethod)
+    private List<GeneralMoleculeResultDataSet<?, ?, ?>> getMoleculeDataSets(NormalizationMethod normalizationMethod)
     {
         NormalizationMethod.RatioToSurrogate ratioToSurrogate = null;
         if (normalizationMethod instanceof NormalizationMethod.RatioToSurrogate)
         {
             ratioToSurrogate = (NormalizationMethod.RatioToSurrogate) normalizationMethod;
         }
-        List<GeneralMoleculeResultDataSet> dataSets = _moleculeDataSets.get(normalizationMethod);
+        List<GeneralMoleculeResultDataSet<?, ?, ?>> dataSets = _moleculeDataSets.get(normalizationMethod);
         if (dataSets != null)
         {
             return dataSets;
@@ -146,7 +139,7 @@ public class NormalizationMethodAreas
                     continue;
                 }
             }
-            GeneralMolecule generalMolecule;
+            GeneralMolecule<?, ?> generalMolecule;
             if (standardEntry.getPeptideId() != null)
             {
                 generalMolecule = PeptideManager.getPeptide(_container, standardEntry.getPeptideId());
@@ -155,7 +148,7 @@ public class NormalizationMethodAreas
             {
                 generalMolecule = MoleculeManager.getMolecule(_container, standardEntry.getMoleculeId());
             }
-            dataSets.add(new GeneralMoleculeResultDataSet(_user, _container, _replicateDataSet, generalMolecule));
+            dataSets.add(new GeneralMoleculeResultDataSet<>(_user, _container, _replicateDataSet, generalMolecule));
         }
         _moleculeDataSets.put(normalizationMethod, dataSets);
         return dataSets;

--- a/src/org/labkey/targetedms/calculations/ReplicateDataSet.java
+++ b/src/org/labkey/targetedms/calculations/ReplicateDataSet.java
@@ -29,9 +29,9 @@ import org.labkey.targetedms.query.TransitionManager;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -41,11 +41,11 @@ import java.util.stream.Collectors;
  */
 public class ReplicateDataSet
 {
-    Map<Long, Replicate> _replicates = new HashMap<>();
-    Map<Long, Long> _fileIdToReplicateId = new HashMap<>();
+    Map<Long, Replicate> _replicates;
+    Map<Long, Long> _fileIdToReplicateId;
     Map<Long, Map<String, ReplicateAnnotation>> _replicateAnnotations;
     Map<Long, PeptideSettings.IsotopeLabel> _isotopeLabels;
-    private boolean _useTransitionChromInfos;
+    private final boolean _useTransitionChromInfos;
 
     public ReplicateDataSet(TargetedMSRun run)
     {
@@ -92,11 +92,7 @@ public class ReplicateDataSet
     public Map<String, ReplicateAnnotation> getReplicateAnnotations(Replicate replicate)
     {
         Map<String, ReplicateAnnotation> annotations = _replicateAnnotations.get(replicate.getId());
-        if (annotations != null)
-        {
-            return annotations;
-        }
-        return Collections.emptyMap();
+        return Objects.requireNonNullElse(annotations, Collections.emptyMap());
     }
 
     @Nullable

--- a/src/org/labkey/targetedms/calculations/quantification/CalibrationCurveDataSet.java
+++ b/src/org/labkey/targetedms/calculations/quantification/CalibrationCurveDataSet.java
@@ -23,7 +23,7 @@ public class CalibrationCurveDataSet {
     private NormalizationMethod normalizationMethod = NormalizationMethod.NONE;
     private RegressionFit regressionFit = RegressionFit.NONE;
     private RegressionWeighting regressionWeighting = RegressionWeighting.NONE;
-    private List<Replicate> replicates = new ArrayList<>();
+    private final List<Replicate> replicates = new ArrayList<>();
 
     public Replicate addReplicate(SampleType sampleType, Double analyteConcentration, double sampleDilutionFactor, boolean excludeFromCalibration) {
         Replicate replicate = new Replicate(sampleType, analyteConcentration, sampleDilutionFactor, excludeFromCalibration);
@@ -115,10 +115,10 @@ public class CalibrationCurveDataSet {
      * Created by nicksh on 4/15/2016.
      */
     public static class Replicate extends ReplicateData {
-        private SampleType sampleType;
-        private Double analyteConcentration;
-        private double sampleDilutionFactor;
-        private boolean excludeFromCalibration;
+        private final SampleType sampleType;
+        private final Double analyteConcentration;
+        private final double sampleDilutionFactor;
+        private final boolean excludeFromCalibration;
         public Replicate(SampleType sampleType, Double analyteConcentration, double sampleDilutionFactor, boolean excludeFromCalibration) {
             this.sampleType = sampleType;
             this.analyteConcentration = analyteConcentration;

--- a/src/org/labkey/targetedms/calculations/quantification/DesignMatrix.java
+++ b/src/org/labkey/targetedms/calculations/quantification/DesignMatrix.java
@@ -97,7 +97,7 @@ class DesignMatrix {
         }
 
         return new DesignMatrix(dataSet, matrixColumns.toArray(new double[matrixColumns.size()][]),
-                contrastValueMatrix, columnNames.toArray(new String[columnNames.size()]));
+                contrastValueMatrix, columnNames.toArray(new String[0]));
     }
 
     private static RealMatrix matrixFromColumnVectors(double[][] columnVectors) {

--- a/src/org/labkey/targetedms/calculations/quantification/FoldChangeDataSet.java
+++ b/src/org/labkey/targetedms/calculations/quantification/FoldChangeDataSet.java
@@ -60,7 +60,7 @@ class FoldChangeDataSet {
         this.features = features.stream().mapToInt(Integer::intValue).toArray();
         this.runs = runs.stream().mapToInt(Integer::intValue).toArray();
         this.subjects = subjects.stream().mapToInt(Integer::intValue).toArray();
-        this.subjectControls = ArrayUtils.toPrimitive(subjectControls.toArray(new Boolean[subjectControls.size()]));
+        this.subjectControls = ArrayUtils.toPrimitive(subjectControls.toArray(new Boolean[0]));
         if (this.abundances.length == 0) {
             featureCount = 0;
             subjectCount = 0;

--- a/src/org/labkey/targetedms/calculations/quantification/GroupComparisonDataSet.java
+++ b/src/org/labkey/targetedms/calculations/quantification/GroupComparisonDataSet.java
@@ -25,7 +25,7 @@ import java.util.stream.IntStream;
 
 public class GroupComparisonDataSet {
     private NormalizationMethod normalizationMethod = NormalizationMethod.NONE;
-    private List<Replicate> replicates = new ArrayList<>();
+    private final List<Replicate> replicates = new ArrayList<>();
 
     public Replicate addReplicate(boolean control, Object bioReplicate) {
         Replicate replicate = new Replicate(control, bioReplicate);
@@ -45,7 +45,7 @@ public class GroupComparisonDataSet {
 
     public LinearFitResult calculateFoldChange(String label) {
         List<Replicate> replicates = removeIncompleteReplicates(label, this.replicates);
-        if (replicates.size() == 0) {
+        if (replicates.isEmpty()) {
             return null;
         }
         List<Replicate> summarizedRows;
@@ -114,7 +114,7 @@ public class GroupComparisonDataSet {
         List<Replicate> completeReplicates = new ArrayList<>();
         for (Replicate replicateData : replicates) {
             TransitionAreas transitionAreas = replicateData.getTransitionAreas(label);
-            if (transitionAreas == null || transitionAreas.getKeys().size() == 0) {
+            if (transitionAreas == null || transitionAreas.getKeys().isEmpty()) {
                 continue;
             }
             if (requiredTransitions != null && !transitionAreas.getKeys().containsAll(requiredTransitions)) {
@@ -145,8 +145,8 @@ public class GroupComparisonDataSet {
     }
 
     public class Replicate extends ReplicateData {
-        private boolean control;
-        private Object bioReplicate;
+        private final boolean control;
+        private final Object bioReplicate;
 
         public Replicate(boolean control, Object bioReplicate) {
             this.control = control;

--- a/src/org/labkey/targetedms/calculations/quantification/LinearModel.java
+++ b/src/org/labkey/targetedms/calculations/quantification/LinearModel.java
@@ -27,11 +27,11 @@ import java.util.List;
 import java.util.stream.IntStream;
 
 class LinearModel {
-    private RealMatrix designMatrix;
-    private RealMatrix contrastValues;
-    private QRDecomposition qrDecomposition;
-    private RealMatrix matrixCrossproductInverse;
-    private int[] independentColumnIndices;
+    private final RealMatrix designMatrix;
+    private final RealMatrix contrastValues;
+    private final QRDecomposition qrDecomposition;
+    private final RealMatrix matrixCrossproductInverse;
+    private final int[] independentColumnIndices;
     public LinearModel(RealMatrix designMatrix, RealMatrix contrastValues) {
         this.designMatrix = designMatrix;
         this.contrastValues = contrastValues;

--- a/src/org/labkey/targetedms/calculations/quantification/NormalizationMethod.java
+++ b/src/org/labkey/targetedms/calculations/quantification/NormalizationMethod.java
@@ -28,7 +28,7 @@ public abstract class NormalizationMethod {
 
 
     public static NormalizationMethod fromName(String name) {
-        if (name == null || name.length() == 0) {
+        if (name == null || name.isEmpty()) {
             return null;
         }
         if (name.startsWith(ratio_prefix)) {
@@ -86,7 +86,7 @@ public abstract class NormalizationMethod {
         }
 
         public String getIsotopeLabelTitle() {
-            if (isotopeLabelName == null || isotopeLabelName.length() == 0) {
+            if (isotopeLabelName == null || isotopeLabelName.isEmpty()) {
                 return isotopeLabelName;
             }
             return isotopeLabelName.substring(0, 1).toUpperCase(Locale.US) + isotopeLabelName.substring(1);

--- a/src/org/labkey/targetedms/calculations/quantification/RegressionFit.java
+++ b/src/org/labkey/targetedms/calculations/quantification/RegressionFit.java
@@ -112,7 +112,7 @@ public abstract class RegressionFit {
     }
 
     public CalibrationCurve fit(List<WeightedObservedPoint> points) {
-        if (points.size() == 0) {
+        if (points.isEmpty()) {
             CalibrationCurve curve = new CalibrationCurve();
             curve.setErrorMessage("Unable to calculate curve, since there are no data points available");
             return curve;

--- a/src/org/labkey/targetedms/calculations/quantification/RegressionWeighting.java
+++ b/src/org/labkey/targetedms/calculations/quantification/RegressionWeighting.java
@@ -44,8 +44,8 @@ public abstract class RegressionWeighting {
             = Collections.unmodifiableList(Arrays.asList(NONE, ONE_OVER_X, ONE_OVER_X_SQUARED));
 
 
-    private String name;
-    private String label;
+    private final String name;
+    private final String label;
     private RegressionWeighting(String name, String label) {
         this.name = name;
         this.label = label;

--- a/src/org/labkey/targetedms/calculations/quantification/SampleType.java
+++ b/src/org/labkey/targetedms/calculations/quantification/SampleType.java
@@ -23,15 +23,15 @@ public enum SampleType {
     solvent(new Color(255,226,43)),
     blank(Color.blue),
     double_blank(new Color(255, 230, 216));
-    private Color color;
-    private SampleType(Color color) {
+    private final Color color;
+    SampleType(Color color) {
         this.color = color;
     }
     public Color getColor() {
         return color;
     }
     public static SampleType fromName(String name) {
-        if (name == null || 0 == name.length()) {
+        if (name == null || name.isEmpty()) {
             return unknown;
         }
         try {

--- a/src/org/labkey/targetedms/calculations/quantification/TransitionAreas.java
+++ b/src/org/labkey/targetedms/calculations/quantification/TransitionAreas.java
@@ -65,7 +65,7 @@ public class TransitionAreas {
     }
 
     public boolean isEmpty() {
-        return keys.size() == 0;
+        return keys.isEmpty();
     }
 
     public TransitionAreas merge(TransitionAreas that) {

--- a/src/org/labkey/targetedms/chart/ComparisonAxis.java
+++ b/src/org/labkey/targetedms/chart/ComparisonAxis.java
@@ -66,15 +66,15 @@ abstract class ComparisonAxis extends CategoryAxis
     private void calculateDisplayLabels(float availableWidth, Graphics2D g2)
     {
         CategoryPlot plot = (CategoryPlot) getPlot();
-        java.util.List categories = plot.getCategoriesForAxis(this);
+        java.util.List<String> categories = plot.getCategoriesForAxis(this);
 
         Map<String, String> originalLabels = getFullLengthLabels(categories);
 
         FontMetrics fm = g2.getFontMetrics(getTickLabelFont());
         final Font font = fm.getFont();
         final int originalSize = font.getSize();
-        final int smallestSize = originalSize; // 8; // Changing the font makes the legend overlap category labels.
-        for(int i = originalSize; i >= smallestSize; i--)
+        // 8; // Changing the font makes the legend overlap category labels.
+        for(int i = originalSize; i >= originalSize; i--)
         {
             Font newFont = font.deriveFont((float)i);
             if(tryFont(availableWidth, originalLabels.values(), newFont, g2))
@@ -90,7 +90,7 @@ abstract class ComparisonAxis extends CategoryAxis
             // Full size labels did not fit. Try minimized labels
             while(minimizeLabels(trimmedLabels))
             {
-                for(int i = originalSize; i >= smallestSize; i--)
+                for(int i = originalSize; i >= originalSize; i--)
                 {
                     Font newFont = font.deriveFont((float)i);
                     if(tryFont(availableWidth, trimmedLabels.values(), newFont, g2))
@@ -104,7 +104,7 @@ abstract class ComparisonAxis extends CategoryAxis
 
         // If we are here we did not find a combination of labels and font size that fits.
         // Select the smallest font-size and trimmed labels
-        setTickLabelFont(font.deriveFont((float)smallestSize));
+        setTickLabelFont(font.deriveFont((float) originalSize));
         _displayLabels = trimmedLabels;
     }
 
@@ -157,7 +157,7 @@ abstract class ComparisonAxis extends CategoryAxis
 
     static class GeneralMoleculeAxis extends ComparisonAxis
     {
-        private Map<String, ComparisonCategory> _categoryMap;
+        private final Map<String, ComparisonCategory> _categoryMap;
         public GeneralMoleculeAxis(String label, Map<String, ComparisonCategory> categoryMap)
         {
             super(label);
@@ -167,10 +167,10 @@ abstract class ComparisonAxis extends CategoryAxis
         @Override
         protected Map<String, String> getFullLengthLabels(Collection<String> categories)
         {
-            Iterator iterator = categories.iterator();
+            Iterator<String> iterator = categories.iterator();
             Map<String, String> originalLabels = new HashMap<>();
             while (iterator.hasNext()) {
-                String category = iterator.next().toString();
+                String category = iterator.next();
                 ComparisonCategory pepCategory = _categoryMap.get(category);
                 if(pepCategory != null)
                 {
@@ -207,10 +207,10 @@ abstract class ComparisonAxis extends CategoryAxis
         @Override
         protected Map<String, String> getFullLengthLabels(Collection<String> categories)
         {
-            Iterator iterator = categories.iterator();
+            Iterator<String> iterator = categories.iterator();
             Map<String, String> originalLabels = new HashMap<>();
             while (iterator.hasNext()) {
-                String category = iterator.next().toString();
+                String category = iterator.next();
                 originalLabels.put(category, category);
             }
             return originalLabels;

--- a/src/org/labkey/targetedms/chart/ComparisonCategory.java
+++ b/src/org/labkey/targetedms/chart/ComparisonCategory.java
@@ -276,7 +276,7 @@ public interface ComparisonCategory
 
         private static void makeUniquePrefixes(List<PeptideCategory> peptideCategories, int prefixLen)
         {
-            if(peptideCategories == null || peptideCategories.size() == 0)
+            if(peptideCategories == null || peptideCategories.isEmpty())
                 return;
 
             if(peptideCategories.size() == 1)

--- a/src/org/labkey/targetedms/chart/PrecursorColorIndexer.java
+++ b/src/org/labkey/targetedms/chart/PrecursorColorIndexer.java
@@ -34,7 +34,7 @@ public class PrecursorColorIndexer
 {
     private long _lightLabelId = Integer.MAX_VALUE;
     private int _minCharge = Integer.MAX_VALUE;
-    private int _isotopeLabelCount;
+    private final int _isotopeLabelCount;
 
     public PrecursorColorIndexer(long runId, User user, Container container)
     {

--- a/src/org/labkey/targetedms/chart/ReplicateLabelMinimizer.java
+++ b/src/org/labkey/targetedms/chart/ReplicateLabelMinimizer.java
@@ -43,7 +43,7 @@ public class ReplicateLabelMinimizer
 
     public static Map<String, String> minimize(List<String> labels)
     {
-        if(labels == null || labels.size() == 0)
+        if(labels == null || labels.isEmpty())
             return Collections.emptyMap();
 
         List<String> normalizedLabels = normalizeLabels(labels);
@@ -101,9 +101,9 @@ public class ReplicateLabelMinimizer
     private static List<String> normalizeLabels(List<String> labels)
     {
         List<String> normalized = new ArrayList<>(labels.size());
-        for(Object label: labels)
+        for(String label: labels)
         {
-            normalized.add(normalizeLabel((String) label));
+            normalized.add(normalizeLabel(label));
         }
         return normalized;
     }
@@ -225,18 +225,18 @@ public class ReplicateLabelMinimizer
                 iteration++;
                 if(iteration == 1)
                 {
-                    assertEquals(labels.get("Prefix_name_1_Suffix"), "name_1_Suffix");
-                    assertEquals(labels.get("Prefix_name_2_Suffix"), "name_2_Suffix");
+                    assertEquals("name_1_Suffix", labels.get("Prefix_name_1_Suffix"));
+                    assertEquals("name_2_Suffix", labels.get("Prefix_name_2_Suffix"));
                 }
                 if(iteration == 2)
                 {
-                    assertEquals(labels.get("Prefix_name_1_Suffix"), "1_Suffix");
-                    assertEquals(labels.get("Prefix_name_2_Suffix"), "2_Suffix");
+                    assertEquals("1_Suffix", labels.get("Prefix_name_1_Suffix"));
+                    assertEquals("2_Suffix", labels.get("Prefix_name_2_Suffix"));
                 }
                 if(iteration == 3)
                 {
-                    assertEquals(labels.get("Prefix_name_1_Suffix"), "1");
-                    assertEquals(labels.get("Prefix_name_2_Suffix"), "2");
+                    assertEquals("1", labels.get("Prefix_name_1_Suffix"));
+                    assertEquals("2", labels.get("Prefix_name_2_Suffix"));
                 }
             }
             assertEquals(3, iteration);
@@ -250,13 +250,13 @@ public class ReplicateLabelMinimizer
                 iteration++;
                 if(iteration == 1)
                 {
-                    assertEquals(labels.get("1,ABC-XYZ_File1"), "1...XYZ_File1");
-                    assertEquals(labels.get("2_ABC-XYZ_File2"), "2...XYZ_File2");
+                    assertEquals("1...XYZ_File1", labels.get("1,ABC-XYZ_File1"));
+                    assertEquals("2...XYZ_File2", labels.get("2_ABC-XYZ_File2"));
                 }
                 if(iteration == 2)
                 {
-                    assertEquals(labels.get("1,ABC-XYZ_File1"), "1...File1");
-                    assertEquals(labels.get("2_ABC-XYZ_File2"), "2...File2");
+                    assertEquals("1...File1", labels.get("1,ABC-XYZ_File1"));
+                    assertEquals("2...File2", labels.get("2_ABC-XYZ_File2"));
                 }
             }
             assertEquals(2, iteration);

--- a/src/org/labkey/targetedms/chart/RetentionTimeBoxAndWhiskerRenderer.java
+++ b/src/org/labkey/targetedms/chart/RetentionTimeBoxAndWhiskerRenderer.java
@@ -47,7 +47,7 @@ public class RetentionTimeBoxAndWhiskerRenderer extends BoxAndWhiskerRenderer
         setItemMargin(0.1);
     }
 
-    // Need to override drawVertical and drawHorizontal methods so that we can draw the FWHM line and whisters
+    // Need to override drawVertical and drawHorizontal methods so that we can draw the FWHM line and whiskers
     @Override
     public void drawHorizontalItem(Graphics2D g2, CategoryItemRendererState state, Rectangle2D dataArea, CategoryPlot plot, CategoryAxis domainAxis, ValueAxis rangeAxis, CategoryDataset dataset, int row, int column)
     {
@@ -57,7 +57,7 @@ public class RetentionTimeBoxAndWhiskerRenderer extends BoxAndWhiskerRenderer
         // TODO
     }
 
-    // Need to override drawVertical and drawHorizontal methods so that we can draw the FWHM line and whisters
+    // Need to override drawVertical and drawHorizontal methods so that we can draw the FWHM line and whiskers
     @Override
     public void drawVerticalItem(Graphics2D g2, CategoryItemRendererState state, Rectangle2D dataArea, CategoryPlot plot, CategoryAxis domainAxis, ValueAxis rangeAxis, CategoryDataset dataset, int row, int column)
     {
@@ -66,9 +66,8 @@ public class RetentionTimeBoxAndWhiskerRenderer extends BoxAndWhiskerRenderer
         // Draw the FWHM lines
         DefaultBoxAndWhiskerCategoryDataset rtDataset = (DefaultBoxAndWhiskerCategoryDataset) dataset;
 
-        if(!(rtDataset.getItem(row, column) instanceof ComparisonDataset.RetentionTimeDatasetItem))
+        if(!(rtDataset.getItem(row, column) instanceof ComparisonDataset.RetentionTimeDatasetItem item))
             return;
-        ComparisonDataset.RetentionTimeDatasetItem item = (ComparisonDataset.RetentionTimeDatasetItem) rtDataset.getItem(row, column);
 
         RectangleEdge location = plot.getRangeAxisEdge();
 

--- a/src/org/labkey/targetedms/chromlib/ChromLibSqliteSchemaCreator.java
+++ b/src/org/labkey/targetedms/chromlib/ChromLibSqliteSchemaCreator.java
@@ -178,16 +178,15 @@ public class ChromLibSqliteSchemaCreator
             {
                 try (Statement stmt = conn.createStatement())
                 {
-                    StringBuilder indexSQL = new StringBuilder("CREATE INDEX IDX_");
-                    indexSQL.append(tableName);
-                    indexSQL.append("_");
-                    indexSQL.append(column.baseColumn().name());
-                    indexSQL.append(" ON ");
-                    indexSQL.append(tableName);
-                    indexSQL.append("(");
-                    indexSQL.append(column.baseColumn().name());
-                    indexSQL.append(")");
-                    stmt.execute(indexSQL.toString());
+                    String indexSQL = "CREATE INDEX IDX_" + tableName +
+                            "_" +
+                            column.baseColumn().name() +
+                            " ON " +
+                            tableName +
+                            "(" +
+                            column.baseColumn().name() +
+                            ")";
+                    stmt.execute(indexSQL);
                 }
             }
         }

--- a/src/org/labkey/targetedms/chromlib/ChromatogramLibraryUtils.java
+++ b/src/org/labkey/targetedms/chromlib/ChromatogramLibraryUtils.java
@@ -254,7 +254,7 @@ public class ChromatogramLibraryUtils
 
         SQLiteConfig config = new SQLiteConfig();
         config.setReadOnly(true);
-        try (Connection conn = DriverManager.getConnection("jdbc:sqlite:/" + archiveFile.toAbsolutePath().toString(), config.toProperties()))
+        try (Connection conn = DriverManager.getConnection("jdbc:sqlite:/" + archiveFile.toAbsolutePath(), config.toProperties()))
         {
             TargetedMSController.ChromLibAnalyteCounts analyteCountsInLib = new TargetedMSController.ChromLibAnalyteCounts();
             analyteCountsInLib.setPeptideGroupCount(getCountsIn(Constants.Table.Protein, conn, null));

--- a/src/org/labkey/targetedms/chromlib/ContainerChromatogramLibraryWriter.java
+++ b/src/org/labkey/targetedms/chromlib/ContainerChromatogramLibraryWriter.java
@@ -397,7 +397,7 @@ public class ContainerChromatogramLibraryWriter
         {
             if(precursor.getGeneralMoleculeId() != lastPeptideId)
             {
-                if(peptidePrecursors.size() > 0)
+                if(!peptidePrecursors.isEmpty())
                 {
                     Peptide peptide = PeptideManager.getPeptide(_container, lastPeptideId);
                     LibPeptide libPeptide = makeLibPeptide(peptide, peptidePrecursors, run);
@@ -410,7 +410,7 @@ public class ContainerChromatogramLibraryWriter
             }
             peptidePrecursors.add(precursor);
         }
-        if(peptidePrecursors.size() > 0)
+        if(!peptidePrecursors.isEmpty())
         {
             Peptide peptide = PeptideManager.getPeptide(_container, lastPeptideId);
             LibPeptide libPeptide = makeLibPeptide(peptide, peptidePrecursors, run);
@@ -430,7 +430,7 @@ public class ContainerChromatogramLibraryWriter
         {
             if(precursor.getGeneralMoleculeId() != lastMoleculeId)
             {
-                if(moleculePrecursors.size() > 0)
+                if(!moleculePrecursors.isEmpty())
                 {
                     Molecule molecule = MoleculeManager.getMolecule(_container, lastMoleculeId);
                     LibPeptide libMolecule = makeLibMolecule(molecule, moleculePrecursors, run);
@@ -443,7 +443,7 @@ public class ContainerChromatogramLibraryWriter
             }
             moleculePrecursors.add(precursor);
         }
-        if(moleculePrecursors.size() > 0)
+        if(!moleculePrecursors.isEmpty())
         {
             Molecule molecule = MoleculeManager.getMolecule(_container, lastMoleculeId);
             LibPeptide libMolecule = makeLibMolecule(molecule, moleculePrecursors, run);
@@ -479,7 +479,7 @@ public class ContainerChromatogramLibraryWriter
         for(Peptide peptide: peptides)
         {
             List<Precursor> precursors = PrecursorManager.getPrecursorsForPeptide(peptide.getId(), schema);
-            if(precursors.size() == 0)
+            if(precursors.isEmpty())
             {
                 throw new IllegalStateException(String.format("No precursors found for peptide '%s'. Empty peptides are not allowed in library folders." +
                         " Empty peptides can be removed in Skyline by selecting Refine > Remove Empty Peptides.", peptide.getSequence()));
@@ -538,12 +538,12 @@ public class ContainerChromatogramLibraryWriter
         libPeptide.setStartIndex(peptide.getStartIndex());
         libPeptide.setEndIndex(peptide.getEndIndex());
         String previousAa = peptide.getPreviousAa();
-        if(previousAa != null && previousAa.length() > 0)
+        if(previousAa != null && !previousAa.isEmpty())
         {
             libPeptide.setPreviousAa(previousAa.charAt(0));
         }
         String nextAa = peptide.getNextAa();
-        if(nextAa != null && nextAa.length() > 0)
+        if(nextAa != null && !nextAa.isEmpty())
         {
             libPeptide.setNextAa(nextAa.charAt(0));
         }

--- a/src/org/labkey/targetedms/chromlib/LibInfoDao.java
+++ b/src/org/labkey/targetedms/chromlib/LibInfoDao.java
@@ -41,15 +41,14 @@ public class LibInfoDao implements Dao<LibInfo>
     {
         if(libInfo != null)
         {
-            StringBuilder sql = new StringBuilder();
-            sql.append("INSERT INTO ");
-            sql.append(Table.LibInfo);
-            sql.append(" (");
-            sql.append(getInsertColumnSql());
-            sql.append(")");
-            sql.append(" VALUES (?,?,?,?,?,?,?,?,?)");
+            String sql = "INSERT INTO " +
+                    Table.LibInfo +
+                    " (" +
+                    getInsertColumnSql() +
+                    ")" +
+                    " VALUES (?,?,?,?,?,?,?,?,?)";
 
-            try (PreparedStatement stmt = connection.prepareStatement(sql.toString()))
+            try (PreparedStatement stmt = connection.prepareStatement(sql))
             {
                 int colIndex = 1;
                 stmt.setString(colIndex++, libInfo.getPanoramaServer());

--- a/src/org/labkey/targetedms/chromlib/LibIrtLibrary.java
+++ b/src/org/labkey/targetedms/chromlib/LibIrtLibrary.java
@@ -74,9 +74,7 @@ public class LibIrtLibrary extends AbstractLibEntity
     public boolean equals(Object o)
     {
         if (this == o) return true;
-        if (!(o instanceof LibIrtLibrary)) return false;
-
-        LibIrtLibrary that = (LibIrtLibrary) o;
+        if (!(o instanceof LibIrtLibrary that)) return false;
 
         if (!_modifiedSequence.equals(that._modifiedSequence)) return false;
         if (!_irtValue.equals(that._irtValue)) return false;

--- a/src/org/labkey/targetedms/chromlib/LibIsotopeModification.java
+++ b/src/org/labkey/targetedms/chromlib/LibIsotopeModification.java
@@ -159,9 +159,7 @@ public class LibIsotopeModification extends AbstractLibEntity
     public boolean equals(Object o)
     {
         if (this == o) return true;
-        if (!(o instanceof LibIsotopeModification)) return false;
-
-        LibIsotopeModification that = (LibIsotopeModification) o;
+        if (!(o instanceof LibIsotopeModification that)) return false;
 
         if (_aminoAcid != null ? !_aminoAcid.equals(that._aminoAcid) : that._aminoAcid != null) return false;
         if (_formula != null ? !_formula.equals(that._formula) : that._formula != null) return false;

--- a/src/org/labkey/targetedms/chromlib/LibPeptide.java
+++ b/src/org/labkey/targetedms/chromlib/LibPeptide.java
@@ -223,9 +223,7 @@ public class LibPeptide extends AbstractLibEntity
     public boolean equals(Object o)
     {
         if (this == o) return true;
-        if (!(o instanceof LibPeptide)) return false;
-
-        LibPeptide peptide = (LibPeptide) o;
+        if (!(o instanceof LibPeptide peptide)) return false;
 
         if (!_calcNeutralMass.equals(peptide._calcNeutralMass)) return false;
         if (_endIndex != null ? !_endIndex.equals(peptide._endIndex) : peptide._endIndex != null) return false;

--- a/src/org/labkey/targetedms/chromlib/LibPeptideDao.java
+++ b/src/org/labkey/targetedms/chromlib/LibPeptideDao.java
@@ -105,7 +105,7 @@ public class LibPeptideDao extends BaseDaoImpl<LibPeptide>
     @Override
     public void saveAll(Collection<LibPeptide> peptides, Connection connection) throws SQLException
     {
-        if(peptides.size() > 0)
+        if(!peptides.isEmpty())
         {
             super.saveAll(peptides, connection);
 

--- a/src/org/labkey/targetedms/chromlib/LibPeptideStructuralModification.java
+++ b/src/org/labkey/targetedms/chromlib/LibPeptideStructuralModification.java
@@ -71,9 +71,7 @@ public class LibPeptideStructuralModification extends AbstractLibEntity
     public boolean equals(Object o)
     {
         if (this == o) return true;
-        if (!(o instanceof LibPeptideStructuralModification)) return false;
-
-        LibPeptideStructuralModification that = (LibPeptideStructuralModification) o;
+        if (!(o instanceof LibPeptideStructuralModification that)) return false;
 
         if (_peptideId != that._peptideId) return false;
         if (_structuralModificationId != that._structuralModificationId) return false;

--- a/src/org/labkey/targetedms/chromlib/LibPrecursorDao.java
+++ b/src/org/labkey/targetedms/chromlib/LibPrecursorDao.java
@@ -131,7 +131,7 @@ public class LibPrecursorDao extends BaseDaoImpl<LibPrecursor>
     @Override
     public void saveAll(Collection<LibPrecursor> precursors, Connection connection) throws SQLException
     {
-        if(precursors.size() > 0)
+        if(!precursors.isEmpty())
         {
             super.saveAll(precursors, connection);
 

--- a/src/org/labkey/targetedms/chromlib/LibPrecursorIsotopeModification.java
+++ b/src/org/labkey/targetedms/chromlib/LibPrecursorIsotopeModification.java
@@ -70,9 +70,7 @@ public class LibPrecursorIsotopeModification extends AbstractLibEntity
     public boolean equals(Object o)
     {
         if (this == o) return true;
-        if (!(o instanceof LibPrecursorIsotopeModification)) return false;
-
-        LibPrecursorIsotopeModification that = (LibPrecursorIsotopeModification) o;
+        if (!(o instanceof LibPrecursorIsotopeModification that)) return false;
 
         if (_isotopeModificationId != that._isotopeModificationId) return false;
         if (_precursorId != that._precursorId) return false;

--- a/src/org/labkey/targetedms/chromlib/LibPrecursorRetentionTime.java
+++ b/src/org/labkey/targetedms/chromlib/LibPrecursorRetentionTime.java
@@ -94,9 +94,7 @@ public class LibPrecursorRetentionTime extends AbstractLibEntity
     public boolean equals(Object o)
     {
         if (this == o) return true;
-        if (!(o instanceof LibPrecursorRetentionTime)) return false;
-
-        LibPrecursorRetentionTime that = (LibPrecursorRetentionTime) o;
+        if (!(o instanceof LibPrecursorRetentionTime that)) return false;
 
         if (_precursorId != that._precursorId) return false;
         if (_sampleFileId != that._sampleFileId) return false;

--- a/src/org/labkey/targetedms/chromlib/LibProteinDao.java
+++ b/src/org/labkey/targetedms/chromlib/LibProteinDao.java
@@ -81,7 +81,7 @@ public class LibProteinDao extends BaseDaoImpl<LibProtein>
     @Override
     public void saveAll(Collection<LibProtein> proteins, Connection connection) throws SQLException
     {
-        if(proteins != null && proteins.size() > 0)
+        if(proteins != null && !proteins.isEmpty())
         {
             super.saveAll(proteins, connection);
 

--- a/src/org/labkey/targetedms/chromlib/LibStructuralModLoss.java
+++ b/src/org/labkey/targetedms/chromlib/LibStructuralModLoss.java
@@ -71,9 +71,7 @@ public class LibStructuralModLoss extends AbstractLibEntity
     public boolean equals(Object o)
     {
         if (this == o) return true;
-        if (!(o instanceof LibStructuralModLoss)) return false;
-
-        LibStructuralModLoss that = (LibStructuralModLoss) o;
+        if (!(o instanceof LibStructuralModLoss that)) return false;
 
         if (_formula != null ? !_formula.equals(that._formula) : that._formula != null) return false;
         if (_massDiffAvg != null ? !_massDiffAvg.equals(that._massDiffAvg) : that._massDiffAvg != null) return false;

--- a/src/org/labkey/targetedms/chromlib/LibStructuralModification.java
+++ b/src/org/labkey/targetedms/chromlib/LibStructuralModification.java
@@ -149,9 +149,7 @@ public class LibStructuralModification extends AbstractLibEntity
     public boolean equals(Object o)
     {
         if (this == o) return true;
-        if (!(o instanceof LibStructuralModification)) return false;
-
-        LibStructuralModification that = (LibStructuralModification) o;
+        if (!(o instanceof LibStructuralModification that)) return false;
 
         if (_aminoAcid != null ? !_aminoAcid.equals(that._aminoAcid) : that._aminoAcid != null) return false;
         if (_explicitMod != null ? !_explicitMod.equals(that._explicitMod) : that._explicitMod != null) return false;

--- a/src/org/labkey/targetedms/chromlib/LibTransition.java
+++ b/src/org/labkey/targetedms/chromlib/LibTransition.java
@@ -26,7 +26,6 @@ import org.labkey.targetedms.parser.TransitionOptimization;
 import org.labkey.targetedms.parser.TransitionSettings;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 import java.util.Objects;
@@ -65,7 +64,7 @@ public class LibTransition extends AbstractLibEntity
     private String _adduct;
 
 
-    private List<LibTransitionOptimization> _optimizations = new ArrayList<>();
+    private final List<LibTransitionOptimization> _optimizations = new ArrayList<>();
 
     public LibTransition() {}
 

--- a/src/org/labkey/targetedms/chromlib/LibTransitionDao.java
+++ b/src/org/labkey/targetedms/chromlib/LibTransitionDao.java
@@ -128,7 +128,7 @@ public class LibTransitionDao extends BaseDaoImpl<LibTransition>
     @Override
     public void saveAll(Collection<LibTransition> transitions, Connection connection) throws SQLException
     {
-        if (transitions.size() > 0)
+        if (!transitions.isEmpty())
         {
             super.saveAll(transitions, connection);
 

--- a/src/org/labkey/targetedms/conflict/ConflictTransition.java
+++ b/src/org/labkey/targetedms/conflict/ConflictTransition.java
@@ -17,8 +17,6 @@ package org.labkey.targetedms.conflict;
 
 import org.labkey.targetedms.parser.GeneralPrecursor;
 import org.labkey.targetedms.parser.GeneralTransition;
-import org.labkey.targetedms.parser.Precursor;
-import org.labkey.targetedms.parser.Transition;
 
 /**
  * User: vsharma

--- a/src/org/labkey/targetedms/datasource/MsDataSourceUtil.java
+++ b/src/org/labkey/targetedms/datasource/MsDataSourceUtil.java
@@ -127,7 +127,7 @@ public class MsDataSourceUtil
     {
         List<? extends ExpData> expDatas = getExpData(sampleFile.getFileName(), container, rawFilesDir, expSvc);
 
-        if(expDatas.size() == 0)
+        if(expDatas.isEmpty())
         {
             return null;
         }
@@ -277,7 +277,7 @@ public class MsDataSourceUtil
         {
             List<? extends ExpData> expDatas = getExpData(fileName, container, rawFilesDir, expSvc);
 
-            if (expDatas.size() > 0)
+            if (!expDatas.isEmpty())
             {
                 for (ExpData data : expDatas)
                 {

--- a/src/org/labkey/targetedms/datasource/MsMultiDataSource.java
+++ b/src/org/labkey/targetedms/datasource/MsMultiDataSource.java
@@ -12,8 +12,8 @@ import java.util.List;
 
 class MsMultiDataSource extends MsDataSource
 {
-    private List<MsDataDirSource> _dirSources;
-    private List<MsDataFileSource> _fileSources;
+    private final List<MsDataDirSource> _dirSources;
+    private final List<MsDataFileSource> _fileSources;
 
     MsMultiDataSource()
     {

--- a/src/org/labkey/targetedms/datasource/PsiInstruments.java
+++ b/src/org/labkey/targetedms/datasource/PsiInstruments.java
@@ -41,7 +41,7 @@ import java.util.Map;
 
 public class PsiInstruments
 {
-    private static Map<String, PsiInstrument> _instruments = new HashMap<>();
+    private static final Map<String, PsiInstrument> _instruments = new HashMap<>();
 
     private static final Logger LOG = LogManager.getLogger(PsiInstruments.class);
 

--- a/src/org/labkey/targetedms/parser/ComplexFragmentIonName.java
+++ b/src/org/labkey/targetedms/parser/ComplexFragmentIonName.java
@@ -151,7 +151,7 @@ public class ComplexFragmentIonName
             return false;
         }
         // Current format: Precursors always look like some number of "p" separated by hyphens
-        if ("".equals(name.substring(1).replace("-p", ""))) {
+        if (name.substring(1).replace("-p", "").isEmpty()) {
             return true;
         }
         if (name.indexOf('}') < 0) {

--- a/src/org/labkey/targetedms/parser/DataSettings.java
+++ b/src/org/labkey/targetedms/parser/DataSettings.java
@@ -40,9 +40,9 @@ public class DataSettings
         true_false(JdbcType.BOOLEAN, false, true),
         value_list(JdbcType.VARCHAR, false, true);
 
-        private JdbcType _dataType;
-        private boolean _isMeasure;
-        private boolean _isDimension;
+        private final JdbcType _dataType;
+        private final boolean _isMeasure;
+        private final boolean _isDimension;
 
         AnnotationType(JdbcType dataType, boolean isMeasure, boolean isDimension)
         {
@@ -88,11 +88,11 @@ public class DataSettings
         transition_result
     }
 
-    private Map<String, AnnotationDefinition> _annotationDefinitions = new HashMap<>();
-    private Map<AnnotationTarget, List<AnnotationDefinition>> _targetAnnotationsMap =
+    private final Map<String, AnnotationDefinition> _annotationDefinitions = new HashMap<>();
+    private final Map<AnnotationTarget, List<AnnotationDefinition>> _targetAnnotationsMap =
                         new HashMap<>();
-    private List<GroupComparisonSettings> _groupComparisons = new ArrayList<>();
-    private List<ListData> _listDatas = new ArrayList<>();
+    private final List<GroupComparisonSettings> _groupComparisons = new ArrayList<>();
+    private final List<ListData> _listDatas = new ArrayList<>();
 
     public void addAnnotations(String name, String targetsString, String type, String lookup)
     {

--- a/src/org/labkey/targetedms/parser/Instrument.java
+++ b/src/org/labkey/targetedms/parser/Instrument.java
@@ -94,9 +94,7 @@ public class Instrument
     public boolean equals(Object o)
     {
         if (this == o) return true;
-        if (!(o instanceof Instrument)) return false;
-
-        Instrument that = (Instrument) o;
+        if (!(o instanceof Instrument that)) return false;
 
         if (analyzer != null ? !analyzer.equals(that.analyzer) : that.analyzer != null) return false;
         if (detector != null ? !detector.equals(that.detector) : that.detector != null) return false;

--- a/src/org/labkey/targetedms/parser/Peptide.java
+++ b/src/org/labkey/targetedms/parser/Peptide.java
@@ -385,7 +385,7 @@ public class Peptide extends GeneralMolecule<Transition, Precursor>
                     if (modifications != null)
                     {
                         String strModification = modifiedSequence.substring(modificationStart, i);
-                        modifications.add(new Pair<Integer, String>(unmodifiedSequence.length() - 1, strModification));
+                        modifications.add(new Pair<>(unmodifiedSequence.length() - 1, strModification));
                     }
                     modificationStart = null;
                 }

--- a/src/org/labkey/targetedms/parser/PeptideSettings.java
+++ b/src/org/labkey/targetedms/parser/PeptideSettings.java
@@ -868,6 +868,7 @@ public class PeptideSettings
         private Boolean _useExplicitPeakBounds;
         private String _panoramaServer;
 
+        @Override
         public long getRunId()
         {
             return _runId;

--- a/src/org/labkey/targetedms/parser/PeptideSettingsParser.java
+++ b/src/org/labkey/targetedms/parser/PeptideSettingsParser.java
@@ -230,7 +230,7 @@ class PeptideSettingsParser
 
         // If we did not find either the "internal_standard" attribute or elements, check if we have
         // a "heavy" isotope label.  If we do, set "heavy" as the internal standard
-        if(internalStandards.size() == 0 && isotopeLabelNames.contains(PeptideSettings.HEAVY_LABEL))
+        if(internalStandards.isEmpty() && isotopeLabelNames.contains(PeptideSettings.HEAVY_LABEL))
         {
             internalStandards.add(PeptideSettings.HEAVY_LABEL);
         }

--- a/src/org/labkey/targetedms/parser/SampleFile.java
+++ b/src/org/labkey/targetedms/parser/SampleFile.java
@@ -54,6 +54,7 @@ public class SampleFile extends SkylineEntity implements ISampleFile
 
     private List<Instrument> _instrumentInfoList;
 
+    @Override
     public long getReplicateId()
     {
         return _replicateId;

--- a/src/org/labkey/targetedms/parser/SpectrumFilter.java
+++ b/src/org/labkey/targetedms/parser/SpectrumFilter.java
@@ -26,7 +26,6 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import java.io.StringReader;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;

--- a/src/org/labkey/targetedms/parser/Target.java
+++ b/src/org/labkey/targetedms/parser/Target.java
@@ -129,7 +129,7 @@ public class Target
             return null;
         }
 
-        if (parts.size() > 0)
+        if (!parts.isEmpty())
         {
             target.name = parts.get(0);
         }

--- a/src/org/labkey/targetedms/parser/TransitionSettings.java
+++ b/src/org/labkey/targetedms/parser/TransitionSettings.java
@@ -419,7 +419,7 @@ public class TransitionSettings
         private Predictor _cePredictor;
         private Predictor _dpPredictor;
 
-        private Map<String, String> _optimizedLibraries = new HashMap<>();
+        private final Map<String, String> _optimizedLibraries = new HashMap<>();
 
         public long getRunId()
         {

--- a/src/org/labkey/targetedms/parser/XmlUtil.java
+++ b/src/org/labkey/targetedms/parser/XmlUtil.java
@@ -66,7 +66,7 @@ public class XmlUtil
             int evtType = reader.next();
             if (evtType == XMLStreamReader.END_ELEMENT && endElementName.equalsIgnoreCase(reader.getLocalName()))
             {
-                if (sb.length() == 0)
+                if (sb.isEmpty())
                 {
                     return null;
                 }

--- a/src/org/labkey/targetedms/parser/list/ListData.java
+++ b/src/org/labkey/targetedms/parser/list/ListData.java
@@ -21,9 +21,9 @@ import java.util.List;
 
 public class ListData
 {
-    private ListDefinition _listDefinition;
-    private List<ListColumn> _columns;
-    private List<List<Object>> _columnDatas;
+    private final ListDefinition _listDefinition;
+    private final List<ListColumn> _columns;
+    private final List<List<Object>> _columnDatas;
 
     public ListData()
     {

--- a/src/org/labkey/targetedms/parser/proto/ChromatogramGroupDataOuterClass.java
+++ b/src/org/labkey/targetedms/parser/proto/ChromatogramGroupDataOuterClass.java
@@ -248,6 +248,7 @@ public final class ChromatogramGroupDataOuterClass {
        * <code>repeated float times = 1;</code>
        * @return The count of times.
        */
+      @Override
       public int getTimesCount() {
         return times_.size();
       }
@@ -256,6 +257,7 @@ public final class ChromatogramGroupDataOuterClass {
        * @param index The index of the element to return.
        * @return The times at the given index.
        */
+      @Override
       public float getTimes(int index) {
         return times_.getFloat(index);
       }
@@ -276,7 +278,7 @@ public final class ChromatogramGroupDataOuterClass {
       public void writeTo(com.google.protobuf.CodedOutputStream output)
                           throws java.io.IOException {
         getSerializedSize();
-        if (getTimesList().size() > 0) {
+        if (!getTimesList().isEmpty()) {
           output.writeUInt32NoTag(10);
           output.writeUInt32NoTag(timesMemoizedSerializedSize);
         }
@@ -293,7 +295,7 @@ public final class ChromatogramGroupDataOuterClass {
 
         size = 0;
         {
-          int dataSize = 0;
+          int dataSize;
           dataSize = 4 * getTimesList().size();
           size += dataSize;
           if (!getTimesList().isEmpty()) {
@@ -313,12 +315,11 @@ public final class ChromatogramGroupDataOuterClass {
         if (obj == this) {
          return true;
         }
-        if (!(obj instanceof org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.TimeList)) {
+        if (!(obj instanceof TimeList other)) {
           return super.equals(obj);
         }
-        org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.TimeList other = (org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.TimeList) obj;
 
-        if (!getTimesList()
+          if (!getTimesList()
             .equals(other.getTimesList())) return false;
         if (!getUnknownFields().equals(other.getUnknownFields())) return false;
         return true;
@@ -638,6 +639,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>repeated float times = 1;</code>
          * @return A list containing the times.
          */
+        @Override
         public java.util.List<java.lang.Float>
             getTimesList() {
           times_.makeImmutable();
@@ -647,6 +649,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>repeated float times = 1;</code>
          * @return The count of times.
          */
+        @Override
         public int getTimesCount() {
           return times_.size();
         }
@@ -655,6 +658,7 @@ public final class ChromatogramGroupDataOuterClass {
          * @param index The index of the element to return.
          * @return The times at the given index.
          */
+        @Override
         public float getTimes(int index) {
           return times_.getFloat(index);
         }
@@ -737,25 +741,34 @@ public final class ChromatogramGroupDataOuterClass {
       }
 
       private static final com.google.protobuf.Parser<TimeList>
-          PARSER = new com.google.protobuf.AbstractParser<TimeList>() {
-        @java.lang.Override
-        public TimeList parsePartialFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
-          Builder builder = newBuilder();
-          try {
-            builder.mergeFrom(input, extensionRegistry);
-          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-            throw e.setUnfinishedMessage(builder.buildPartial());
-          } catch (com.google.protobuf.UninitializedMessageException e) {
-            throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
-          } catch (java.io.IOException e) {
-            throw new com.google.protobuf.InvalidProtocolBufferException(e)
-                .setUnfinishedMessage(builder.buildPartial());
+          PARSER = new com.google.protobuf.AbstractParser<>()
+      {
+          @java.lang.Override
+          public TimeList parsePartialFrom(
+                  com.google.protobuf.CodedInputStream input,
+                  com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                  throws com.google.protobuf.InvalidProtocolBufferException
+          {
+              Builder builder = newBuilder();
+              try
+              {
+                  builder.mergeFrom(input, extensionRegistry);
+              }
+              catch (com.google.protobuf.InvalidProtocolBufferException e)
+              {
+                  throw e.setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (com.google.protobuf.UninitializedMessageException e)
+              {
+                  throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (java.io.IOException e)
+              {
+                  throw new com.google.protobuf.InvalidProtocolBufferException(e)
+                          .setUnfinishedMessage(builder.buildPartial());
+              }
+              return builder.buildPartial();
           }
-          return builder.buildPartial();
-        }
       };
 
       public static com.google.protobuf.Parser<TimeList> parser() {
@@ -848,6 +861,7 @@ public final class ChromatogramGroupDataOuterClass {
        * <code>repeated int32 scanIds = 2;</code>
        * @return The count of scanIds.
        */
+      @Override
       public int getScanIdsCount() {
         return scanIds_.size();
       }
@@ -856,6 +870,7 @@ public final class ChromatogramGroupDataOuterClass {
        * @param index The index of the element to return.
        * @return The scanIds at the given index.
        */
+      @Override
       public int getScanIds(int index) {
         return scanIds_.getInt(index);
       }
@@ -876,7 +891,7 @@ public final class ChromatogramGroupDataOuterClass {
       public void writeTo(com.google.protobuf.CodedOutputStream output)
                           throws java.io.IOException {
         getSerializedSize();
-        if (getScanIdsList().size() > 0) {
+        if (!getScanIdsList().isEmpty()) {
           output.writeUInt32NoTag(18);
           output.writeUInt32NoTag(scanIdsMemoizedSerializedSize);
         }
@@ -916,12 +931,11 @@ public final class ChromatogramGroupDataOuterClass {
         if (obj == this) {
          return true;
         }
-        if (!(obj instanceof org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.ScanIdList)) {
+        if (!(obj instanceof ScanIdList other)) {
           return super.equals(obj);
         }
-        org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.ScanIdList other = (org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.ScanIdList) obj;
 
-        if (!getScanIdsList()
+          if (!getScanIdsList()
             .equals(other.getScanIdsList())) return false;
         if (!getUnknownFields().equals(other.getUnknownFields())) return false;
         return true;
@@ -1234,6 +1248,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>repeated int32 scanIds = 2;</code>
          * @return A list containing the scanIds.
          */
+        @Override
         public java.util.List<java.lang.Integer>
             getScanIdsList() {
           scanIds_.makeImmutable();
@@ -1243,6 +1258,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>repeated int32 scanIds = 2;</code>
          * @return The count of scanIds.
          */
+        @Override
         public int getScanIdsCount() {
           return scanIds_.size();
         }
@@ -1251,6 +1267,7 @@ public final class ChromatogramGroupDataOuterClass {
          * @param index The index of the element to return.
          * @return The scanIds at the given index.
          */
+        @Override
         public int getScanIds(int index) {
           return scanIds_.getInt(index);
         }
@@ -1333,25 +1350,34 @@ public final class ChromatogramGroupDataOuterClass {
       }
 
       private static final com.google.protobuf.Parser<ScanIdList>
-          PARSER = new com.google.protobuf.AbstractParser<ScanIdList>() {
-        @java.lang.Override
-        public ScanIdList parsePartialFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
-          Builder builder = newBuilder();
-          try {
-            builder.mergeFrom(input, extensionRegistry);
-          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-            throw e.setUnfinishedMessage(builder.buildPartial());
-          } catch (com.google.protobuf.UninitializedMessageException e) {
-            throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
-          } catch (java.io.IOException e) {
-            throw new com.google.protobuf.InvalidProtocolBufferException(e)
-                .setUnfinishedMessage(builder.buildPartial());
+          PARSER = new com.google.protobuf.AbstractParser<>()
+      {
+          @java.lang.Override
+          public ScanIdList parsePartialFrom(
+                  com.google.protobuf.CodedInputStream input,
+                  com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                  throws com.google.protobuf.InvalidProtocolBufferException
+          {
+              Builder builder = newBuilder();
+              try
+              {
+                  builder.mergeFrom(input, extensionRegistry);
+              }
+              catch (com.google.protobuf.InvalidProtocolBufferException e)
+              {
+                  throw e.setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (com.google.protobuf.UninitializedMessageException e)
+              {
+                  throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (java.io.IOException e)
+              {
+                  throw new com.google.protobuf.InvalidProtocolBufferException(e)
+                          .setUnfinishedMessage(builder.buildPartial());
+              }
+              return builder.buildPartial();
           }
-          return builder.buildPartial();
-        }
       };
 
       public static com.google.protobuf.Parser<ScanIdList> parser() {
@@ -1515,6 +1541,7 @@ public final class ChromatogramGroupDataOuterClass {
        * <code>repeated float intensities = 2;</code>
        * @return The count of intensities.
        */
+      @Override
       public int getIntensitiesCount() {
         return intensities_.size();
       }
@@ -1523,6 +1550,7 @@ public final class ChromatogramGroupDataOuterClass {
        * @param index The index of the element to return.
        * @return The intensities at the given index.
        */
+      @Override
       public float getIntensities(int index) {
         return intensities_.getFloat(index);
       }
@@ -1545,6 +1573,7 @@ public final class ChromatogramGroupDataOuterClass {
        * <code>repeated float massErrorsDeprecated = 3;</code>
        * @return The count of massErrorsDeprecated.
        */
+      @Override
       public int getMassErrorsDeprecatedCount() {
         return massErrorsDeprecated_.size();
       }
@@ -1553,6 +1582,7 @@ public final class ChromatogramGroupDataOuterClass {
        * @param index The index of the element to return.
        * @return The massErrorsDeprecated at the given index.
        */
+      @Override
       public float getMassErrorsDeprecated(int index) {
         return massErrorsDeprecated_.getFloat(index);
       }
@@ -1575,6 +1605,7 @@ public final class ChromatogramGroupDataOuterClass {
        * <code>repeated sint32 massErrors100X = 5;</code>
        * @return The count of massErrors100X.
        */
+      @Override
       public int getMassErrors100XCount() {
         return massErrors100X_.size();
       }
@@ -1583,6 +1614,7 @@ public final class ChromatogramGroupDataOuterClass {
        * @param index The index of the element to return.
        * @return The massErrors100X at the given index.
        */
+      @Override
       public int getMassErrors100X(int index) {
         return massErrors100X_.getInt(index);
       }
@@ -1621,14 +1653,14 @@ public final class ChromatogramGroupDataOuterClass {
         if (timeListIndex_ != 0) {
           output.writeInt32(1, timeListIndex_);
         }
-        if (getIntensitiesList().size() > 0) {
+        if (!getIntensitiesList().isEmpty()) {
           output.writeUInt32NoTag(18);
           output.writeUInt32NoTag(intensitiesMemoizedSerializedSize);
         }
         for (int i = 0; i < intensities_.size(); i++) {
           output.writeFloatNoTag(intensities_.getFloat(i));
         }
-        if (getMassErrorsDeprecatedList().size() > 0) {
+        if (!getMassErrorsDeprecatedList().isEmpty()) {
           output.writeUInt32NoTag(26);
           output.writeUInt32NoTag(massErrorsDeprecatedMemoizedSerializedSize);
         }
@@ -1638,7 +1670,7 @@ public final class ChromatogramGroupDataOuterClass {
         if (scanIdListIndex_ != 0) {
           output.writeInt32(4, scanIdListIndex_);
         }
-        if (getMassErrors100XList().size() > 0) {
+        if (!getMassErrors100XList().isEmpty()) {
           output.writeUInt32NoTag(42);
           output.writeUInt32NoTag(massErrors100XMemoizedSerializedSize);
         }
@@ -1659,7 +1691,7 @@ public final class ChromatogramGroupDataOuterClass {
             .computeInt32Size(1, timeListIndex_);
         }
         {
-          int dataSize = 0;
+          int dataSize;
           dataSize = 4 * getIntensitiesList().size();
           size += dataSize;
           if (!getIntensitiesList().isEmpty()) {
@@ -1670,7 +1702,7 @@ public final class ChromatogramGroupDataOuterClass {
           intensitiesMemoizedSerializedSize = dataSize;
         }
         {
-          int dataSize = 0;
+          int dataSize;
           dataSize = 4 * getMassErrorsDeprecatedList().size();
           size += dataSize;
           if (!getMassErrorsDeprecatedList().isEmpty()) {
@@ -1708,12 +1740,11 @@ public final class ChromatogramGroupDataOuterClass {
         if (obj == this) {
          return true;
         }
-        if (!(obj instanceof org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.Chromatogram)) {
+        if (!(obj instanceof Chromatogram other)) {
           return super.equals(obj);
         }
-        org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.Chromatogram other = (org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.Chromatogram) obj;
 
-        if (getTimeListIndex()
+          if (getTimeListIndex()
             != other.getTimeListIndex()) return false;
         if (!getIntensitiesList()
             .equals(other.getIntensitiesList())) return false;
@@ -2186,6 +2217,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>repeated float intensities = 2;</code>
          * @return A list containing the intensities.
          */
+        @Override
         public java.util.List<java.lang.Float>
             getIntensitiesList() {
           intensities_.makeImmutable();
@@ -2195,6 +2227,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>repeated float intensities = 2;</code>
          * @return The count of intensities.
          */
+        @Override
         public int getIntensitiesCount() {
           return intensities_.size();
         }
@@ -2203,6 +2236,7 @@ public final class ChromatogramGroupDataOuterClass {
          * @param index The index of the element to return.
          * @return The intensities at the given index.
          */
+        @Override
         public float getIntensities(int index) {
           return intensities_.getFloat(index);
         }
@@ -2276,6 +2310,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>repeated float massErrorsDeprecated = 3;</code>
          * @return A list containing the massErrorsDeprecated.
          */
+        @Override
         public java.util.List<java.lang.Float>
             getMassErrorsDeprecatedList() {
           massErrorsDeprecated_.makeImmutable();
@@ -2285,6 +2320,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>repeated float massErrorsDeprecated = 3;</code>
          * @return The count of massErrorsDeprecated.
          */
+        @Override
         public int getMassErrorsDeprecatedCount() {
           return massErrorsDeprecated_.size();
         }
@@ -2293,6 +2329,7 @@ public final class ChromatogramGroupDataOuterClass {
          * @param index The index of the element to return.
          * @return The massErrorsDeprecated at the given index.
          */
+        @Override
         public float getMassErrorsDeprecated(int index) {
           return massErrorsDeprecated_.getFloat(index);
         }
@@ -2360,6 +2397,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>repeated sint32 massErrors100X = 5;</code>
          * @return A list containing the massErrors100X.
          */
+        @Override
         public java.util.List<java.lang.Integer>
             getMassErrors100XList() {
           massErrors100X_.makeImmutable();
@@ -2369,6 +2407,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>repeated sint32 massErrors100X = 5;</code>
          * @return The count of massErrors100X.
          */
+        @Override
         public int getMassErrors100XCount() {
           return massErrors100X_.size();
         }
@@ -2377,6 +2416,7 @@ public final class ChromatogramGroupDataOuterClass {
          * @param index The index of the element to return.
          * @return The massErrors100X at the given index.
          */
+        @Override
         public int getMassErrors100X(int index) {
           return massErrors100X_.getInt(index);
         }
@@ -2503,25 +2543,34 @@ public final class ChromatogramGroupDataOuterClass {
       }
 
       private static final com.google.protobuf.Parser<Chromatogram>
-          PARSER = new com.google.protobuf.AbstractParser<Chromatogram>() {
-        @java.lang.Override
-        public Chromatogram parsePartialFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
-          Builder builder = newBuilder();
-          try {
-            builder.mergeFrom(input, extensionRegistry);
-          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-            throw e.setUnfinishedMessage(builder.buildPartial());
-          } catch (com.google.protobuf.UninitializedMessageException e) {
-            throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
-          } catch (java.io.IOException e) {
-            throw new com.google.protobuf.InvalidProtocolBufferException(e)
-                .setUnfinishedMessage(builder.buildPartial());
+          PARSER = new com.google.protobuf.AbstractParser<>()
+      {
+          @java.lang.Override
+          public Chromatogram parsePartialFrom(
+                  com.google.protobuf.CodedInputStream input,
+                  com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                  throws com.google.protobuf.InvalidProtocolBufferException
+          {
+              Builder builder = newBuilder();
+              try
+              {
+                  builder.mergeFrom(input, extensionRegistry);
+              }
+              catch (com.google.protobuf.InvalidProtocolBufferException e)
+              {
+                  throw e.setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (com.google.protobuf.UninitializedMessageException e)
+              {
+                  throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (java.io.IOException e)
+              {
+                  throw new com.google.protobuf.InvalidProtocolBufferException(e)
+                          .setUnfinishedMessage(builder.buildPartial());
+              }
+              return builder.buildPartial();
           }
-          return builder.buildPartial();
-        }
       };
 
       public static com.google.protobuf.Parser<Chromatogram> parser() {
@@ -2632,6 +2681,7 @@ public final class ChromatogramGroupDataOuterClass {
        * <code>repeated float startTimes = 1;</code>
        * @return The count of startTimes.
        */
+      @Override
       public int getStartTimesCount() {
         return startTimes_.size();
       }
@@ -2640,6 +2690,7 @@ public final class ChromatogramGroupDataOuterClass {
        * @param index The index of the element to return.
        * @return The startTimes at the given index.
        */
+      @Override
       public float getStartTimes(int index) {
         return startTimes_.getFloat(index);
       }
@@ -2662,6 +2713,7 @@ public final class ChromatogramGroupDataOuterClass {
        * <code>repeated float endTimes = 2;</code>
        * @return The count of endTimes.
        */
+      @Override
       public int getEndTimesCount() {
         return endTimes_.size();
       }
@@ -2670,6 +2722,7 @@ public final class ChromatogramGroupDataOuterClass {
        * @param index The index of the element to return.
        * @return The endTimes at the given index.
        */
+      @Override
       public float getEndTimes(int index) {
         return endTimes_.getFloat(index);
       }
@@ -2690,14 +2743,14 @@ public final class ChromatogramGroupDataOuterClass {
       public void writeTo(com.google.protobuf.CodedOutputStream output)
                           throws java.io.IOException {
         getSerializedSize();
-        if (getStartTimesList().size() > 0) {
+        if (!getStartTimesList().isEmpty()) {
           output.writeUInt32NoTag(10);
           output.writeUInt32NoTag(startTimesMemoizedSerializedSize);
         }
         for (int i = 0; i < startTimes_.size(); i++) {
           output.writeFloatNoTag(startTimes_.getFloat(i));
         }
-        if (getEndTimesList().size() > 0) {
+        if (!getEndTimesList().isEmpty()) {
           output.writeUInt32NoTag(18);
           output.writeUInt32NoTag(endTimesMemoizedSerializedSize);
         }
@@ -2714,7 +2767,7 @@ public final class ChromatogramGroupDataOuterClass {
 
         size = 0;
         {
-          int dataSize = 0;
+          int dataSize;
           dataSize = 4 * getStartTimesList().size();
           size += dataSize;
           if (!getStartTimesList().isEmpty()) {
@@ -2725,7 +2778,7 @@ public final class ChromatogramGroupDataOuterClass {
           startTimesMemoizedSerializedSize = dataSize;
         }
         {
-          int dataSize = 0;
+          int dataSize;
           dataSize = 4 * getEndTimesList().size();
           size += dataSize;
           if (!getEndTimesList().isEmpty()) {
@@ -2745,12 +2798,11 @@ public final class ChromatogramGroupDataOuterClass {
         if (obj == this) {
          return true;
         }
-        if (!(obj instanceof org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.TimeIntervals)) {
+        if (!(obj instanceof TimeIntervals other)) {
           return super.equals(obj);
         }
-        org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.TimeIntervals other = (org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.TimeIntervals) obj;
 
-        if (!getStartTimesList()
+          if (!getStartTimesList()
             .equals(other.getStartTimesList())) return false;
         if (!getEndTimesList()
             .equals(other.getEndTimesList())) return false;
@@ -3109,6 +3161,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>repeated float startTimes = 1;</code>
          * @return A list containing the startTimes.
          */
+        @Override
         public java.util.List<java.lang.Float>
             getStartTimesList() {
           startTimes_.makeImmutable();
@@ -3118,6 +3171,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>repeated float startTimes = 1;</code>
          * @return The count of startTimes.
          */
+        @Override
         public int getStartTimesCount() {
           return startTimes_.size();
         }
@@ -3126,6 +3180,7 @@ public final class ChromatogramGroupDataOuterClass {
          * @param index The index of the element to return.
          * @return The startTimes at the given index.
          */
+        @Override
         public float getStartTimes(int index) {
           return startTimes_.getFloat(index);
         }
@@ -3199,6 +3254,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>repeated float endTimes = 2;</code>
          * @return A list containing the endTimes.
          */
+        @Override
         public java.util.List<java.lang.Float>
             getEndTimesList() {
           endTimes_.makeImmutable();
@@ -3208,6 +3264,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>repeated float endTimes = 2;</code>
          * @return The count of endTimes.
          */
+        @Override
         public int getEndTimesCount() {
           return endTimes_.size();
         }
@@ -3216,6 +3273,7 @@ public final class ChromatogramGroupDataOuterClass {
          * @param index The index of the element to return.
          * @return The endTimes at the given index.
          */
+        @Override
         public float getEndTimes(int index) {
           return endTimes_.getFloat(index);
         }
@@ -3298,25 +3356,34 @@ public final class ChromatogramGroupDataOuterClass {
       }
 
       private static final com.google.protobuf.Parser<TimeIntervals>
-          PARSER = new com.google.protobuf.AbstractParser<TimeIntervals>() {
-        @java.lang.Override
-        public TimeIntervals parsePartialFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
-          Builder builder = newBuilder();
-          try {
-            builder.mergeFrom(input, extensionRegistry);
-          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-            throw e.setUnfinishedMessage(builder.buildPartial());
-          } catch (com.google.protobuf.UninitializedMessageException e) {
-            throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
-          } catch (java.io.IOException e) {
-            throw new com.google.protobuf.InvalidProtocolBufferException(e)
-                .setUnfinishedMessage(builder.buildPartial());
+          PARSER = new com.google.protobuf.AbstractParser<>()
+      {
+          @java.lang.Override
+          public TimeIntervals parsePartialFrom(
+                  com.google.protobuf.CodedInputStream input,
+                  com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                  throws com.google.protobuf.InvalidProtocolBufferException
+          {
+              Builder builder = newBuilder();
+              try
+              {
+                  builder.mergeFrom(input, extensionRegistry);
+              }
+              catch (com.google.protobuf.InvalidProtocolBufferException e)
+              {
+                  throw e.setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (com.google.protobuf.UninitializedMessageException e)
+              {
+                  throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (java.io.IOException e)
+              {
+                  throw new com.google.protobuf.InvalidProtocolBufferException(e)
+                          .setUnfinishedMessage(builder.buildPartial());
+              }
+              return builder.buildPartial();
           }
-          return builder.buildPartial();
-        }
       };
 
       public static com.google.protobuf.Parser<TimeIntervals> parser() {
@@ -3636,12 +3703,11 @@ public final class ChromatogramGroupDataOuterClass {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData)) {
+      if (!(obj instanceof ChromatogramGroupData other)) {
         return super.equals(obj);
       }
-      org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData other = (org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData) obj;
 
-      if (!getTimeListsList()
+        if (!getTimeListsList()
           .equals(other.getTimeListsList())) return false;
       if (!getScanIdListsList()
           .equals(other.getScanIdListsList())) return false;
@@ -4224,7 +4290,7 @@ public final class ChromatogramGroupDataOuterClass {
         java.util.Collections.emptyList();
       private void ensureTimeListsIsMutable() {
         if (!((bitField0_ & 0x00000001) != 0)) {
-          timeLists_ = new java.util.ArrayList<org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.TimeList>(timeLists_);
+          timeLists_ = new java.util.ArrayList<>(timeLists_);
           bitField0_ |= 0x00000001;
          }
       }
@@ -4235,6 +4301,7 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ChromatogramGroupData.TimeList timeLists = 1;</code>
        */
+      @Override
       public java.util.List<org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.TimeList> getTimeListsList() {
         if (timeListsBuilder_ == null) {
           return java.util.Collections.unmodifiableList(timeLists_);
@@ -4245,6 +4312,7 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ChromatogramGroupData.TimeList timeLists = 1;</code>
        */
+      @Override
       public int getTimeListsCount() {
         if (timeListsBuilder_ == null) {
           return timeLists_.size();
@@ -4255,6 +4323,7 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ChromatogramGroupData.TimeList timeLists = 1;</code>
        */
+      @Override
       public org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.TimeList getTimeLists(int index) {
         if (timeListsBuilder_ == null) {
           return timeLists_.get(index);
@@ -4405,6 +4474,7 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ChromatogramGroupData.TimeList timeLists = 1;</code>
        */
+      @Override
       public org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.TimeListOrBuilder getTimeListsOrBuilder(
           int index) {
         if (timeListsBuilder_ == null) {
@@ -4415,7 +4485,8 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ChromatogramGroupData.TimeList timeLists = 1;</code>
        */
-      public java.util.List<? extends org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.TimeListOrBuilder> 
+      @Override
+      public java.util.List<? extends org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.TimeListOrBuilder>
            getTimeListsOrBuilderList() {
         if (timeListsBuilder_ != null) {
           return timeListsBuilder_.getMessageOrBuilderList();
@@ -4449,8 +4520,7 @@ public final class ChromatogramGroupDataOuterClass {
           org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.TimeList, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.TimeList.Builder, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.TimeListOrBuilder> 
           getTimeListsFieldBuilder() {
         if (timeListsBuilder_ == null) {
-          timeListsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.TimeList, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.TimeList.Builder, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.TimeListOrBuilder>(
+          timeListsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<>(
                   timeLists_,
                   ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),
@@ -4464,7 +4534,7 @@ public final class ChromatogramGroupDataOuterClass {
         java.util.Collections.emptyList();
       private void ensureScanIdListsIsMutable() {
         if (!((bitField0_ & 0x00000002) != 0)) {
-          scanIdLists_ = new java.util.ArrayList<org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.ScanIdList>(scanIdLists_);
+          scanIdLists_ = new java.util.ArrayList<>(scanIdLists_);
           bitField0_ |= 0x00000002;
          }
       }
@@ -4475,6 +4545,7 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ChromatogramGroupData.ScanIdList scanIdLists = 2;</code>
        */
+      @Override
       public java.util.List<org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.ScanIdList> getScanIdListsList() {
         if (scanIdListsBuilder_ == null) {
           return java.util.Collections.unmodifiableList(scanIdLists_);
@@ -4485,6 +4556,7 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ChromatogramGroupData.ScanIdList scanIdLists = 2;</code>
        */
+      @Override
       public int getScanIdListsCount() {
         if (scanIdListsBuilder_ == null) {
           return scanIdLists_.size();
@@ -4495,6 +4567,7 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ChromatogramGroupData.ScanIdList scanIdLists = 2;</code>
        */
+      @Override
       public org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.ScanIdList getScanIdLists(int index) {
         if (scanIdListsBuilder_ == null) {
           return scanIdLists_.get(index);
@@ -4645,6 +4718,7 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ChromatogramGroupData.ScanIdList scanIdLists = 2;</code>
        */
+      @Override
       public org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.ScanIdListOrBuilder getScanIdListsOrBuilder(
           int index) {
         if (scanIdListsBuilder_ == null) {
@@ -4655,7 +4729,8 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ChromatogramGroupData.ScanIdList scanIdLists = 2;</code>
        */
-      public java.util.List<? extends org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.ScanIdListOrBuilder> 
+      @Override
+      public java.util.List<? extends org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.ScanIdListOrBuilder>
            getScanIdListsOrBuilderList() {
         if (scanIdListsBuilder_ != null) {
           return scanIdListsBuilder_.getMessageOrBuilderList();
@@ -4689,8 +4764,7 @@ public final class ChromatogramGroupDataOuterClass {
           org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.ScanIdList, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.ScanIdList.Builder, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.ScanIdListOrBuilder> 
           getScanIdListsFieldBuilder() {
         if (scanIdListsBuilder_ == null) {
-          scanIdListsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.ScanIdList, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.ScanIdList.Builder, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.ScanIdListOrBuilder>(
+          scanIdListsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<>(
                   scanIdLists_,
                   ((bitField0_ & 0x00000002) != 0),
                   getParentForChildren(),
@@ -4704,7 +4778,7 @@ public final class ChromatogramGroupDataOuterClass {
         java.util.Collections.emptyList();
       private void ensureChromatogramsIsMutable() {
         if (!((bitField0_ & 0x00000004) != 0)) {
-          chromatograms_ = new java.util.ArrayList<org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.Chromatogram>(chromatograms_);
+          chromatograms_ = new java.util.ArrayList<>(chromatograms_);
           bitField0_ |= 0x00000004;
          }
       }
@@ -4715,6 +4789,7 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ChromatogramGroupData.Chromatogram chromatograms = 3;</code>
        */
+      @Override
       public java.util.List<org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.Chromatogram> getChromatogramsList() {
         if (chromatogramsBuilder_ == null) {
           return java.util.Collections.unmodifiableList(chromatograms_);
@@ -4725,6 +4800,7 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ChromatogramGroupData.Chromatogram chromatograms = 3;</code>
        */
+      @Override
       public int getChromatogramsCount() {
         if (chromatogramsBuilder_ == null) {
           return chromatograms_.size();
@@ -4735,6 +4811,7 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ChromatogramGroupData.Chromatogram chromatograms = 3;</code>
        */
+      @Override
       public org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.Chromatogram getChromatograms(int index) {
         if (chromatogramsBuilder_ == null) {
           return chromatograms_.get(index);
@@ -4885,6 +4962,7 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ChromatogramGroupData.Chromatogram chromatograms = 3;</code>
        */
+      @Override
       public org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.ChromatogramOrBuilder getChromatogramsOrBuilder(
           int index) {
         if (chromatogramsBuilder_ == null) {
@@ -4895,7 +4973,8 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ChromatogramGroupData.Chromatogram chromatograms = 3;</code>
        */
-      public java.util.List<? extends org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.ChromatogramOrBuilder> 
+      @Override
+      public java.util.List<? extends org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.ChromatogramOrBuilder>
            getChromatogramsOrBuilderList() {
         if (chromatogramsBuilder_ != null) {
           return chromatogramsBuilder_.getMessageOrBuilderList();
@@ -4929,8 +5008,7 @@ public final class ChromatogramGroupDataOuterClass {
           org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.Chromatogram, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.Chromatogram.Builder, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.ChromatogramOrBuilder> 
           getChromatogramsFieldBuilder() {
         if (chromatogramsBuilder_ == null) {
-          chromatogramsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.Chromatogram, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.Chromatogram.Builder, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.ChromatogramOrBuilder>(
+          chromatogramsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<>(
                   chromatograms_,
                   ((bitField0_ & 0x00000004) != 0),
                   getParentForChildren(),
@@ -5107,6 +5185,7 @@ public final class ChromatogramGroupDataOuterClass {
        * <code>.ChromatogramGroupData.TimeIntervals timeIntervals = 10;</code>
        * @return Whether the timeIntervals field is set.
        */
+      @Override
       public boolean hasTimeIntervals() {
         return ((bitField0_ & 0x00000100) != 0);
       }
@@ -5114,6 +5193,7 @@ public final class ChromatogramGroupDataOuterClass {
        * <code>.ChromatogramGroupData.TimeIntervals timeIntervals = 10;</code>
        * @return The timeIntervals.
        */
+      @Override
       public org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.TimeIntervals getTimeIntervals() {
         if (timeIntervalsBuilder_ == null) {
           return timeIntervals_ == null ? org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.TimeIntervals.getDefaultInstance() : timeIntervals_;
@@ -5196,6 +5276,7 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>.ChromatogramGroupData.TimeIntervals timeIntervals = 10;</code>
        */
+      @Override
       public org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.TimeIntervalsOrBuilder getTimeIntervalsOrBuilder() {
         if (timeIntervalsBuilder_ != null) {
           return timeIntervalsBuilder_.getMessageOrBuilder();
@@ -5211,8 +5292,7 @@ public final class ChromatogramGroupDataOuterClass {
           org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.TimeIntervals, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.TimeIntervals.Builder, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.TimeIntervalsOrBuilder> 
           getTimeIntervalsFieldBuilder() {
         if (timeIntervalsBuilder_ == null) {
-          timeIntervalsBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.TimeIntervals, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.TimeIntervals.Builder, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupData.TimeIntervalsOrBuilder>(
+          timeIntervalsBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<>(
                   getTimeIntervals(),
                   getParentForChildren(),
                   isClean());
@@ -5247,25 +5327,34 @@ public final class ChromatogramGroupDataOuterClass {
     }
 
     private static final com.google.protobuf.Parser<ChromatogramGroupData>
-        PARSER = new com.google.protobuf.AbstractParser<ChromatogramGroupData>() {
-      @java.lang.Override
-      public ChromatogramGroupData parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        Builder builder = newBuilder();
-        try {
-          builder.mergeFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          throw e.setUnfinishedMessage(builder.buildPartial());
-        } catch (com.google.protobuf.UninitializedMessageException e) {
-          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
-        } catch (java.io.IOException e) {
-          throw new com.google.protobuf.InvalidProtocolBufferException(e)
-              .setUnfinishedMessage(builder.buildPartial());
+        PARSER = new com.google.protobuf.AbstractParser<>()
+    {
+        @java.lang.Override
+        public ChromatogramGroupData parsePartialFrom(
+                com.google.protobuf.CodedInputStream input,
+                com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                throws com.google.protobuf.InvalidProtocolBufferException
+        {
+            Builder builder = newBuilder();
+            try
+            {
+                builder.mergeFrom(input, extensionRegistry);
+            }
+            catch (com.google.protobuf.InvalidProtocolBufferException e)
+            {
+                throw e.setUnfinishedMessage(builder.buildPartial());
+            }
+            catch (com.google.protobuf.UninitializedMessageException e)
+            {
+                throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+            }
+            catch (java.io.IOException e)
+            {
+                throw new com.google.protobuf.InvalidProtocolBufferException(e)
+                        .setUnfinishedMessage(builder.buildPartial());
+            }
+            return builder.buildPartial();
         }
-        return builder.buildPartial();
-      }
     };
 
     public static com.google.protobuf.Parser<ChromatogramGroupData> parser() {
@@ -5567,6 +5656,7 @@ public final class ChromatogramGroupDataOuterClass {
        * <code>repeated int32 scanIdParts = 2;</code>
        * @return The count of scanIdParts.
        */
+      @Override
       public int getScanIdPartsCount() {
         return scanIdParts_.size();
       }
@@ -5575,6 +5665,7 @@ public final class ChromatogramGroupDataOuterClass {
        * @param index The index of the element to return.
        * @return The scanIdParts at the given index.
        */
+      @Override
       public int getScanIdParts(int index) {
         return scanIdParts_.getInt(index);
       }
@@ -5636,6 +5727,7 @@ public final class ChromatogramGroupDataOuterClass {
        * <code>repeated int32 precursorIndex = 4;</code>
        * @return The count of precursorIndex.
        */
+      @Override
       public int getPrecursorIndexCount() {
         return precursorIndex_.size();
       }
@@ -5644,6 +5736,7 @@ public final class ChromatogramGroupDataOuterClass {
        * @param index The index of the element to return.
        * @return The precursorIndex at the given index.
        */
+      @Override
       public int getPrecursorIndex(int index) {
         return precursorIndex_.getInt(index);
       }
@@ -5700,7 +5793,7 @@ public final class ChromatogramGroupDataOuterClass {
         if (java.lang.Double.doubleToRawLongBits(retentionTime_) != 0) {
           output.writeDouble(1, retentionTime_);
         }
-        if (getScanIdPartsList().size() > 0) {
+        if (!getScanIdPartsList().isEmpty()) {
           output.writeUInt32NoTag(18);
           output.writeUInt32NoTag(scanIdPartsMemoizedSerializedSize);
         }
@@ -5710,7 +5803,7 @@ public final class ChromatogramGroupDataOuterClass {
         if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(scanIdText_)) {
           com.google.protobuf.GeneratedMessageV3.writeString(output, 3, scanIdText_);
         }
-        if (getPrecursorIndexList().size() > 0) {
+        if (!getPrecursorIndexList().isEmpty()) {
           output.writeUInt32NoTag(34);
           output.writeUInt32NoTag(precursorIndexMemoizedSerializedSize);
         }
@@ -5792,12 +5885,11 @@ public final class ChromatogramGroupDataOuterClass {
         if (obj == this) {
          return true;
         }
-        if (!(obj instanceof org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ResultFileMetaDataProto.SpectrumMetadata)) {
+        if (!(obj instanceof SpectrumMetadata other)) {
           return super.equals(obj);
         }
-        org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ResultFileMetaDataProto.SpectrumMetadata other = (org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ResultFileMetaDataProto.SpectrumMetadata) obj;
 
-        if (java.lang.Double.doubleToLongBits(getRetentionTime())
+          if (java.lang.Double.doubleToLongBits(getRetentionTime())
             != java.lang.Double.doubleToLongBits(
                 other.getRetentionTime())) return false;
         if (!getScanIdPartsList()
@@ -6264,6 +6356,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>repeated int32 scanIdParts = 2;</code>
          * @return A list containing the scanIdParts.
          */
+        @Override
         public java.util.List<java.lang.Integer>
             getScanIdPartsList() {
           scanIdParts_.makeImmutable();
@@ -6273,6 +6366,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>repeated int32 scanIdParts = 2;</code>
          * @return The count of scanIdParts.
          */
+        @Override
         public int getScanIdPartsCount() {
           return scanIdParts_.size();
         }
@@ -6281,6 +6375,7 @@ public final class ChromatogramGroupDataOuterClass {
          * @param index The index of the element to return.
          * @return The scanIdParts at the given index.
          */
+        @Override
         public int getScanIdParts(int index) {
           return scanIdParts_.getInt(index);
         }
@@ -6342,6 +6437,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>string scanIdText = 3;</code>
          * @return The scanIdText.
          */
+        @Override
         public java.lang.String getScanIdText() {
           java.lang.Object ref = scanIdText_;
           if (!(ref instanceof java.lang.String)) {
@@ -6358,6 +6454,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>string scanIdText = 3;</code>
          * @return The bytes for scanIdText.
          */
+        @Override
         public com.google.protobuf.ByteString
             getScanIdTextBytes() {
           java.lang.Object ref = scanIdText_;
@@ -6420,6 +6517,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>repeated int32 precursorIndex = 4;</code>
          * @return A list containing the precursorIndex.
          */
+        @Override
         public java.util.List<java.lang.Integer>
             getPrecursorIndexList() {
           precursorIndex_.makeImmutable();
@@ -6429,6 +6527,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>repeated int32 precursorIndex = 4;</code>
          * @return The count of precursorIndex.
          */
+        @Override
         public int getPrecursorIndexCount() {
           return precursorIndex_.size();
         }
@@ -6437,6 +6536,7 @@ public final class ChromatogramGroupDataOuterClass {
          * @param index The index of the element to return.
          * @return The precursorIndex at the given index.
          */
+        @Override
         public int getPrecursorIndex(int index) {
           return precursorIndex_.getInt(index);
         }
@@ -6615,25 +6715,34 @@ public final class ChromatogramGroupDataOuterClass {
       }
 
       private static final com.google.protobuf.Parser<SpectrumMetadata>
-          PARSER = new com.google.protobuf.AbstractParser<SpectrumMetadata>() {
-        @java.lang.Override
-        public SpectrumMetadata parsePartialFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
-          Builder builder = newBuilder();
-          try {
-            builder.mergeFrom(input, extensionRegistry);
-          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-            throw e.setUnfinishedMessage(builder.buildPartial());
-          } catch (com.google.protobuf.UninitializedMessageException e) {
-            throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
-          } catch (java.io.IOException e) {
-            throw new com.google.protobuf.InvalidProtocolBufferException(e)
-                .setUnfinishedMessage(builder.buildPartial());
+          PARSER = new com.google.protobuf.AbstractParser<>()
+      {
+          @java.lang.Override
+          public SpectrumMetadata parsePartialFrom(
+                  com.google.protobuf.CodedInputStream input,
+                  com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                  throws com.google.protobuf.InvalidProtocolBufferException
+          {
+              Builder builder = newBuilder();
+              try
+              {
+                  builder.mergeFrom(input, extensionRegistry);
+              }
+              catch (com.google.protobuf.InvalidProtocolBufferException e)
+              {
+                  throw e.setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (com.google.protobuf.UninitializedMessageException e)
+              {
+                  throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (java.io.IOException e)
+              {
+                  throw new com.google.protobuf.InvalidProtocolBufferException(e)
+                          .setUnfinishedMessage(builder.buildPartial());
+              }
+              return builder.buildPartial();
           }
-          return builder.buildPartial();
-        }
       };
 
       public static com.google.protobuf.Parser<SpectrumMetadata> parser() {
@@ -6844,12 +6953,11 @@ public final class ChromatogramGroupDataOuterClass {
         if (obj == this) {
          return true;
         }
-        if (!(obj instanceof org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ResultFileMetaDataProto.Precursor)) {
+        if (!(obj instanceof Precursor other)) {
           return super.equals(obj);
         }
-        org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ResultFileMetaDataProto.Precursor other = (org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ResultFileMetaDataProto.Precursor) obj;
 
-        if (java.lang.Double.doubleToLongBits(getTargetMz())
+          if (java.lang.Double.doubleToLongBits(getTargetMz())
             != java.lang.Double.doubleToLongBits(
                 other.getTargetMz())) return false;
         if (java.lang.Double.doubleToLongBits(getIsolationWindowLower())
@@ -7387,25 +7495,34 @@ public final class ChromatogramGroupDataOuterClass {
       }
 
       private static final com.google.protobuf.Parser<Precursor>
-          PARSER = new com.google.protobuf.AbstractParser<Precursor>() {
-        @java.lang.Override
-        public Precursor parsePartialFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
-          Builder builder = newBuilder();
-          try {
-            builder.mergeFrom(input, extensionRegistry);
-          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-            throw e.setUnfinishedMessage(builder.buildPartial());
-          } catch (com.google.protobuf.UninitializedMessageException e) {
-            throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
-          } catch (java.io.IOException e) {
-            throw new com.google.protobuf.InvalidProtocolBufferException(e)
-                .setUnfinishedMessage(builder.buildPartial());
+          PARSER = new com.google.protobuf.AbstractParser<>()
+      {
+          @java.lang.Override
+          public Precursor parsePartialFrom(
+                  com.google.protobuf.CodedInputStream input,
+                  com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                  throws com.google.protobuf.InvalidProtocolBufferException
+          {
+              Builder builder = newBuilder();
+              try
+              {
+                  builder.mergeFrom(input, extensionRegistry);
+              }
+              catch (com.google.protobuf.InvalidProtocolBufferException e)
+              {
+                  throw e.setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (com.google.protobuf.UninitializedMessageException e)
+              {
+                  throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (java.io.IOException e)
+              {
+                  throw new com.google.protobuf.InvalidProtocolBufferException(e)
+                          .setUnfinishedMessage(builder.buildPartial());
+              }
+              return builder.buildPartial();
           }
-          return builder.buildPartial();
-        }
       };
 
       public static com.google.protobuf.Parser<Precursor> parser() {
@@ -7514,6 +7631,7 @@ public final class ChromatogramGroupDataOuterClass {
      * <code>repeated string scanDescriptions = 3;</code>
      * @return A list containing the scanDescriptions.
      */
+    @Override
     public com.google.protobuf.ProtocolStringList
         getScanDescriptionsList() {
       return scanDescriptions_;
@@ -7522,6 +7640,7 @@ public final class ChromatogramGroupDataOuterClass {
      * <code>repeated string scanDescriptions = 3;</code>
      * @return The count of scanDescriptions.
      */
+    @Override
     public int getScanDescriptionsCount() {
       return scanDescriptions_.size();
     }
@@ -7530,6 +7649,7 @@ public final class ChromatogramGroupDataOuterClass {
      * @param index The index of the element to return.
      * @return The scanDescriptions at the given index.
      */
+    @Override
     public java.lang.String getScanDescriptions(int index) {
       return scanDescriptions_.get(index);
     }
@@ -7538,6 +7658,7 @@ public final class ChromatogramGroupDataOuterClass {
      * @param index The index of the value to return.
      * @return The bytes of the scanDescriptions at the given index.
      */
+    @Override
     public com.google.protobuf.ByteString
         getScanDescriptionsBytes(int index) {
       return scanDescriptions_.getByteString(index);
@@ -7551,6 +7672,7 @@ public final class ChromatogramGroupDataOuterClass {
      * <code>repeated string analyzers = 4;</code>
      * @return A list containing the analyzers.
      */
+    @Override
     public com.google.protobuf.ProtocolStringList
         getAnalyzersList() {
       return analyzers_;
@@ -7559,6 +7681,7 @@ public final class ChromatogramGroupDataOuterClass {
      * <code>repeated string analyzers = 4;</code>
      * @return The count of analyzers.
      */
+    @Override
     public int getAnalyzersCount() {
       return analyzers_.size();
     }
@@ -7567,6 +7690,7 @@ public final class ChromatogramGroupDataOuterClass {
      * @param index The index of the element to return.
      * @return The analyzers at the given index.
      */
+    @Override
     public java.lang.String getAnalyzers(int index) {
       return analyzers_.get(index);
     }
@@ -7575,6 +7699,7 @@ public final class ChromatogramGroupDataOuterClass {
      * @param index The index of the value to return.
      * @return The bytes of the analyzers at the given index.
      */
+    @Override
     public com.google.protobuf.ByteString
         getAnalyzersBytes(int index) {
       return analyzers_.getByteString(index);
@@ -7649,12 +7774,11 @@ public final class ChromatogramGroupDataOuterClass {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ResultFileMetaDataProto)) {
+      if (!(obj instanceof ResultFileMetaDataProto other)) {
         return super.equals(obj);
       }
-      org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ResultFileMetaDataProto other = (org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ResultFileMetaDataProto) obj;
 
-      if (!getSpectraList()
+        if (!getSpectraList()
           .equals(other.getSpectraList())) return false;
       if (!getPrecursorsList()
           .equals(other.getPrecursorsList())) return false;
@@ -8104,7 +8228,7 @@ public final class ChromatogramGroupDataOuterClass {
         java.util.Collections.emptyList();
       private void ensureSpectraIsMutable() {
         if (!((bitField0_ & 0x00000001) != 0)) {
-          spectra_ = new java.util.ArrayList<org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ResultFileMetaDataProto.SpectrumMetadata>(spectra_);
+          spectra_ = new java.util.ArrayList<>(spectra_);
           bitField0_ |= 0x00000001;
          }
       }
@@ -8115,6 +8239,7 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ResultFileMetaDataProto.SpectrumMetadata spectra = 1;</code>
        */
+      @Override
       public java.util.List<org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ResultFileMetaDataProto.SpectrumMetadata> getSpectraList() {
         if (spectraBuilder_ == null) {
           return java.util.Collections.unmodifiableList(spectra_);
@@ -8125,6 +8250,7 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ResultFileMetaDataProto.SpectrumMetadata spectra = 1;</code>
        */
+      @Override
       public int getSpectraCount() {
         if (spectraBuilder_ == null) {
           return spectra_.size();
@@ -8135,6 +8261,7 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ResultFileMetaDataProto.SpectrumMetadata spectra = 1;</code>
        */
+      @Override
       public org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ResultFileMetaDataProto.SpectrumMetadata getSpectra(int index) {
         if (spectraBuilder_ == null) {
           return spectra_.get(index);
@@ -8285,6 +8412,7 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ResultFileMetaDataProto.SpectrumMetadata spectra = 1;</code>
        */
+      @Override
       public org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ResultFileMetaDataProto.SpectrumMetadataOrBuilder getSpectraOrBuilder(
           int index) {
         if (spectraBuilder_ == null) {
@@ -8295,7 +8423,8 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ResultFileMetaDataProto.SpectrumMetadata spectra = 1;</code>
        */
-      public java.util.List<? extends org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ResultFileMetaDataProto.SpectrumMetadataOrBuilder> 
+      @Override
+      public java.util.List<? extends org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ResultFileMetaDataProto.SpectrumMetadataOrBuilder>
            getSpectraOrBuilderList() {
         if (spectraBuilder_ != null) {
           return spectraBuilder_.getMessageOrBuilderList();
@@ -8329,8 +8458,7 @@ public final class ChromatogramGroupDataOuterClass {
           org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ResultFileMetaDataProto.SpectrumMetadata, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ResultFileMetaDataProto.SpectrumMetadata.Builder, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ResultFileMetaDataProto.SpectrumMetadataOrBuilder> 
           getSpectraFieldBuilder() {
         if (spectraBuilder_ == null) {
-          spectraBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ResultFileMetaDataProto.SpectrumMetadata, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ResultFileMetaDataProto.SpectrumMetadata.Builder, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ResultFileMetaDataProto.SpectrumMetadataOrBuilder>(
+          spectraBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<>(
                   spectra_,
                   ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),
@@ -8344,7 +8472,7 @@ public final class ChromatogramGroupDataOuterClass {
         java.util.Collections.emptyList();
       private void ensurePrecursorsIsMutable() {
         if (!((bitField0_ & 0x00000002) != 0)) {
-          precursors_ = new java.util.ArrayList<org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ResultFileMetaDataProto.Precursor>(precursors_);
+          precursors_ = new java.util.ArrayList<>(precursors_);
           bitField0_ |= 0x00000002;
          }
       }
@@ -8355,6 +8483,7 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ResultFileMetaDataProto.Precursor precursors = 2;</code>
        */
+      @Override
       public java.util.List<org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ResultFileMetaDataProto.Precursor> getPrecursorsList() {
         if (precursorsBuilder_ == null) {
           return java.util.Collections.unmodifiableList(precursors_);
@@ -8365,6 +8494,7 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ResultFileMetaDataProto.Precursor precursors = 2;</code>
        */
+      @Override
       public int getPrecursorsCount() {
         if (precursorsBuilder_ == null) {
           return precursors_.size();
@@ -8375,6 +8505,7 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ResultFileMetaDataProto.Precursor precursors = 2;</code>
        */
+      @Override
       public org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ResultFileMetaDataProto.Precursor getPrecursors(int index) {
         if (precursorsBuilder_ == null) {
           return precursors_.get(index);
@@ -8525,6 +8656,7 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ResultFileMetaDataProto.Precursor precursors = 2;</code>
        */
+      @Override
       public org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ResultFileMetaDataProto.PrecursorOrBuilder getPrecursorsOrBuilder(
           int index) {
         if (precursorsBuilder_ == null) {
@@ -8535,7 +8667,8 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ResultFileMetaDataProto.Precursor precursors = 2;</code>
        */
-      public java.util.List<? extends org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ResultFileMetaDataProto.PrecursorOrBuilder> 
+      @Override
+      public java.util.List<? extends org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ResultFileMetaDataProto.PrecursorOrBuilder>
            getPrecursorsOrBuilderList() {
         if (precursorsBuilder_ != null) {
           return precursorsBuilder_.getMessageOrBuilderList();
@@ -8569,8 +8702,7 @@ public final class ChromatogramGroupDataOuterClass {
           org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ResultFileMetaDataProto.Precursor, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ResultFileMetaDataProto.Precursor.Builder, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ResultFileMetaDataProto.PrecursorOrBuilder> 
           getPrecursorsFieldBuilder() {
         if (precursorsBuilder_ == null) {
-          precursorsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ResultFileMetaDataProto.Precursor, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ResultFileMetaDataProto.Precursor.Builder, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ResultFileMetaDataProto.PrecursorOrBuilder>(
+          precursorsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<>(
                   precursors_,
                   ((bitField0_ & 0x00000002) != 0),
                   getParentForChildren(),
@@ -8592,6 +8724,7 @@ public final class ChromatogramGroupDataOuterClass {
        * <code>repeated string scanDescriptions = 3;</code>
        * @return A list containing the scanDescriptions.
        */
+      @Override
       public com.google.protobuf.ProtocolStringList
           getScanDescriptionsList() {
         scanDescriptions_.makeImmutable();
@@ -8601,6 +8734,7 @@ public final class ChromatogramGroupDataOuterClass {
        * <code>repeated string scanDescriptions = 3;</code>
        * @return The count of scanDescriptions.
        */
+      @Override
       public int getScanDescriptionsCount() {
         return scanDescriptions_.size();
       }
@@ -8609,6 +8743,7 @@ public final class ChromatogramGroupDataOuterClass {
        * @param index The index of the element to return.
        * @return The scanDescriptions at the given index.
        */
+      @Override
       public java.lang.String getScanDescriptions(int index) {
         return scanDescriptions_.get(index);
       }
@@ -8617,6 +8752,7 @@ public final class ChromatogramGroupDataOuterClass {
        * @param index The index of the value to return.
        * @return The bytes of the scanDescriptions at the given index.
        */
+      @Override
       public com.google.protobuf.ByteString
           getScanDescriptionsBytes(int index) {
         return scanDescriptions_.getByteString(index);
@@ -8671,8 +8807,8 @@ public final class ChromatogramGroupDataOuterClass {
       public Builder clearScanDescriptions() {
         scanDescriptions_ =
           com.google.protobuf.LazyStringArrayList.emptyList();
-        bitField0_ = (bitField0_ & ~0x00000004);;
-        onChanged();
+        bitField0_ = (bitField0_ & ~0x00000004);
+          onChanged();
         return this;
       }
       /**
@@ -8703,6 +8839,7 @@ public final class ChromatogramGroupDataOuterClass {
        * <code>repeated string analyzers = 4;</code>
        * @return A list containing the analyzers.
        */
+      @Override
       public com.google.protobuf.ProtocolStringList
           getAnalyzersList() {
         analyzers_.makeImmutable();
@@ -8712,6 +8849,7 @@ public final class ChromatogramGroupDataOuterClass {
        * <code>repeated string analyzers = 4;</code>
        * @return The count of analyzers.
        */
+      @Override
       public int getAnalyzersCount() {
         return analyzers_.size();
       }
@@ -8720,6 +8858,7 @@ public final class ChromatogramGroupDataOuterClass {
        * @param index The index of the element to return.
        * @return The analyzers at the given index.
        */
+      @Override
       public java.lang.String getAnalyzers(int index) {
         return analyzers_.get(index);
       }
@@ -8728,6 +8867,7 @@ public final class ChromatogramGroupDataOuterClass {
        * @param index The index of the value to return.
        * @return The bytes of the analyzers at the given index.
        */
+      @Override
       public com.google.protobuf.ByteString
           getAnalyzersBytes(int index) {
         return analyzers_.getByteString(index);
@@ -8782,8 +8922,8 @@ public final class ChromatogramGroupDataOuterClass {
       public Builder clearAnalyzers() {
         analyzers_ =
           com.google.protobuf.LazyStringArrayList.emptyList();
-        bitField0_ = (bitField0_ & ~0x00000008);;
-        onChanged();
+        bitField0_ = (bitField0_ & ~0x00000008);
+          onChanged();
         return this;
       }
       /**
@@ -8828,25 +8968,34 @@ public final class ChromatogramGroupDataOuterClass {
     }
 
     private static final com.google.protobuf.Parser<ResultFileMetaDataProto>
-        PARSER = new com.google.protobuf.AbstractParser<ResultFileMetaDataProto>() {
-      @java.lang.Override
-      public ResultFileMetaDataProto parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        Builder builder = newBuilder();
-        try {
-          builder.mergeFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          throw e.setUnfinishedMessage(builder.buildPartial());
-        } catch (com.google.protobuf.UninitializedMessageException e) {
-          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
-        } catch (java.io.IOException e) {
-          throw new com.google.protobuf.InvalidProtocolBufferException(e)
-              .setUnfinishedMessage(builder.buildPartial());
+        PARSER = new com.google.protobuf.AbstractParser<>()
+    {
+        @java.lang.Override
+        public ResultFileMetaDataProto parsePartialFrom(
+                com.google.protobuf.CodedInputStream input,
+                com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                throws com.google.protobuf.InvalidProtocolBufferException
+        {
+            Builder builder = newBuilder();
+            try
+            {
+                builder.mergeFrom(input, extensionRegistry);
+            }
+            catch (com.google.protobuf.InvalidProtocolBufferException e)
+            {
+                throw e.setUnfinishedMessage(builder.buildPartial());
+            }
+            catch (com.google.protobuf.UninitializedMessageException e)
+            {
+                throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+            }
+            catch (java.io.IOException e)
+            {
+                throw new com.google.protobuf.InvalidProtocolBufferException(e)
+                        .setUnfinishedMessage(builder.buildPartial());
+            }
+            return builder.buildPartial();
         }
-        return builder.buildPartial();
-      }
     };
 
     public static com.google.protobuf.Parser<ResultFileMetaDataProto> parser() {
@@ -9093,6 +9242,7 @@ public final class ChromatogramGroupDataOuterClass {
       public static final int FILTER_OP_NOT_STARTS_WITH_VALUE = 12;
 
 
+      @Override
       public final int getNumber() {
         if (this == UNRECOGNIZED) {
           throw new java.lang.IllegalArgumentException(
@@ -9140,12 +9290,16 @@ public final class ChromatogramGroupDataOuterClass {
       }
       private static final com.google.protobuf.Internal.EnumLiteMap<
           FilterOperation> internalValueMap =
-            new com.google.protobuf.Internal.EnumLiteMap<FilterOperation>() {
-              public FilterOperation findValueByNumber(int number) {
-                return FilterOperation.forNumber(number);
-              }
-            };
+              new com.google.protobuf.Internal.EnumLiteMap<>()
+              {
+                  @Override
+                  public FilterOperation findValueByNumber(int number)
+                  {
+                      return FilterOperation.forNumber(number);
+                  }
+              };
 
+      @Override
       public final com.google.protobuf.Descriptors.EnumValueDescriptor
           getValueDescriptor() {
         if (this == UNRECOGNIZED) {
@@ -9154,6 +9308,7 @@ public final class ChromatogramGroupDataOuterClass {
         }
         return getDescriptor().getValues().get(ordinal());
       }
+      @Override
       public final com.google.protobuf.Descriptors.EnumDescriptor
           getDescriptorForType() {
         return getDescriptor();
@@ -9179,7 +9334,7 @@ public final class ChromatogramGroupDataOuterClass {
 
       private final int value;
 
-      private FilterOperation(int value) {
+      FilterOperation(int value) {
         this.value = value;
       }
 
@@ -9340,12 +9495,11 @@ public final class ChromatogramGroupDataOuterClass {
         if (obj == this) {
          return true;
         }
-        if (!(obj instanceof org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.AccessionNumber)) {
+        if (!(obj instanceof AccessionNumber other)) {
           return super.equals(obj);
         }
-        org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.AccessionNumber other = (org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.AccessionNumber) obj;
 
-        if (getTypeName()
+          if (getTypeName()
             != other.getTypeName()) return false;
         if (!getValue()
             .equals(other.getValue())) return false;
@@ -9680,6 +9834,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>string value = 2;</code>
          * @return The value.
          */
+        @Override
         public java.lang.String getValue() {
           java.lang.Object ref = value_;
           if (!(ref instanceof java.lang.String)) {
@@ -9696,6 +9851,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>string value = 2;</code>
          * @return The bytes for value.
          */
+        @Override
         public com.google.protobuf.ByteString
             getValueBytes() {
           java.lang.Object ref = value_;
@@ -9773,25 +9929,34 @@ public final class ChromatogramGroupDataOuterClass {
       }
 
       private static final com.google.protobuf.Parser<AccessionNumber>
-          PARSER = new com.google.protobuf.AbstractParser<AccessionNumber>() {
-        @java.lang.Override
-        public AccessionNumber parsePartialFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
-          Builder builder = newBuilder();
-          try {
-            builder.mergeFrom(input, extensionRegistry);
-          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-            throw e.setUnfinishedMessage(builder.buildPartial());
-          } catch (com.google.protobuf.UninitializedMessageException e) {
-            throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
-          } catch (java.io.IOException e) {
-            throw new com.google.protobuf.InvalidProtocolBufferException(e)
-                .setUnfinishedMessage(builder.buildPartial());
+          PARSER = new com.google.protobuf.AbstractParser<>()
+      {
+          @java.lang.Override
+          public AccessionNumber parsePartialFrom(
+                  com.google.protobuf.CodedInputStream input,
+                  com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                  throws com.google.protobuf.InvalidProtocolBufferException
+          {
+              Builder builder = newBuilder();
+              try
+              {
+                  builder.mergeFrom(input, extensionRegistry);
+              }
+              catch (com.google.protobuf.InvalidProtocolBufferException e)
+              {
+                  throw e.setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (com.google.protobuf.UninitializedMessageException e)
+              {
+                  throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (java.io.IOException e)
+              {
+                  throw new com.google.protobuf.InvalidProtocolBufferException(e)
+                          .setUnfinishedMessage(builder.buildPartial());
+              }
+              return builder.buildPartial();
           }
-          return builder.buildPartial();
-        }
       };
 
       public static com.google.protobuf.Parser<AccessionNumber> parser() {
@@ -10452,12 +10617,11 @@ public final class ChromatogramGroupDataOuterClass {
         if (obj == this) {
          return true;
         }
-        if (!(obj instanceof org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.Target)) {
+        if (!(obj instanceof Target other)) {
           return super.equals(obj);
         }
-        org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.Target other = (org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.Target) obj;
 
-        if (!getModifiedPeptideSequence()
+          if (!getModifiedPeptideSequence()
             .equals(other.getModifiedPeptideSequence())) return false;
         if (!getFormula()
             .equals(other.getFormula())) return false;
@@ -10924,6 +11088,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>string modifiedPeptideSequence = 1;</code>
          * @return The modifiedPeptideSequence.
          */
+        @Override
         public java.lang.String getModifiedPeptideSequence() {
           java.lang.Object ref = modifiedPeptideSequence_;
           if (!(ref instanceof java.lang.String)) {
@@ -10940,6 +11105,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>string modifiedPeptideSequence = 1;</code>
          * @return The bytes for modifiedPeptideSequence.
          */
+        @Override
         public com.google.protobuf.ByteString
             getModifiedPeptideSequenceBytes() {
           java.lang.Object ref = modifiedPeptideSequence_;
@@ -10996,6 +11162,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>string formula = 2;</code>
          * @return The formula.
          */
+        @Override
         public java.lang.String getFormula() {
           java.lang.Object ref = formula_;
           if (!(ref instanceof java.lang.String)) {
@@ -11012,6 +11179,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>string formula = 2;</code>
          * @return The bytes for formula.
          */
+        @Override
         public com.google.protobuf.ByteString
             getFormulaBytes() {
           java.lang.Object ref = formula_;
@@ -11068,6 +11236,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>string name = 3;</code>
          * @return The name.
          */
+        @Override
         public java.lang.String getName() {
           java.lang.Object ref = name_;
           if (!(ref instanceof java.lang.String)) {
@@ -11084,6 +11253,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>string name = 3;</code>
          * @return The bytes for name.
          */
+        @Override
         public com.google.protobuf.ByteString
             getNameBytes() {
           java.lang.Object ref = name_;
@@ -11204,6 +11374,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>string inChiKey = 6;</code>
          * @return The inChiKey.
          */
+        @Override
         public java.lang.String getInChiKey() {
           java.lang.Object ref = inChiKey_;
           if (!(ref instanceof java.lang.String)) {
@@ -11220,6 +11391,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>string inChiKey = 6;</code>
          * @return The bytes for inChiKey.
          */
+        @Override
         public com.google.protobuf.ByteString
             getInChiKeyBytes() {
           java.lang.Object ref = inChiKey_;
@@ -11276,6 +11448,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>string cas = 7;</code>
          * @return The cas.
          */
+        @Override
         public java.lang.String getCas() {
           java.lang.Object ref = cas_;
           if (!(ref instanceof java.lang.String)) {
@@ -11292,6 +11465,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>string cas = 7;</code>
          * @return The bytes for cas.
          */
+        @Override
         public com.google.protobuf.ByteString
             getCasBytes() {
           java.lang.Object ref = cas_;
@@ -11348,6 +11522,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>string hmdb = 8;</code>
          * @return The hmdb.
          */
+        @Override
         public java.lang.String getHmdb() {
           java.lang.Object ref = hmdb_;
           if (!(ref instanceof java.lang.String)) {
@@ -11364,6 +11539,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>string hmdb = 8;</code>
          * @return The bytes for hmdb.
          */
+        @Override
         public com.google.protobuf.ByteString
             getHmdbBytes() {
           java.lang.Object ref = hmdb_;
@@ -11420,6 +11596,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>string inChi = 9;</code>
          * @return The inChi.
          */
+        @Override
         public java.lang.String getInChi() {
           java.lang.Object ref = inChi_;
           if (!(ref instanceof java.lang.String)) {
@@ -11436,6 +11613,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>string inChi = 9;</code>
          * @return The bytes for inChi.
          */
+        @Override
         public com.google.protobuf.ByteString
             getInChiBytes() {
           java.lang.Object ref = inChi_;
@@ -11492,6 +11670,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>string smiles = 10;</code>
          * @return The smiles.
          */
+        @Override
         public java.lang.String getSmiles() {
           java.lang.Object ref = smiles_;
           if (!(ref instanceof java.lang.String)) {
@@ -11508,6 +11687,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>string smiles = 10;</code>
          * @return The bytes for smiles.
          */
+        @Override
         public com.google.protobuf.ByteString
             getSmilesBytes() {
           java.lang.Object ref = smiles_;
@@ -11564,6 +11744,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>string kegg = 11;</code>
          * @return The kegg.
          */
+        @Override
         public java.lang.String getKegg() {
           java.lang.Object ref = kegg_;
           if (!(ref instanceof java.lang.String)) {
@@ -11580,6 +11761,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>string kegg = 11;</code>
          * @return The bytes for kegg.
          */
+        @Override
         public com.google.protobuf.ByteString
             getKeggBytes() {
           java.lang.Object ref = kegg_;
@@ -11657,25 +11839,34 @@ public final class ChromatogramGroupDataOuterClass {
       }
 
       private static final com.google.protobuf.Parser<Target>
-          PARSER = new com.google.protobuf.AbstractParser<Target>() {
-        @java.lang.Override
-        public Target parsePartialFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
-          Builder builder = newBuilder();
-          try {
-            builder.mergeFrom(input, extensionRegistry);
-          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-            throw e.setUnfinishedMessage(builder.buildPartial());
-          } catch (com.google.protobuf.UninitializedMessageException e) {
-            throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
-          } catch (java.io.IOException e) {
-            throw new com.google.protobuf.InvalidProtocolBufferException(e)
-                .setUnfinishedMessage(builder.buildPartial());
+          PARSER = new com.google.protobuf.AbstractParser<>()
+      {
+          @java.lang.Override
+          public Target parsePartialFrom(
+                  com.google.protobuf.CodedInputStream input,
+                  com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                  throws com.google.protobuf.InvalidProtocolBufferException
+          {
+              Builder builder = newBuilder();
+              try
+              {
+                  builder.mergeFrom(input, extensionRegistry);
+              }
+              catch (com.google.protobuf.InvalidProtocolBufferException e)
+              {
+                  throw e.setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (com.google.protobuf.UninitializedMessageException e)
+              {
+                  throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (java.io.IOException e)
+              {
+                  throw new com.google.protobuf.InvalidProtocolBufferException(e)
+                          .setUnfinishedMessage(builder.buildPartial());
+              }
+              return builder.buildPartial();
           }
-          return builder.buildPartial();
-        }
       };
 
       public static com.google.protobuf.Parser<Target> parser() {
@@ -11826,6 +12017,7 @@ public final class ChromatogramGroupDataOuterClass {
        * <code>repeated int32 filterIndexes = 2;</code>
        * @return The count of filterIndexes.
        */
+      @Override
       public int getFilterIndexesCount() {
         return filterIndexes_.size();
       }
@@ -11838,6 +12030,7 @@ public final class ChromatogramGroupDataOuterClass {
        * @param index The index of the element to return.
        * @return The filterIndexes at the given index.
        */
+      @Override
       public int getFilterIndexes(int index) {
         return filterIndexes_.getInt(index);
       }
@@ -11900,7 +12093,7 @@ public final class ChromatogramGroupDataOuterClass {
         if (targetIndex_ != 0) {
           output.writeInt32(1, targetIndex_);
         }
-        if (getFilterIndexesList().size() > 0) {
+        if (!getFilterIndexesList().isEmpty()) {
           output.writeUInt32NoTag(18);
           output.writeUInt32NoTag(filterIndexesMemoizedSerializedSize);
         }
@@ -11950,12 +12143,11 @@ public final class ChromatogramGroupDataOuterClass {
         if (obj == this) {
          return true;
         }
-        if (!(obj instanceof org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.ChromatogramGroupId)) {
+        if (!(obj instanceof ChromatogramGroupId other)) {
           return super.equals(obj);
         }
-        org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.ChromatogramGroupId other = (org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.ChromatogramGroupId) obj;
 
-        if (getTargetIndex()
+          if (getTargetIndex()
             != other.getTargetIndex()) return false;
         if (!getFilterIndexesList()
             .equals(other.getFilterIndexesList())) return false;
@@ -12350,6 +12542,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>repeated int32 filterIndexes = 2;</code>
          * @return A list containing the filterIndexes.
          */
+        @Override
         public java.util.List<java.lang.Integer>
             getFilterIndexesList() {
           filterIndexes_.makeImmutable();
@@ -12363,6 +12556,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>repeated int32 filterIndexes = 2;</code>
          * @return The count of filterIndexes.
          */
+        @Override
         public int getFilterIndexesCount() {
           return filterIndexes_.size();
         }
@@ -12375,6 +12569,7 @@ public final class ChromatogramGroupDataOuterClass {
          * @param index The index of the element to return.
          * @return The filterIndexes at the given index.
          */
+        @Override
         public int getFilterIndexes(int index) {
           return filterIndexes_.getInt(index);
         }
@@ -12452,6 +12647,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>string qcTraceName = 3;</code>
          * @return The qcTraceName.
          */
+        @Override
         public java.lang.String getQcTraceName() {
           java.lang.Object ref = qcTraceName_;
           if (!(ref instanceof java.lang.String)) {
@@ -12468,6 +12664,7 @@ public final class ChromatogramGroupDataOuterClass {
          * <code>string qcTraceName = 3;</code>
          * @return The bytes for qcTraceName.
          */
+        @Override
         public com.google.protobuf.ByteString
             getQcTraceNameBytes() {
           java.lang.Object ref = qcTraceName_;
@@ -12545,25 +12742,34 @@ public final class ChromatogramGroupDataOuterClass {
       }
 
       private static final com.google.protobuf.Parser<ChromatogramGroupId>
-          PARSER = new com.google.protobuf.AbstractParser<ChromatogramGroupId>() {
-        @java.lang.Override
-        public ChromatogramGroupId parsePartialFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
-          Builder builder = newBuilder();
-          try {
-            builder.mergeFrom(input, extensionRegistry);
-          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-            throw e.setUnfinishedMessage(builder.buildPartial());
-          } catch (com.google.protobuf.UninitializedMessageException e) {
-            throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
-          } catch (java.io.IOException e) {
-            throw new com.google.protobuf.InvalidProtocolBufferException(e)
-                .setUnfinishedMessage(builder.buildPartial());
+          PARSER = new com.google.protobuf.AbstractParser<>()
+      {
+          @java.lang.Override
+          public ChromatogramGroupId parsePartialFrom(
+                  com.google.protobuf.CodedInputStream input,
+                  com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                  throws com.google.protobuf.InvalidProtocolBufferException
+          {
+              Builder builder = newBuilder();
+              try
+              {
+                  builder.mergeFrom(input, extensionRegistry);
+              }
+              catch (com.google.protobuf.InvalidProtocolBufferException e)
+              {
+                  throw e.setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (com.google.protobuf.UninitializedMessageException e)
+              {
+                  throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (java.io.IOException e)
+              {
+                  throw new com.google.protobuf.InvalidProtocolBufferException(e)
+                          .setUnfinishedMessage(builder.buildPartial());
+              }
+              return builder.buildPartial();
           }
-          return builder.buildPartial();
-        }
       };
 
       public static com.google.protobuf.Parser<ChromatogramGroupId> parser() {
@@ -12871,12 +13077,11 @@ public final class ChromatogramGroupDataOuterClass {
           if (obj == this) {
            return true;
           }
-          if (!(obj instanceof org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.SpectrumFilter.Predicate)) {
+          if (!(obj instanceof Predicate other)) {
             return super.equals(obj);
           }
-          org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.SpectrumFilter.Predicate other = (org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.SpectrumFilter.Predicate) obj;
 
-          if (!getPropertyPath()
+            if (!getPropertyPath()
               .equals(other.getPropertyPath())) return false;
           if (operation_ != other.operation_) return false;
           if (!getOperand()
@@ -13196,6 +13401,7 @@ public final class ChromatogramGroupDataOuterClass {
            * <code>string propertyPath = 1;</code>
            * @return The propertyPath.
            */
+          @Override
           public java.lang.String getPropertyPath() {
             java.lang.Object ref = propertyPath_;
             if (!(ref instanceof java.lang.String)) {
@@ -13212,6 +13418,7 @@ public final class ChromatogramGroupDataOuterClass {
            * <code>string propertyPath = 1;</code>
            * @return The bytes for propertyPath.
            */
+          @Override
           public com.google.protobuf.ByteString
               getPropertyPathBytes() {
             java.lang.Object ref = propertyPath_;
@@ -13321,6 +13528,7 @@ public final class ChromatogramGroupDataOuterClass {
            * <code>string operand = 3;</code>
            * @return The operand.
            */
+          @Override
           public java.lang.String getOperand() {
             java.lang.Object ref = operand_;
             if (!(ref instanceof java.lang.String)) {
@@ -13337,6 +13545,7 @@ public final class ChromatogramGroupDataOuterClass {
            * <code>string operand = 3;</code>
            * @return The bytes for operand.
            */
+          @Override
           public com.google.protobuf.ByteString
               getOperandBytes() {
             java.lang.Object ref = operand_;
@@ -13414,25 +13623,34 @@ public final class ChromatogramGroupDataOuterClass {
         }
 
         private static final com.google.protobuf.Parser<Predicate>
-            PARSER = new com.google.protobuf.AbstractParser<Predicate>() {
-          @java.lang.Override
-          public Predicate parsePartialFrom(
-              com.google.protobuf.CodedInputStream input,
-              com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-              throws com.google.protobuf.InvalidProtocolBufferException {
-            Builder builder = newBuilder();
-            try {
-              builder.mergeFrom(input, extensionRegistry);
-            } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-              throw e.setUnfinishedMessage(builder.buildPartial());
-            } catch (com.google.protobuf.UninitializedMessageException e) {
-              throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
-            } catch (java.io.IOException e) {
-              throw new com.google.protobuf.InvalidProtocolBufferException(e)
-                  .setUnfinishedMessage(builder.buildPartial());
+            PARSER = new com.google.protobuf.AbstractParser<>()
+        {
+            @java.lang.Override
+            public Predicate parsePartialFrom(
+                    com.google.protobuf.CodedInputStream input,
+                    com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                    throws com.google.protobuf.InvalidProtocolBufferException
+            {
+                Builder builder = newBuilder();
+                try
+                {
+                    builder.mergeFrom(input, extensionRegistry);
+                }
+                catch (com.google.protobuf.InvalidProtocolBufferException e)
+                {
+                    throw e.setUnfinishedMessage(builder.buildPartial());
+                }
+                catch (com.google.protobuf.UninitializedMessageException e)
+                {
+                    throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+                }
+                catch (java.io.IOException e)
+                {
+                    throw new com.google.protobuf.InvalidProtocolBufferException(e)
+                            .setUnfinishedMessage(builder.buildPartial());
+                }
+                return builder.buildPartial();
             }
-            return builder.buildPartial();
-          }
         };
 
         public static com.google.protobuf.Parser<Predicate> parser() {
@@ -13532,12 +13750,11 @@ public final class ChromatogramGroupDataOuterClass {
         if (obj == this) {
          return true;
         }
-        if (!(obj instanceof org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.SpectrumFilter)) {
+        if (!(obj instanceof SpectrumFilter other)) {
           return super.equals(obj);
         }
-        org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.SpectrumFilter other = (org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.SpectrumFilter) obj;
 
-        if (!getPredicatesList()
+          if (!getPredicatesList()
             .equals(other.getPredicatesList())) return false;
         if (!getUnknownFields().equals(other.getUnknownFields())) return false;
         return true;
@@ -13870,7 +14087,7 @@ public final class ChromatogramGroupDataOuterClass {
           java.util.Collections.emptyList();
         private void ensurePredicatesIsMutable() {
           if (!((bitField0_ & 0x00000001) != 0)) {
-            predicates_ = new java.util.ArrayList<org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.SpectrumFilter.Predicate>(predicates_);
+            predicates_ = new java.util.ArrayList<>(predicates_);
             bitField0_ |= 0x00000001;
            }
         }
@@ -13881,6 +14098,7 @@ public final class ChromatogramGroupDataOuterClass {
         /**
          * <code>repeated .ChromatogramGroupIdsProto.SpectrumFilter.Predicate predicates = 1;</code>
          */
+        @Override
         public java.util.List<org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.SpectrumFilter.Predicate> getPredicatesList() {
           if (predicatesBuilder_ == null) {
             return java.util.Collections.unmodifiableList(predicates_);
@@ -13891,6 +14109,7 @@ public final class ChromatogramGroupDataOuterClass {
         /**
          * <code>repeated .ChromatogramGroupIdsProto.SpectrumFilter.Predicate predicates = 1;</code>
          */
+        @Override
         public int getPredicatesCount() {
           if (predicatesBuilder_ == null) {
             return predicates_.size();
@@ -13901,6 +14120,7 @@ public final class ChromatogramGroupDataOuterClass {
         /**
          * <code>repeated .ChromatogramGroupIdsProto.SpectrumFilter.Predicate predicates = 1;</code>
          */
+        @Override
         public org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.SpectrumFilter.Predicate getPredicates(int index) {
           if (predicatesBuilder_ == null) {
             return predicates_.get(index);
@@ -14051,6 +14271,7 @@ public final class ChromatogramGroupDataOuterClass {
         /**
          * <code>repeated .ChromatogramGroupIdsProto.SpectrumFilter.Predicate predicates = 1;</code>
          */
+        @Override
         public org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.SpectrumFilter.PredicateOrBuilder getPredicatesOrBuilder(
             int index) {
           if (predicatesBuilder_ == null) {
@@ -14061,7 +14282,8 @@ public final class ChromatogramGroupDataOuterClass {
         /**
          * <code>repeated .ChromatogramGroupIdsProto.SpectrumFilter.Predicate predicates = 1;</code>
          */
-        public java.util.List<? extends org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.SpectrumFilter.PredicateOrBuilder> 
+        @Override
+        public java.util.List<? extends org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.SpectrumFilter.PredicateOrBuilder>
              getPredicatesOrBuilderList() {
           if (predicatesBuilder_ != null) {
             return predicatesBuilder_.getMessageOrBuilderList();
@@ -14095,8 +14317,7 @@ public final class ChromatogramGroupDataOuterClass {
             org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.SpectrumFilter.Predicate, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.SpectrumFilter.Predicate.Builder, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.SpectrumFilter.PredicateOrBuilder> 
             getPredicatesFieldBuilder() {
           if (predicatesBuilder_ == null) {
-            predicatesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-                org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.SpectrumFilter.Predicate, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.SpectrumFilter.Predicate.Builder, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.SpectrumFilter.PredicateOrBuilder>(
+            predicatesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<>(
                     predicates_,
                     ((bitField0_ & 0x00000001) != 0),
                     getParentForChildren(),
@@ -14132,25 +14353,34 @@ public final class ChromatogramGroupDataOuterClass {
       }
 
       private static final com.google.protobuf.Parser<SpectrumFilter>
-          PARSER = new com.google.protobuf.AbstractParser<SpectrumFilter>() {
-        @java.lang.Override
-        public SpectrumFilter parsePartialFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
-          Builder builder = newBuilder();
-          try {
-            builder.mergeFrom(input, extensionRegistry);
-          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-            throw e.setUnfinishedMessage(builder.buildPartial());
-          } catch (com.google.protobuf.UninitializedMessageException e) {
-            throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
-          } catch (java.io.IOException e) {
-            throw new com.google.protobuf.InvalidProtocolBufferException(e)
-                .setUnfinishedMessage(builder.buildPartial());
+          PARSER = new com.google.protobuf.AbstractParser<>()
+      {
+          @java.lang.Override
+          public SpectrumFilter parsePartialFrom(
+                  com.google.protobuf.CodedInputStream input,
+                  com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                  throws com.google.protobuf.InvalidProtocolBufferException
+          {
+              Builder builder = newBuilder();
+              try
+              {
+                  builder.mergeFrom(input, extensionRegistry);
+              }
+              catch (com.google.protobuf.InvalidProtocolBufferException e)
+              {
+                  throw e.setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (com.google.protobuf.UninitializedMessageException e)
+              {
+                  throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (java.io.IOException e)
+              {
+                  throw new com.google.protobuf.InvalidProtocolBufferException(e)
+                          .setUnfinishedMessage(builder.buildPartial());
+              }
+              return builder.buildPartial();
           }
-          return builder.buildPartial();
-        }
       };
 
       public static com.google.protobuf.Parser<SpectrumFilter> parser() {
@@ -14346,12 +14576,11 @@ public final class ChromatogramGroupDataOuterClass {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto)) {
+      if (!(obj instanceof ChromatogramGroupIdsProto other)) {
         return super.equals(obj);
       }
-      org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto other = (org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto) obj;
 
-      if (!getTargetsList()
+        if (!getTargetsList()
           .equals(other.getTargetsList())) return false;
       if (!getFiltersList()
           .equals(other.getFiltersList())) return false;
@@ -14806,7 +15035,7 @@ public final class ChromatogramGroupDataOuterClass {
         java.util.Collections.emptyList();
       private void ensureTargetsIsMutable() {
         if (!((bitField0_ & 0x00000001) != 0)) {
-          targets_ = new java.util.ArrayList<org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.Target>(targets_);
+          targets_ = new java.util.ArrayList<>(targets_);
           bitField0_ |= 0x00000001;
          }
       }
@@ -14817,6 +15046,7 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ChromatogramGroupIdsProto.Target targets = 1;</code>
        */
+      @Override
       public java.util.List<org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.Target> getTargetsList() {
         if (targetsBuilder_ == null) {
           return java.util.Collections.unmodifiableList(targets_);
@@ -14827,6 +15057,7 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ChromatogramGroupIdsProto.Target targets = 1;</code>
        */
+      @Override
       public int getTargetsCount() {
         if (targetsBuilder_ == null) {
           return targets_.size();
@@ -14837,6 +15068,7 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ChromatogramGroupIdsProto.Target targets = 1;</code>
        */
+      @Override
       public org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.Target getTargets(int index) {
         if (targetsBuilder_ == null) {
           return targets_.get(index);
@@ -14987,6 +15219,7 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ChromatogramGroupIdsProto.Target targets = 1;</code>
        */
+      @Override
       public org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.TargetOrBuilder getTargetsOrBuilder(
           int index) {
         if (targetsBuilder_ == null) {
@@ -14997,7 +15230,8 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ChromatogramGroupIdsProto.Target targets = 1;</code>
        */
-      public java.util.List<? extends org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.TargetOrBuilder> 
+      @Override
+      public java.util.List<? extends org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.TargetOrBuilder>
            getTargetsOrBuilderList() {
         if (targetsBuilder_ != null) {
           return targetsBuilder_.getMessageOrBuilderList();
@@ -15031,8 +15265,7 @@ public final class ChromatogramGroupDataOuterClass {
           org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.Target, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.Target.Builder, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.TargetOrBuilder> 
           getTargetsFieldBuilder() {
         if (targetsBuilder_ == null) {
-          targetsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.Target, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.Target.Builder, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.TargetOrBuilder>(
+          targetsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<>(
                   targets_,
                   ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),
@@ -15046,7 +15279,7 @@ public final class ChromatogramGroupDataOuterClass {
         java.util.Collections.emptyList();
       private void ensureFiltersIsMutable() {
         if (!((bitField0_ & 0x00000002) != 0)) {
-          filters_ = new java.util.ArrayList<org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.SpectrumFilter>(filters_);
+          filters_ = new java.util.ArrayList<>(filters_);
           bitField0_ |= 0x00000002;
          }
       }
@@ -15057,6 +15290,7 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ChromatogramGroupIdsProto.SpectrumFilter filters = 2;</code>
        */
+      @Override
       public java.util.List<org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.SpectrumFilter> getFiltersList() {
         if (filtersBuilder_ == null) {
           return java.util.Collections.unmodifiableList(filters_);
@@ -15067,6 +15301,7 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ChromatogramGroupIdsProto.SpectrumFilter filters = 2;</code>
        */
+      @Override
       public int getFiltersCount() {
         if (filtersBuilder_ == null) {
           return filters_.size();
@@ -15077,6 +15312,7 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ChromatogramGroupIdsProto.SpectrumFilter filters = 2;</code>
        */
+      @Override
       public org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.SpectrumFilter getFilters(int index) {
         if (filtersBuilder_ == null) {
           return filters_.get(index);
@@ -15227,6 +15463,7 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ChromatogramGroupIdsProto.SpectrumFilter filters = 2;</code>
        */
+      @Override
       public org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.SpectrumFilterOrBuilder getFiltersOrBuilder(
           int index) {
         if (filtersBuilder_ == null) {
@@ -15237,7 +15474,8 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ChromatogramGroupIdsProto.SpectrumFilter filters = 2;</code>
        */
-      public java.util.List<? extends org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.SpectrumFilterOrBuilder> 
+      @Override
+      public java.util.List<? extends org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.SpectrumFilterOrBuilder>
            getFiltersOrBuilderList() {
         if (filtersBuilder_ != null) {
           return filtersBuilder_.getMessageOrBuilderList();
@@ -15271,8 +15509,7 @@ public final class ChromatogramGroupDataOuterClass {
           org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.SpectrumFilter, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.SpectrumFilter.Builder, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.SpectrumFilterOrBuilder> 
           getFiltersFieldBuilder() {
         if (filtersBuilder_ == null) {
-          filtersBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.SpectrumFilter, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.SpectrumFilter.Builder, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.SpectrumFilterOrBuilder>(
+          filtersBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<>(
                   filters_,
                   ((bitField0_ & 0x00000002) != 0),
                   getParentForChildren(),
@@ -15286,7 +15523,7 @@ public final class ChromatogramGroupDataOuterClass {
         java.util.Collections.emptyList();
       private void ensureChromatogramGroupIdsIsMutable() {
         if (!((bitField0_ & 0x00000004) != 0)) {
-          chromatogramGroupIds_ = new java.util.ArrayList<org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.ChromatogramGroupId>(chromatogramGroupIds_);
+          chromatogramGroupIds_ = new java.util.ArrayList<>(chromatogramGroupIds_);
           bitField0_ |= 0x00000004;
          }
       }
@@ -15297,6 +15534,7 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ChromatogramGroupIdsProto.ChromatogramGroupId chromatogramGroupIds = 3;</code>
        */
+      @Override
       public java.util.List<org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.ChromatogramGroupId> getChromatogramGroupIdsList() {
         if (chromatogramGroupIdsBuilder_ == null) {
           return java.util.Collections.unmodifiableList(chromatogramGroupIds_);
@@ -15307,6 +15545,7 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ChromatogramGroupIdsProto.ChromatogramGroupId chromatogramGroupIds = 3;</code>
        */
+      @Override
       public int getChromatogramGroupIdsCount() {
         if (chromatogramGroupIdsBuilder_ == null) {
           return chromatogramGroupIds_.size();
@@ -15317,6 +15556,7 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ChromatogramGroupIdsProto.ChromatogramGroupId chromatogramGroupIds = 3;</code>
        */
+      @Override
       public org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.ChromatogramGroupId getChromatogramGroupIds(int index) {
         if (chromatogramGroupIdsBuilder_ == null) {
           return chromatogramGroupIds_.get(index);
@@ -15467,6 +15707,7 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ChromatogramGroupIdsProto.ChromatogramGroupId chromatogramGroupIds = 3;</code>
        */
+      @Override
       public org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.ChromatogramGroupIdOrBuilder getChromatogramGroupIdsOrBuilder(
           int index) {
         if (chromatogramGroupIdsBuilder_ == null) {
@@ -15477,7 +15718,8 @@ public final class ChromatogramGroupDataOuterClass {
       /**
        * <code>repeated .ChromatogramGroupIdsProto.ChromatogramGroupId chromatogramGroupIds = 3;</code>
        */
-      public java.util.List<? extends org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.ChromatogramGroupIdOrBuilder> 
+      @Override
+      public java.util.List<? extends org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.ChromatogramGroupIdOrBuilder>
            getChromatogramGroupIdsOrBuilderList() {
         if (chromatogramGroupIdsBuilder_ != null) {
           return chromatogramGroupIdsBuilder_.getMessageOrBuilderList();
@@ -15511,8 +15753,7 @@ public final class ChromatogramGroupDataOuterClass {
           org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.ChromatogramGroupId, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.ChromatogramGroupId.Builder, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.ChromatogramGroupIdOrBuilder> 
           getChromatogramGroupIdsFieldBuilder() {
         if (chromatogramGroupIdsBuilder_ == null) {
-          chromatogramGroupIdsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.ChromatogramGroupId, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.ChromatogramGroupId.Builder, org.labkey.targetedms.parser.proto.ChromatogramGroupDataOuterClass.ChromatogramGroupIdsProto.ChromatogramGroupIdOrBuilder>(
+          chromatogramGroupIdsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<>(
                   chromatogramGroupIds_,
                   ((bitField0_ & 0x00000004) != 0),
                   getParentForChildren(),
@@ -15548,25 +15789,34 @@ public final class ChromatogramGroupDataOuterClass {
     }
 
     private static final com.google.protobuf.Parser<ChromatogramGroupIdsProto>
-        PARSER = new com.google.protobuf.AbstractParser<ChromatogramGroupIdsProto>() {
-      @java.lang.Override
-      public ChromatogramGroupIdsProto parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        Builder builder = newBuilder();
-        try {
-          builder.mergeFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          throw e.setUnfinishedMessage(builder.buildPartial());
-        } catch (com.google.protobuf.UninitializedMessageException e) {
-          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
-        } catch (java.io.IOException e) {
-          throw new com.google.protobuf.InvalidProtocolBufferException(e)
-              .setUnfinishedMessage(builder.buildPartial());
+        PARSER = new com.google.protobuf.AbstractParser<>()
+    {
+        @java.lang.Override
+        public ChromatogramGroupIdsProto parsePartialFrom(
+                com.google.protobuf.CodedInputStream input,
+                com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                throws com.google.protobuf.InvalidProtocolBufferException
+        {
+            Builder builder = newBuilder();
+            try
+            {
+                builder.mergeFrom(input, extensionRegistry);
+            }
+            catch (com.google.protobuf.InvalidProtocolBufferException e)
+            {
+                throw e.setUnfinishedMessage(builder.buildPartial());
+            }
+            catch (com.google.protobuf.UninitializedMessageException e)
+            {
+                throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+            }
+            catch (java.io.IOException e)
+            {
+                throw new com.google.protobuf.InvalidProtocolBufferException(e)
+                        .setUnfinishedMessage(builder.buildPartial());
+            }
+            return builder.buildPartial();
         }
-        return builder.buildPartial();
-      }
     };
 
     public static com.google.protobuf.Parser<ChromatogramGroupIdsProto> parser() {
@@ -15660,7 +15910,7 @@ public final class ChromatogramGroupDataOuterClass {
       getDescriptor() {
     return descriptor;
   }
-  private static  com.google.protobuf.Descriptors.FileDescriptor
+  private static final com.google.protobuf.Descriptors.FileDescriptor
       descriptor;
   static {
     java.lang.String[] descriptorData = {

--- a/src/org/labkey/targetedms/parser/proto/SkylineDocument.java
+++ b/src/org/labkey/targetedms/parser/proto/SkylineDocument.java
@@ -104,6 +104,7 @@ public final class SkylineDocument {
       public static final int USER_SET_MATCHED_VALUE = 4;
 
 
+      @Override
       public final int getNumber() {
         if (this == UNRECOGNIZED) {
           throw new java.lang.IllegalArgumentException(
@@ -143,12 +144,16 @@ public final class SkylineDocument {
       }
       private static final com.google.protobuf.Internal.EnumLiteMap<
           UserSet> internalValueMap =
-            new com.google.protobuf.Internal.EnumLiteMap<UserSet>() {
-              public UserSet findValueByNumber(int number) {
-                return UserSet.forNumber(number);
-              }
-            };
+              new com.google.protobuf.Internal.EnumLiteMap<>()
+              {
+                  @Override
+                  public UserSet findValueByNumber(int number)
+                  {
+                      return UserSet.forNumber(number);
+                  }
+              };
 
+      @Override
       public final com.google.protobuf.Descriptors.EnumValueDescriptor
           getValueDescriptor() {
         if (this == UNRECOGNIZED) {
@@ -157,6 +162,7 @@ public final class SkylineDocument {
         }
         return getDescriptor().getValues().get(ordinal());
       }
+      @Override
       public final com.google.protobuf.Descriptors.EnumDescriptor
           getDescriptorForType() {
         return getDescriptor();
@@ -182,7 +188,7 @@ public final class SkylineDocument {
 
       private final int value;
 
-      private UserSet(int value) {
+      UserSet(int value) {
         this.value = value;
       }
 
@@ -223,6 +229,7 @@ public final class SkylineDocument {
       public static final int OPTIONAL_BOOL_FALSE_VALUE = 2;
 
 
+      @Override
       public final int getNumber() {
         if (this == UNRECOGNIZED) {
           throw new java.lang.IllegalArgumentException(
@@ -260,12 +267,16 @@ public final class SkylineDocument {
       }
       private static final com.google.protobuf.Internal.EnumLiteMap<
           OptionalBool> internalValueMap =
-            new com.google.protobuf.Internal.EnumLiteMap<OptionalBool>() {
-              public OptionalBool findValueByNumber(int number) {
-                return OptionalBool.forNumber(number);
-              }
-            };
+              new com.google.protobuf.Internal.EnumLiteMap<>()
+              {
+                  @Override
+                  public OptionalBool findValueByNumber(int number)
+                  {
+                      return OptionalBool.forNumber(number);
+                  }
+              };
 
+      @Override
       public final com.google.protobuf.Descriptors.EnumValueDescriptor
           getValueDescriptor() {
         if (this == UNRECOGNIZED) {
@@ -274,6 +285,7 @@ public final class SkylineDocument {
         }
         return getDescriptor().getValues().get(ordinal());
       }
+      @Override
       public final com.google.protobuf.Descriptors.EnumDescriptor
           getDescriptorForType() {
         return getDescriptor();
@@ -299,7 +311,7 @@ public final class SkylineDocument {
 
       private final int value;
 
-      private OptionalBool(int value) {
+      OptionalBool(int value) {
         this.value = value;
       }
 
@@ -340,6 +352,7 @@ public final class SkylineDocument {
       public static final int PEAK_IDENTIFICATION_ALIGNED_VALUE = 2;
 
 
+      @Override
       public final int getNumber() {
         if (this == UNRECOGNIZED) {
           throw new java.lang.IllegalArgumentException(
@@ -377,12 +390,16 @@ public final class SkylineDocument {
       }
       private static final com.google.protobuf.Internal.EnumLiteMap<
           PeakIdentification> internalValueMap =
-            new com.google.protobuf.Internal.EnumLiteMap<PeakIdentification>() {
-              public PeakIdentification findValueByNumber(int number) {
-                return PeakIdentification.forNumber(number);
-              }
-            };
+              new com.google.protobuf.Internal.EnumLiteMap<>()
+              {
+                  @Override
+                  public PeakIdentification findValueByNumber(int number)
+                  {
+                      return PeakIdentification.forNumber(number);
+                  }
+              };
 
+      @Override
       public final com.google.protobuf.Descriptors.EnumValueDescriptor
           getValueDescriptor() {
         if (this == UNRECOGNIZED) {
@@ -391,6 +408,7 @@ public final class SkylineDocument {
         }
         return getDescriptor().getValues().get(ordinal());
       }
+      @Override
       public final com.google.protobuf.Descriptors.EnumDescriptor
           getDescriptorForType() {
         return getDescriptor();
@@ -416,7 +434,7 @@ public final class SkylineDocument {
 
       private final int value;
 
-      private PeakIdentification(int value) {
+      PeakIdentification(int value) {
         this.value = value;
       }
 
@@ -521,6 +539,7 @@ public final class SkylineDocument {
       public static final int ION_TYPE_zHH_VALUE = 10;
 
 
+      @Override
       public final int getNumber() {
         if (this == UNRECOGNIZED) {
           throw new java.lang.IllegalArgumentException(
@@ -566,12 +585,16 @@ public final class SkylineDocument {
       }
       private static final com.google.protobuf.Internal.EnumLiteMap<
           IonType> internalValueMap =
-            new com.google.protobuf.Internal.EnumLiteMap<IonType>() {
-              public IonType findValueByNumber(int number) {
-                return IonType.forNumber(number);
-              }
-            };
+              new com.google.protobuf.Internal.EnumLiteMap<>()
+              {
+                  @Override
+                  public IonType findValueByNumber(int number)
+                  {
+                      return IonType.forNumber(number);
+                  }
+              };
 
+      @Override
       public final com.google.protobuf.Descriptors.EnumValueDescriptor
           getValueDescriptor() {
         if (this == UNRECOGNIZED) {
@@ -580,6 +603,7 @@ public final class SkylineDocument {
         }
         return getDescriptor().getValues().get(ordinal());
       }
+      @Override
       public final com.google.protobuf.Descriptors.EnumDescriptor
           getDescriptorForType() {
         return getDescriptor();
@@ -605,7 +629,7 @@ public final class SkylineDocument {
 
       private final int value;
 
-      private IonType(int value) {
+      IonType(int value) {
         this.value = value;
       }
 
@@ -646,6 +670,7 @@ public final class SkylineDocument {
       public static final int Always_VALUE = 2;
 
 
+      @Override
       public final int getNumber() {
         if (this == UNRECOGNIZED) {
           throw new java.lang.IllegalArgumentException(
@@ -683,12 +708,16 @@ public final class SkylineDocument {
       }
       private static final com.google.protobuf.Internal.EnumLiteMap<
           LossInclusion> internalValueMap =
-            new com.google.protobuf.Internal.EnumLiteMap<LossInclusion>() {
-              public LossInclusion findValueByNumber(int number) {
-                return LossInclusion.forNumber(number);
-              }
-            };
+              new com.google.protobuf.Internal.EnumLiteMap<>()
+              {
+                  @Override
+                  public LossInclusion findValueByNumber(int number)
+                  {
+                      return LossInclusion.forNumber(number);
+                  }
+              };
 
+      @Override
       public final com.google.protobuf.Descriptors.EnumValueDescriptor
           getValueDescriptor() {
         if (this == UNRECOGNIZED) {
@@ -697,6 +726,7 @@ public final class SkylineDocument {
         }
         return getDescriptor().getValues().get(ordinal());
       }
+      @Override
       public final com.google.protobuf.Descriptors.EnumDescriptor
           getDescriptorForType() {
         return getDescriptor();
@@ -722,7 +752,7 @@ public final class SkylineDocument {
 
       private final int value;
 
-      private LossInclusion(int value) {
+      LossInclusion(int value) {
         this.value = value;
       }
 
@@ -956,12 +986,11 @@ public final class SkylineDocument {
         if (obj == this) {
          return true;
         }
-        if (!(obj instanceof org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.Annotations)) {
+        if (!(obj instanceof Annotations other)) {
           return super.equals(obj);
         }
-        org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.Annotations other = (org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.Annotations) obj;
 
-        if (!getNote()
+          if (!getNote()
             .equals(other.getNote())) return false;
         if (getColor()
             != other.getColor()) return false;
@@ -1329,6 +1358,7 @@ public final class SkylineDocument {
          * <code>string note = 1;</code>
          * @return The note.
          */
+        @Override
         public java.lang.String getNote() {
           java.lang.Object ref = note_;
           if (!(ref instanceof java.lang.String)) {
@@ -1345,6 +1375,7 @@ public final class SkylineDocument {
          * <code>string note = 1;</code>
          * @return The bytes for note.
          */
+        @Override
         public com.google.protobuf.ByteString
             getNoteBytes() {
           java.lang.Object ref = note_;
@@ -1432,7 +1463,7 @@ public final class SkylineDocument {
           java.util.Collections.emptyList();
         private void ensureValuesIsMutable() {
           if (!((bitField0_ & 0x00000004) != 0)) {
-            values_ = new java.util.ArrayList<org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.AnnotationValue>(values_);
+            values_ = new java.util.ArrayList<>(values_);
             bitField0_ |= 0x00000004;
            }
         }
@@ -1443,6 +1474,7 @@ public final class SkylineDocument {
         /**
          * <code>repeated .SkylineDocumentProto.AnnotationValue values = 3;</code>
          */
+        @Override
         public java.util.List<org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.AnnotationValue> getValuesList() {
           if (valuesBuilder_ == null) {
             return java.util.Collections.unmodifiableList(values_);
@@ -1453,6 +1485,7 @@ public final class SkylineDocument {
         /**
          * <code>repeated .SkylineDocumentProto.AnnotationValue values = 3;</code>
          */
+        @Override
         public int getValuesCount() {
           if (valuesBuilder_ == null) {
             return values_.size();
@@ -1463,6 +1496,7 @@ public final class SkylineDocument {
         /**
          * <code>repeated .SkylineDocumentProto.AnnotationValue values = 3;</code>
          */
+        @Override
         public org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.AnnotationValue getValues(int index) {
           if (valuesBuilder_ == null) {
             return values_.get(index);
@@ -1613,6 +1647,7 @@ public final class SkylineDocument {
         /**
          * <code>repeated .SkylineDocumentProto.AnnotationValue values = 3;</code>
          */
+        @Override
         public org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.AnnotationValueOrBuilder getValuesOrBuilder(
             int index) {
           if (valuesBuilder_ == null) {
@@ -1623,7 +1658,8 @@ public final class SkylineDocument {
         /**
          * <code>repeated .SkylineDocumentProto.AnnotationValue values = 3;</code>
          */
-        public java.util.List<? extends org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.AnnotationValueOrBuilder> 
+        @Override
+        public java.util.List<? extends org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.AnnotationValueOrBuilder>
              getValuesOrBuilderList() {
           if (valuesBuilder_ != null) {
             return valuesBuilder_.getMessageOrBuilderList();
@@ -1657,8 +1693,7 @@ public final class SkylineDocument {
             org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.AnnotationValue, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.AnnotationValue.Builder, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.AnnotationValueOrBuilder> 
             getValuesFieldBuilder() {
           if (valuesBuilder_ == null) {
-            valuesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-                org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.AnnotationValue, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.AnnotationValue.Builder, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.AnnotationValueOrBuilder>(
+            valuesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<>(
                     values_,
                     ((bitField0_ & 0x00000004) != 0),
                     getParentForChildren(),
@@ -1694,25 +1729,34 @@ public final class SkylineDocument {
       }
 
       private static final com.google.protobuf.Parser<Annotations>
-          PARSER = new com.google.protobuf.AbstractParser<Annotations>() {
-        @java.lang.Override
-        public Annotations parsePartialFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
-          Builder builder = newBuilder();
-          try {
-            builder.mergeFrom(input, extensionRegistry);
-          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-            throw e.setUnfinishedMessage(builder.buildPartial());
-          } catch (com.google.protobuf.UninitializedMessageException e) {
-            throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
-          } catch (java.io.IOException e) {
-            throw new com.google.protobuf.InvalidProtocolBufferException(e)
-                .setUnfinishedMessage(builder.buildPartial());
+          PARSER = new com.google.protobuf.AbstractParser<>()
+      {
+          @java.lang.Override
+          public Annotations parsePartialFrom(
+                  com.google.protobuf.CodedInputStream input,
+                  com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                  throws com.google.protobuf.InvalidProtocolBufferException
+          {
+              Builder builder = newBuilder();
+              try
+              {
+                  builder.mergeFrom(input, extensionRegistry);
+              }
+              catch (com.google.protobuf.InvalidProtocolBufferException e)
+              {
+                  throw e.setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (com.google.protobuf.UninitializedMessageException e)
+              {
+                  throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (java.io.IOException e)
+              {
+                  throw new com.google.protobuf.InvalidProtocolBufferException(e)
+                          .setUnfinishedMessage(builder.buildPartial());
+              }
+              return builder.buildPartial();
           }
-          return builder.buildPartial();
-        }
       };
 
       public static com.google.protobuf.Parser<Annotations> parser() {
@@ -1919,12 +1963,11 @@ public final class SkylineDocument {
         if (obj == this) {
          return true;
         }
-        if (!(obj instanceof org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.AnnotationValue)) {
+        if (!(obj instanceof AnnotationValue other)) {
           return super.equals(obj);
         }
-        org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.AnnotationValue other = (org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.AnnotationValue) obj;
 
-        if (!getName()
+          if (!getName()
             .equals(other.getName())) return false;
         if (!getTextValue()
             .equals(other.getTextValue())) return false;
@@ -2229,6 +2272,7 @@ public final class SkylineDocument {
          * <code>string name = 1;</code>
          * @return The name.
          */
+        @Override
         public java.lang.String getName() {
           java.lang.Object ref = name_;
           if (!(ref instanceof java.lang.String)) {
@@ -2245,6 +2289,7 @@ public final class SkylineDocument {
          * <code>string name = 1;</code>
          * @return The bytes for name.
          */
+        @Override
         public com.google.protobuf.ByteString
             getNameBytes() {
           java.lang.Object ref = name_;
@@ -2301,6 +2346,7 @@ public final class SkylineDocument {
          * <code>string textValue = 2;</code>
          * @return The textValue.
          */
+        @Override
         public java.lang.String getTextValue() {
           java.lang.Object ref = textValue_;
           if (!(ref instanceof java.lang.String)) {
@@ -2317,6 +2363,7 @@ public final class SkylineDocument {
          * <code>string textValue = 2;</code>
          * @return The bytes for textValue.
          */
+        @Override
         public com.google.protobuf.ByteString
             getTextValueBytes() {
           java.lang.Object ref = textValue_;
@@ -2394,25 +2441,34 @@ public final class SkylineDocument {
       }
 
       private static final com.google.protobuf.Parser<AnnotationValue>
-          PARSER = new com.google.protobuf.AbstractParser<AnnotationValue>() {
-        @java.lang.Override
-        public AnnotationValue parsePartialFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
-          Builder builder = newBuilder();
-          try {
-            builder.mergeFrom(input, extensionRegistry);
-          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-            throw e.setUnfinishedMessage(builder.buildPartial());
-          } catch (com.google.protobuf.UninitializedMessageException e) {
-            throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
-          } catch (java.io.IOException e) {
-            throw new com.google.protobuf.InvalidProtocolBufferException(e)
-                .setUnfinishedMessage(builder.buildPartial());
+          PARSER = new com.google.protobuf.AbstractParser<>()
+      {
+          @java.lang.Override
+          public AnnotationValue parsePartialFrom(
+                  com.google.protobuf.CodedInputStream input,
+                  com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                  throws com.google.protobuf.InvalidProtocolBufferException
+          {
+              Builder builder = newBuilder();
+              try
+              {
+                  builder.mergeFrom(input, extensionRegistry);
+              }
+              catch (com.google.protobuf.InvalidProtocolBufferException e)
+              {
+                  throw e.setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (com.google.protobuf.UninitializedMessageException e)
+              {
+                  throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (java.io.IOException e)
+              {
+                  throw new com.google.protobuf.InvalidProtocolBufferException(e)
+                          .setUnfinishedMessage(builder.buildPartial());
+              }
+              return builder.buildPartial();
           }
-          return builder.buildPartial();
-        }
       };
 
       public static com.google.protobuf.Parser<AnnotationValue> parser() {
@@ -2863,12 +2919,11 @@ public final class SkylineDocument {
           if (obj == this) {
            return true;
           }
-          if (!(obj instanceof org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionPeak.PeakShapeValues)) {
+          if (!(obj instanceof PeakShapeValues other)) {
             return super.equals(obj);
           }
-          org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionPeak.PeakShapeValues other = (org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionPeak.PeakShapeValues) obj;
 
-          if (java.lang.Float.floatToIntBits(getStdDev())
+            if (java.lang.Float.floatToIntBits(getStdDev())
               != java.lang.Float.floatToIntBits(
                   other.getStdDev())) return false;
           if (java.lang.Float.floatToIntBits(getSkewness())
@@ -3358,25 +3413,34 @@ public final class SkylineDocument {
         }
 
         private static final com.google.protobuf.Parser<PeakShapeValues>
-            PARSER = new com.google.protobuf.AbstractParser<PeakShapeValues>() {
-          @java.lang.Override
-          public PeakShapeValues parsePartialFrom(
-              com.google.protobuf.CodedInputStream input,
-              com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-              throws com.google.protobuf.InvalidProtocolBufferException {
-            Builder builder = newBuilder();
-            try {
-              builder.mergeFrom(input, extensionRegistry);
-            } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-              throw e.setUnfinishedMessage(builder.buildPartial());
-            } catch (com.google.protobuf.UninitializedMessageException e) {
-              throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
-            } catch (java.io.IOException e) {
-              throw new com.google.protobuf.InvalidProtocolBufferException(e)
-                  .setUnfinishedMessage(builder.buildPartial());
+            PARSER = new com.google.protobuf.AbstractParser<>()
+        {
+            @java.lang.Override
+            public PeakShapeValues parsePartialFrom(
+                    com.google.protobuf.CodedInputStream input,
+                    com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                    throws com.google.protobuf.InvalidProtocolBufferException
+            {
+                Builder builder = newBuilder();
+                try
+                {
+                    builder.mergeFrom(input, extensionRegistry);
+                }
+                catch (com.google.protobuf.InvalidProtocolBufferException e)
+                {
+                    throw e.setUnfinishedMessage(builder.buildPartial());
+                }
+                catch (com.google.protobuf.UninitializedMessageException e)
+                {
+                    throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+                }
+                catch (java.io.IOException e)
+                {
+                    throw new com.google.protobuf.InvalidProtocolBufferException(e)
+                            .setUnfinishedMessage(builder.buildPartial());
+                }
+                return builder.buildPartial();
             }
-            return builder.buildPartial();
-          }
         };
 
         public static com.google.protobuf.Parser<PeakShapeValues> parser() {
@@ -3987,12 +4051,11 @@ public final class SkylineDocument {
         if (obj == this) {
          return true;
         }
-        if (!(obj instanceof org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionPeak)) {
+        if (!(obj instanceof TransitionPeak other)) {
           return super.equals(obj);
         }
-        org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionPeak other = (org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionPeak) obj;
 
-        if (getReplicateIndex()
+          if (getReplicateIndex()
             != other.getReplicateIndex()) return false;
         if (getFileIndexInReplicate()
             != other.getFileIndexInReplicate()) return false;
@@ -4836,6 +4899,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.FloatValue massError = 3;</code>
          * @return Whether the massError field is set.
          */
+        @Override
         public boolean hasMassError() {
           return ((bitField0_ & 0x00000004) != 0);
         }
@@ -4843,6 +4907,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.FloatValue massError = 3;</code>
          * @return The massError.
          */
+        @Override
         public com.google.protobuf.FloatValue getMassError() {
           if (massErrorBuilder_ == null) {
             return massError_ == null ? com.google.protobuf.FloatValue.getDefaultInstance() : massError_;
@@ -4925,6 +4990,7 @@ public final class SkylineDocument {
         /**
          * <code>.google.protobuf.FloatValue massError = 3;</code>
          */
+        @Override
         public com.google.protobuf.FloatValueOrBuilder getMassErrorOrBuilder() {
           if (massErrorBuilder_ != null) {
             return massErrorBuilder_.getMessageOrBuilder();
@@ -4940,8 +5006,7 @@ public final class SkylineDocument {
             com.google.protobuf.FloatValue, com.google.protobuf.FloatValue.Builder, com.google.protobuf.FloatValueOrBuilder> 
             getMassErrorFieldBuilder() {
           if (massErrorBuilder_ == null) {
-            massErrorBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-                com.google.protobuf.FloatValue, com.google.protobuf.FloatValue.Builder, com.google.protobuf.FloatValueOrBuilder>(
+            massErrorBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<>(
                     getMassError(),
                     getParentForChildren(),
                     isClean());
@@ -5053,6 +5118,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.DoubleValue ionMobility = 7;</code>
          * @return Whether the ionMobility field is set.
          */
+        @Override
         public boolean hasIonMobility() {
           return ((bitField0_ & 0x00000040) != 0);
         }
@@ -5060,6 +5126,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.DoubleValue ionMobility = 7;</code>
          * @return The ionMobility.
          */
+        @Override
         public com.google.protobuf.DoubleValue getIonMobility() {
           if (ionMobilityBuilder_ == null) {
             return ionMobility_ == null ? com.google.protobuf.DoubleValue.getDefaultInstance() : ionMobility_;
@@ -5142,6 +5209,7 @@ public final class SkylineDocument {
         /**
          * <code>.google.protobuf.DoubleValue ionMobility = 7;</code>
          */
+        @Override
         public com.google.protobuf.DoubleValueOrBuilder getIonMobilityOrBuilder() {
           if (ionMobilityBuilder_ != null) {
             return ionMobilityBuilder_.getMessageOrBuilder();
@@ -5157,8 +5225,7 @@ public final class SkylineDocument {
             com.google.protobuf.DoubleValue, com.google.protobuf.DoubleValue.Builder, com.google.protobuf.DoubleValueOrBuilder> 
             getIonMobilityFieldBuilder() {
           if (ionMobilityBuilder_ == null) {
-            ionMobilityBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-                com.google.protobuf.DoubleValue, com.google.protobuf.DoubleValue.Builder, com.google.protobuf.DoubleValueOrBuilder>(
+            ionMobilityBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<>(
                     getIonMobility(),
                     getParentForChildren(),
                     isClean());
@@ -5174,6 +5241,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.DoubleValue ionMobilityWindow = 8;</code>
          * @return Whether the ionMobilityWindow field is set.
          */
+        @Override
         public boolean hasIonMobilityWindow() {
           return ((bitField0_ & 0x00000080) != 0);
         }
@@ -5181,6 +5249,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.DoubleValue ionMobilityWindow = 8;</code>
          * @return The ionMobilityWindow.
          */
+        @Override
         public com.google.protobuf.DoubleValue getIonMobilityWindow() {
           if (ionMobilityWindowBuilder_ == null) {
             return ionMobilityWindow_ == null ? com.google.protobuf.DoubleValue.getDefaultInstance() : ionMobilityWindow_;
@@ -5263,6 +5332,7 @@ public final class SkylineDocument {
         /**
          * <code>.google.protobuf.DoubleValue ionMobilityWindow = 8;</code>
          */
+        @Override
         public com.google.protobuf.DoubleValueOrBuilder getIonMobilityWindowOrBuilder() {
           if (ionMobilityWindowBuilder_ != null) {
             return ionMobilityWindowBuilder_.getMessageOrBuilder();
@@ -5278,8 +5348,7 @@ public final class SkylineDocument {
             com.google.protobuf.DoubleValue, com.google.protobuf.DoubleValue.Builder, com.google.protobuf.DoubleValueOrBuilder> 
             getIonMobilityWindowFieldBuilder() {
           if (ionMobilityWindowBuilder_ == null) {
-            ionMobilityWindowBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-                com.google.protobuf.DoubleValue, com.google.protobuf.DoubleValue.Builder, com.google.protobuf.DoubleValueOrBuilder>(
+            ionMobilityWindowBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<>(
                     getIonMobilityWindow(),
                     getParentForChildren(),
                     isClean());
@@ -5625,6 +5694,7 @@ public final class SkylineDocument {
          * <code>.SkylineDocumentProto.OptionalInt pointsAcrossPeak = 18;</code>
          * @return Whether the pointsAcrossPeak field is set.
          */
+        @Override
         public boolean hasPointsAcrossPeak() {
           return ((bitField0_ & 0x00020000) != 0);
         }
@@ -5632,6 +5702,7 @@ public final class SkylineDocument {
          * <code>.SkylineDocumentProto.OptionalInt pointsAcrossPeak = 18;</code>
          * @return The pointsAcrossPeak.
          */
+        @Override
         public org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.OptionalInt getPointsAcrossPeak() {
           if (pointsAcrossPeakBuilder_ == null) {
             return pointsAcrossPeak_ == null ? org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.OptionalInt.getDefaultInstance() : pointsAcrossPeak_;
@@ -5714,6 +5785,7 @@ public final class SkylineDocument {
         /**
          * <code>.SkylineDocumentProto.OptionalInt pointsAcrossPeak = 18;</code>
          */
+        @Override
         public org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.OptionalIntOrBuilder getPointsAcrossPeakOrBuilder() {
           if (pointsAcrossPeakBuilder_ != null) {
             return pointsAcrossPeakBuilder_.getMessageOrBuilder();
@@ -5729,8 +5801,7 @@ public final class SkylineDocument {
             org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.OptionalInt, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.OptionalInt.Builder, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.OptionalIntOrBuilder> 
             getPointsAcrossPeakFieldBuilder() {
           if (pointsAcrossPeakBuilder_ == null) {
-            pointsAcrossPeakBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-                org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.OptionalInt, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.OptionalInt.Builder, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.OptionalIntOrBuilder>(
+            pointsAcrossPeakBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<>(
                     getPointsAcrossPeak(),
                     getParentForChildren(),
                     isClean());
@@ -5831,6 +5902,7 @@ public final class SkylineDocument {
          * <code>.SkylineDocumentProto.Annotations annotations = 24;</code>
          * @return Whether the annotations field is set.
          */
+        @Override
         public boolean hasAnnotations() {
           return ((bitField0_ & 0x00100000) != 0);
         }
@@ -5838,6 +5910,7 @@ public final class SkylineDocument {
          * <code>.SkylineDocumentProto.Annotations annotations = 24;</code>
          * @return The annotations.
          */
+        @Override
         public org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.Annotations getAnnotations() {
           if (annotationsBuilder_ == null) {
             return annotations_ == null ? org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.Annotations.getDefaultInstance() : annotations_;
@@ -5920,6 +5993,7 @@ public final class SkylineDocument {
         /**
          * <code>.SkylineDocumentProto.Annotations annotations = 24;</code>
          */
+        @Override
         public org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.AnnotationsOrBuilder getAnnotationsOrBuilder() {
           if (annotationsBuilder_ != null) {
             return annotationsBuilder_.getMessageOrBuilder();
@@ -5935,8 +6009,7 @@ public final class SkylineDocument {
             org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.Annotations, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.Annotations.Builder, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.AnnotationsOrBuilder> 
             getAnnotationsFieldBuilder() {
           if (annotationsBuilder_ == null) {
-            annotationsBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-                org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.Annotations, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.Annotations.Builder, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.AnnotationsOrBuilder>(
+            annotationsBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<>(
                     getAnnotations(),
                     getParentForChildren(),
                     isClean());
@@ -5984,6 +6057,7 @@ public final class SkylineDocument {
          * <code>.SkylineDocumentProto.TransitionPeak.PeakShapeValues peakShapeValues = 26;</code>
          * @return Whether the peakShapeValues field is set.
          */
+        @Override
         public boolean hasPeakShapeValues() {
           return ((bitField0_ & 0x00400000) != 0);
         }
@@ -5991,6 +6065,7 @@ public final class SkylineDocument {
          * <code>.SkylineDocumentProto.TransitionPeak.PeakShapeValues peakShapeValues = 26;</code>
          * @return The peakShapeValues.
          */
+        @Override
         public org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionPeak.PeakShapeValues getPeakShapeValues() {
           if (peakShapeValuesBuilder_ == null) {
             return peakShapeValues_ == null ? org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionPeak.PeakShapeValues.getDefaultInstance() : peakShapeValues_;
@@ -6073,6 +6148,7 @@ public final class SkylineDocument {
         /**
          * <code>.SkylineDocumentProto.TransitionPeak.PeakShapeValues peakShapeValues = 26;</code>
          */
+        @Override
         public org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionPeak.PeakShapeValuesOrBuilder getPeakShapeValuesOrBuilder() {
           if (peakShapeValuesBuilder_ != null) {
             return peakShapeValuesBuilder_.getMessageOrBuilder();
@@ -6088,8 +6164,7 @@ public final class SkylineDocument {
             org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionPeak.PeakShapeValues, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionPeak.PeakShapeValues.Builder, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionPeak.PeakShapeValuesOrBuilder> 
             getPeakShapeValuesFieldBuilder() {
           if (peakShapeValuesBuilder_ == null) {
-            peakShapeValuesBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-                org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionPeak.PeakShapeValues, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionPeak.PeakShapeValues.Builder, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionPeak.PeakShapeValuesOrBuilder>(
+            peakShapeValuesBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<>(
                     getPeakShapeValues(),
                     getParentForChildren(),
                     isClean());
@@ -6105,6 +6180,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.DoubleValue ionMobilityCollisionCrossSection = 27;</code>
          * @return Whether the ionMobilityCollisionCrossSection field is set.
          */
+        @Override
         public boolean hasIonMobilityCollisionCrossSection() {
           return ((bitField0_ & 0x00800000) != 0);
         }
@@ -6112,6 +6188,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.DoubleValue ionMobilityCollisionCrossSection = 27;</code>
          * @return The ionMobilityCollisionCrossSection.
          */
+        @Override
         public com.google.protobuf.DoubleValue getIonMobilityCollisionCrossSection() {
           if (ionMobilityCollisionCrossSectionBuilder_ == null) {
             return ionMobilityCollisionCrossSection_ == null ? com.google.protobuf.DoubleValue.getDefaultInstance() : ionMobilityCollisionCrossSection_;
@@ -6194,6 +6271,7 @@ public final class SkylineDocument {
         /**
          * <code>.google.protobuf.DoubleValue ionMobilityCollisionCrossSection = 27;</code>
          */
+        @Override
         public com.google.protobuf.DoubleValueOrBuilder getIonMobilityCollisionCrossSectionOrBuilder() {
           if (ionMobilityCollisionCrossSectionBuilder_ != null) {
             return ionMobilityCollisionCrossSectionBuilder_.getMessageOrBuilder();
@@ -6209,8 +6287,7 @@ public final class SkylineDocument {
             com.google.protobuf.DoubleValue, com.google.protobuf.DoubleValue.Builder, com.google.protobuf.DoubleValueOrBuilder> 
             getIonMobilityCollisionCrossSectionFieldBuilder() {
           if (ionMobilityCollisionCrossSectionBuilder_ == null) {
-            ionMobilityCollisionCrossSectionBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-                com.google.protobuf.DoubleValue, com.google.protobuf.DoubleValue.Builder, com.google.protobuf.DoubleValueOrBuilder>(
+            ionMobilityCollisionCrossSectionBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<>(
                     getIonMobilityCollisionCrossSection(),
                     getParentForChildren(),
                     isClean());
@@ -6245,25 +6322,34 @@ public final class SkylineDocument {
       }
 
       private static final com.google.protobuf.Parser<TransitionPeak>
-          PARSER = new com.google.protobuf.AbstractParser<TransitionPeak>() {
-        @java.lang.Override
-        public TransitionPeak parsePartialFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
-          Builder builder = newBuilder();
-          try {
-            builder.mergeFrom(input, extensionRegistry);
-          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-            throw e.setUnfinishedMessage(builder.buildPartial());
-          } catch (com.google.protobuf.UninitializedMessageException e) {
-            throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
-          } catch (java.io.IOException e) {
-            throw new com.google.protobuf.InvalidProtocolBufferException(e)
-                .setUnfinishedMessage(builder.buildPartial());
+          PARSER = new com.google.protobuf.AbstractParser<>()
+      {
+          @java.lang.Override
+          public TransitionPeak parsePartialFrom(
+                  com.google.protobuf.CodedInputStream input,
+                  com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                  throws com.google.protobuf.InvalidProtocolBufferException
+          {
+              Builder builder = newBuilder();
+              try
+              {
+                  builder.mergeFrom(input, extensionRegistry);
+              }
+              catch (com.google.protobuf.InvalidProtocolBufferException e)
+              {
+                  throw e.setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (com.google.protobuf.UninitializedMessageException e)
+              {
+                  throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (java.io.IOException e)
+              {
+                  throw new com.google.protobuf.InvalidProtocolBufferException(e)
+                          .setUnfinishedMessage(builder.buildPartial());
+              }
+              return builder.buildPartial();
           }
-          return builder.buildPartial();
-        }
       };
 
       public static com.google.protobuf.Parser<TransitionPeak> parser() {
@@ -6427,12 +6513,11 @@ public final class SkylineDocument {
         if (obj == this) {
          return true;
         }
-        if (!(obj instanceof org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionResults)) {
+        if (!(obj instanceof TransitionResults other)) {
           return super.equals(obj);
         }
-        org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionResults other = (org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionResults) obj;
 
-        if (!getPeaksList()
+          if (!getPeaksList()
             .equals(other.getPeaksList())) return false;
         if (!getUnknownFields().equals(other.getUnknownFields())) return false;
         return true;
@@ -6765,7 +6850,7 @@ public final class SkylineDocument {
           java.util.Collections.emptyList();
         private void ensurePeaksIsMutable() {
           if (!((bitField0_ & 0x00000001) != 0)) {
-            peaks_ = new java.util.ArrayList<org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionPeak>(peaks_);
+            peaks_ = new java.util.ArrayList<>(peaks_);
             bitField0_ |= 0x00000001;
            }
         }
@@ -6776,6 +6861,7 @@ public final class SkylineDocument {
         /**
          * <code>repeated .SkylineDocumentProto.TransitionPeak peaks = 1;</code>
          */
+        @Override
         public java.util.List<org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionPeak> getPeaksList() {
           if (peaksBuilder_ == null) {
             return java.util.Collections.unmodifiableList(peaks_);
@@ -6786,6 +6872,7 @@ public final class SkylineDocument {
         /**
          * <code>repeated .SkylineDocumentProto.TransitionPeak peaks = 1;</code>
          */
+        @Override
         public int getPeaksCount() {
           if (peaksBuilder_ == null) {
             return peaks_.size();
@@ -6796,6 +6883,7 @@ public final class SkylineDocument {
         /**
          * <code>repeated .SkylineDocumentProto.TransitionPeak peaks = 1;</code>
          */
+        @Override
         public org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionPeak getPeaks(int index) {
           if (peaksBuilder_ == null) {
             return peaks_.get(index);
@@ -6946,6 +7034,7 @@ public final class SkylineDocument {
         /**
          * <code>repeated .SkylineDocumentProto.TransitionPeak peaks = 1;</code>
          */
+        @Override
         public org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionPeakOrBuilder getPeaksOrBuilder(
             int index) {
           if (peaksBuilder_ == null) {
@@ -6956,7 +7045,8 @@ public final class SkylineDocument {
         /**
          * <code>repeated .SkylineDocumentProto.TransitionPeak peaks = 1;</code>
          */
-        public java.util.List<? extends org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionPeakOrBuilder> 
+        @Override
+        public java.util.List<? extends org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionPeakOrBuilder>
              getPeaksOrBuilderList() {
           if (peaksBuilder_ != null) {
             return peaksBuilder_.getMessageOrBuilderList();
@@ -6990,8 +7080,7 @@ public final class SkylineDocument {
             org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionPeak, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionPeak.Builder, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionPeakOrBuilder> 
             getPeaksFieldBuilder() {
           if (peaksBuilder_ == null) {
-            peaksBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-                org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionPeak, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionPeak.Builder, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionPeakOrBuilder>(
+            peaksBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<>(
                     peaks_,
                     ((bitField0_ & 0x00000001) != 0),
                     getParentForChildren(),
@@ -7027,25 +7116,34 @@ public final class SkylineDocument {
       }
 
       private static final com.google.protobuf.Parser<TransitionResults>
-          PARSER = new com.google.protobuf.AbstractParser<TransitionResults>() {
-        @java.lang.Override
-        public TransitionResults parsePartialFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
-          Builder builder = newBuilder();
-          try {
-            builder.mergeFrom(input, extensionRegistry);
-          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-            throw e.setUnfinishedMessage(builder.buildPartial());
-          } catch (com.google.protobuf.UninitializedMessageException e) {
-            throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
-          } catch (java.io.IOException e) {
-            throw new com.google.protobuf.InvalidProtocolBufferException(e)
-                .setUnfinishedMessage(builder.buildPartial());
+          PARSER = new com.google.protobuf.AbstractParser<>()
+      {
+          @java.lang.Override
+          public TransitionResults parsePartialFrom(
+                  com.google.protobuf.CodedInputStream input,
+                  com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                  throws com.google.protobuf.InvalidProtocolBufferException
+          {
+              Builder builder = newBuilder();
+              try
+              {
+                  builder.mergeFrom(input, extensionRegistry);
+              }
+              catch (com.google.protobuf.InvalidProtocolBufferException e)
+              {
+                  throw e.setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (com.google.protobuf.UninitializedMessageException e)
+              {
+                  throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (java.io.IOException e)
+              {
+                  throw new com.google.protobuf.InvalidProtocolBufferException(e)
+                          .setUnfinishedMessage(builder.buildPartial());
+              }
+              return builder.buildPartial();
           }
-          return builder.buildPartial();
-        }
       };
 
       public static com.google.protobuf.Parser<TransitionResults> parser() {
@@ -8696,12 +8794,11 @@ public final class SkylineDocument {
         if (obj == this) {
          return true;
         }
-        if (!(obj instanceof org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.Transition)) {
+        if (!(obj instanceof Transition other)) {
           return super.equals(obj);
         }
-        org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.Transition other = (org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.Transition) obj;
 
-        if (hasFormula() != other.hasFormula()) return false;
+          if (hasFormula() != other.hasFormula()) return false;
         if (hasFormula()) {
           if (!getFormula()
               .equals(other.getFormula())) return false;
@@ -9983,6 +10080,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.StringValue formula = 1;</code>
          * @return Whether the formula field is set.
          */
+        @Override
         public boolean hasFormula() {
           return ((bitField0_ & 0x00000001) != 0);
         }
@@ -9990,6 +10088,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.StringValue formula = 1;</code>
          * @return The formula.
          */
+        @Override
         public com.google.protobuf.StringValue getFormula() {
           if (formulaBuilder_ == null) {
             return formula_ == null ? com.google.protobuf.StringValue.getDefaultInstance() : formula_;
@@ -10072,6 +10171,7 @@ public final class SkylineDocument {
         /**
          * <code>.google.protobuf.StringValue formula = 1;</code>
          */
+        @Override
         public com.google.protobuf.StringValueOrBuilder getFormulaOrBuilder() {
           if (formulaBuilder_ != null) {
             return formulaBuilder_.getMessageOrBuilder();
@@ -10087,8 +10187,7 @@ public final class SkylineDocument {
             com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder> 
             getFormulaFieldBuilder() {
           if (formulaBuilder_ == null) {
-            formulaBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-                com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder>(
+            formulaBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<>(
                     getFormula(),
                     getParentForChildren(),
                     isClean());
@@ -10108,6 +10207,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.DoubleValue averageMassH = 2;</code>
          * @return Whether the averageMassH field is set.
          */
+        @Override
         public boolean hasAverageMassH() {
           return ((bitField0_ & 0x00000002) != 0);
         }
@@ -10119,6 +10219,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.DoubleValue averageMassH = 2;</code>
          * @return The averageMassH.
          */
+        @Override
         public com.google.protobuf.DoubleValue getAverageMassH() {
           if (averageMassHBuilder_ == null) {
             return averageMassH_ == null ? com.google.protobuf.DoubleValue.getDefaultInstance() : averageMassH_;
@@ -10225,6 +10326,7 @@ public final class SkylineDocument {
          *
          * <code>.google.protobuf.DoubleValue averageMassH = 2;</code>
          */
+        @Override
         public com.google.protobuf.DoubleValueOrBuilder getAverageMassHOrBuilder() {
           if (averageMassHBuilder_ != null) {
             return averageMassHBuilder_.getMessageOrBuilder();
@@ -10244,8 +10346,7 @@ public final class SkylineDocument {
             com.google.protobuf.DoubleValue, com.google.protobuf.DoubleValue.Builder, com.google.protobuf.DoubleValueOrBuilder> 
             getAverageMassHFieldBuilder() {
           if (averageMassHBuilder_ == null) {
-            averageMassHBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-                com.google.protobuf.DoubleValue, com.google.protobuf.DoubleValue.Builder, com.google.protobuf.DoubleValueOrBuilder>(
+            averageMassHBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<>(
                     getAverageMassH(),
                     getParentForChildren(),
                     isClean());
@@ -10265,6 +10366,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.DoubleValue monoMassH = 3;</code>
          * @return Whether the monoMassH field is set.
          */
+        @Override
         public boolean hasMonoMassH() {
           return ((bitField0_ & 0x00000004) != 0);
         }
@@ -10276,6 +10378,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.DoubleValue monoMassH = 3;</code>
          * @return The monoMassH.
          */
+        @Override
         public com.google.protobuf.DoubleValue getMonoMassH() {
           if (monoMassHBuilder_ == null) {
             return monoMassH_ == null ? com.google.protobuf.DoubleValue.getDefaultInstance() : monoMassH_;
@@ -10382,6 +10485,7 @@ public final class SkylineDocument {
          *
          * <code>.google.protobuf.DoubleValue monoMassH = 3;</code>
          */
+        @Override
         public com.google.protobuf.DoubleValueOrBuilder getMonoMassHOrBuilder() {
           if (monoMassHBuilder_ != null) {
             return monoMassHBuilder_.getMessageOrBuilder();
@@ -10401,8 +10505,7 @@ public final class SkylineDocument {
             com.google.protobuf.DoubleValue, com.google.protobuf.DoubleValue.Builder, com.google.protobuf.DoubleValueOrBuilder> 
             getMonoMassHFieldBuilder() {
           if (monoMassHBuilder_ == null) {
-            monoMassHBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-                com.google.protobuf.DoubleValue, com.google.protobuf.DoubleValue.Builder, com.google.protobuf.DoubleValueOrBuilder>(
+            monoMassHBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<>(
                     getMonoMassH(),
                     getParentForChildren(),
                     isClean());
@@ -10422,6 +10525,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.StringValue custom_ion_name = 6;</code>
          * @return Whether the customIonName field is set.
          */
+        @Override
         public boolean hasCustomIonName() {
           return ((bitField0_ & 0x00000008) != 0);
         }
@@ -10433,6 +10537,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.StringValue custom_ion_name = 6;</code>
          * @return The customIonName.
          */
+        @Override
         public com.google.protobuf.StringValue getCustomIonName() {
           if (customIonNameBuilder_ == null) {
             return customIonName_ == null ? com.google.protobuf.StringValue.getDefaultInstance() : customIonName_;
@@ -10539,6 +10644,7 @@ public final class SkylineDocument {
          *
          * <code>.google.protobuf.StringValue custom_ion_name = 6;</code>
          */
+        @Override
         public com.google.protobuf.StringValueOrBuilder getCustomIonNameOrBuilder() {
           if (customIonNameBuilder_ != null) {
             return customIonNameBuilder_.getMessageOrBuilder();
@@ -10558,8 +10664,7 @@ public final class SkylineDocument {
             com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder> 
             getCustomIonNameFieldBuilder() {
           if (customIonNameBuilder_ == null) {
-            customIonNameBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-                com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder>(
+            customIonNameBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<>(
                     getCustomIonName(),
                     getParentForChildren(),
                     isClean());
@@ -10575,6 +10680,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.StringValue measured_ion_name = 7;</code>
          * @return Whether the measuredIonName field is set.
          */
+        @Override
         public boolean hasMeasuredIonName() {
           return ((bitField0_ & 0x00000010) != 0);
         }
@@ -10582,6 +10688,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.StringValue measured_ion_name = 7;</code>
          * @return The measuredIonName.
          */
+        @Override
         public com.google.protobuf.StringValue getMeasuredIonName() {
           if (measuredIonNameBuilder_ == null) {
             return measuredIonName_ == null ? com.google.protobuf.StringValue.getDefaultInstance() : measuredIonName_;
@@ -10664,6 +10771,7 @@ public final class SkylineDocument {
         /**
          * <code>.google.protobuf.StringValue measured_ion_name = 7;</code>
          */
+        @Override
         public com.google.protobuf.StringValueOrBuilder getMeasuredIonNameOrBuilder() {
           if (measuredIonNameBuilder_ != null) {
             return measuredIonNameBuilder_.getMessageOrBuilder();
@@ -10679,8 +10787,7 @@ public final class SkylineDocument {
             com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder> 
             getMeasuredIonNameFieldBuilder() {
           if (measuredIonNameBuilder_ == null) {
-            measuredIonNameBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-                com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder>(
+            measuredIonNameBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<>(
                     getMeasuredIonName(),
                     getParentForChildren(),
                     isClean());
@@ -10696,6 +10803,7 @@ public final class SkylineDocument {
          * <code>.SkylineDocumentProto.OptionalInt decoyMassShift = 8;</code>
          * @return Whether the decoyMassShift field is set.
          */
+        @Override
         public boolean hasDecoyMassShift() {
           return ((bitField0_ & 0x00000020) != 0);
         }
@@ -10703,6 +10811,7 @@ public final class SkylineDocument {
          * <code>.SkylineDocumentProto.OptionalInt decoyMassShift = 8;</code>
          * @return The decoyMassShift.
          */
+        @Override
         public org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.OptionalInt getDecoyMassShift() {
           if (decoyMassShiftBuilder_ == null) {
             return decoyMassShift_ == null ? org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.OptionalInt.getDefaultInstance() : decoyMassShift_;
@@ -10785,6 +10894,7 @@ public final class SkylineDocument {
         /**
          * <code>.SkylineDocumentProto.OptionalInt decoyMassShift = 8;</code>
          */
+        @Override
         public org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.OptionalIntOrBuilder getDecoyMassShiftOrBuilder() {
           if (decoyMassShiftBuilder_ != null) {
             return decoyMassShiftBuilder_.getMessageOrBuilder();
@@ -10800,8 +10910,7 @@ public final class SkylineDocument {
             org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.OptionalInt, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.OptionalInt.Builder, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.OptionalIntOrBuilder> 
             getDecoyMassShiftFieldBuilder() {
           if (decoyMassShiftBuilder_ == null) {
-            decoyMassShiftBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-                org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.OptionalInt, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.OptionalInt.Builder, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.OptionalIntOrBuilder>(
+            decoyMassShiftBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<>(
                     getDecoyMassShift(),
                     getParentForChildren(),
                     isClean());
@@ -10849,6 +10958,7 @@ public final class SkylineDocument {
          * <code>.SkylineDocumentProto.OptionalInt isotopeDistRank = 11;</code>
          * @return Whether the isotopeDistRank field is set.
          */
+        @Override
         public boolean hasIsotopeDistRank() {
           return ((bitField0_ & 0x00000080) != 0);
         }
@@ -10856,6 +10966,7 @@ public final class SkylineDocument {
          * <code>.SkylineDocumentProto.OptionalInt isotopeDistRank = 11;</code>
          * @return The isotopeDistRank.
          */
+        @Override
         public org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.OptionalInt getIsotopeDistRank() {
           if (isotopeDistRankBuilder_ == null) {
             return isotopeDistRank_ == null ? org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.OptionalInt.getDefaultInstance() : isotopeDistRank_;
@@ -10938,6 +11049,7 @@ public final class SkylineDocument {
         /**
          * <code>.SkylineDocumentProto.OptionalInt isotopeDistRank = 11;</code>
          */
+        @Override
         public org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.OptionalIntOrBuilder getIsotopeDistRankOrBuilder() {
           if (isotopeDistRankBuilder_ != null) {
             return isotopeDistRankBuilder_.getMessageOrBuilder();
@@ -10953,8 +11065,7 @@ public final class SkylineDocument {
             org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.OptionalInt, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.OptionalInt.Builder, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.OptionalIntOrBuilder> 
             getIsotopeDistRankFieldBuilder() {
           if (isotopeDistRankBuilder_ == null) {
-            isotopeDistRankBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-                org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.OptionalInt, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.OptionalInt.Builder, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.OptionalIntOrBuilder>(
+            isotopeDistRankBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<>(
                     getIsotopeDistRank(),
                     getParentForChildren(),
                     isClean());
@@ -10970,6 +11081,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.FloatValue isotopeDistProportion = 12;</code>
          * @return Whether the isotopeDistProportion field is set.
          */
+        @Override
         public boolean hasIsotopeDistProportion() {
           return ((bitField0_ & 0x00000100) != 0);
         }
@@ -10977,6 +11089,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.FloatValue isotopeDistProportion = 12;</code>
          * @return The isotopeDistProportion.
          */
+        @Override
         public com.google.protobuf.FloatValue getIsotopeDistProportion() {
           if (isotopeDistProportionBuilder_ == null) {
             return isotopeDistProportion_ == null ? com.google.protobuf.FloatValue.getDefaultInstance() : isotopeDistProportion_;
@@ -11059,6 +11172,7 @@ public final class SkylineDocument {
         /**
          * <code>.google.protobuf.FloatValue isotopeDistProportion = 12;</code>
          */
+        @Override
         public com.google.protobuf.FloatValueOrBuilder getIsotopeDistProportionOrBuilder() {
           if (isotopeDistProportionBuilder_ != null) {
             return isotopeDistProportionBuilder_.getMessageOrBuilder();
@@ -11074,8 +11188,7 @@ public final class SkylineDocument {
             com.google.protobuf.FloatValue, com.google.protobuf.FloatValue.Builder, com.google.protobuf.FloatValueOrBuilder> 
             getIsotopeDistProportionFieldBuilder() {
           if (isotopeDistProportionBuilder_ == null) {
-            isotopeDistProportionBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-                com.google.protobuf.FloatValue, com.google.protobuf.FloatValue.Builder, com.google.protobuf.FloatValueOrBuilder>(
+            isotopeDistProportionBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<>(
                     getIsotopeDistProportion(),
                     getParentForChildren(),
                     isClean());
@@ -11263,6 +11376,7 @@ public final class SkylineDocument {
          * <code>.SkylineDocumentProto.Annotations annotations = 18;</code>
          * @return Whether the annotations field is set.
          */
+        @Override
         public boolean hasAnnotations() {
           return ((bitField0_ & 0x00004000) != 0);
         }
@@ -11270,6 +11384,7 @@ public final class SkylineDocument {
          * <code>.SkylineDocumentProto.Annotations annotations = 18;</code>
          * @return The annotations.
          */
+        @Override
         public org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.Annotations getAnnotations() {
           if (annotationsBuilder_ == null) {
             return annotations_ == null ? org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.Annotations.getDefaultInstance() : annotations_;
@@ -11352,6 +11467,7 @@ public final class SkylineDocument {
         /**
          * <code>.SkylineDocumentProto.Annotations annotations = 18;</code>
          */
+        @Override
         public org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.AnnotationsOrBuilder getAnnotationsOrBuilder() {
           if (annotationsBuilder_ != null) {
             return annotationsBuilder_.getMessageOrBuilder();
@@ -11367,8 +11483,7 @@ public final class SkylineDocument {
             org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.Annotations, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.Annotations.Builder, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.AnnotationsOrBuilder> 
             getAnnotationsFieldBuilder() {
           if (annotationsBuilder_ == null) {
-            annotationsBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-                org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.Annotations, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.Annotations.Builder, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.AnnotationsOrBuilder>(
+            annotationsBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<>(
                     getAnnotations(),
                     getParentForChildren(),
                     isClean());
@@ -11448,6 +11563,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.DoubleValue collisionEnergy = 21;</code>
          * @return Whether the collisionEnergy field is set.
          */
+        @Override
         public boolean hasCollisionEnergy() {
           return ((bitField0_ & 0x00020000) != 0);
         }
@@ -11455,6 +11571,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.DoubleValue collisionEnergy = 21;</code>
          * @return The collisionEnergy.
          */
+        @Override
         public com.google.protobuf.DoubleValue getCollisionEnergy() {
           if (collisionEnergyBuilder_ == null) {
             return collisionEnergy_ == null ? com.google.protobuf.DoubleValue.getDefaultInstance() : collisionEnergy_;
@@ -11537,6 +11654,7 @@ public final class SkylineDocument {
         /**
          * <code>.google.protobuf.DoubleValue collisionEnergy = 21;</code>
          */
+        @Override
         public com.google.protobuf.DoubleValueOrBuilder getCollisionEnergyOrBuilder() {
           if (collisionEnergyBuilder_ != null) {
             return collisionEnergyBuilder_.getMessageOrBuilder();
@@ -11552,8 +11670,7 @@ public final class SkylineDocument {
             com.google.protobuf.DoubleValue, com.google.protobuf.DoubleValue.Builder, com.google.protobuf.DoubleValueOrBuilder> 
             getCollisionEnergyFieldBuilder() {
           if (collisionEnergyBuilder_ == null) {
-            collisionEnergyBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-                com.google.protobuf.DoubleValue, com.google.protobuf.DoubleValue.Builder, com.google.protobuf.DoubleValueOrBuilder>(
+            collisionEnergyBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<>(
                     getCollisionEnergy(),
                     getParentForChildren(),
                     isClean());
@@ -11569,6 +11686,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.DoubleValue declusteringPotential = 22;</code>
          * @return Whether the declusteringPotential field is set.
          */
+        @Override
         public boolean hasDeclusteringPotential() {
           return ((bitField0_ & 0x00040000) != 0);
         }
@@ -11576,6 +11694,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.DoubleValue declusteringPotential = 22;</code>
          * @return The declusteringPotential.
          */
+        @Override
         public com.google.protobuf.DoubleValue getDeclusteringPotential() {
           if (declusteringPotentialBuilder_ == null) {
             return declusteringPotential_ == null ? com.google.protobuf.DoubleValue.getDefaultInstance() : declusteringPotential_;
@@ -11658,6 +11777,7 @@ public final class SkylineDocument {
         /**
          * <code>.google.protobuf.DoubleValue declusteringPotential = 22;</code>
          */
+        @Override
         public com.google.protobuf.DoubleValueOrBuilder getDeclusteringPotentialOrBuilder() {
           if (declusteringPotentialBuilder_ != null) {
             return declusteringPotentialBuilder_.getMessageOrBuilder();
@@ -11673,8 +11793,7 @@ public final class SkylineDocument {
             com.google.protobuf.DoubleValue, com.google.protobuf.DoubleValue.Builder, com.google.protobuf.DoubleValueOrBuilder> 
             getDeclusteringPotentialFieldBuilder() {
           if (declusteringPotentialBuilder_ == null) {
-            declusteringPotentialBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-                com.google.protobuf.DoubleValue, com.google.protobuf.DoubleValue.Builder, com.google.protobuf.DoubleValueOrBuilder>(
+            declusteringPotentialBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<>(
                     getDeclusteringPotential(),
                     getParentForChildren(),
                     isClean());
@@ -11687,7 +11806,7 @@ public final class SkylineDocument {
           java.util.Collections.emptyList();
         private void ensureLossesIsMutable() {
           if (!((bitField0_ & 0x00080000) != 0)) {
-            losses_ = new java.util.ArrayList<org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionLoss>(losses_);
+            losses_ = new java.util.ArrayList<>(losses_);
             bitField0_ |= 0x00080000;
            }
         }
@@ -11698,6 +11817,7 @@ public final class SkylineDocument {
         /**
          * <code>repeated .SkylineDocumentProto.TransitionLoss losses = 23;</code>
          */
+        @Override
         public java.util.List<org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionLoss> getLossesList() {
           if (lossesBuilder_ == null) {
             return java.util.Collections.unmodifiableList(losses_);
@@ -11708,6 +11828,7 @@ public final class SkylineDocument {
         /**
          * <code>repeated .SkylineDocumentProto.TransitionLoss losses = 23;</code>
          */
+        @Override
         public int getLossesCount() {
           if (lossesBuilder_ == null) {
             return losses_.size();
@@ -11718,6 +11839,7 @@ public final class SkylineDocument {
         /**
          * <code>repeated .SkylineDocumentProto.TransitionLoss losses = 23;</code>
          */
+        @Override
         public org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionLoss getLosses(int index) {
           if (lossesBuilder_ == null) {
             return losses_.get(index);
@@ -11868,6 +11990,7 @@ public final class SkylineDocument {
         /**
          * <code>repeated .SkylineDocumentProto.TransitionLoss losses = 23;</code>
          */
+        @Override
         public org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionLossOrBuilder getLossesOrBuilder(
             int index) {
           if (lossesBuilder_ == null) {
@@ -11878,7 +12001,8 @@ public final class SkylineDocument {
         /**
          * <code>repeated .SkylineDocumentProto.TransitionLoss losses = 23;</code>
          */
-        public java.util.List<? extends org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionLossOrBuilder> 
+        @Override
+        public java.util.List<? extends org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionLossOrBuilder>
              getLossesOrBuilderList() {
           if (lossesBuilder_ != null) {
             return lossesBuilder_.getMessageOrBuilderList();
@@ -11912,8 +12036,7 @@ public final class SkylineDocument {
             org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionLoss, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionLoss.Builder, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionLossOrBuilder> 
             getLossesFieldBuilder() {
           if (lossesBuilder_ == null) {
-            lossesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-                org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionLoss, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionLoss.Builder, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionLossOrBuilder>(
+            lossesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<>(
                     losses_,
                     ((bitField0_ & 0x00080000) != 0),
                     getParentForChildren(),
@@ -11983,6 +12106,7 @@ public final class SkylineDocument {
          * <code>.SkylineDocumentProto.TransitionLibInfo libInfo = 25;</code>
          * @return Whether the libInfo field is set.
          */
+        @Override
         public boolean hasLibInfo() {
           return ((bitField0_ & 0x00200000) != 0);
         }
@@ -11990,6 +12114,7 @@ public final class SkylineDocument {
          * <code>.SkylineDocumentProto.TransitionLibInfo libInfo = 25;</code>
          * @return The libInfo.
          */
+        @Override
         public org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionLibInfo getLibInfo() {
           if (libInfoBuilder_ == null) {
             return libInfo_ == null ? org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionLibInfo.getDefaultInstance() : libInfo_;
@@ -12072,6 +12197,7 @@ public final class SkylineDocument {
         /**
          * <code>.SkylineDocumentProto.TransitionLibInfo libInfo = 25;</code>
          */
+        @Override
         public org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionLibInfoOrBuilder getLibInfoOrBuilder() {
           if (libInfoBuilder_ != null) {
             return libInfoBuilder_.getMessageOrBuilder();
@@ -12087,8 +12213,7 @@ public final class SkylineDocument {
             org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionLibInfo, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionLibInfo.Builder, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionLibInfoOrBuilder> 
             getLibInfoFieldBuilder() {
           if (libInfoBuilder_ == null) {
-            libInfoBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-                org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionLibInfo, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionLibInfo.Builder, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionLibInfoOrBuilder>(
+            libInfoBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<>(
                     getLibInfo(),
                     getParentForChildren(),
                     isClean());
@@ -12104,6 +12229,7 @@ public final class SkylineDocument {
          * <code>.SkylineDocumentProto.TransitionResults results = 26;</code>
          * @return Whether the results field is set.
          */
+        @Override
         public boolean hasResults() {
           return ((bitField0_ & 0x00400000) != 0);
         }
@@ -12111,6 +12237,7 @@ public final class SkylineDocument {
          * <code>.SkylineDocumentProto.TransitionResults results = 26;</code>
          * @return The results.
          */
+        @Override
         public org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionResults getResults() {
           if (resultsBuilder_ == null) {
             return results_ == null ? org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionResults.getDefaultInstance() : results_;
@@ -12193,6 +12320,7 @@ public final class SkylineDocument {
         /**
          * <code>.SkylineDocumentProto.TransitionResults results = 26;</code>
          */
+        @Override
         public org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionResultsOrBuilder getResultsOrBuilder() {
           if (resultsBuilder_ != null) {
             return resultsBuilder_.getMessageOrBuilder();
@@ -12208,8 +12336,7 @@ public final class SkylineDocument {
             org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionResults, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionResults.Builder, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionResultsOrBuilder> 
             getResultsFieldBuilder() {
           if (resultsBuilder_ == null) {
-            resultsBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-                org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionResults, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionResults.Builder, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionResultsOrBuilder>(
+            resultsBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<>(
                     getResults(),
                     getParentForChildren(),
                     isClean());
@@ -12225,6 +12352,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.DoubleValue averageMass = 27;</code>
          * @return Whether the averageMass field is set.
          */
+        @Override
         public boolean hasAverageMass() {
           return ((bitField0_ & 0x00800000) != 0);
         }
@@ -12232,6 +12360,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.DoubleValue averageMass = 27;</code>
          * @return The averageMass.
          */
+        @Override
         public com.google.protobuf.DoubleValue getAverageMass() {
           if (averageMassBuilder_ == null) {
             return averageMass_ == null ? com.google.protobuf.DoubleValue.getDefaultInstance() : averageMass_;
@@ -12314,6 +12443,7 @@ public final class SkylineDocument {
         /**
          * <code>.google.protobuf.DoubleValue averageMass = 27;</code>
          */
+        @Override
         public com.google.protobuf.DoubleValueOrBuilder getAverageMassOrBuilder() {
           if (averageMassBuilder_ != null) {
             return averageMassBuilder_.getMessageOrBuilder();
@@ -12329,8 +12459,7 @@ public final class SkylineDocument {
             com.google.protobuf.DoubleValue, com.google.protobuf.DoubleValue.Builder, com.google.protobuf.DoubleValueOrBuilder> 
             getAverageMassFieldBuilder() {
           if (averageMassBuilder_ == null) {
-            averageMassBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-                com.google.protobuf.DoubleValue, com.google.protobuf.DoubleValue.Builder, com.google.protobuf.DoubleValueOrBuilder>(
+            averageMassBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<>(
                     getAverageMass(),
                     getParentForChildren(),
                     isClean());
@@ -12346,6 +12475,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.DoubleValue monoMass = 28;</code>
          * @return Whether the monoMass field is set.
          */
+        @Override
         public boolean hasMonoMass() {
           return ((bitField0_ & 0x01000000) != 0);
         }
@@ -12353,6 +12483,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.DoubleValue monoMass = 28;</code>
          * @return The monoMass.
          */
+        @Override
         public com.google.protobuf.DoubleValue getMonoMass() {
           if (monoMassBuilder_ == null) {
             return monoMass_ == null ? com.google.protobuf.DoubleValue.getDefaultInstance() : monoMass_;
@@ -12435,6 +12566,7 @@ public final class SkylineDocument {
         /**
          * <code>.google.protobuf.DoubleValue monoMass = 28;</code>
          */
+        @Override
         public com.google.protobuf.DoubleValueOrBuilder getMonoMassOrBuilder() {
           if (monoMassBuilder_ != null) {
             return monoMassBuilder_.getMessageOrBuilder();
@@ -12450,8 +12582,7 @@ public final class SkylineDocument {
             com.google.protobuf.DoubleValue, com.google.protobuf.DoubleValue.Builder, com.google.protobuf.DoubleValueOrBuilder> 
             getMonoMassFieldBuilder() {
           if (monoMassBuilder_ == null) {
-            monoMassBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-                com.google.protobuf.DoubleValue, com.google.protobuf.DoubleValue.Builder, com.google.protobuf.DoubleValueOrBuilder>(
+            monoMassBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<>(
                     getMonoMass(),
                     getParentForChildren(),
                     isClean());
@@ -12467,6 +12598,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.StringValue adduct = 29;</code>
          * @return Whether the adduct field is set.
          */
+        @Override
         public boolean hasAdduct() {
           return ((bitField0_ & 0x02000000) != 0);
         }
@@ -12474,6 +12606,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.StringValue adduct = 29;</code>
          * @return The adduct.
          */
+        @Override
         public com.google.protobuf.StringValue getAdduct() {
           if (adductBuilder_ == null) {
             return adduct_ == null ? com.google.protobuf.StringValue.getDefaultInstance() : adduct_;
@@ -12556,6 +12689,7 @@ public final class SkylineDocument {
         /**
          * <code>.google.protobuf.StringValue adduct = 29;</code>
          */
+        @Override
         public com.google.protobuf.StringValueOrBuilder getAdductOrBuilder() {
           if (adductBuilder_ != null) {
             return adductBuilder_.getMessageOrBuilder();
@@ -12571,8 +12705,7 @@ public final class SkylineDocument {
             com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder> 
             getAdductFieldBuilder() {
           if (adductBuilder_ == null) {
-            adductBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-                com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder>(
+            adductBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<>(
                     getAdduct(),
                     getParentForChildren(),
                     isClean());
@@ -12588,6 +12721,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.StringValue molecule_id = 30;</code>
          * @return Whether the moleculeId field is set.
          */
+        @Override
         public boolean hasMoleculeId() {
           return ((bitField0_ & 0x04000000) != 0);
         }
@@ -12595,6 +12729,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.StringValue molecule_id = 30;</code>
          * @return The moleculeId.
          */
+        @Override
         public com.google.protobuf.StringValue getMoleculeId() {
           if (moleculeIdBuilder_ == null) {
             return moleculeId_ == null ? com.google.protobuf.StringValue.getDefaultInstance() : moleculeId_;
@@ -12677,6 +12812,7 @@ public final class SkylineDocument {
         /**
          * <code>.google.protobuf.StringValue molecule_id = 30;</code>
          */
+        @Override
         public com.google.protobuf.StringValueOrBuilder getMoleculeIdOrBuilder() {
           if (moleculeIdBuilder_ != null) {
             return moleculeIdBuilder_.getMessageOrBuilder();
@@ -12692,8 +12828,7 @@ public final class SkylineDocument {
             com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder> 
             getMoleculeIdFieldBuilder() {
           if (moleculeIdBuilder_ == null) {
-            moleculeIdBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-                com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder>(
+            moleculeIdBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<>(
                     getMoleculeId(),
                     getParentForChildren(),
                     isClean());
@@ -12741,6 +12876,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.DoubleValue explicitCollisionEnergy = 32;</code>
          * @return Whether the explicitCollisionEnergy field is set.
          */
+        @Override
         public boolean hasExplicitCollisionEnergy() {
           return ((bitField0_ & 0x10000000) != 0);
         }
@@ -12748,6 +12884,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.DoubleValue explicitCollisionEnergy = 32;</code>
          * @return The explicitCollisionEnergy.
          */
+        @Override
         public com.google.protobuf.DoubleValue getExplicitCollisionEnergy() {
           if (explicitCollisionEnergyBuilder_ == null) {
             return explicitCollisionEnergy_ == null ? com.google.protobuf.DoubleValue.getDefaultInstance() : explicitCollisionEnergy_;
@@ -12830,6 +12967,7 @@ public final class SkylineDocument {
         /**
          * <code>.google.protobuf.DoubleValue explicitCollisionEnergy = 32;</code>
          */
+        @Override
         public com.google.protobuf.DoubleValueOrBuilder getExplicitCollisionEnergyOrBuilder() {
           if (explicitCollisionEnergyBuilder_ != null) {
             return explicitCollisionEnergyBuilder_.getMessageOrBuilder();
@@ -12845,8 +12983,7 @@ public final class SkylineDocument {
             com.google.protobuf.DoubleValue, com.google.protobuf.DoubleValue.Builder, com.google.protobuf.DoubleValueOrBuilder> 
             getExplicitCollisionEnergyFieldBuilder() {
           if (explicitCollisionEnergyBuilder_ == null) {
-            explicitCollisionEnergyBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-                com.google.protobuf.DoubleValue, com.google.protobuf.DoubleValue.Builder, com.google.protobuf.DoubleValueOrBuilder>(
+            explicitCollisionEnergyBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<>(
                     getExplicitCollisionEnergy(),
                     getParentForChildren(),
                     isClean());
@@ -12862,6 +12999,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.DoubleValue explicitIonMobilityHighEnergyOffset = 33;</code>
          * @return Whether the explicitIonMobilityHighEnergyOffset field is set.
          */
+        @Override
         public boolean hasExplicitIonMobilityHighEnergyOffset() {
           return ((bitField0_ & 0x20000000) != 0);
         }
@@ -12869,6 +13007,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.DoubleValue explicitIonMobilityHighEnergyOffset = 33;</code>
          * @return The explicitIonMobilityHighEnergyOffset.
          */
+        @Override
         public com.google.protobuf.DoubleValue getExplicitIonMobilityHighEnergyOffset() {
           if (explicitIonMobilityHighEnergyOffsetBuilder_ == null) {
             return explicitIonMobilityHighEnergyOffset_ == null ? com.google.protobuf.DoubleValue.getDefaultInstance() : explicitIonMobilityHighEnergyOffset_;
@@ -12951,6 +13090,7 @@ public final class SkylineDocument {
         /**
          * <code>.google.protobuf.DoubleValue explicitIonMobilityHighEnergyOffset = 33;</code>
          */
+        @Override
         public com.google.protobuf.DoubleValueOrBuilder getExplicitIonMobilityHighEnergyOffsetOrBuilder() {
           if (explicitIonMobilityHighEnergyOffsetBuilder_ != null) {
             return explicitIonMobilityHighEnergyOffsetBuilder_.getMessageOrBuilder();
@@ -12966,8 +13106,7 @@ public final class SkylineDocument {
             com.google.protobuf.DoubleValue, com.google.protobuf.DoubleValue.Builder, com.google.protobuf.DoubleValueOrBuilder> 
             getExplicitIonMobilityHighEnergyOffsetFieldBuilder() {
           if (explicitIonMobilityHighEnergyOffsetBuilder_ == null) {
-            explicitIonMobilityHighEnergyOffsetBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-                com.google.protobuf.DoubleValue, com.google.protobuf.DoubleValue.Builder, com.google.protobuf.DoubleValueOrBuilder>(
+            explicitIonMobilityHighEnergyOffsetBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<>(
                     getExplicitIonMobilityHighEnergyOffset(),
                     getParentForChildren(),
                     isClean());
@@ -12983,6 +13122,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.DoubleValue explicitSLens = 34;</code>
          * @return Whether the explicitSLens field is set.
          */
+        @Override
         public boolean hasExplicitSLens() {
           return ((bitField0_ & 0x40000000) != 0);
         }
@@ -12990,6 +13130,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.DoubleValue explicitSLens = 34;</code>
          * @return The explicitSLens.
          */
+        @Override
         public com.google.protobuf.DoubleValue getExplicitSLens() {
           if (explicitSLensBuilder_ == null) {
             return explicitSLens_ == null ? com.google.protobuf.DoubleValue.getDefaultInstance() : explicitSLens_;
@@ -13072,6 +13213,7 @@ public final class SkylineDocument {
         /**
          * <code>.google.protobuf.DoubleValue explicitSLens = 34;</code>
          */
+        @Override
         public com.google.protobuf.DoubleValueOrBuilder getExplicitSLensOrBuilder() {
           if (explicitSLensBuilder_ != null) {
             return explicitSLensBuilder_.getMessageOrBuilder();
@@ -13087,8 +13229,7 @@ public final class SkylineDocument {
             com.google.protobuf.DoubleValue, com.google.protobuf.DoubleValue.Builder, com.google.protobuf.DoubleValueOrBuilder> 
             getExplicitSLensFieldBuilder() {
           if (explicitSLensBuilder_ == null) {
-            explicitSLensBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-                com.google.protobuf.DoubleValue, com.google.protobuf.DoubleValue.Builder, com.google.protobuf.DoubleValueOrBuilder>(
+            explicitSLensBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<>(
                     getExplicitSLens(),
                     getParentForChildren(),
                     isClean());
@@ -13104,6 +13245,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.DoubleValue explicitConeVoltage = 35;</code>
          * @return Whether the explicitConeVoltage field is set.
          */
+        @Override
         public boolean hasExplicitConeVoltage() {
           return ((bitField0_ & 0x80000000) != 0);
         }
@@ -13111,6 +13253,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.DoubleValue explicitConeVoltage = 35;</code>
          * @return The explicitConeVoltage.
          */
+        @Override
         public com.google.protobuf.DoubleValue getExplicitConeVoltage() {
           if (explicitConeVoltageBuilder_ == null) {
             return explicitConeVoltage_ == null ? com.google.protobuf.DoubleValue.getDefaultInstance() : explicitConeVoltage_;
@@ -13193,6 +13336,7 @@ public final class SkylineDocument {
         /**
          * <code>.google.protobuf.DoubleValue explicitConeVoltage = 35;</code>
          */
+        @Override
         public com.google.protobuf.DoubleValueOrBuilder getExplicitConeVoltageOrBuilder() {
           if (explicitConeVoltageBuilder_ != null) {
             return explicitConeVoltageBuilder_.getMessageOrBuilder();
@@ -13208,8 +13352,7 @@ public final class SkylineDocument {
             com.google.protobuf.DoubleValue, com.google.protobuf.DoubleValue.Builder, com.google.protobuf.DoubleValueOrBuilder> 
             getExplicitConeVoltageFieldBuilder() {
           if (explicitConeVoltageBuilder_ == null) {
-            explicitConeVoltageBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-                com.google.protobuf.DoubleValue, com.google.protobuf.DoubleValue.Builder, com.google.protobuf.DoubleValueOrBuilder>(
+            explicitConeVoltageBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<>(
                     getExplicitConeVoltage(),
                     getParentForChildren(),
                     isClean());
@@ -13225,6 +13368,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.DoubleValue explicitDeclusteringPotential = 36;</code>
          * @return Whether the explicitDeclusteringPotential field is set.
          */
+        @Override
         public boolean hasExplicitDeclusteringPotential() {
           return ((bitField1_ & 0x00000001) != 0);
         }
@@ -13232,6 +13376,7 @@ public final class SkylineDocument {
          * <code>.google.protobuf.DoubleValue explicitDeclusteringPotential = 36;</code>
          * @return The explicitDeclusteringPotential.
          */
+        @Override
         public com.google.protobuf.DoubleValue getExplicitDeclusteringPotential() {
           if (explicitDeclusteringPotentialBuilder_ == null) {
             return explicitDeclusteringPotential_ == null ? com.google.protobuf.DoubleValue.getDefaultInstance() : explicitDeclusteringPotential_;
@@ -13314,6 +13459,7 @@ public final class SkylineDocument {
         /**
          * <code>.google.protobuf.DoubleValue explicitDeclusteringPotential = 36;</code>
          */
+        @Override
         public com.google.protobuf.DoubleValueOrBuilder getExplicitDeclusteringPotentialOrBuilder() {
           if (explicitDeclusteringPotentialBuilder_ != null) {
             return explicitDeclusteringPotentialBuilder_.getMessageOrBuilder();
@@ -13329,8 +13475,7 @@ public final class SkylineDocument {
             com.google.protobuf.DoubleValue, com.google.protobuf.DoubleValue.Builder, com.google.protobuf.DoubleValueOrBuilder> 
             getExplicitDeclusteringPotentialFieldBuilder() {
           if (explicitDeclusteringPotentialBuilder_ == null) {
-            explicitDeclusteringPotentialBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-                com.google.protobuf.DoubleValue, com.google.protobuf.DoubleValue.Builder, com.google.protobuf.DoubleValueOrBuilder>(
+            explicitDeclusteringPotentialBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<>(
                     getExplicitDeclusteringPotential(),
                     getParentForChildren(),
                     isClean());
@@ -13375,7 +13520,7 @@ public final class SkylineDocument {
           java.util.Collections.emptyList();
         private void ensureLinkedIonsIsMutable() {
           if (!((bitField1_ & 0x00000004) != 0)) {
-            linkedIons_ = new java.util.ArrayList<org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.LinkedIon>(linkedIons_);
+            linkedIons_ = new java.util.ArrayList<>(linkedIons_);
             bitField1_ |= 0x00000004;
            }
         }
@@ -13386,6 +13531,7 @@ public final class SkylineDocument {
         /**
          * <code>repeated .SkylineDocumentProto.LinkedIon linkedIons = 38;</code>
          */
+        @Override
         public java.util.List<org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.LinkedIon> getLinkedIonsList() {
           if (linkedIonsBuilder_ == null) {
             return java.util.Collections.unmodifiableList(linkedIons_);
@@ -13396,6 +13542,7 @@ public final class SkylineDocument {
         /**
          * <code>repeated .SkylineDocumentProto.LinkedIon linkedIons = 38;</code>
          */
+        @Override
         public int getLinkedIonsCount() {
           if (linkedIonsBuilder_ == null) {
             return linkedIons_.size();
@@ -13406,6 +13553,7 @@ public final class SkylineDocument {
         /**
          * <code>repeated .SkylineDocumentProto.LinkedIon linkedIons = 38;</code>
          */
+        @Override
         public org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.LinkedIon getLinkedIons(int index) {
           if (linkedIonsBuilder_ == null) {
             return linkedIons_.get(index);
@@ -13556,6 +13704,7 @@ public final class SkylineDocument {
         /**
          * <code>repeated .SkylineDocumentProto.LinkedIon linkedIons = 38;</code>
          */
+        @Override
         public org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.LinkedIonOrBuilder getLinkedIonsOrBuilder(
             int index) {
           if (linkedIonsBuilder_ == null) {
@@ -13566,7 +13715,8 @@ public final class SkylineDocument {
         /**
          * <code>repeated .SkylineDocumentProto.LinkedIon linkedIons = 38;</code>
          */
-        public java.util.List<? extends org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.LinkedIonOrBuilder> 
+        @Override
+        public java.util.List<? extends org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.LinkedIonOrBuilder>
              getLinkedIonsOrBuilderList() {
           if (linkedIonsBuilder_ != null) {
             return linkedIonsBuilder_.getMessageOrBuilderList();
@@ -13600,8 +13750,7 @@ public final class SkylineDocument {
             org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.LinkedIon, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.LinkedIon.Builder, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.LinkedIonOrBuilder> 
             getLinkedIonsFieldBuilder() {
           if (linkedIonsBuilder_ == null) {
-            linkedIonsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-                org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.LinkedIon, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.LinkedIon.Builder, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.LinkedIonOrBuilder>(
+            linkedIonsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<>(
                     linkedIons_,
                     ((bitField1_ & 0x00000004) != 0),
                     getParentForChildren(),
@@ -13637,25 +13786,34 @@ public final class SkylineDocument {
       }
 
       private static final com.google.protobuf.Parser<Transition>
-          PARSER = new com.google.protobuf.AbstractParser<Transition>() {
-        @java.lang.Override
-        public Transition parsePartialFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
-          Builder builder = newBuilder();
-          try {
-            builder.mergeFrom(input, extensionRegistry);
-          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-            throw e.setUnfinishedMessage(builder.buildPartial());
-          } catch (com.google.protobuf.UninitializedMessageException e) {
-            throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
-          } catch (java.io.IOException e) {
-            throw new com.google.protobuf.InvalidProtocolBufferException(e)
-                .setUnfinishedMessage(builder.buildPartial());
+          PARSER = new com.google.protobuf.AbstractParser<>()
+      {
+          @java.lang.Override
+          public Transition parsePartialFrom(
+                  com.google.protobuf.CodedInputStream input,
+                  com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                  throws com.google.protobuf.InvalidProtocolBufferException
+          {
+              Builder builder = newBuilder();
+              try
+              {
+                  builder.mergeFrom(input, extensionRegistry);
+              }
+              catch (com.google.protobuf.InvalidProtocolBufferException e)
+              {
+                  throw e.setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (com.google.protobuf.UninitializedMessageException e)
+              {
+                  throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (java.io.IOException e)
+              {
+                  throw new com.google.protobuf.InvalidProtocolBufferException(e)
+                          .setUnfinishedMessage(builder.buildPartial());
+              }
+              return builder.buildPartial();
           }
-          return builder.buildPartial();
-        }
       };
 
       public static com.google.protobuf.Parser<Transition> parser() {
@@ -13775,12 +13933,11 @@ public final class SkylineDocument {
         if (obj == this) {
          return true;
         }
-        if (!(obj instanceof org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.OptionalInt)) {
+        if (!(obj instanceof OptionalInt other)) {
           return super.equals(obj);
         }
-        org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.OptionalInt other = (org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.OptionalInt) obj;
 
-        if (getValue()
+          if (getValue()
             != other.getValue()) return false;
         if (!getUnknownFields().equals(other.getUnknownFields())) return false;
         return true;
@@ -14123,25 +14280,34 @@ public final class SkylineDocument {
       }
 
       private static final com.google.protobuf.Parser<OptionalInt>
-          PARSER = new com.google.protobuf.AbstractParser<OptionalInt>() {
-        @java.lang.Override
-        public OptionalInt parsePartialFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
-          Builder builder = newBuilder();
-          try {
-            builder.mergeFrom(input, extensionRegistry);
-          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-            throw e.setUnfinishedMessage(builder.buildPartial());
-          } catch (com.google.protobuf.UninitializedMessageException e) {
-            throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
-          } catch (java.io.IOException e) {
-            throw new com.google.protobuf.InvalidProtocolBufferException(e)
-                .setUnfinishedMessage(builder.buildPartial());
+          PARSER = new com.google.protobuf.AbstractParser<>()
+      {
+          @java.lang.Override
+          public OptionalInt parsePartialFrom(
+                  com.google.protobuf.CodedInputStream input,
+                  com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                  throws com.google.protobuf.InvalidProtocolBufferException
+          {
+              Builder builder = newBuilder();
+              try
+              {
+                  builder.mergeFrom(input, extensionRegistry);
+              }
+              catch (com.google.protobuf.InvalidProtocolBufferException e)
+              {
+                  throw e.setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (com.google.protobuf.UninitializedMessageException e)
+              {
+                  throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (java.io.IOException e)
+              {
+                  throw new com.google.protobuf.InvalidProtocolBufferException(e)
+                          .setUnfinishedMessage(builder.buildPartial());
+              }
+              return builder.buildPartial();
           }
-          return builder.buildPartial();
-        }
       };
 
       public static com.google.protobuf.Parser<OptionalInt> parser() {
@@ -14481,12 +14647,11 @@ public final class SkylineDocument {
         if (obj == this) {
          return true;
         }
-        if (!(obj instanceof org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionLoss)) {
+        if (!(obj instanceof TransitionLoss other)) {
           return super.equals(obj);
         }
-        org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionLoss other = (org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionLoss) obj;
 
-        if (!getFormula()
+          if (!getFormula()
             .equals(other.getFormula())) return false;
         if (java.lang.Double.doubleToLongBits(getMonoisotopicMass())
             != java.lang.Double.doubleToLongBits(
@@ -14874,6 +15039,7 @@ public final class SkylineDocument {
          * <code>string formula = 1;</code>
          * @return The formula.
          */
+        @Override
         public java.lang.String getFormula() {
           java.lang.Object ref = formula_;
           if (!(ref instanceof java.lang.String)) {
@@ -14890,6 +15056,7 @@ public final class SkylineDocument {
          * <code>string formula = 1;</code>
          * @return The bytes for formula.
          */
+        @Override
         public com.google.protobuf.ByteString
             getFormulaBytes() {
           java.lang.Object ref = formula_;
@@ -15063,6 +15230,7 @@ public final class SkylineDocument {
          * <code>string modificationName = 5;</code>
          * @return The modificationName.
          */
+        @Override
         public java.lang.String getModificationName() {
           java.lang.Object ref = modificationName_;
           if (!(ref instanceof java.lang.String)) {
@@ -15079,6 +15247,7 @@ public final class SkylineDocument {
          * <code>string modificationName = 5;</code>
          * @return The bytes for modificationName.
          */
+        @Override
         public com.google.protobuf.ByteString
             getModificationNameBytes() {
           java.lang.Object ref = modificationName_;
@@ -15220,25 +15389,34 @@ public final class SkylineDocument {
       }
 
       private static final com.google.protobuf.Parser<TransitionLoss>
-          PARSER = new com.google.protobuf.AbstractParser<TransitionLoss>() {
-        @java.lang.Override
-        public TransitionLoss parsePartialFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
-          Builder builder = newBuilder();
-          try {
-            builder.mergeFrom(input, extensionRegistry);
-          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-            throw e.setUnfinishedMessage(builder.buildPartial());
-          } catch (com.google.protobuf.UninitializedMessageException e) {
-            throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
-          } catch (java.io.IOException e) {
-            throw new com.google.protobuf.InvalidProtocolBufferException(e)
-                .setUnfinishedMessage(builder.buildPartial());
+          PARSER = new com.google.protobuf.AbstractParser<>()
+      {
+          @java.lang.Override
+          public TransitionLoss parsePartialFrom(
+                  com.google.protobuf.CodedInputStream input,
+                  com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                  throws com.google.protobuf.InvalidProtocolBufferException
+          {
+              Builder builder = newBuilder();
+              try
+              {
+                  builder.mergeFrom(input, extensionRegistry);
+              }
+              catch (com.google.protobuf.InvalidProtocolBufferException e)
+              {
+                  throw e.setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (com.google.protobuf.UninitializedMessageException e)
+              {
+                  throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (java.io.IOException e)
+              {
+                  throw new com.google.protobuf.InvalidProtocolBufferException(e)
+                          .setUnfinishedMessage(builder.buildPartial());
+              }
+              return builder.buildPartial();
           }
-          return builder.buildPartial();
-        }
       };
 
       public static com.google.protobuf.Parser<TransitionLoss> parser() {
@@ -15377,12 +15555,11 @@ public final class SkylineDocument {
         if (obj == this) {
          return true;
         }
-        if (!(obj instanceof org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionLibInfo)) {
+        if (!(obj instanceof TransitionLibInfo other)) {
           return super.equals(obj);
         }
-        org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionLibInfo other = (org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionLibInfo) obj;
 
-        if (getRank()
+          if (getRank()
             != other.getRank()) return false;
         if (java.lang.Float.floatToIntBits(getIntensity())
             != java.lang.Float.floatToIntBits(
@@ -15770,25 +15947,34 @@ public final class SkylineDocument {
       }
 
       private static final com.google.protobuf.Parser<TransitionLibInfo>
-          PARSER = new com.google.protobuf.AbstractParser<TransitionLibInfo>() {
-        @java.lang.Override
-        public TransitionLibInfo parsePartialFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
-          Builder builder = newBuilder();
-          try {
-            builder.mergeFrom(input, extensionRegistry);
-          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-            throw e.setUnfinishedMessage(builder.buildPartial());
-          } catch (com.google.protobuf.UninitializedMessageException e) {
-            throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
-          } catch (java.io.IOException e) {
-            throw new com.google.protobuf.InvalidProtocolBufferException(e)
-                .setUnfinishedMessage(builder.buildPartial());
+          PARSER = new com.google.protobuf.AbstractParser<>()
+      {
+          @java.lang.Override
+          public TransitionLibInfo parsePartialFrom(
+                  com.google.protobuf.CodedInputStream input,
+                  com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                  throws com.google.protobuf.InvalidProtocolBufferException
+          {
+              Builder builder = newBuilder();
+              try
+              {
+                  builder.mergeFrom(input, extensionRegistry);
+              }
+              catch (com.google.protobuf.InvalidProtocolBufferException e)
+              {
+                  throw e.setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (com.google.protobuf.UninitializedMessageException e)
+              {
+                  throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (java.io.IOException e)
+              {
+                  throw new com.google.protobuf.InvalidProtocolBufferException(e)
+                          .setUnfinishedMessage(builder.buildPartial());
+              }
+              return builder.buildPartial();
           }
-          return builder.buildPartial();
-        }
       };
 
       public static com.google.protobuf.Parser<TransitionLibInfo> parser() {
@@ -15952,12 +16138,11 @@ public final class SkylineDocument {
         if (obj == this) {
          return true;
         }
-        if (!(obj instanceof org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionData)) {
+        if (!(obj instanceof TransitionData other)) {
           return super.equals(obj);
         }
-        org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionData other = (org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionData) obj;
 
-        if (!getTransitionsList()
+          if (!getTransitionsList()
             .equals(other.getTransitionsList())) return false;
         if (!getUnknownFields().equals(other.getUnknownFields())) return false;
         return true;
@@ -16290,7 +16475,7 @@ public final class SkylineDocument {
           java.util.Collections.emptyList();
         private void ensureTransitionsIsMutable() {
           if (!((bitField0_ & 0x00000001) != 0)) {
-            transitions_ = new java.util.ArrayList<org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.Transition>(transitions_);
+            transitions_ = new java.util.ArrayList<>(transitions_);
             bitField0_ |= 0x00000001;
            }
         }
@@ -16301,6 +16486,7 @@ public final class SkylineDocument {
         /**
          * <code>repeated .SkylineDocumentProto.Transition transitions = 1;</code>
          */
+        @Override
         public java.util.List<org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.Transition> getTransitionsList() {
           if (transitionsBuilder_ == null) {
             return java.util.Collections.unmodifiableList(transitions_);
@@ -16311,6 +16497,7 @@ public final class SkylineDocument {
         /**
          * <code>repeated .SkylineDocumentProto.Transition transitions = 1;</code>
          */
+        @Override
         public int getTransitionsCount() {
           if (transitionsBuilder_ == null) {
             return transitions_.size();
@@ -16321,6 +16508,7 @@ public final class SkylineDocument {
         /**
          * <code>repeated .SkylineDocumentProto.Transition transitions = 1;</code>
          */
+        @Override
         public org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.Transition getTransitions(int index) {
           if (transitionsBuilder_ == null) {
             return transitions_.get(index);
@@ -16471,6 +16659,7 @@ public final class SkylineDocument {
         /**
          * <code>repeated .SkylineDocumentProto.Transition transitions = 1;</code>
          */
+        @Override
         public org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionOrBuilder getTransitionsOrBuilder(
             int index) {
           if (transitionsBuilder_ == null) {
@@ -16481,7 +16670,8 @@ public final class SkylineDocument {
         /**
          * <code>repeated .SkylineDocumentProto.Transition transitions = 1;</code>
          */
-        public java.util.List<? extends org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionOrBuilder> 
+        @Override
+        public java.util.List<? extends org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionOrBuilder>
              getTransitionsOrBuilderList() {
           if (transitionsBuilder_ != null) {
             return transitionsBuilder_.getMessageOrBuilderList();
@@ -16515,8 +16705,7 @@ public final class SkylineDocument {
             org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.Transition, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.Transition.Builder, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionOrBuilder> 
             getTransitionsFieldBuilder() {
           if (transitionsBuilder_ == null) {
-            transitionsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-                org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.Transition, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.Transition.Builder, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.TransitionOrBuilder>(
+            transitionsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<>(
                     transitions_,
                     ((bitField0_ & 0x00000001) != 0),
                     getParentForChildren(),
@@ -16552,25 +16741,34 @@ public final class SkylineDocument {
       }
 
       private static final com.google.protobuf.Parser<TransitionData>
-          PARSER = new com.google.protobuf.AbstractParser<TransitionData>() {
-        @java.lang.Override
-        public TransitionData parsePartialFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
-          Builder builder = newBuilder();
-          try {
-            builder.mergeFrom(input, extensionRegistry);
-          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-            throw e.setUnfinishedMessage(builder.buildPartial());
-          } catch (com.google.protobuf.UninitializedMessageException e) {
-            throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
-          } catch (java.io.IOException e) {
-            throw new com.google.protobuf.InvalidProtocolBufferException(e)
-                .setUnfinishedMessage(builder.buildPartial());
+          PARSER = new com.google.protobuf.AbstractParser<>()
+      {
+          @java.lang.Override
+          public TransitionData parsePartialFrom(
+                  com.google.protobuf.CodedInputStream input,
+                  com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                  throws com.google.protobuf.InvalidProtocolBufferException
+          {
+              Builder builder = newBuilder();
+              try
+              {
+                  builder.mergeFrom(input, extensionRegistry);
+              }
+              catch (com.google.protobuf.InvalidProtocolBufferException e)
+              {
+                  throw e.setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (com.google.protobuf.UninitializedMessageException e)
+              {
+                  throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (java.io.IOException e)
+              {
+                  throw new com.google.protobuf.InvalidProtocolBufferException(e)
+                          .setUnfinishedMessage(builder.buildPartial());
+              }
+              return builder.buildPartial();
           }
-          return builder.buildPartial();
-        }
       };
 
       public static com.google.protobuf.Parser<TransitionData> parser() {
@@ -16901,12 +17099,11 @@ public final class SkylineDocument {
         if (obj == this) {
          return true;
         }
-        if (!(obj instanceof org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.LinkedIon)) {
+        if (!(obj instanceof LinkedIon other)) {
           return super.equals(obj);
         }
-        org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.LinkedIon other = (org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.LinkedIon) obj;
 
-        if (ionType_ != other.ionType_) return false;
+          if (ionType_ != other.ionType_) return false;
         if (getOrdinal()
             != other.getOrdinal()) return false;
         if (getModificationIndex()
@@ -17439,6 +17636,7 @@ public final class SkylineDocument {
          * <code>string modificationName = 4;</code>
          * @return The modificationName.
          */
+        @Override
         public java.lang.String getModificationName() {
           java.lang.Object ref = modificationName_;
           if (!(ref instanceof java.lang.String)) {
@@ -17455,6 +17653,7 @@ public final class SkylineDocument {
          * <code>string modificationName = 4;</code>
          * @return The bytes for modificationName.
          */
+        @Override
         public com.google.protobuf.ByteString
             getModificationNameBytes() {
           java.lang.Object ref = modificationName_;
@@ -17510,7 +17709,7 @@ public final class SkylineDocument {
           java.util.Collections.emptyList();
         private void ensureChildrenIsMutable() {
           if (!((bitField0_ & 0x00000010) != 0)) {
-            children_ = new java.util.ArrayList<org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.LinkedIon>(children_);
+            children_ = new java.util.ArrayList<>(children_);
             bitField0_ |= 0x00000010;
            }
         }
@@ -17521,6 +17720,7 @@ public final class SkylineDocument {
         /**
          * <code>repeated .SkylineDocumentProto.LinkedIon children = 5;</code>
          */
+        @Override
         public java.util.List<org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.LinkedIon> getChildrenList() {
           if (childrenBuilder_ == null) {
             return java.util.Collections.unmodifiableList(children_);
@@ -17531,6 +17731,7 @@ public final class SkylineDocument {
         /**
          * <code>repeated .SkylineDocumentProto.LinkedIon children = 5;</code>
          */
+        @Override
         public int getChildrenCount() {
           if (childrenBuilder_ == null) {
             return children_.size();
@@ -17541,6 +17742,7 @@ public final class SkylineDocument {
         /**
          * <code>repeated .SkylineDocumentProto.LinkedIon children = 5;</code>
          */
+        @Override
         public org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.LinkedIon getChildren(int index) {
           if (childrenBuilder_ == null) {
             return children_.get(index);
@@ -17691,6 +17893,7 @@ public final class SkylineDocument {
         /**
          * <code>repeated .SkylineDocumentProto.LinkedIon children = 5;</code>
          */
+        @Override
         public org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.LinkedIonOrBuilder getChildrenOrBuilder(
             int index) {
           if (childrenBuilder_ == null) {
@@ -17701,7 +17904,8 @@ public final class SkylineDocument {
         /**
          * <code>repeated .SkylineDocumentProto.LinkedIon children = 5;</code>
          */
-        public java.util.List<? extends org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.LinkedIonOrBuilder> 
+        @Override
+        public java.util.List<? extends org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.LinkedIonOrBuilder>
              getChildrenOrBuilderList() {
           if (childrenBuilder_ != null) {
             return childrenBuilder_.getMessageOrBuilderList();
@@ -17735,8 +17939,7 @@ public final class SkylineDocument {
             org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.LinkedIon, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.LinkedIon.Builder, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.LinkedIonOrBuilder> 
             getChildrenFieldBuilder() {
           if (childrenBuilder_ == null) {
-            childrenBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-                org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.LinkedIon, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.LinkedIon.Builder, org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto.LinkedIonOrBuilder>(
+            childrenBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<>(
                     children_,
                     ((bitField0_ & 0x00000010) != 0),
                     getParentForChildren(),
@@ -17804,25 +18007,34 @@ public final class SkylineDocument {
       }
 
       private static final com.google.protobuf.Parser<LinkedIon>
-          PARSER = new com.google.protobuf.AbstractParser<LinkedIon>() {
-        @java.lang.Override
-        public LinkedIon parsePartialFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
-          Builder builder = newBuilder();
-          try {
-            builder.mergeFrom(input, extensionRegistry);
-          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-            throw e.setUnfinishedMessage(builder.buildPartial());
-          } catch (com.google.protobuf.UninitializedMessageException e) {
-            throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
-          } catch (java.io.IOException e) {
-            throw new com.google.protobuf.InvalidProtocolBufferException(e)
-                .setUnfinishedMessage(builder.buildPartial());
+          PARSER = new com.google.protobuf.AbstractParser<>()
+      {
+          @java.lang.Override
+          public LinkedIon parsePartialFrom(
+                  com.google.protobuf.CodedInputStream input,
+                  com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                  throws com.google.protobuf.InvalidProtocolBufferException
+          {
+              Builder builder = newBuilder();
+              try
+              {
+                  builder.mergeFrom(input, extensionRegistry);
+              }
+              catch (com.google.protobuf.InvalidProtocolBufferException e)
+              {
+                  throw e.setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (com.google.protobuf.UninitializedMessageException e)
+              {
+                  throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (java.io.IOException e)
+              {
+                  throw new com.google.protobuf.InvalidProtocolBufferException(e)
+                          .setUnfinishedMessage(builder.buildPartial());
+              }
+              return builder.buildPartial();
           }
-          return builder.buildPartial();
-        }
       };
 
       public static com.google.protobuf.Parser<LinkedIon> parser() {
@@ -17874,12 +18086,11 @@ public final class SkylineDocument {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto)) {
+      if (!(obj instanceof SkylineDocumentProto other)) {
         return super.equals(obj);
       }
-      org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto other = (org.labkey.targetedms.parser.proto.SkylineDocument.SkylineDocumentProto) obj;
 
-      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
+        if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
 
@@ -18162,25 +18373,34 @@ public final class SkylineDocument {
     }
 
     private static final com.google.protobuf.Parser<SkylineDocumentProto>
-        PARSER = new com.google.protobuf.AbstractParser<SkylineDocumentProto>() {
-      @java.lang.Override
-      public SkylineDocumentProto parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        Builder builder = newBuilder();
-        try {
-          builder.mergeFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          throw e.setUnfinishedMessage(builder.buildPartial());
-        } catch (com.google.protobuf.UninitializedMessageException e) {
-          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
-        } catch (java.io.IOException e) {
-          throw new com.google.protobuf.InvalidProtocolBufferException(e)
-              .setUnfinishedMessage(builder.buildPartial());
+        PARSER = new com.google.protobuf.AbstractParser<>()
+    {
+        @java.lang.Override
+        public SkylineDocumentProto parsePartialFrom(
+                com.google.protobuf.CodedInputStream input,
+                com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                throws com.google.protobuf.InvalidProtocolBufferException
+        {
+            Builder builder = newBuilder();
+            try
+            {
+                builder.mergeFrom(input, extensionRegistry);
+            }
+            catch (com.google.protobuf.InvalidProtocolBufferException e)
+            {
+                throw e.setUnfinishedMessage(builder.buildPartial());
+            }
+            catch (com.google.protobuf.UninitializedMessageException e)
+            {
+                throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+            }
+            catch (java.io.IOException e)
+            {
+                throw new com.google.protobuf.InvalidProtocolBufferException(e)
+                        .setUnfinishedMessage(builder.buildPartial());
+            }
+            return builder.buildPartial();
         }
-        return builder.buildPartial();
-      }
     };
 
     public static com.google.protobuf.Parser<SkylineDocumentProto> parser() {
@@ -18440,6 +18660,7 @@ public final class SkylineDocument {
       public static final int crosslink_VALUE = 3;
 
 
+      @Override
       public final int getNumber() {
         if (this == UNRECOGNIZED) {
           throw new java.lang.IllegalArgumentException(
@@ -18478,12 +18699,16 @@ public final class SkylineDocument {
       }
       private static final com.google.protobuf.Internal.EnumLiteMap<
           KeyType> internalValueMap =
-            new com.google.protobuf.Internal.EnumLiteMap<KeyType>() {
-              public KeyType findValueByNumber(int number) {
-                return KeyType.forNumber(number);
-              }
-            };
+              new com.google.protobuf.Internal.EnumLiteMap<>()
+              {
+                  @Override
+                  public KeyType findValueByNumber(int number)
+                  {
+                      return KeyType.forNumber(number);
+                  }
+              };
 
+      @Override
       public final com.google.protobuf.Descriptors.EnumValueDescriptor
           getValueDescriptor() {
         if (this == UNRECOGNIZED) {
@@ -18492,6 +18717,7 @@ public final class SkylineDocument {
         }
         return getDescriptor().getValues().get(ordinal());
       }
+      @Override
       public final com.google.protobuf.Descriptors.EnumDescriptor
           getDescriptorForType() {
         return getDescriptor();
@@ -18517,7 +18743,7 @@ public final class SkylineDocument {
 
       private final int value;
 
-      private KeyType(int value) {
+      KeyType(int value) {
         this.value = value;
       }
 
@@ -18727,12 +18953,11 @@ public final class SkylineDocument {
         if (obj == this) {
          return true;
         }
-        if (!(obj instanceof org.labkey.targetedms.parser.proto.SkylineDocument.LibraryKeyProto.Crosslinker)) {
+        if (!(obj instanceof Crosslinker other)) {
           return super.equals(obj);
         }
-        org.labkey.targetedms.parser.proto.SkylineDocument.LibraryKeyProto.Crosslinker other = (org.labkey.targetedms.parser.proto.SkylineDocument.LibraryKeyProto.Crosslinker) obj;
 
-        if (!getName()
+          if (!getName()
             .equals(other.getName())) return false;
         if (!getPositionsList()
             .equals(other.getPositionsList())) return false;
@@ -19084,6 +19309,7 @@ public final class SkylineDocument {
          * <code>string name = 1;</code>
          * @return The name.
          */
+        @Override
         public java.lang.String getName() {
           java.lang.Object ref = name_;
           if (!(ref instanceof java.lang.String)) {
@@ -19100,6 +19326,7 @@ public final class SkylineDocument {
          * <code>string name = 1;</code>
          * @return The bytes for name.
          */
+        @Override
         public com.google.protobuf.ByteString
             getNameBytes() {
           java.lang.Object ref = name_;
@@ -19155,7 +19382,7 @@ public final class SkylineDocument {
           java.util.Collections.emptyList();
         private void ensurePositionsIsMutable() {
           if (!((bitField0_ & 0x00000002) != 0)) {
-            positions_ = new java.util.ArrayList<org.labkey.targetedms.parser.proto.SkylineDocument.LibraryKeyProto.Positions>(positions_);
+            positions_ = new java.util.ArrayList<>(positions_);
             bitField0_ |= 0x00000002;
            }
         }
@@ -19166,6 +19393,7 @@ public final class SkylineDocument {
         /**
          * <code>repeated .LibraryKeyProto.Positions positions = 2;</code>
          */
+        @Override
         public java.util.List<org.labkey.targetedms.parser.proto.SkylineDocument.LibraryKeyProto.Positions> getPositionsList() {
           if (positionsBuilder_ == null) {
             return java.util.Collections.unmodifiableList(positions_);
@@ -19176,6 +19404,7 @@ public final class SkylineDocument {
         /**
          * <code>repeated .LibraryKeyProto.Positions positions = 2;</code>
          */
+        @Override
         public int getPositionsCount() {
           if (positionsBuilder_ == null) {
             return positions_.size();
@@ -19186,6 +19415,7 @@ public final class SkylineDocument {
         /**
          * <code>repeated .LibraryKeyProto.Positions positions = 2;</code>
          */
+        @Override
         public org.labkey.targetedms.parser.proto.SkylineDocument.LibraryKeyProto.Positions getPositions(int index) {
           if (positionsBuilder_ == null) {
             return positions_.get(index);
@@ -19336,6 +19566,7 @@ public final class SkylineDocument {
         /**
          * <code>repeated .LibraryKeyProto.Positions positions = 2;</code>
          */
+        @Override
         public org.labkey.targetedms.parser.proto.SkylineDocument.LibraryKeyProto.PositionsOrBuilder getPositionsOrBuilder(
             int index) {
           if (positionsBuilder_ == null) {
@@ -19346,7 +19577,8 @@ public final class SkylineDocument {
         /**
          * <code>repeated .LibraryKeyProto.Positions positions = 2;</code>
          */
-        public java.util.List<? extends org.labkey.targetedms.parser.proto.SkylineDocument.LibraryKeyProto.PositionsOrBuilder> 
+        @Override
+        public java.util.List<? extends org.labkey.targetedms.parser.proto.SkylineDocument.LibraryKeyProto.PositionsOrBuilder>
              getPositionsOrBuilderList() {
           if (positionsBuilder_ != null) {
             return positionsBuilder_.getMessageOrBuilderList();
@@ -19380,8 +19612,7 @@ public final class SkylineDocument {
             org.labkey.targetedms.parser.proto.SkylineDocument.LibraryKeyProto.Positions, org.labkey.targetedms.parser.proto.SkylineDocument.LibraryKeyProto.Positions.Builder, org.labkey.targetedms.parser.proto.SkylineDocument.LibraryKeyProto.PositionsOrBuilder> 
             getPositionsFieldBuilder() {
           if (positionsBuilder_ == null) {
-            positionsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-                org.labkey.targetedms.parser.proto.SkylineDocument.LibraryKeyProto.Positions, org.labkey.targetedms.parser.proto.SkylineDocument.LibraryKeyProto.Positions.Builder, org.labkey.targetedms.parser.proto.SkylineDocument.LibraryKeyProto.PositionsOrBuilder>(
+            positionsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<>(
                     positions_,
                     ((bitField0_ & 0x00000002) != 0),
                     getParentForChildren(),
@@ -19417,25 +19648,34 @@ public final class SkylineDocument {
       }
 
       private static final com.google.protobuf.Parser<Crosslinker>
-          PARSER = new com.google.protobuf.AbstractParser<Crosslinker>() {
-        @java.lang.Override
-        public Crosslinker parsePartialFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
-          Builder builder = newBuilder();
-          try {
-            builder.mergeFrom(input, extensionRegistry);
-          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-            throw e.setUnfinishedMessage(builder.buildPartial());
-          } catch (com.google.protobuf.UninitializedMessageException e) {
-            throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
-          } catch (java.io.IOException e) {
-            throw new com.google.protobuf.InvalidProtocolBufferException(e)
-                .setUnfinishedMessage(builder.buildPartial());
+          PARSER = new com.google.protobuf.AbstractParser<>()
+      {
+          @java.lang.Override
+          public Crosslinker parsePartialFrom(
+                  com.google.protobuf.CodedInputStream input,
+                  com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                  throws com.google.protobuf.InvalidProtocolBufferException
+          {
+              Builder builder = newBuilder();
+              try
+              {
+                  builder.mergeFrom(input, extensionRegistry);
+              }
+              catch (com.google.protobuf.InvalidProtocolBufferException e)
+              {
+                  throw e.setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (com.google.protobuf.UninitializedMessageException e)
+              {
+                  throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (java.io.IOException e)
+              {
+                  throw new com.google.protobuf.InvalidProtocolBufferException(e)
+                          .setUnfinishedMessage(builder.buildPartial());
+              }
+              return builder.buildPartial();
           }
-          return builder.buildPartial();
-        }
       };
 
       public static com.google.protobuf.Parser<Crosslinker> parser() {
@@ -19528,6 +19768,7 @@ public final class SkylineDocument {
        * <code>repeated int32 position = 1;</code>
        * @return The count of position.
        */
+      @Override
       public int getPositionCount() {
         return position_.size();
       }
@@ -19536,6 +19777,7 @@ public final class SkylineDocument {
        * @param index The index of the element to return.
        * @return The position at the given index.
        */
+      @Override
       public int getPosition(int index) {
         return position_.getInt(index);
       }
@@ -19556,7 +19798,7 @@ public final class SkylineDocument {
       public void writeTo(com.google.protobuf.CodedOutputStream output)
                           throws java.io.IOException {
         getSerializedSize();
-        if (getPositionList().size() > 0) {
+        if (!getPositionList().isEmpty()) {
           output.writeUInt32NoTag(10);
           output.writeUInt32NoTag(positionMemoizedSerializedSize);
         }
@@ -19596,12 +19838,11 @@ public final class SkylineDocument {
         if (obj == this) {
          return true;
         }
-        if (!(obj instanceof org.labkey.targetedms.parser.proto.SkylineDocument.LibraryKeyProto.Positions)) {
+        if (!(obj instanceof Positions other)) {
           return super.equals(obj);
         }
-        org.labkey.targetedms.parser.proto.SkylineDocument.LibraryKeyProto.Positions other = (org.labkey.targetedms.parser.proto.SkylineDocument.LibraryKeyProto.Positions) obj;
 
-        if (!getPositionList()
+          if (!getPositionList()
             .equals(other.getPositionList())) return false;
         if (!getUnknownFields().equals(other.getUnknownFields())) return false;
         return true;
@@ -19914,6 +20155,7 @@ public final class SkylineDocument {
          * <code>repeated int32 position = 1;</code>
          * @return A list containing the position.
          */
+        @Override
         public java.util.List<java.lang.Integer>
             getPositionList() {
           position_.makeImmutable();
@@ -19923,6 +20165,7 @@ public final class SkylineDocument {
          * <code>repeated int32 position = 1;</code>
          * @return The count of position.
          */
+        @Override
         public int getPositionCount() {
           return position_.size();
         }
@@ -19931,6 +20174,7 @@ public final class SkylineDocument {
          * @param index The index of the element to return.
          * @return The position at the given index.
          */
+        @Override
         public int getPosition(int index) {
           return position_.getInt(index);
         }
@@ -20013,25 +20257,34 @@ public final class SkylineDocument {
       }
 
       private static final com.google.protobuf.Parser<Positions>
-          PARSER = new com.google.protobuf.AbstractParser<Positions>() {
-        @java.lang.Override
-        public Positions parsePartialFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
-          Builder builder = newBuilder();
-          try {
-            builder.mergeFrom(input, extensionRegistry);
-          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-            throw e.setUnfinishedMessage(builder.buildPartial());
-          } catch (com.google.protobuf.UninitializedMessageException e) {
-            throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
-          } catch (java.io.IOException e) {
-            throw new com.google.protobuf.InvalidProtocolBufferException(e)
-                .setUnfinishedMessage(builder.buildPartial());
+          PARSER = new com.google.protobuf.AbstractParser<>()
+      {
+          @java.lang.Override
+          public Positions parsePartialFrom(
+                  com.google.protobuf.CodedInputStream input,
+                  com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                  throws com.google.protobuf.InvalidProtocolBufferException
+          {
+              Builder builder = newBuilder();
+              try
+              {
+                  builder.mergeFrom(input, extensionRegistry);
+              }
+              catch (com.google.protobuf.InvalidProtocolBufferException e)
+              {
+                  throw e.setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (com.google.protobuf.UninitializedMessageException e)
+              {
+                  throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+              }
+              catch (java.io.IOException e)
+              {
+                  throw new com.google.protobuf.InvalidProtocolBufferException(e)
+                          .setUnfinishedMessage(builder.buildPartial());
+              }
+              return builder.buildPartial();
           }
-          return builder.buildPartial();
-        }
       };
 
       public static com.google.protobuf.Parser<Positions> parser() {
@@ -20343,6 +20596,7 @@ public final class SkylineDocument {
      * <code>repeated string crosslinkedSequences = 11;</code>
      * @return A list containing the crosslinkedSequences.
      */
+    @Override
     public com.google.protobuf.ProtocolStringList
         getCrosslinkedSequencesList() {
       return crosslinkedSequences_;
@@ -20351,6 +20605,7 @@ public final class SkylineDocument {
      * <code>repeated string crosslinkedSequences = 11;</code>
      * @return The count of crosslinkedSequences.
      */
+    @Override
     public int getCrosslinkedSequencesCount() {
       return crosslinkedSequences_.size();
     }
@@ -20359,6 +20614,7 @@ public final class SkylineDocument {
      * @param index The index of the element to return.
      * @return The crosslinkedSequences at the given index.
      */
+    @Override
     public java.lang.String getCrosslinkedSequences(int index) {
       return crosslinkedSequences_.get(index);
     }
@@ -20367,6 +20623,7 @@ public final class SkylineDocument {
      * @param index The index of the value to return.
      * @return The bytes of the crosslinkedSequences at the given index.
      */
+    @Override
     public com.google.protobuf.ByteString
         getCrosslinkedSequencesBytes(int index) {
       return crosslinkedSequences_.getByteString(index);
@@ -20528,12 +20785,11 @@ public final class SkylineDocument {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof org.labkey.targetedms.parser.proto.SkylineDocument.LibraryKeyProto)) {
+      if (!(obj instanceof LibraryKeyProto other)) {
         return super.equals(obj);
       }
-      org.labkey.targetedms.parser.proto.SkylineDocument.LibraryKeyProto other = (org.labkey.targetedms.parser.proto.SkylineDocument.LibraryKeyProto) obj;
 
-      if (keyType_ != other.keyType_) return false;
+        if (keyType_ != other.keyType_) return false;
       if (!getModifiedSequence()
           .equals(other.getModifiedSequence())) return false;
       if (getCharge()
@@ -21123,6 +21379,7 @@ public final class SkylineDocument {
        * <code>string modifiedSequence = 2;</code>
        * @return The modifiedSequence.
        */
+      @Override
       public java.lang.String getModifiedSequence() {
         java.lang.Object ref = modifiedSequence_;
         if (!(ref instanceof java.lang.String)) {
@@ -21139,6 +21396,7 @@ public final class SkylineDocument {
        * <code>string modifiedSequence = 2;</code>
        * @return The bytes for modifiedSequence.
        */
+      @Override
       public com.google.protobuf.ByteString
           getModifiedSequenceBytes() {
         java.lang.Object ref = modifiedSequence_;
@@ -21227,6 +21485,7 @@ public final class SkylineDocument {
        * <code>string moleculeName = 4;</code>
        * @return The moleculeName.
        */
+      @Override
       public java.lang.String getMoleculeName() {
         java.lang.Object ref = moleculeName_;
         if (!(ref instanceof java.lang.String)) {
@@ -21243,6 +21502,7 @@ public final class SkylineDocument {
        * <code>string moleculeName = 4;</code>
        * @return The bytes for moleculeName.
        */
+      @Override
       public com.google.protobuf.ByteString
           getMoleculeNameBytes() {
         java.lang.Object ref = moleculeName_;
@@ -21299,6 +21559,7 @@ public final class SkylineDocument {
        * <code>string chemicalFormula = 5;</code>
        * @return The chemicalFormula.
        */
+      @Override
       public java.lang.String getChemicalFormula() {
         java.lang.Object ref = chemicalFormula_;
         if (!(ref instanceof java.lang.String)) {
@@ -21315,6 +21576,7 @@ public final class SkylineDocument {
        * <code>string chemicalFormula = 5;</code>
        * @return The bytes for chemicalFormula.
        */
+      @Override
       public com.google.protobuf.ByteString
           getChemicalFormulaBytes() {
         java.lang.Object ref = chemicalFormula_;
@@ -21371,6 +21633,7 @@ public final class SkylineDocument {
        * <code>string inChiKey = 6;</code>
        * @return The inChiKey.
        */
+      @Override
       public java.lang.String getInChiKey() {
         java.lang.Object ref = inChiKey_;
         if (!(ref instanceof java.lang.String)) {
@@ -21387,6 +21650,7 @@ public final class SkylineDocument {
        * <code>string inChiKey = 6;</code>
        * @return The bytes for inChiKey.
        */
+      @Override
       public com.google.protobuf.ByteString
           getInChiKeyBytes() {
         java.lang.Object ref = inChiKey_;
@@ -21443,6 +21707,7 @@ public final class SkylineDocument {
        * <code>string otherKeys = 7;</code>
        * @return The otherKeys.
        */
+      @Override
       public java.lang.String getOtherKeys() {
         java.lang.Object ref = otherKeys_;
         if (!(ref instanceof java.lang.String)) {
@@ -21459,6 +21724,7 @@ public final class SkylineDocument {
        * <code>string otherKeys = 7;</code>
        * @return The bytes for otherKeys.
        */
+      @Override
       public com.google.protobuf.ByteString
           getOtherKeysBytes() {
         java.lang.Object ref = otherKeys_;
@@ -21515,6 +21781,7 @@ public final class SkylineDocument {
        * <code>string adduct = 8;</code>
        * @return The adduct.
        */
+      @Override
       public java.lang.String getAdduct() {
         java.lang.Object ref = adduct_;
         if (!(ref instanceof java.lang.String)) {
@@ -21531,6 +21798,7 @@ public final class SkylineDocument {
        * <code>string adduct = 8;</code>
        * @return The bytes for adduct.
        */
+      @Override
       public com.google.protobuf.ByteString
           getAdductBytes() {
         java.lang.Object ref = adduct_;
@@ -21658,6 +21926,7 @@ public final class SkylineDocument {
        * <code>repeated string crosslinkedSequences = 11;</code>
        * @return A list containing the crosslinkedSequences.
        */
+      @Override
       public com.google.protobuf.ProtocolStringList
           getCrosslinkedSequencesList() {
         crosslinkedSequences_.makeImmutable();
@@ -21667,6 +21936,7 @@ public final class SkylineDocument {
        * <code>repeated string crosslinkedSequences = 11;</code>
        * @return The count of crosslinkedSequences.
        */
+      @Override
       public int getCrosslinkedSequencesCount() {
         return crosslinkedSequences_.size();
       }
@@ -21675,6 +21945,7 @@ public final class SkylineDocument {
        * @param index The index of the element to return.
        * @return The crosslinkedSequences at the given index.
        */
+      @Override
       public java.lang.String getCrosslinkedSequences(int index) {
         return crosslinkedSequences_.get(index);
       }
@@ -21683,6 +21954,7 @@ public final class SkylineDocument {
        * @param index The index of the value to return.
        * @return The bytes of the crosslinkedSequences at the given index.
        */
+      @Override
       public com.google.protobuf.ByteString
           getCrosslinkedSequencesBytes(int index) {
         return crosslinkedSequences_.getByteString(index);
@@ -21737,8 +22009,8 @@ public final class SkylineDocument {
       public Builder clearCrosslinkedSequences() {
         crosslinkedSequences_ =
           com.google.protobuf.LazyStringArrayList.emptyList();
-        bitField0_ = (bitField0_ & ~0x00000400);;
-        onChanged();
+        bitField0_ = (bitField0_ & ~0x00000400);
+          onChanged();
         return this;
       }
       /**
@@ -21761,7 +22033,7 @@ public final class SkylineDocument {
         java.util.Collections.emptyList();
       private void ensureCrosslinkersIsMutable() {
         if (!((bitField0_ & 0x00000800) != 0)) {
-          crosslinkers_ = new java.util.ArrayList<org.labkey.targetedms.parser.proto.SkylineDocument.LibraryKeyProto.Crosslinker>(crosslinkers_);
+          crosslinkers_ = new java.util.ArrayList<>(crosslinkers_);
           bitField0_ |= 0x00000800;
          }
       }
@@ -21772,6 +22044,7 @@ public final class SkylineDocument {
       /**
        * <code>repeated .LibraryKeyProto.Crosslinker crosslinkers = 12;</code>
        */
+      @Override
       public java.util.List<org.labkey.targetedms.parser.proto.SkylineDocument.LibraryKeyProto.Crosslinker> getCrosslinkersList() {
         if (crosslinkersBuilder_ == null) {
           return java.util.Collections.unmodifiableList(crosslinkers_);
@@ -21782,6 +22055,7 @@ public final class SkylineDocument {
       /**
        * <code>repeated .LibraryKeyProto.Crosslinker crosslinkers = 12;</code>
        */
+      @Override
       public int getCrosslinkersCount() {
         if (crosslinkersBuilder_ == null) {
           return crosslinkers_.size();
@@ -21792,6 +22066,7 @@ public final class SkylineDocument {
       /**
        * <code>repeated .LibraryKeyProto.Crosslinker crosslinkers = 12;</code>
        */
+      @Override
       public org.labkey.targetedms.parser.proto.SkylineDocument.LibraryKeyProto.Crosslinker getCrosslinkers(int index) {
         if (crosslinkersBuilder_ == null) {
           return crosslinkers_.get(index);
@@ -21942,6 +22217,7 @@ public final class SkylineDocument {
       /**
        * <code>repeated .LibraryKeyProto.Crosslinker crosslinkers = 12;</code>
        */
+      @Override
       public org.labkey.targetedms.parser.proto.SkylineDocument.LibraryKeyProto.CrosslinkerOrBuilder getCrosslinkersOrBuilder(
           int index) {
         if (crosslinkersBuilder_ == null) {
@@ -21952,7 +22228,8 @@ public final class SkylineDocument {
       /**
        * <code>repeated .LibraryKeyProto.Crosslinker crosslinkers = 12;</code>
        */
-      public java.util.List<? extends org.labkey.targetedms.parser.proto.SkylineDocument.LibraryKeyProto.CrosslinkerOrBuilder> 
+      @Override
+      public java.util.List<? extends org.labkey.targetedms.parser.proto.SkylineDocument.LibraryKeyProto.CrosslinkerOrBuilder>
            getCrosslinkersOrBuilderList() {
         if (crosslinkersBuilder_ != null) {
           return crosslinkersBuilder_.getMessageOrBuilderList();
@@ -21986,8 +22263,7 @@ public final class SkylineDocument {
           org.labkey.targetedms.parser.proto.SkylineDocument.LibraryKeyProto.Crosslinker, org.labkey.targetedms.parser.proto.SkylineDocument.LibraryKeyProto.Crosslinker.Builder, org.labkey.targetedms.parser.proto.SkylineDocument.LibraryKeyProto.CrosslinkerOrBuilder> 
           getCrosslinkersFieldBuilder() {
         if (crosslinkersBuilder_ == null) {
-          crosslinkersBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              org.labkey.targetedms.parser.proto.SkylineDocument.LibraryKeyProto.Crosslinker, org.labkey.targetedms.parser.proto.SkylineDocument.LibraryKeyProto.Crosslinker.Builder, org.labkey.targetedms.parser.proto.SkylineDocument.LibraryKeyProto.CrosslinkerOrBuilder>(
+          crosslinkersBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<>(
                   crosslinkers_,
                   ((bitField0_ & 0x00000800) != 0),
                   getParentForChildren(),
@@ -22023,25 +22299,34 @@ public final class SkylineDocument {
     }
 
     private static final com.google.protobuf.Parser<LibraryKeyProto>
-        PARSER = new com.google.protobuf.AbstractParser<LibraryKeyProto>() {
-      @java.lang.Override
-      public LibraryKeyProto parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        Builder builder = newBuilder();
-        try {
-          builder.mergeFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          throw e.setUnfinishedMessage(builder.buildPartial());
-        } catch (com.google.protobuf.UninitializedMessageException e) {
-          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
-        } catch (java.io.IOException e) {
-          throw new com.google.protobuf.InvalidProtocolBufferException(e)
-              .setUnfinishedMessage(builder.buildPartial());
+        PARSER = new com.google.protobuf.AbstractParser<>()
+    {
+        @java.lang.Override
+        public LibraryKeyProto parsePartialFrom(
+                com.google.protobuf.CodedInputStream input,
+                com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                throws com.google.protobuf.InvalidProtocolBufferException
+        {
+            Builder builder = newBuilder();
+            try
+            {
+                builder.mergeFrom(input, extensionRegistry);
+            }
+            catch (com.google.protobuf.InvalidProtocolBufferException e)
+            {
+                throw e.setUnfinishedMessage(builder.buildPartial());
+            }
+            catch (com.google.protobuf.UninitializedMessageException e)
+            {
+                throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+            }
+            catch (java.io.IOException e)
+            {
+                throw new com.google.protobuf.InvalidProtocolBufferException(e)
+                        .setUnfinishedMessage(builder.buildPartial());
+            }
+            return builder.buildPartial();
         }
-        return builder.buildPartial();
-      }
     };
 
     public static com.google.protobuf.Parser<LibraryKeyProto> parser() {
@@ -22140,7 +22425,7 @@ public final class SkylineDocument {
       getDescriptor() {
     return descriptor;
   }
-  private static  com.google.protobuf.Descriptors.FileDescriptor
+  private static final com.google.protobuf.Descriptors.FileDescriptor
       descriptor;
   static {
     java.lang.String[] descriptorData = {

--- a/src/org/labkey/targetedms/parser/skyaudit/AuditLogTree.java
+++ b/src/org/labkey/targetedms/parser/skyaudit/AuditLogTree.java
@@ -170,7 +170,7 @@ public class AuditLogTree implements Iterable<AuditLogTree>
                 entityCount.put(currentEntry.getEntryHash(), 1);
             }
 
-            if (currentEntry._children.size() == 0)      //if this is a leaf
+            if (currentEntry._children.isEmpty())      //if this is a leaf
             {
                 if (currentEntry._versionId == null)
                 {

--- a/src/org/labkey/targetedms/parser/skyaudit/UnitTestUtil.java
+++ b/src/org/labkey/targetedms/parser/skyaudit/UnitTestUtil.java
@@ -47,7 +47,7 @@ import java.util.List;
 
 public class UnitTestUtil
 {
-    private static String[] _resourcePath = {"server", "customModules", "targetedms", "resources"};
+    private static final String[] _resourcePath = {"server", "customModules", "targetedms", "resources"};
 
     public static File getSampleDataFile(String pFileName) throws IOException
     {
@@ -69,7 +69,7 @@ public class UnitTestUtil
         //not good for production code but for testing util it should be fine) and append the
         //known path and file name to the Labkey root.
         URL r = UnitTestUtil.class.getResource("/");
-        String decodedUrl = "";
+        String decodedUrl;
         decodedUrl = URLDecoder.decode(r.getFile(), StandardCharsets.UTF_8);
         if(decodedUrl.startsWith("/"))
             decodedUrl = decodedUrl.replaceFirst("/", "");

--- a/src/org/labkey/targetedms/parser/skyd/CacheHeaderStruct.java
+++ b/src/org/labkey/targetedms/parser/skyd/CacheHeaderStruct.java
@@ -151,7 +151,7 @@ public class CacheHeaderStruct
     }
 
     public static StructSerializer<CacheHeaderStruct> getStructSerializer(CacheFormatVersion cacheFormatVersion) {
-        return new StructSerializer<CacheHeaderStruct>(
+        return new StructSerializer<>(
                 CacheHeaderStruct.class, getStructSize(CacheFormatVersion.CURRENT), getStructSize(cacheFormatVersion))
         {
             @Override

--- a/src/org/labkey/targetedms/parser/skyd/CachedFileHeaderStruct.java
+++ b/src/org/labkey/targetedms/parser/skyd/CachedFileHeaderStruct.java
@@ -150,6 +150,6 @@ public class CachedFileHeaderStruct
     public enum Flags {
         single_match_mz_known,
         single_match_mz,
-        has_midas_spectra;
+        has_midas_spectra
     }
 }

--- a/src/org/labkey/targetedms/parser/skyd/ChromGroupHeaderInfo.java
+++ b/src/org/labkey/targetedms/parser/skyd/ChromGroupHeaderInfo.java
@@ -32,15 +32,15 @@ public class ChromGroupHeaderInfo
     // For reducing memory usage, following instance variables are commented out because of the
     // absence of accessors and reading from inputStream is left to correctly advance the size of the fields
     private int textIdIndex;
-    private int startTransitionIndex;
+    private final int startTransitionIndex;
 //    private int startPeakIndex;
 //    private int startScoreIndex;
-    private int numPoints;
-    private int compressedSize;
-    private EnumSet<FlagValues> flagValues;
-    private short fileIndex;
+    private final int numPoints;
+    private final int compressedSize;
+    private final EnumSet<FlagValues> flagValues;
+    private final short fileIndex;
     private short textIdLen;
-    private short numTransitions;
+    private final short numTransitions;
 //    private byte numPeaks;
 //    private byte maxPeakIndex;
 //    private byte isProcessedScans;
@@ -48,10 +48,10 @@ public class ChromGroupHeaderInfo
 //    private short statusId;
 //    private short statusRank;
     private double precursor;
-    private long locationPoints;
-    private int uncompressedSize;
-    private float startTime;
-    private float endTime;
+    private final long locationPoints;
+    private final int uncompressedSize;
+    private final float startTime;
+    private final float endTime;
 //    private float collisionalCrossSection;
 
     public ChromGroupHeaderInfo(CacheFormatVersion cacheFormatVersion, LittleEndianInput dataInputStream)
@@ -193,8 +193,8 @@ public class ChromGroupHeaderInfo
         dda_acquisition_method(0x40, 0x800),
         extracted_qc_trace(0x80, 0x1000);
 
-        private int currentFlagValue;
-        private int legacyFlagValue;
+        private final int currentFlagValue;
+        private final int legacyFlagValue;
 
         /**
          * @param currentFlagValue the value that the flag has in current (skyd format 18 or greater, Skyline 23_1) skyd files.

--- a/src/org/labkey/targetedms/parser/skyd/ChromPeak.java
+++ b/src/org/labkey/targetedms/parser/skyd/ChromPeak.java
@@ -21,19 +21,19 @@ import org.apache.poi.util.LittleEndianInput;
  */
 public class ChromPeak
 {
-    private float _retentionTime;
-    private float _startTime;
-    private float _endTime;
-    private float _area;
-    private float _backgroundArea;
-    private float _height;
-    private float _fwhm;
-    private int _flagBits;
-    private short _pointsAcross;
-    private float _stdDev;
-    private float _skewness;
-    private float _kurtosis;
-    private float _shapeCorrelation;
+    private final float _retentionTime;
+    private final float _startTime;
+    private final float _endTime;
+    private final float _area;
+    private final float _backgroundArea;
+    private final float _height;
+    private final float _fwhm;
+    private final int _flagBits;
+    private final short _pointsAcross;
+    private final float _stdDev;
+    private final float _skewness;
+    private final float _kurtosis;
+    private final float _shapeCorrelation;
 
     private static final int FLAGVALUE_HAS_PEAK_SHAPE = 0x80;
 

--- a/src/org/labkey/targetedms/parser/speclib/BlibSpectrumReader.java
+++ b/src/org/labkey/targetedms/parser/speclib/BlibSpectrumReader.java
@@ -165,12 +165,11 @@ public class BlibSpectrumReader extends LibSpectrumReader
                 return Collections.emptyList();
             }
 
-            StringBuilder sql = new StringBuilder("SELECT rt.retentionTime, rt.bestSpectrum, rs.peptideModSeq, rs.precursorCharge, ssf.fileName from RetentionTimes AS rt ");
-            sql.append(" INNER JOIN RefSpectra AS rs ON (rt.RefSpectraID = rs.id)");
-            sql.append(" INNER JOIN SpectrumSourceFiles ssf ON (rt.SpectrumSourceID = ssf.id)");
-            sql.append(" WHERE rs.peptideModSeq = ?");
+            String sql = "SELECT rt.retentionTime, rt.bestSpectrum, rs.peptideModSeq, rs.precursorCharge, ssf.fileName from RetentionTimes AS rt " + " INNER JOIN RefSpectra AS rs ON (rt.RefSpectraID = rs.id)" +
+                    " INNER JOIN SpectrumSourceFiles ssf ON (rt.SpectrumSourceID = ssf.id)" +
+                    " WHERE rs.peptideModSeq = ?";
 
-            try(PreparedStatement stmt = conn.prepareStatement(sql.toString()))
+            try(PreparedStatement stmt = conn.prepareStatement(sql))
             {
                 stmt.setString(1, modifiedPeptide);
                 List<LibrarySpectrumMatchGetter.PeptideIdRtInfo> retentionTimes = new ArrayList<>();
@@ -398,11 +397,10 @@ public class BlibSpectrumReader extends LibSpectrumReader
 
     private static void addRedundantSpectrumInfo(Connection conn, BlibSpectrum spectrum) throws SQLException
     {
-        StringBuilder sql = new StringBuilder("SELECT rt.*, sf.fileName ");
-        sql.append("FROM RetentionTimes AS rt INNER JOIN SpectrumSourceFiles AS sf ON rt.spectrumSourceID = sf.id ");
-        sql.append("WHERE RefSpectraID=").append(spectrum.getBlibId());
+        String sql = "SELECT rt.*, sf.fileName " + "FROM RetentionTimes AS rt INNER JOIN SpectrumSourceFiles AS sf ON rt.spectrumSourceID = sf.id " +
+                "WHERE RefSpectraID=" + spectrum.getBlibId();
 
-        try (Statement stmt = conn.createStatement(); ResultSet rs = stmt.executeQuery(sql.toString()))
+        try (Statement stmt = conn.createStatement(); ResultSet rs = stmt.executeQuery(sql))
         {
             List<RedundantSpectrum> redundantSpectra = new ArrayList<>();
 
@@ -431,11 +429,10 @@ public class BlibSpectrumReader extends LibSpectrumReader
 
     private static BlibSpectrum readRedundantSpectrum(Connection conn, int redundantRefSpectrumid) throws SQLException
     {
-        StringBuilder sql = new StringBuilder("SELECT rf.*, ssf.fileName FROM RefSpectra AS rf ");
-        sql.append("LEFT JOIN SpectrumSourceFiles AS ssf ON rf.FileID = ssf.id ");
-        sql.append(" WHERE rf.id=").append(redundantRefSpectrumid);
+        String sql = "SELECT rf.*, ssf.fileName FROM RefSpectra AS rf " + "LEFT JOIN SpectrumSourceFiles AS ssf ON rf.FileID = ssf.id " +
+                " WHERE rf.id=" + redundantRefSpectrumid;
 
-        try (Statement stmt = conn.createStatement(); ResultSet rs = stmt.executeQuery(sql.toString()))
+        try (Statement stmt = conn.createStatement(); ResultSet rs = stmt.executeQuery(sql))
         {
             BlibSpectrum spectrum = null;
 

--- a/src/org/labkey/targetedms/parser/speclib/ElibSpectrumReader.java
+++ b/src/org/labkey/targetedms/parser/speclib/ElibSpectrumReader.java
@@ -103,7 +103,7 @@ public class ElibSpectrumReader extends LibSpectrumReader
             }
         }
 
-        if(spectra.size() > 0)
+        if(!spectra.isEmpty())
         {
             sortElibSpectra(spectra);
             ElibSpectrum bestSpectrum = spectra.get(0);

--- a/src/org/labkey/targetedms/parser/speclib/LibSpectrumReader.java
+++ b/src/org/labkey/targetedms/parser/speclib/LibSpectrumReader.java
@@ -257,7 +257,7 @@ public abstract class LibSpectrumReader
         // Find the modified sequence representation from the library that matches
         List<Pair<Integer, String>> mods = new ArrayList<>();
         String unmodifiedSequence = Peptide.stripModifications(modifiedSequence, mods);
-        if (mods.size() == 0) {
+        if (mods.isEmpty()) {
             return modifiedSequence;
         }
 

--- a/src/org/labkey/targetedms/pipeline/AreaProportionRecalcJob.java
+++ b/src/org/labkey/targetedms/pipeline/AreaProportionRecalcJob.java
@@ -2,33 +2,16 @@ package org.labkey.targetedms.pipeline;
 
 import org.apache.commons.lang3.mutable.MutableLong;
 import org.jetbrains.annotations.NotNull;
-import org.labkey.api.data.Container;
-import org.labkey.api.data.ContainerFilter;
-import org.labkey.api.data.ContainerManager;
-import org.labkey.api.data.RuntimeSQLException;
-import org.labkey.api.data.SimpleFilter;
-import org.labkey.api.data.Sort;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineJob;
-import org.labkey.api.query.FieldKey;
 import org.labkey.api.util.FileUtil;
-import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.ViewBackgroundInfo;
 import org.labkey.targetedms.TargetedMSManager;
 import org.labkey.targetedms.TargetedMSRun;
-import org.labkey.targetedms.TargetedMSSchema;
-import org.labkey.targetedms.parser.Chromatogram;
-import org.labkey.targetedms.parser.PrecursorChromInfo;
-import org.labkey.targetedms.parser.SampleFile;
-import org.labkey.targetedms.query.PrecursorManager;
 
 import java.io.File;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
 
 public class AreaProportionRecalcJob extends PipelineJob
 {

--- a/src/org/labkey/targetedms/pipeline/ChromatogramCrawlerJob.java
+++ b/src/org/labkey/targetedms/pipeline/ChromatogramCrawlerJob.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 public class ChromatogramCrawlerJob extends PipelineJob
 {
-    private CrawlType _crawlType = CrawlType.verifyOnly;
+    private final CrawlType _crawlType = CrawlType.verifyOnly;
 
     /** For JSON serialization/deserialzation round-tripping
      * @noinspection unused*/

--- a/src/org/labkey/targetedms/pipeline/TargetedMSImportPipelineJob.java
+++ b/src/org/labkey/targetedms/pipeline/TargetedMSImportPipelineJob.java
@@ -116,9 +116,8 @@ public class TargetedMSImportPipelineJob extends PipelineJob
     public List<String> compareJobs(PipelineJob job2)
     {
         List<String> errors = super.compareJobs(job2);
-        if (job2 instanceof TargetedMSImportPipelineJob)
+        if (job2 instanceof TargetedMSImportPipelineJob copyJob2)
         {
-            TargetedMSImportPipelineJob copyJob2 = (TargetedMSImportPipelineJob)job2;
             if (!this._representative.equals(copyJob2._representative))
                 errors.add("_representative");
         }

--- a/src/org/labkey/targetedms/pipeline/TargetedMSPipelineProvider.java
+++ b/src/org/labkey/targetedms/pipeline/TargetedMSPipelineProvider.java
@@ -40,7 +40,7 @@ import java.util.List;
 public class TargetedMSPipelineProvider extends PipelineProvider
 {
     static String name = "Targeted MS";
-    private static String ACTION_LABEL = "Import Skyline Results";
+    private static final String ACTION_LABEL = "Import Skyline Results";
 
     public TargetedMSPipelineProvider(Module owningModule)
     {

--- a/src/org/labkey/targetedms/query/ConflictResultsManager.java
+++ b/src/org/labkey/targetedms/query/ConflictResultsManager.java
@@ -393,7 +393,7 @@ public class ConflictResultsManager
             }
             TransitionWithAreaAndRank twr = new TransitionWithAreaAndRank();
             twr.setTransition(transition);
-            twr.setAvgArea(transChromInfoList.size() == 0 ? 0 : totalArea / transChromInfoList.size());
+            twr.setAvgArea(transChromInfoList.isEmpty() ? 0 : totalArea / transChromInfoList.size());
             transWithRankList.add(twr);
         }
 

--- a/src/org/labkey/targetedms/query/GuideSetTable.java
+++ b/src/org/labkey/targetedms/query/GuideSetTable.java
@@ -26,7 +26,6 @@ import org.labkey.api.data.Table;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.FieldKey;
-import org.labkey.api.query.FilteredTable;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.RowIdQueryUpdateService;
 import org.labkey.api.query.SimpleUserSchema;

--- a/src/org/labkey/targetedms/query/LibraryManager.java
+++ b/src/org/labkey/targetedms/query/LibraryManager.java
@@ -94,7 +94,7 @@ public class LibraryManager
 
     private static LinkedHashMap<PeptideSettings.SpectrumLibrary, Path> getLibraryFilePaths(long runId, List<PeptideSettings.SpectrumLibrary> libraries)
     {
-        if(libraries.size() == 0)
+        if(libraries.isEmpty())
             return new LinkedHashMap<>(Collections.emptyMap());
 
         Path skyFilesDir = getSkylineFilesDir(runId);

--- a/src/org/labkey/targetedms/query/ModificationManager.java
+++ b/src/org/labkey/targetedms/query/ModificationManager.java
@@ -62,7 +62,6 @@ public class ModificationManager
     }
 
     /**
-     * @param peptideId
      * @return Map of the modified amino acid index in the peptide sequence
      *         and the mass of the modification.
      *         ModifiedIndex -> MassDiff
@@ -94,7 +93,6 @@ public class ModificationManager
     }
 
     /**
-     * @param peptideId
      * @return Map of the modified amino acid index in the peptide sequence
      *         and the mass of the modification.
      *         ModifiedIndex -> MassDiff
@@ -111,7 +109,7 @@ public class ModificationManager
                      "AND m.IsotopeLabelId=?";
         SQLFragment sf = new SQLFragment(sql, peptideId, isotopeLabelId);
 
-        new SqlSelector(getSchema(), sf).forEach(new Selector.ForEachBlock<ResultSet>()
+        new SqlSelector(getSchema(), sf).forEach(new Selector.ForEachBlock<>()
         {
             @Override
             public void exec(ResultSet rs) throws SQLException
@@ -120,7 +118,7 @@ public class ModificationManager
                 double massDiff = rs.getDouble("MassDiff");
 
                 Double diffAtIndex = isotopeModIndexMassDiff.get(index);
-                if(diffAtIndex != null)
+                if (diffAtIndex != null)
                 {
                     massDiff += diffAtIndex;
                 }
@@ -136,7 +134,6 @@ public class ModificationManager
      * that were checked in the Peptide Settings > Modifications tab in Skyline.  The modifications are under
      * <peptide_settings> -> <peptide_modification> -> <heavy_modifications> element in the .sky file.  They are stored
      * in the targetedms.RunIsotopeModification table.
-     * @param runId
      * @return List of isotopic modifications
      */
     public static List<PeptideSettings.RunIsotopeModification> getIsotopeModificationsForRun(long runId)
@@ -159,7 +156,6 @@ public class ModificationManager
      * that were checked in the Peptide Settings > Modifications tab in Skyline.  The modifications are under
      * <peptide_settings> -> <peptide_modification> -> <static_modifications> element in the .sky file.  They are stored
      * in the targetedms.RunStructuralModification table.
-     * @param runId
      * @return List of structural modifications
      */
     public static List<PeptideSettings.RunStructuralModification> getStructuralModificationsForRun(long runId)
@@ -179,7 +175,6 @@ public class ModificationManager
 
     /**
      * Returns a list of isotopic modifications found in at least one peptide in the run (Skyline document).
-     * @param runId
      * @return List of isotopic modifications
      */
     public static List<PeptideSettings.IsotopeModification> getIsotopeModificationsUsedInRun(long runId)
@@ -191,7 +186,6 @@ public class ModificationManager
 
     /**
      * Returns a list of structural modifications found in at least one peptide in the run (Skyline document).
-     * @param runId
      * @return List of structural modifications
      */
     public static List<PeptideSettings.StructuralModification> getStructuralModificationsUsedInRun(long runId)

--- a/src/org/labkey/targetedms/query/MoleculeTransitionManager.java
+++ b/src/org/labkey/targetedms/query/MoleculeTransitionManager.java
@@ -26,7 +26,6 @@ import org.labkey.api.security.User;
 import org.labkey.targetedms.TargetedMSSchema;
 import org.labkey.targetedms.parser.MoleculeTransition;
 
-import java.util.Collection;
 import java.util.List;
 
 public class MoleculeTransitionManager

--- a/src/org/labkey/targetedms/query/MoleculeTransitionsTableInfo.java
+++ b/src/org/labkey/targetedms/query/MoleculeTransitionsTableInfo.java
@@ -18,13 +18,11 @@ package org.labkey.targetedms.query;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.SQLFragment;
-import org.labkey.api.data.WrappedColumn;
 import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryForeignKey;
 import org.labkey.targetedms.TargetedMSManager;
 import org.labkey.targetedms.TargetedMSSchema;
-import org.labkey.targetedms.view.AnnotationUIDisplayColumn;
 
 import java.util.ArrayList;
 

--- a/src/org/labkey/targetedms/query/PTMPercentsCustomizer.java
+++ b/src/org/labkey/targetedms/query/PTMPercentsCustomizer.java
@@ -1,33 +1,12 @@
 package org.labkey.targetedms.query;
 
 import org.apache.commons.collections4.MultiValuedMap;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.labkey.api.collections.CaseInsensitiveHashMap;
-import org.labkey.api.data.ColumnInfo;
-import org.labkey.api.data.CompareType;
-import org.labkey.api.data.ConditionalFormat;
-import org.labkey.api.data.DataColumn;
-import org.labkey.api.data.DisplayColumn;
-import org.labkey.api.data.DisplayColumnFactory;
-import org.labkey.api.data.MutableColumnInfo;
-import org.labkey.api.data.RenderContext;
-import org.labkey.api.data.SQLFragment;
-import org.labkey.api.data.SimpleFilter;
-import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.TableCustomizer;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.query.FieldKey;
-import org.labkey.api.util.Pair;
-import org.labkey.targetedms.TargetedMSManager;
-import org.labkey.targetedms.parser.Protein;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 
 /**
  * Customizes the set of columns available on a pivot query that operates on samples, hiding all of the pivot values

--- a/src/org/labkey/targetedms/query/PeptideGroupManager.java
+++ b/src/org/labkey/targetedms/query/PeptideGroupManager.java
@@ -129,7 +129,7 @@ public class PeptideGroupManager
 
     public static void updateRepresentativeStatus(List<Long> peptideGroupIds, RepresentativeDataState representativeState)
     {
-        if(peptideGroupIds == null || peptideGroupIds.size() == 0)
+        if(peptideGroupIds == null || peptideGroupIds.isEmpty())
             return;
 
         String peptideGroupIdsString = StringUtils.join(peptideGroupIds, ",");
@@ -185,7 +185,7 @@ public class PeptideGroupManager
 
     public static void updateStatusToDeprecatedOrNotRepresentative(List<Long> peptideGroupIds)
     {
-        if(peptideGroupIds == null || peptideGroupIds.size() == 0)
+        if(peptideGroupIds == null || peptideGroupIds.isEmpty())
             return;
 
         String peptideGroupIdsString = StringUtils.join(peptideGroupIds, ",");
@@ -278,7 +278,7 @@ public class PeptideGroupManager
         {
             pepGrpIds.append(",").append(id);
         }
-        if(pepGrpIds.length() > 0)
+        if(!pepGrpIds.isEmpty())
             pepGrpIds.deleteCharAt(0);
         SQLFragment sql = new SQLFragment("SELECT COUNT(pg.Id) FROM ");
         sql.append(TargetedMSManager.getTableInfoPeptideGroup(), "pg");

--- a/src/org/labkey/targetedms/query/PrecursorManager.java
+++ b/src/org/labkey/targetedms/query/PrecursorManager.java
@@ -161,7 +161,7 @@ public class PrecursorManager
     @Nullable
     public static PrecursorChromInfo getBestPrecursorChromInfo(@NotNull List<PrecursorChromInfo> chromInfos)
     {
-        if(chromInfos.size() == 0)
+        if(chromInfos.isEmpty())
         {
             return null;
         }
@@ -453,7 +453,7 @@ public class PrecursorManager
 
     public static void updateRepresentativeStatus(List<Long> precursorIds, RepresentativeDataState representativeState)
     {
-        if(precursorIds == null || precursorIds.size() == 0)
+        if(precursorIds == null || precursorIds.isEmpty())
             return;
 
         SQLFragment sql = new SQLFragment("UPDATE "+TargetedMSManager.getTableInfoGeneralPrecursor());
@@ -468,7 +468,7 @@ public class PrecursorManager
 
     public static void updateStatusToDeprecatedOrNotRepresentative(List<Long> precursorIds)
     {
-        if(precursorIds == null || precursorIds.size() == 0)
+        if(precursorIds == null || precursorIds.isEmpty())
             return;
 
         SQLFragment sql = new SQLFragment("UPDATE "+TargetedMSManager.getTableInfoGeneralPrecursor());

--- a/src/org/labkey/targetedms/query/QCAnnotationTypeTable.java
+++ b/src/org/labkey/targetedms/query/QCAnnotationTypeTable.java
@@ -25,7 +25,6 @@ import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.DisplayColumnFactory;
 import org.labkey.api.data.SqlExecutor;
 import org.labkey.api.query.DefaultQueryUpdateService;
-import org.labkey.api.query.FilteredTable;
 import org.labkey.api.query.InvalidKeyException;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.QueryUpdateServiceException;

--- a/src/org/labkey/targetedms/query/ReplicateManager.java
+++ b/src/org/labkey/targetedms/query/ReplicateManager.java
@@ -19,7 +19,6 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
-import org.labkey.api.data.Sort;
 import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.Table;
 import org.labkey.api.data.TableSelector;

--- a/src/org/labkey/targetedms/query/RepresentativeStateManager.java
+++ b/src/org/labkey/targetedms/query/RepresentativeStateManager.java
@@ -191,7 +191,7 @@ public class RepresentativeStateManager
         makeActiveSQL.add(RepresentativeDataState.Representative.ordinal());
         makeActiveSQL.append(" WHERE RunId=? ");
         makeActiveSQL.add(run.getId());
-        if(peptideGroupIdsToExclude.size() > 0)
+        if(!peptideGroupIdsToExclude.isEmpty())
         {
             makeActiveSQL.append(" AND Id NOT IN (").append(StringUtils.join(peptideGroupIdsToExclude, ',')).append(")");
         }
@@ -254,7 +254,7 @@ public class RepresentativeStateManager
         makeConflictedSQL.add(RepresentativeDataState.Conflicted.ordinal());
         makeConflictedSQL.append(" WHERE RunId=?");
         makeConflictedSQL.add(run.getId());
-        if(peptideGroupIdsToExclude.size() > 0)
+        if(!peptideGroupIdsToExclude.isEmpty())
         {
             makeConflictedSQL.append(" AND Id NOT IN (").append(StringUtils.join(peptideGroupIdsToExclude, ',')).append(")");
         }
@@ -268,7 +268,7 @@ public class RepresentativeStateManager
         // If this run has "standard" proteins, mark them as being representative.
         // Older versions of the proteins, from previous runs, will be marked as deprecated.
         List<Long> standardPeptideGroupIds = getAllStandardPeptideGroups(run);
-        if(standardPeptideGroupIds.size() > 0)
+        if(!standardPeptideGroupIds.isEmpty())
         {
             updateStandardPeptideGroups(container, standardPeptideGroupIds);
         }
@@ -379,7 +379,7 @@ public class RepresentativeStateManager
 
     private static List<Long> getCurrentStandardPrecursorIds(Container container, List<Long> stdPrecursorIdsInRun, TableInfo precursorTable, BiFunction<String, String, String> joinValue)
     {
-        if(stdPrecursorIdsInRun == null || stdPrecursorIdsInRun.size() == 0)
+        if(stdPrecursorIdsInRun == null || stdPrecursorIdsInRun.isEmpty())
         {
             return Collections.emptyList();
         }
@@ -525,7 +525,7 @@ public class RepresentativeStateManager
         // If there are standard peptides in this run, we will mark them as representative. Older versions of these
         // peptides, from previous runs, will be marked as deprecated.
         List<Long> stdPrecursorIdsInRun = getStdPrecursorIdsInRun(run);
-        if(stdPrecursorIdsInRun.size() > 0)
+        if(!stdPrecursorIdsInRun.isEmpty())
         {
             // Get a list of current representative precursors in the folder that have the same identifier and charge
             // as the standard precursors in the run.

--- a/src/org/labkey/targetedms/query/SampleFileTable.java
+++ b/src/org/labkey/targetedms/query/SampleFileTable.java
@@ -68,8 +68,6 @@ import org.labkey.targetedms.datasource.MsDataSourceUtil;
 import org.labkey.targetedms.parser.DataSettings;
 import org.labkey.targetedms.parser.SampleFile;
 
-import java.io.IOException;
-import java.io.Writer;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/org/labkey/targetedms/query/SkylineListSchema.java
+++ b/src/org/labkey/targetedms/query/SkylineListSchema.java
@@ -26,7 +26,7 @@ public class SkylineListSchema extends UserSchema
     public static final String ID_SEPARATOR = "_";
     public static final String UNION_PREFIX = "All" + ID_SEPARATOR;
 
-    private Map<ContainerFilter, List<ListDefinition>> _listDefinitions = new HashMap<>();
+    private final Map<ContainerFilter, List<ListDefinition>> _listDefinitions = new HashMap<>();
 
     static public void register(Module module)
     {

--- a/src/org/labkey/targetedms/query/TargetedMSCrosstabView.java
+++ b/src/org/labkey/targetedms/query/TargetedMSCrosstabView.java
@@ -5,7 +5,6 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ExcelWriter;
 import org.labkey.api.query.CrosstabView;
 import org.labkey.api.query.QuerySettings;
-import org.labkey.api.query.QueryView;
 import org.labkey.targetedms.TargetedMSSchema;
 import org.springframework.validation.BindException;
 

--- a/src/org/labkey/targetedms/query/TargetedMSForeignKey.java
+++ b/src/org/labkey/targetedms/query/TargetedMSForeignKey.java
@@ -17,7 +17,6 @@ package org.labkey.targetedms.query;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.query.LookupForeignKey;

--- a/src/org/labkey/targetedms/view/GroupComparisonView.java
+++ b/src/org/labkey/targetedms/view/GroupComparisonView.java
@@ -37,7 +37,7 @@ public class GroupComparisonView extends QuantificationView
 {
     public static final String DATAREGION_NAME = "group_comparison";
     public static final String DATAREGION_NAME_SM_MOL = DATAREGION_NAME + SMALL_MOLECULE_SUFFIX;
-    private GroupComparisonSettings _groupComparisonSettings;
+    private final GroupComparisonSettings _groupComparisonSettings;
 
     public GroupComparisonView(ViewContext ctx, TargetedMSSchema schema, Form form, boolean forExport, String dataRegionName)
     {

--- a/src/org/labkey/targetedms/view/TargetedMSRunsWebPartView.java
+++ b/src/org/labkey/targetedms/view/TargetedMSRunsWebPartView.java
@@ -37,7 +37,7 @@ public class TargetedMSRunsWebPartView extends VBox
         TargetedMSService.FolderType folderType = TargetedMSManager.getFolderType(viewContext.getContainer());
         if(folderType == TargetedMSService.FolderType.Library || folderType == TargetedMSService.FolderType.LibraryProtein)
         {
-            addView(new JspView("/org/labkey/targetedms/view/conflictSummary.jsp"));
+            addView(new JspView<>("/org/labkey/targetedms/view/conflictSummary.jsp"));
         }
         TargetedMsRunListView runListView = TargetedMsRunListView.createView(viewContext);
         runListView.setFrame(WebPartView.FrameType.NONE);

--- a/src/org/labkey/targetedms/view/TargetedMsRunListView.java
+++ b/src/org/labkey/targetedms/view/TargetedMsRunListView.java
@@ -52,12 +52,12 @@ public class TargetedMsRunListView extends ExperimentRunListView
 {
 
     private ViewType _viewType;
-    private boolean _hasDocVersions;
-    private boolean _showAllVersions;
+    private final boolean _hasDocVersions;
+    private final boolean _showAllVersions;
     private static final boolean DEFAULT_SHOW_ALL_VERSIONS = true;
     private static final String DEFAULT_VERSIONS_PARAM = DEFAULT_SHOW_ALL_VERSIONS ? "latestVersions" : "allVersions";
 
-    public static enum ViewType
+    public enum ViewType
     {
         FOLDER_VIEW,
         EXPERIMENT_VIEW,

--- a/src/org/labkey/targetedms/view/passport/beforeAfterReport.jsp
+++ b/src/org/labkey/targetedms/view/passport/beforeAfterReport.jsp
@@ -60,7 +60,7 @@
 <!-- PROTEIN INFO HEADER START -->
 <div id="passportContainer">
     <!-- PROTEIN INFO HEADER END -->
-    <%if(protein.getPep() != null && protein.getPep().size() != 0) {%>
+    <%if(protein.getPep() != null && !protein.getPep().isEmpty()) {%>
     <!-- FILTER OPTIONS START -->
         <div id="filterContainer"><img src="<%=h(contextPath)%>/passport/img/filtericon.png" id="filtericon"/>
             <h1>Filter Options</h1>
@@ -94,7 +94,7 @@
             <div id="pepListBox">
                 <ul id="livepeptidelist"></ul>
             </div>
-            <%if(protein.getFeatures() != null && protein.getFeatures().size() > 0) {%>
+            <%if(protein.getFeatures() != null && !protein.getFeatures().isEmpty()) {%>
                 <div class="filterBox" style="margin-left:10px; padding-left:20px;">
                     <h2>Features:</h2>
                     <input id="showFeatures" type="checkbox" name="showFeatures" readonly="readonly" style="border:0; color:#A01C00; font-weight:bold;"/>

--- a/src/org/labkey/targetedms/view/spectrum/LibrarySpectrumMatch.java
+++ b/src/org/labkey/targetedms/view/spectrum/LibrarySpectrumMatch.java
@@ -46,7 +46,7 @@ public class LibrarySpectrumMatch
     private List<PeptideSettings.SpectrumLibrary> _libraries; // All libraries that have a match
     private String _lorikeetId;
     List<Peptide.StructuralModification> _structuralModifications;
-    private Set<Long> _variableStructuralMods = new HashSet<>();
+    private final Set<Long> _variableStructuralMods = new HashSet<>();
 
     PeptideSettings.RunStructuralModification _ntermMod = null;
     PeptideSettings.RunStructuralModification _ctermMod = null;
@@ -160,7 +160,7 @@ public class LibrarySpectrumMatch
 
     public boolean hasRedundantSpectra()
     {
-        return _spectrum != null && _spectrum.getRedundantSpectrumList().size() > 0;
+        return _spectrum != null && !_spectrum.getRedundantSpectrumList().isEmpty();
     }
 
     public String getPeaks()
@@ -228,14 +228,14 @@ public class LibrarySpectrumMatch
             return "[]";
 
         // Example: [{modMass: 42.0, aminoAcid: 'K'}]
-        StringBuilder mods = new StringBuilder();
-        mods.append("[");
 
-        // Return all static (not variable) structural modifications.
-        mods.append(appendStructuralModifications(_structuralModifications, false)); // only static mods
+        String mods = "[" +
 
-        mods.append("]");
-        return mods.toString();
+                // Return all static (not variable) structural modifications.
+                appendStructuralModifications(_structuralModifications, false) + // only static mods
+
+                "]";
+        return mods;
     }
 
     public String getVariableModifications()
@@ -420,7 +420,7 @@ public class LibrarySpectrumMatch
         private static final Pattern formulaPattern = Pattern.compile("([A-Z]'*)([0-9]*)");
         public static double[] getMass(String formula)
         {
-            if(formula == null || formula.trim().length() == 0)
+            if(formula == null || formula.trim().isEmpty())
                 return new double[] {0.0, 0.0};
 
             double monoMass = 0.0;
@@ -439,11 +439,11 @@ public class LibrarySpectrumMatch
 
                 }
                 String atom = matcher.group(1);
-                int count = 0;
+                int count;
                 try
                 {
                     String num = matcher.group(2);
-                    if(num.length() > 0)
+                    if(!num.isEmpty())
                     {
                         count = Integer.parseInt(matcher.group(2));
                     }
@@ -476,7 +476,7 @@ public class LibrarySpectrumMatch
             return new double[] {monoMass, avgMass};
         }
 
-        private static Map<String, double[]> atomicMasses = new HashMap<String, double[]>();
+        private static final Map<String, double[]> atomicMasses = new HashMap<>();
         static
         {
             atomicMasses.put("H", new double[]{ 1.007825035, 1.00794}); //Unimod

--- a/src/org/labkey/targetedms/view/spectrum/LibrarySpectrumMatchGetter.java
+++ b/src/org/labkey/targetedms/view/spectrum/LibrarySpectrumMatchGetter.java
@@ -60,7 +60,7 @@ public class LibrarySpectrumMatchGetter
 {
     private static final int CACHE_SIZE = 10;
 
-    private static BlockingCache<PrecursorKey, List<PeptideIdRtInfo>> _peptideIdRtsCache =
+    private static final BlockingCache<PrecursorKey, List<PeptideIdRtInfo>> _peptideIdRtsCache =
             CacheManager.getBlockingCache(CACHE_SIZE, CacheManager.DAY, "TargetedMS peptide ID retention times",
                     (precursor, argument) -> {
                         if (!(argument instanceof Container))
@@ -81,7 +81,7 @@ public class LibrarySpectrumMatchGetter
                                 List<PeptideIdRtInfo> rtInfos = reader.getRetentionTimes((Container) argument,
                                         libPath, precursor.getModifiedSequence());
 
-                                if (rtInfos.size() > 0)
+                                if (!rtInfos.isEmpty())
                                 {
                                     return rtInfos;  // return matches from the first library that has a match
                                 }

--- a/src/org/labkey/targetedms/view/spectrum/PeptideSpectrumView.java
+++ b/src/org/labkey/targetedms/view/spectrum/PeptideSpectrumView.java
@@ -17,7 +17,6 @@ package org.labkey.targetedms.view.spectrum;
 
 import org.labkey.api.view.JspView;
 import org.labkey.targetedms.parser.PeptideSettings;
-import org.springframework.validation.BindException;
 
 /**
  * User: vsharma

--- a/test/src/org/labkey/test/components/targetedms/ClustergrammerDialog.java
+++ b/test/src/org/labkey/test/components/targetedms/ClustergrammerDialog.java
@@ -84,7 +84,7 @@ public class ClustergrammerDialog extends Window<ClustergrammerDialog.ElementCac
         Input reportDescriptionEditor = Input(Locator.textarea("reportDescriptionEditor" + "-inputEl"), getDriver()).findWhenNeeded(this);
     }
 
-    public class Confirmation extends Window
+    public static class Confirmation extends Window
     {
         private static final String CONFIRMATION_TITLE = "Publish to Clustergrammer";
 

--- a/test/src/org/labkey/test/components/targetedms/GuideSet.java
+++ b/test/src/org/labkey/test/components/targetedms/GuideSet.java
@@ -24,10 +24,10 @@ import java.util.List;
 public class GuideSet
 {
     private int _rowId;
-    private String _startDate;
-    private String _endDate;
-    private String _comment;
-    private List<GuideSetStats> _stats;
+    private final String _startDate;
+    private final String _endDate;
+    private final String _comment;
+    private final List<GuideSetStats> _stats;
     private Integer _brushSelectedPoints;
 
     public GuideSet(String startDate, String endDate, String comment, Integer brushSelectedPoints)

--- a/test/src/org/labkey/test/components/targetedms/GuideSetStats.java
+++ b/test/src/org/labkey/test/components/targetedms/GuideSetStats.java
@@ -17,8 +17,8 @@ package org.labkey.test.components.targetedms;
 
 public class GuideSetStats
 {
-    private String _metricName;
-    private int _numRecords;
+    private final String _metricName;
+    private final int _numRecords;
     private String _precursor;
     private Double _mean;
     private Double _stdDev;

--- a/test/src/org/labkey/test/components/targetedms/GuideSetWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/GuideSetWebPart.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 public class GuideSetWebPart extends BodyWebPart
 {
     public static final String DEFAULT_TITLE = "Guide Set";
-    private BaseWebDriverTest _test;
+    private final BaseWebDriverTest _test;
     private DataRegionTable _dataRegionTable;
     private String _projectName;
 
@@ -68,7 +68,7 @@ public class GuideSetWebPart extends BodyWebPart
             SelectRowsResponse selResp = selectCmd.execute(cn, _projectName);
 
             // guide sets created from brushing in the QC plot will not have a comment
-            if (selResp.getRows().size() == 0)
+            if (selResp.getRows().isEmpty())
             {
                 selectCmd = new SelectRowsCommand("targetedms", "GuideSet");
                 selectCmd.addFilter(new Filter("TrainingStart", guideSet.getStartDate()));
@@ -76,7 +76,7 @@ public class GuideSetWebPart extends BodyWebPart
                 selResp = selectCmd.execute(cn, _projectName);
             }
 
-            if (selResp.getRows().size() > 0)
+            if (!selResp.getRows().isEmpty())
             {
                 String rowIdStr = selResp.getRows().get(0).get("RowId").toString();
                 return Integer.parseInt(rowIdStr);

--- a/test/src/org/labkey/test/components/targetedms/LinkVersionsGrid.java
+++ b/test/src/org/labkey/test/components/targetedms/LinkVersionsGrid.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertTrue;
 
 public class LinkVersionsGrid extends Component
 {
-    private WebDriverWrapper _test;
+    private final WebDriverWrapper _test;
 
     public LinkVersionsGrid(WebDriverWrapper test)
     {

--- a/test/src/org/labkey/test/components/targetedms/PrecursorsWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/PrecursorsWebPart.java
@@ -128,7 +128,7 @@ public class PrecursorsWebPart extends BodyWebPart<PrecursorsWebPart.Elements>
         Coefficient_of_Variation("Coefficient of Variation"),
         Light_heavy_ratio("Light/heavy ratio");
 
-        private String _text;
+        private final String _text;
 
         SortBy(String text)
         {

--- a/test/src/org/labkey/test/components/targetedms/QCAnnotationTypeWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/QCAnnotationTypeWebPart.java
@@ -24,7 +24,7 @@ public class QCAnnotationTypeWebPart extends BodyWebPart
 {
     public static final String DEFAULT_TITLE = "QC Annotation Type";
     private DataRegionTable _dataRegionTable;
-    private BaseWebDriverTest _test;
+    private final BaseWebDriverTest _test;
 
     public QCAnnotationTypeWebPart(BaseWebDriverTest test)
     {

--- a/test/src/org/labkey/test/components/targetedms/QCAnnotationWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/QCAnnotationWebPart.java
@@ -24,7 +24,7 @@ public class QCAnnotationWebPart extends BodyWebPart
 {
     public static final String DEFAULT_TITLE = "QC Annotation";
     private DataRegionTable _dataRegionTable;
-    private BaseWebDriverTest _test;
+    private final BaseWebDriverTest _test;
 
     public QCAnnotationWebPart(BaseWebDriverTest test)
     {

--- a/test/src/org/labkey/test/components/targetedms/QCPlot.java
+++ b/test/src/org/labkey/test/components/targetedms/QCPlot.java
@@ -111,7 +111,7 @@ public class QCPlot
         return new Elements();
     }
 
-    private class Elements
+    private static class Elements
     {
         Locator precursor = Locator.css(".labkey-wp-title-text");
         Locator.CssLocator svg = Locator.css("svg");

--- a/test/src/org/labkey/test/pages/panoramapremium/ConfigureMetricsUIPage.java
+++ b/test/src/org/labkey/test/pages/panoramapremium/ConfigureMetricsUIPage.java
@@ -9,7 +9,6 @@ import org.labkey.test.components.targetedms.QCPlotsWebPart;
 import org.labkey.test.pages.PortalBodyPanel;
 import org.labkey.test.util.Ext4Helper;
 import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.util.Map;
 

--- a/test/src/org/labkey/test/pages/targetedms/AnnotationInsertPage.java
+++ b/test/src/org/labkey/test/pages/targetedms/AnnotationInsertPage.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.test.pages.targetedms;
 
-import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.pages.InsertPage;
 import org.labkey.test.util.targetedms.QCHelper;

--- a/test/src/org/labkey/test/pages/targetedms/GuideSetPage.java
+++ b/test/src/org/labkey/test/pages/targetedms/GuideSetPage.java
@@ -16,7 +16,6 @@
 package org.labkey.test.pages.targetedms;
 
 import org.jetbrains.annotations.Nullable;
-import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.components.targetedms.GuideSet;
 import org.labkey.test.pages.InsertPage;

--- a/test/src/org/labkey/test/pages/targetedms/PKReportPage.java
+++ b/test/src/org/labkey/test/pages/targetedms/PKReportPage.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.assertEquals;
 
 public class PKReportPage extends LabKeyPage<PKReportPage.ElementCache>
 {
-    private int _totalSubgroupTimeRowCount;
+    private final int _totalSubgroupTimeRowCount;
 
     public PKReportPage(WebDriver driver, int totalSubgroupTimeRowCount)
     {

--- a/test/src/org/labkey/test/pages/targetedms/PanoramaAnnotations.java
+++ b/test/src/org/labkey/test/pages/targetedms/PanoramaAnnotations.java
@@ -22,8 +22,8 @@ import org.labkey.test.pages.PortalBodyPanel;
 
 public class PanoramaAnnotations extends PortalBodyPanel
 {
-    private QCAnnotationWebPart _qcAnnotationWebPart;
-    private QCAnnotationTypeWebPart _qcAnnotationTypeWebPart;
+    private final QCAnnotationWebPart _qcAnnotationWebPart;
+    private final QCAnnotationTypeWebPart _qcAnnotationTypeWebPart;
 
     public PanoramaAnnotations(BaseWebDriverTest test)
     {

--- a/test/src/org/labkey/test/pages/targetedms/ParetoPlotPage.java
+++ b/test/src/org/labkey/test/pages/targetedms/ParetoPlotPage.java
@@ -15,14 +15,13 @@
  */
 package org.labkey.test.pages.targetedms;
 
-import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.components.targetedms.ParetoPlotsWebPart;
 import org.labkey.test.pages.PortalBodyPanel;
 import org.openqa.selenium.WebDriver;
 
 public class ParetoPlotPage extends PortalBodyPanel
 {
-    private ParetoPlotsWebPart _paretoPlotsWebPart;
+    private final ParetoPlotsWebPart _paretoPlotsWebPart;
 
     public ParetoPlotPage(WebDriver driver)
     {

--- a/test/src/org/labkey/test/tests/panoramapremium/TargetedMSHidePeptidesAndMolecules.java
+++ b/test/src/org/labkey/test/tests/panoramapremium/TargetedMSHidePeptidesAndMolecules.java
@@ -30,7 +30,7 @@ public class TargetedMSHidePeptidesAndMolecules extends TargetedMSTest
     @BeforeClass
     public static void initProject()
     {
-        TargetedMSHidePeptidesAndMolecules init = (TargetedMSHidePeptidesAndMolecules) getCurrentTest();
+        TargetedMSHidePeptidesAndMolecules init = getCurrentTest();
         init.doInit();
     }
 

--- a/test/src/org/labkey/test/tests/panoramapremium/TargetedMSQCFolderImportExport.java
+++ b/test/src/org/labkey/test/tests/panoramapremium/TargetedMSQCFolderImportExport.java
@@ -14,7 +14,6 @@ import org.labkey.test.util.APIContainerHelper;
 import org.labkey.test.util.DataRegionTable;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -27,7 +26,7 @@ public class TargetedMSQCFolderImportExport extends TargetedMSPremiumTest
     @BeforeClass
     public static void initProject()
     {
-        TargetedMSQCFolderImportExport init = (TargetedMSQCFolderImportExport) getCurrentTest();
+        TargetedMSQCFolderImportExport init = getCurrentTest();
         init.doInit();
     }
 

--- a/test/src/org/labkey/test/tests/panoramapremium/TargetedMSQCPremiumTest.java
+++ b/test/src/org/labkey/test/tests/panoramapremium/TargetedMSQCPremiumTest.java
@@ -53,7 +53,7 @@ public class TargetedMSQCPremiumTest extends TargetedMSPremiumTest
     @BeforeClass
     public static void initProject()
     {
-        TargetedMSQCPremiumTest init = (TargetedMSQCPremiumTest)getCurrentTest();
+        TargetedMSQCPremiumTest init = getCurrentTest();
         init.doInit();
     }
 

--- a/test/src/org/labkey/test/tests/panoramapremium/TargetedMSSampleManagerIntegrationTest.java
+++ b/test/src/org/labkey/test/tests/panoramapremium/TargetedMSSampleManagerIntegrationTest.java
@@ -27,7 +27,7 @@ public class TargetedMSSampleManagerIntegrationTest extends TargetedMSPremiumTes
     @BeforeClass
     public static void initProject()
     {
-        TargetedMSSampleManagerIntegrationTest init = (TargetedMSSampleManagerIntegrationTest) getCurrentTest();
+        TargetedMSSampleManagerIntegrationTest init = getCurrentTest();
         init.doInit();
     }
 

--- a/test/src/org/labkey/test/tests/panoramapremium/TargetedMSiRTMetricsTest.java
+++ b/test/src/org/labkey/test/tests/panoramapremium/TargetedMSiRTMetricsTest.java
@@ -29,7 +29,7 @@ public class TargetedMSiRTMetricsTest extends TargetedMSPremiumTest
     @BeforeClass
     public static void initProject()
     {
-        TargetedMSiRTMetricsTest init = (TargetedMSiRTMetricsTest) getCurrentTest();
+        TargetedMSiRTMetricsTest init = getCurrentTest();
         init.doInit();
     }
 

--- a/test/src/org/labkey/test/tests/targetedms/ClustergrammerTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/ClustergrammerTest.java
@@ -42,7 +42,7 @@ public class ClustergrammerTest extends TargetedMSTest
     @BeforeClass
     public static void initProject()
     {
-        ClustergrammerTest init = (ClustergrammerTest)getCurrentTest();
+        ClustergrammerTest init = getCurrentTest();
         init.setupFolder(FolderType.QC);
         init.importData(SProCoP_FILE);
     }

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSAuditLogTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSAuditLogTest.java
@@ -19,7 +19,7 @@ public class TargetedMSAuditLogTest extends TargetedMSTest
     @BeforeClass
     public static void initProject()
     {
-        TargetedMSAuditLogTest init = (TargetedMSAuditLogTest) getCurrentTest();
+        TargetedMSAuditLogTest init = getCurrentTest();
         init.doInit();
     }
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSChromatogramOptimizationTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSChromatogramOptimizationTest.java
@@ -30,7 +30,7 @@ public class TargetedMSChromatogramOptimizationTest extends TargetedMSTest
     @BeforeClass
     public static void setupProject()
     {
-        TargetedMSChromatogramOptimizationTest init = (TargetedMSChromatogramOptimizationTest) getCurrentTest();
+        TargetedMSChromatogramOptimizationTest init = getCurrentTest();
         init.setupFolder(FolderType.Library);
     }
 
@@ -49,9 +49,9 @@ public class TargetedMSChromatogramOptimizationTest extends TargetedMSTest
         File downloadedClibFile = doAndWaitForDownload(() -> clickButton("Download", 0));
 
         log("Verifying table exists");
-        List<String> tablesToVerify = new LinkedList<String>(Arrays.asList("TransitionOptimization", "Transition", "Peptide", "Protein", "Precursor", "PrecursorRetentionTime"));
+        List<String> tablesToVerify = new LinkedList<>(Arrays.asList("TransitionOptimization", "Transition", "Peptide", "Protein", "Precursor", "PrecursorRetentionTime"));
         List<String> tablesNotPresent = tableExists(tablesToVerify, downloadedClibFile);
-        if (tablesNotPresent.size() != 0)
+        if (!tablesNotPresent.isEmpty())
             checker().verifyTrue("Some of the tables do not exists in SQLITE file" + Arrays.toString(tablesNotPresent.toArray()), false);
 
         log("Verifying the SampleFile modifications");

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSDocumentFormatsTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSDocumentFormatsTest.java
@@ -41,7 +41,7 @@ public class TargetedMSDocumentFormatsTest extends TargetedMSTest
     @BeforeClass
     public static void setupProject()
     {
-        TargetedMSDocumentFormatsTest init = (TargetedMSDocumentFormatsTest) getCurrentTest();
+        TargetedMSDocumentFormatsTest init = getCurrentTest();
         init.setupFolder(FolderType.Experiment);
     }
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSEarlyStagePTMReportTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSEarlyStagePTMReportTest.java
@@ -17,7 +17,7 @@ public class TargetedMSEarlyStagePTMReportTest extends TargetedMSTest
     @BeforeClass
     public static void initProject()
     {
-        TargetedMSEarlyStagePTMReportTest init = (TargetedMSEarlyStagePTMReportTest) getCurrentTest();
+        TargetedMSEarlyStagePTMReportTest init = getCurrentTest();
         init.doInit();
     }
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentIrtTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentIrtTest.java
@@ -38,7 +38,7 @@ public class TargetedMSExperimentIrtTest extends TargetedMSIrtTest
         // For experiment folders, importing another iRT scale should create another scale and set of iRT Peptide rows. Unlike with library folders,
         // it doesn't matter if the new scale has a different set of standards.
         importData(SKY_FILE_BAD_STANDARDS, 2);
-        assertEquals("Incorrect total iRT peptide count.", getRowCount(), PEPTIDE_COUNT * 2 );
-        assertEquals("Incorrect number of rows for iRT peptide " + UPDATE_PEPTIDE, getRowsForPeptide(UPDATE_PEPTIDE).size(), 2);
+        assertEquals("Incorrect total iRT peptide count.", PEPTIDE_COUNT * 2, getRowCount());
+        assertEquals("Incorrect number of rows for iRT peptide " + UPDATE_PEPTIDE, 2, getRowsForPeptide(UPDATE_PEPTIDE).size());
     }
 }

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSInstrumentNicknameTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSInstrumentNicknameTest.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.test.tests.targetedms;
 
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSIrtTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSIrtTest.java
@@ -18,7 +18,6 @@ package org.labkey.test.tests.targetedms;
 import org.labkey.remoteapi.query.Filter;
 import org.labkey.test.Locator;
 import org.labkey.test.util.PipelineStatusTable;
-import org.labkey.test.util.UIContainerHelper;
 
 import java.io.File;
 import java.util.Collections;

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSLinkVersionsTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSLinkVersionsTest.java
@@ -45,7 +45,7 @@ public class TargetedMSLinkVersionsTest extends TargetedMSTest
     @BeforeClass
     public static void initProject()
     {
-        TargetedMSLinkVersionsTest init = (TargetedMSLinkVersionsTest)getCurrentTest();
+        TargetedMSLinkVersionsTest init = getCurrentTest();
         init.setupFolder(FolderType.Experiment);
 
         // pre-upload the files to the pipeline root so that all of the @Test don't have to worry about it

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSMovingSKYDocAcrossFoldersTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSMovingSKYDocAcrossFoldersTest.java
@@ -22,7 +22,7 @@ public class TargetedMSMovingSKYDocAcrossFoldersTest extends TargetedMSTest
     @BeforeClass
     public static void initProject()
     {
-        TargetedMSMovingSKYDocAcrossFoldersTest init = (TargetedMSMovingSKYDocAcrossFoldersTest) getCurrentTest();
+        TargetedMSMovingSKYDocAcrossFoldersTest init = getCurrentTest();
         init.doInit();
     }
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSMultiplePeptidePlotTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSMultiplePeptidePlotTest.java
@@ -21,7 +21,7 @@ public class TargetedMSMultiplePeptidePlotTest extends TargetedMSTest
     @BeforeClass
     public static void setupProject()
     {
-        TargetedMSMultiplePeptidePlotTest init = (TargetedMSMultiplePeptidePlotTest) getCurrentTest();
+        TargetedMSMultiplePeptidePlotTest init = getCurrentTest();
         init.setupFolder(FolderType.Library);
     }
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSMxNReproducibilityReportTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSMxNReproducibilityReportTest.java
@@ -35,7 +35,7 @@ public class TargetedMSMxNReproducibilityReportTest extends TargetedMSTest
     @BeforeClass
     public static void setupProject()
     {
-        TargetedMSMxNReproducibilityReportTest init = (TargetedMSMxNReproducibilityReportTest) getCurrentTest();
+        TargetedMSMxNReproducibilityReportTest init = getCurrentTest();
         init.setupFolder(FolderType.Library);
     }
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSPeptideSummaryHeatmapTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSPeptideSummaryHeatmapTest.java
@@ -23,7 +23,7 @@ public class TargetedMSPeptideSummaryHeatmapTest extends TargetedMSTest
     @BeforeClass
     public static void setupProject()
     {
-        TargetedMSPeptideSummaryHeatmapTest init = (TargetedMSPeptideSummaryHeatmapTest) getCurrentTest();
+        TargetedMSPeptideSummaryHeatmapTest init = getCurrentTest();
         init.doSetup();
     }
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSPrecursorLevelDataTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSPrecursorLevelDataTest.java
@@ -17,10 +17,6 @@ package org.labkey.test.tests.targetedms;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.labkey.test.Locator;
-import org.labkey.test.ModulePropertyValue;
-
-import java.util.Arrays;
 
 @Category({})
 public class TargetedMSPrecursorLevelDataTest extends AbstractQuantificationTest

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSProteinGroupingTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSProteinGroupingTest.java
@@ -17,7 +17,7 @@ public class TargetedMSProteinGroupingTest extends TargetedMSTest
     @BeforeClass
     public static void initProject()
     {
-        TargetedMSProteinGroupingTest init = (TargetedMSProteinGroupingTest) getCurrentTest();
+        TargetedMSProteinGroupingTest init = getCurrentTest();
         init.doInit();
     }
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSProteinSequenceViewTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSProteinSequenceViewTest.java
@@ -23,7 +23,7 @@ public class TargetedMSProteinSequenceViewTest extends TargetedMSTest
     @BeforeClass
     public static void initProject()
     {
-        TargetedMSProteinSequenceViewTest init = (TargetedMSProteinSequenceViewTest) getCurrentTest();
+        TargetedMSProteinSequenceViewTest init = getCurrentTest();
         init.doInit();
     }
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCConfigureMetricTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCConfigureMetricTest.java
@@ -27,7 +27,7 @@ public class TargetedMSQCConfigureMetricTest extends TargetedMSPremiumTest
     @BeforeClass
     public static void setupProject()
     {
-        TargetedMSQCConfigureMetricTest init = (TargetedMSQCConfigureMetricTest) getCurrentTest();
+        TargetedMSQCConfigureMetricTest init = getCurrentTest();
         init.doSetup();
     }
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCGuideSetTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCGuideSetTest.java
@@ -50,7 +50,6 @@ import java.util.Date;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 25)
@@ -83,7 +82,7 @@ public class TargetedMSQCGuideSetTest extends TargetedMSTest
     @BeforeClass
     public static void initProject()
     {
-        TargetedMSQCGuideSetTest init = (TargetedMSQCGuideSetTest)getCurrentTest();
+        TargetedMSQCGuideSetTest init = getCurrentTest();
 
         init.setupFolder(FolderType.QC);
         init.importData(SProCoP_FILE);

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -89,13 +89,13 @@ public class TargetedMSQCTest extends TargetedMSTest
     private static final String QCREPLICATE_3 = "25fmol_Pepmix_spike_SRM_1601_03";
     private static final String QCREPLICATE_4 = "25fmol_Pepmix_spike_SRM_1601_04";
 
-    private static QCHelper.Annotation instrumentChange = new QCHelper.Annotation("Instrumentation Change", "We changed it", "2013-08-22 14:43:00");
-    private static QCHelper.Annotation reagentChange = new QCHelper.Annotation("Reagent Change", "New reagents", "2013-08-10 15:34:00");
-    private static QCHelper.Annotation technicianChange = new QCHelper.Annotation("Technician Change", "New guy on the scene", "2013-08-10 08:43:00");
-    private static QCHelper.Annotation candyChange = new QCHelper.Annotation("Candy Change", "New candies!", "2013-08-21 6:57:00");
+    private static final QCHelper.Annotation instrumentChange = new QCHelper.Annotation("Instrumentation Change", "We changed it", "2013-08-22 14:43:00");
+    private static final QCHelper.Annotation reagentChange = new QCHelper.Annotation("Reagent Change", "New reagents", "2013-08-10 15:34:00");
+    private static final QCHelper.Annotation technicianChange = new QCHelper.Annotation("Technician Change", "New guy on the scene", "2013-08-10 08:43:00");
+    private static final QCHelper.Annotation candyChange = new QCHelper.Annotation("Candy Change", "New candies!", "2013-08-21 6:57:00");
 
 
-    private static String longPeptideJSTest =
+    private static final String longPeptideJSTest =
             "var testVals = {\n" +
                     "        a: {fragment:'', dataType: 'Peptide', result: ''},\n" +
                     "        b: {fragment:'A', dataType: 'Peptide', result: 'A'},\n" +
@@ -163,7 +163,7 @@ public class TargetedMSQCTest extends TargetedMSTest
     @BeforeClass
     public static void initProject()
     {
-        TargetedMSQCTest init = (TargetedMSQCTest) getCurrentTest();
+        TargetedMSQCTest init = getCurrentTest();
         init.doInit();
     }
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSSampleFileChromInfoTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSSampleFileChromInfoTest.java
@@ -34,7 +34,7 @@ public class TargetedMSSampleFileChromInfoTest extends TargetedMSTest
     @BeforeClass
     public static void setupProject()
     {
-        TargetedMSTest init = (TargetedMSTest) getCurrentTest();
+        TargetedMSTest init = getCurrentTest();
         init.setupFolder(FolderType.Experiment);
     }
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSSkydTextIdTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSSkydTextIdTest.java
@@ -34,7 +34,7 @@ public class TargetedMSSkydTextIdTest extends TargetedMSTest
     @BeforeClass
     public static void setupProject()
     {
-        TargetedMSTest init = (TargetedMSTest) getCurrentTest();
+        TargetedMSTest init = getCurrentTest();
         init.setupFolder(FolderType.Experiment);
     }
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSTest.java
@@ -69,7 +69,7 @@ public abstract class TargetedMSTest extends BaseWebDriverTest
         CIRCLE_OPEN("M0-2"),
         TRIANGLE("M0,2L2");
 
-        private String _pathPrefix;
+        private final String _pathPrefix;
         SvgShapes(String pathPrefix)
         {
             _pathPrefix = pathPrefix;
@@ -147,7 +147,7 @@ public abstract class TargetedMSTest extends BaseWebDriverTest
     @BeforeClass
     public static void initPipeline()
     {
-        TargetedMSTest init = (TargetedMSTest)getCurrentTest();
+        TargetedMSTest init = getCurrentTest();
 
         init.doInitPipeline();
     }
@@ -404,8 +404,6 @@ public abstract class TargetedMSTest extends BaseWebDriverTest
     /**
      * Sets the values of the site-level module properties: "TransitionChromInfo storage limit" and "Precursor storage limit".
      * The values should be set back to defaults after the test completes.
-     * @param transitionStorageLimit
-     * @param precursorStorageLimit
      */
     protected void setStorageLimitModuleProperties(String transitionStorageLimit, String precursorStorageLimit) {
         goToProjectHome();

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSTrailingMeanAndCVTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSTrailingMeanAndCVTest.java
@@ -23,7 +23,7 @@ public class TargetedMSTrailingMeanAndCVTest extends TargetedMSTest
     @BeforeClass
     public static void initProject()
     {
-        TargetedMSTrailingMeanAndCVTest init = (TargetedMSTrailingMeanAndCVTest) getCurrentTest();
+        TargetedMSTrailingMeanAndCVTest init = getCurrentTest();
         init.doInit();
     }
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSTransitionChromInfoLimitTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSTransitionChromInfoLimitTest.java
@@ -22,7 +22,7 @@ public class TargetedMSTransitionChromInfoLimitTest extends TargetedMSTest
     @BeforeClass
     public static void setupProject()
     {
-        TargetedMSTransitionChromInfoLimitTest init = (TargetedMSTransitionChromInfoLimitTest) getCurrentTest();
+        TargetedMSTransitionChromInfoLimitTest init = getCurrentTest();
         init.setupFolder(FolderType.Experiment);
     }
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSUtilizationCalendarTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSUtilizationCalendarTest.java
@@ -27,7 +27,7 @@ public class TargetedMSUtilizationCalendarTest extends TargetedMSTest
     @BeforeClass
     public static void initProject()
     {
-        TargetedMSUtilizationCalendarTest init = (TargetedMSUtilizationCalendarTest) getCurrentTest();
+        TargetedMSUtilizationCalendarTest init = getCurrentTest();
         init.doInit();
     }
 

--- a/test/src/org/labkey/test/util/targetedms/QCHelper.java
+++ b/test/src/org/labkey/test/util/targetedms/QCHelper.java
@@ -28,8 +28,8 @@ public class QCHelper
 
     public static class Annotation
     {
-        private String type;
-        private String description;
+        private final String type;
+        private final String description;
         private String date;
 
         public Annotation(String type, String description, String date)
@@ -88,9 +88,9 @@ public class QCHelper
 
     public static class AnnotationType
     {
-        private String name;
+        private final String name;
         private String description;
-        private String color;
+        private final String color;
 
         public AnnotationType(String name, String description, String color)
         {


### PR DESCRIPTION
#### Rationale
We can cleanup tens of thousands of warnings across our codebase with IntelliJ's autorefactors. In some cases, this adopts newer, leaner syntax. In others, it simply removes code that's not serving any purpose.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6742

#### Changes
- Auto-refactors
  - Eliminate redundant toString()
  - Eliminate redundant cast
  - Empty JavaDoc annotations
  - Member variable can be final
  - length() and size() -> isEmpty()
  - Add missing @Override
  - Class can be static
  - Remove unused imports
  - toArray() passed array length
  - Remove unnecessary semicolon
  - Explicit type syntax can be replaced by <>
  - Redundant access modifiers
  - Remove redundant initializer
  - "".equals() -> isEmpty()
  - StringBuilder can be replaced by String
  - Fix misordered arguments to assertEquals()
  - StringUtils.defaultString() - Objects.toString()
  - Cast can be replaced with pattern variable
  - Collapse identical catch blocks
  - Type may be primitive
- Manual fixups
  - Delete unused GWT code
  - Improve generics
  - new UnexpectedException() -> UnexpectedException.wrap()


