### PR TITLE
Ticket 53293: PTM conditional formatting improvements

### DIFF
--- a/src/org/labkey/targetedms/parser/Peptide.java
+++ b/src/org/labkey/targetedms/parser/Peptide.java
@@ -370,7 +370,7 @@ public class Peptide extends GeneralMolecule<Transition, Precursor>
     }
 
     /**
-     * Adds to a list all of the modifications in a modifiedSequence, and returns the unmodified sequence.
+     * Adds to a list all the modifications in a modifiedSequence, and returns the unmodified sequence.
      */
     public static String stripModifications(String modifiedSequence, List<Pair<Integer, String>> modifications)
     {

--- a/src/org/labkey/targetedms/query/CDRConditionalFormattingDisplayColumnFactory.java
+++ b/src/org/labkey/targetedms/query/CDRConditionalFormattingDisplayColumnFactory.java
@@ -12,8 +12,10 @@ import org.labkey.api.data.RenderContext;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.util.Pair;
+import org.labkey.targetedms.parser.Peptide;
 import org.labkey.targetedms.parser.Protein;
 
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -31,11 +33,26 @@ class CDRConditionalFormattingDisplayColumnFactory implements DisplayColumnFacto
         _runId = runId;
     }
 
-    public static RiskLevel getRiskLevel(Number value, boolean inCDR, boolean stressed)
+    public static RiskLevel getRiskLevel(Number value, boolean inCDR, boolean stressed, String modification, String modifiedSequence)
     {
         if (value == null)
         {
             return null;
+        }
+
+        if ("Gln->pyro-Glu (N-term Q)".equalsIgnoreCase(modification))
+        {
+            return null;
+        }
+
+        if (modifiedSequence != null)
+        {
+            String sequence = Peptide.stripModifications(modifiedSequence, new ArrayList<>());
+            // Ticket 53293 - exempt low-risk IgG1 and IgG4 sequences from scoring
+            if ("EEQYNSTYR".equalsIgnoreCase(sequence) || "EEQFNSTYR".equalsIgnoreCase(sequence))
+            {
+                return null;
+            }
         }
 
         // Apply different cutoffs when the peptide is part of the complementarity determining region (CDR)
@@ -136,12 +153,17 @@ class CDRConditionalFormattingDisplayColumnFactory implements DisplayColumnFacto
             keys.add(FieldKey.fromString(getBoundColumn().getFieldKey().getParent(), "Location"));
             keys.add(FieldKey.fromString(getBoundColumn().getFieldKey().getParent(), "Modification"));
             keys.add(FieldKey.fromString(getBoundColumn().getFieldKey().getParent(), "RunId"));
+            keys.add(FieldKey.fromString(getBoundColumn().getFieldKey().getParent(), "Sequence"));
         }
 
-        @NotNull
-        private ConditionalFormat createConditionalFormat(Number value, boolean inCDR, boolean stressed)
+        @Nullable
+        private ConditionalFormat createConditionalFormat(Number value, boolean inCDR, boolean stressed, String modification, String modifiedSequence)
         {
-            RiskLevel level = getRiskLevel(value, inCDR, stressed);
+            RiskLevel level = getRiskLevel(value, inCDR, stressed, modification, modifiedSequence);
+            if (level == null)
+            {
+                return null;
+            }
 
             ConditionalFormat result = new ConditionalFormat()
             {
@@ -178,10 +200,7 @@ class CDRConditionalFormattingDisplayColumnFactory implements DisplayColumnFacto
             }
 
             String modification = ctx.get(new FieldKey(getBoundColumn().getFieldKey().getParent(), "Modification"), String.class);
-            if ("Gln->pyro-Glu (N-term Q)".equalsIgnoreCase(modification))
-            {
-                return null;
-            }
+            String modifiedSequence = ctx.get(new FieldKey(getBoundColumn().getFieldKey().getParent(), "Sequence"), String.class);
 
             boolean inCDR = isInCDR(getBoundColumn().getFieldKey().getParent(), ctx, _proteinGetter);
 
@@ -192,7 +211,7 @@ class CDRConditionalFormattingDisplayColumnFactory implements DisplayColumnFacto
                 sampleName = sampleName.substring(0, sampleName.indexOf("::"));
             }
             Pair<Boolean, String> metadata = _stressedSamples.get(Pair.of(sampleName, _runId));
