### PR TITLE
Fix test failures when QC Metric config doesn't load in time

### DIFF
--- a/webapp/TargetedMS/js/ParetoPlotPanel.js
+++ b/webapp/TargetedMS/js/ParetoPlotPanel.js
@@ -17,7 +17,10 @@ Ext4.define('LABKEY.targetedms.ParetoPlotPanel', {
 
         Ext4.get(this.plotDivId).mask("Loading...");
 
-        LABKEY.targetedms.QCMetricConfigLoader.getMetrics(this.initPlot, this);
+        LABKEY.targetedms.QCMetricConfigLoader.getMetrics(this.initPlot, this, function() {
+            Ext4.get(this.plotDivId).unmask();
+            Ext4.get(this.plotDivId).update('Failed to load');
+        });
     },
 
     initPlot : function(metrics) {

--- a/webapp/TargetedMS/js/QCMetricConfigLoader.js
+++ b/webapp/TargetedMS/js/QCMetricConfigLoader.js
@@ -5,15 +5,19 @@ if (!LABKEY.targetedms) {
 if (!LABKEY.targetedms.QCMetricConfigLoader) {
     LABKEY.targetedms.QCMetricConfigLoader = {
         initialQcMetrics: null,
+        failureResponse: null,
         initialQcMetricsCallbacks: [],
         initialQcMetricsRequested: false,
 
-        getMetrics : function(successCallback, callbackScope) {
+        getMetrics : function(successCallback, callbackScope, failureCallback) {
             if (this.initialQcMetrics) {
                 successCallback.call(callbackScope, this.initialQcMetrics);
             }
+            else if (this.failureResponse) {
+                failureCallback.call(callbackScope, this.failureResponse);
+            }
             else {
-                this.initialQcMetricsCallbacks.push({callback: successCallback, scope: callbackScope});
+                this.initialQcMetricsCallbacks.push({callback: successCallback, scope: callbackScope, failure: failureCallback});
 
                 if (!this.initialQcMetricsRequested) {
                     this.initialQcMetricsRequested = true;
@@ -29,7 +33,11 @@ if (!LABKEY.targetedms.QCMetricConfigLoader) {
                             this.initialQcMetricsCallbacks = [];
                         },
                         failure: LABKEY.Utils.getCallbackWrapper(function (response) {
-                            this.failureHandler(response);
+                            this.failureResponse = response;
+                            for (const c of this.initialQcMetricsCallbacks) {
+                                c.failure.call(c.scope, response);
+                            }
+                            this.initialQcMetricsCallbacks = [];
                         }, null, true),
                         scope: this
                     });

--- a/webapp/TargetedMS/js/QCMetricConfigLoader.js
+++ b/webapp/TargetedMS/js/QCMetricConfigLoader.js
@@ -28,14 +28,18 @@ if (!LABKEY.targetedms.QCMetricConfigLoader) {
                             const configs = Ext4.JSON.decode(response.responseText).configurations;
                             this.initialQcMetrics = configs;
                             for (const c of this.initialQcMetricsCallbacks) {
-                                c.callback.call(c.scope, this.initialQcMetrics);
+                                if (c.callback) {
+                                    c.callback.call(c.scope, this.initialQcMetrics);
+                                }
                             }
                             this.initialQcMetricsCallbacks = [];
                         },
                         failure: LABKEY.Utils.getCallbackWrapper(function (response) {
                             this.failureResponse = response;
                             for (const c of this.initialQcMetricsCallbacks) {
-                                c.failure.call(c.scope, response);
+                                if (c.failure) {
+                                    c.failure.call(c.scope, response);
+                                }
                             }
                             this.initialQcMetricsCallbacks = [];
                         }, null, true),

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -94,7 +94,9 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         else {
             Ext4.get(this.plotDivId).update("Loading...");
             // Load replicate annotations in the callback.
-            LABKEY.targetedms.QCMetricConfigLoader.getMetrics(this.queryContainerReplicateAnnotations, this);
+            LABKEY.targetedms.QCMetricConfigLoader.getMetrics(this.queryContainerReplicateAnnotations, this, function() {
+                Ext4.get(this.plotDivId).update('Failed to load');
+            });
         }
     },
 


### PR DESCRIPTION
#### Rationale
https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_External_Panorama_PanoramaAPostgres/3546378

```
TypeError: this.failureHandler is not a function
  getMetrics/<.failure< (http://localhost:8111/targetedms/js/QCMetricConfigLoader.js:32:34)
```

#### Changes
* Supply failure handlers and invoke them correctly