-            return createConditionalFormat(value, inCDR, metadata != null && metadata.first.booleanValue());
+            return createConditionalFormat(value, inCDR, metadata != null && metadata.first.booleanValue(), modification, modifiedSequence);
         }
     }
 

--- a/src/org/labkey/targetedms/query/PTMRiskDisplayColumnFactory.java
+++ b/src/org/labkey/targetedms/query/PTMRiskDisplayColumnFactory.java
@@ -48,10 +48,12 @@ public class PTMRiskDisplayColumnFactory implements DisplayColumnFactory
             Object result = super.getValue(ctx);
             if (result == null)
             {
-                Number modified = ctx.get(FieldKey.fromString(getBoundColumn().getFieldKey().getParent(), "PercentModified"), Number.class);
-                String sampleName = ctx.get(FieldKey.fromString(getBoundColumn().getFieldKey().getParent(), "SampleName"), String.class);
+                Number percentModified = ctx.get(FieldKey.fromString(getBoundColumn().getFieldKey().getParent(), "PercentModified"), Number.class);
+                String replicateName = ctx.get(FieldKey.fromString(getBoundColumn().getFieldKey().getParent(), "ReplicateName"), String.class);
                 Long runId = ctx.get(FieldKey.fromString(getBoundColumn().getFieldKey().getParent(), "RunId"), Long.class);
-                if (modified == null || sampleName == null || runId == null)
+                String modification = ctx.get(FieldKey.fromString(getBoundColumn().getFieldKey().getParent(), "Modification"), String.class);
+                String modifiedSequence = ctx.get(FieldKey.fromString(getBoundColumn().getFieldKey().getParent(), "Sequence"), String.class);
+                if (percentModified == null || replicateName == null || runId == null)
                 {
                     return null;
                 }
@@ -62,10 +64,10 @@ public class PTMRiskDisplayColumnFactory implements DisplayColumnFactory
                 }
 
                 boolean cdr = CDRConditionalFormattingDisplayColumnFactory.isInCDR(getBoundColumn().getFieldKey().getParent(), ctx, _proteinGetter);
-                Pair<Boolean, String> metadata = _stressedSamples.get(Pair.of(sampleName, runId));
+                Pair<Boolean, String> metadata = _stressedSamples.get(Pair.of(replicateName, runId));
                 boolean stressed = metadata != null && metadata.first.booleanValue();
 
-                result = CDRConditionalFormattingDisplayColumnFactory.getRiskLevel(modified, cdr, stressed);
+                result = CDRConditionalFormattingDisplayColumnFactory.getRiskLevel(percentModified, cdr, stressed, modification, modifiedSequence);
             }
             return result;
         }
@@ -81,7 +83,7 @@ public class PTMRiskDisplayColumnFactory implements DisplayColumnFactory
         {
             super.addQueryFieldKeys(keys);
             keys.add(FieldKey.fromString(getBoundColumn().getFieldKey().getParent(), "PercentModified"));
-            keys.add(FieldKey.fromString(getBoundColumn().getFieldKey().getParent(), "SampleName"));
+            keys.add(FieldKey.fromString(getBoundColumn().getFieldKey().getParent(), "ReplicateName"));
             keys.add(FieldKey.fromString(getBoundColumn().getFieldKey().getParent(), "PeptideGroupId"));
             keys.add(FieldKey.fromString(getBoundColumn().getFieldKey().getParent(), "Location"));
             keys.add(FieldKey.fromString(getBoundColumn().getFieldKey().getParent(), "RunId"));

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSEarlyStagePTMReportTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSEarlyStagePTMReportTest.java
@@ -8,6 +8,9 @@ import org.labkey.test.Locator;
 import org.labkey.test.util.DataRegionTable;
 
 import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
 
 @Category({})
 public class TargetedMSEarlyStagePTMReportTest extends TargetedMSTest
@@ -34,6 +37,38 @@ public class TargetedMSEarlyStagePTMReportTest extends TargetedMSTest
     }
 
     @Test
+    public void testEarlyStagePrepivot()
+    {
+        goToProjectHome();
+        goToSchemaBrowser();
+        DataRegionTable table = viewQueryData("targetedms", "PTMPercentsGroupedPrepivot");
+
+        // Test special-cased peptide
+        table.setFilter("PeptideModifiedSequence", "Starts With", "EEQ");
+        table = new DataRegionTable("query", this);
+        assertEquals(List.of("false", "false", "false", "false", "false", "false"), table.getColumnDataAsText("IsCdr"));
+        assertEquals(List.of(" ", " ", " ", " ", " ", " "), table.getColumnDataAsText("Risk"));
+
+        // Test "normal" peptide
+        table.setFilter("PeptideModifiedSequence", "Starts With", "WQQ");
+        table = new DataRegionTable("query", this);
+        assertEquals(List.of("false", "false"), table.getColumnDataAsText("IsCdr"));
+        assertEquals(List.of("Low", "Medium"), table.getColumnDataAsText("Risk"));
+
+        // Test CDR peptide
+        table.setFilter("PeptideModifiedSequence", "Starts With", "VTN");
+        table = new DataRegionTable("query", this);
+        assertEquals(List.of("true", "true"), table.getColumnDataAsText("IsCdr"));
+        assertEquals(List.of("High", "Medium"), table.getColumnDataAsText("Risk"));
+
+        // Test special-cased N-Term Modification, present on QVTL peptide (Q is modified, so don't use it in the filter)
+        table.setFilter("PeptideModifiedSequence", "Contains", "VTL");
+        table = new DataRegionTable("query", this);
+        assertEquals(List.of("false", "false"), table.getColumnDataAsText("IsCdr"));
+        assertEquals(List.of(" ", " "), table.getColumnDataAsText("Risk"));
+    }
+
+    @Test
     public void testEarlyStagePTMReport()
     {
         goToProjectHome();
@@ -42,28 +77,34 @@ public class TargetedMSEarlyStagePTMReportTest extends TargetedMSTest
         DataRegionTable reportTable = new DataRegionTable.DataRegionFinder(getDriver()).withName("earlyStagePtmReport").waitFor();
 
         log("Verifying the table headers");
-        Assert.assertEquals("Incorrect column headers", Arrays.asList("Chain", "Site Location", "Sequence", "Modification", "Max Percent Modified",
+        assertEquals("Incorrect column headers", Arrays.asList("Chain", "Site Location", "Sequence", "Modification", "Max Percent Modified",
                 "Percent Modified", "Total Percent Modified", "Percent Modified", "Total Percent Modified"), reportTable.getColumnLabels());
-        Assert.assertEquals("Incorrect Sample Names displayed as headers", "Sample1 QE_2",
+        assertEquals("Incorrect Sample Names displayed as headers", "Sample1 QE_2",
                 Locator.xpath("//table/thead[2]/tr").findElement(reportTable).getText());
 
+        int qvtRowIndex = 0;  // Special-cased modification: Gln->pyro-Glu (N-term Q)
         int vtnRowIndex = 1;
+        int eeqRowIndex = 3;  // Special-cased peptide: EEQYNSTYR(V)
         int wqqRowIndex = 7;
 
         log("Verifying the modified percentage for sequence with CDR Range and stressed or not stressed updates");
-        Assert.assertEquals("Incorrect percentages for (K)VTNMDPADTATYYCAR(D) sequence", Arrays.asList("(K)VTNMDPADTATYYCAR(D)", "11.3%", "11.3%", "11.1%", "11.1%"),
+        assertEquals("Incorrect percentages for (K)VTNMDPADTATYYCAR(D) sequence", Arrays.asList("(K)VTNMDPADTATYYCAR(D)", "11.3%", "11.3%", "11.1%", "11.1%"),
                 reportTable.getRowDataAsText(vtnRowIndex, "Sequence", "QE_1::PercentModified", "QE_1::TotalPercentModified",
                         "QE_2::PercentModified", "QE_2::TotalPercentModified"));
-        Assert.assertEquals("Incorrect percentages for (R)WQQGNVFSCSVMHEALHNHYTQK(S) sequence", Arrays.asList("(R)WQQGNVFSCSVMHEALHNHYTQK(S)", "22.1%", "22.1%", "24.1%", "24.1%"),
+        assertEquals("Incorrect percentages for (R)WQQGNVFSCSVMHEALHNHYTQK(S) sequence", Arrays.asList("(R)WQQGNVFSCSVMHEALHNHYTQK(S)", "22.1%", "22.1%", "24.1%", "24.1%"),
                 reportTable.getRowDataAsText(wqqRowIndex, "Sequence", "QE_1::PercentModified", "QE_1::TotalPercentModified",
                         "QE_2::PercentModified", "QE_2::TotalPercentModified"));
 
-        log("Verifying the cell colors:Green, Yellow and Red");
-        Assert.assertEquals("Incorrect risk category color for - Green", "rgb(137, 202, 83)",
-                Locator.xpath("//table/tbody/tr[" + (wqqRowIndex + 1) + "]/td[6]").findElement(reportTable).getCssValue("background-color"));
-        Assert.assertEquals("Incorrect risk category color for - Yellow", "rgb(254, 255, 63)",
+        log("Verifying the cell colors: Gray, Green, Yellow and Red");
+        assertEquals("Incorrect risk category color for QVT/Sample1 - Green", "rgb(246, 246, 246)",
+                Locator.xpath("//table/tbody/tr[" + (qvtRowIndex + 1) + "]/td[6]").findElement(reportTable).getCssValue("background-color"));
+        assertEquals("Incorrect risk category color for VTN/Sample1 - Yellow", "rgb(254, 255, 63)",
                 Locator.xpath("//table/tbody/tr[" + (vtnRowIndex + 1) + "]/td[6]").findElement(reportTable).getCssValue("background-color"));
-        Assert.assertEquals("Incorrect risk category color for - Red", "rgb(250, 8, 26)",
+        assertEquals("Incorrect risk category color for VTN/QE_2 - Red", "rgb(250, 8, 26)",
                 Locator.xpath("//table/tbody/tr[" + (vtnRowIndex + 1) + "]/td[8]").findElement(reportTable).getCssValue("background-color"));
+        assertEquals("Incorrect risk category color for EEQ/Sample1 - Green", "rgb(246, 246, 246)",
+                Locator.xpath("//table/tbody/tr[" + (eeqRowIndex + 1) + "]/td[6]").findElement(reportTable).getCssValue("background-color"));
+        assertEquals("Incorrect risk category color for WQQ/Sample1 - Green", "rgb(137, 202, 83)",
+                Locator.xpath("//table/tbody/tr[" + (wqqRowIndex + 1) + "]/td[6]").findElement(reportTable).getCssValue("background-color"));
     }
 }


### PR DESCRIPTION
#### Rationale
We can further streamline some customer reporting scenarios by making the Early Stage PTM report closer to their desired output.

#### Changes
* Exempt a couple of peptides from conditional formatting
* Fix sample/replicate name mismatch to restore Risk column in `targetedms.PTMPercentsGroupedPrepivot`
* Test coverage