### PR TITLE
Improved test coverage for peptide heatmap report

### DIFF
--- a/resources/views/peptideSummary.html
+++ b/resources/views/peptideSummary.html
@@ -2,6 +2,7 @@
   .date-picker-container {
     display: none;
     margin-top: 10px;
+    margin-bottom: 10px;
   }
 
   .legend-container {
@@ -78,6 +79,7 @@
     <button id="apply-button">Apply</button>
 </div>
 
+<span id="fom-error" class='labkey-error'></span>
 <div class="legend-container">
     <div class="legend-label">&nbsp; &nbsp;No outliers</div>
     <div id="legend" class="legend"></div>
@@ -87,7 +89,6 @@
 </div>
 
 <span id="fom-loading">Loading...<i class="fa fa-spinner fa-pulse"></i></span>
-<span id="fom-error" class='labkey-error'></span>
 <div id="table-container" class="table-container">
 
 </div>
@@ -328,8 +329,16 @@
         const endDateVal = document.getElementById('ps-end-date').value;
 
         if (!startDateVal || !endDateVal) {
-            alert('Please select both start and end dates.');
             $('#fom-loading').hide();
+            $('#fom-error').text('Please select both start and end dates.').show();
+            return;
+        }
+
+        const parsedStart = new Date(startDateVal);
+        const parsedEnd = new Date(endDateVal);
+        if (parsedStart.getTime() > parsedEnd.getTime()) {
+            $('#fom-loading').hide();
+            $('#fom-error').text('Please choose a start date that is before the end date.').show();
             return;
         }
 

--- a/test/src/org/labkey/test/components/targetedms/PeptideSummaryWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/PeptideSummaryWebPart.java
@@ -38,20 +38,51 @@ public class PeptideSummaryWebPart extends BodyWebPart<PeptideSummaryWebPart.Ele
 
     public PeptideSummaryWebPart setStartDate(String value)
     {
-        elementCache().startDate.set(value);
+        if (value != null)
+        {
+            elementCache().startDate.set(value);
+        }
+        else
+        {
+            elementCache().startDate.clear();
+        }
         return this;
     }
 
     public PeptideSummaryWebPart setEndDate(String value)
     {
-        elementCache().endDate.set(value);
+        if (value != null)
+        {
+            elementCache().endDate.set(value);
+        }
+        else
+        {
+            elementCache().endDate.clear();
+        }
         return this;
     }
 
-    public PeptideSummaryWebPart apply()
+    public String getStartDate()
     {
-        doAndWaitForElementToRefresh(() -> elementCache().applyButton.findElement(this).click(),
-                elementCache().heatmapLoc, getWrapper().defaultWaitForPage);
+        return elementCache().startDate.get();
+    }
+
+    public String getEndDate()
+    {
+        return elementCache().endDate.get();
+    }
+
+    public PeptideSummaryWebPart apply(boolean wait)
+    {
+        if (wait)
+        {
+            doAndWaitForElementToRefresh(() -> elementCache().applyButton.findElement(this).click(),
+                    elementCache().heatmapLoc, getWrapper().defaultWaitForPage);
+        }
+        else
+        {
+            elementCache().applyButton.findElement(this).click();
+        }
 
         return this;
     }

--- a/test/src/org/labkey/test/components/targetedms/PeptideSummaryWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/PeptideSummaryWebPart.java
@@ -72,18 +72,17 @@ public class PeptideSummaryWebPart extends BodyWebPart<PeptideSummaryWebPart.Ele
         return elementCache().endDate.get();
     }
 
-    public PeptideSummaryWebPart apply(boolean wait)
+    public PeptideSummaryWebPart apply()
     {
-        if (wait)
-        {
-            doAndWaitForElementToRefresh(() -> elementCache().applyButton.findElement(this).click(),
-                    elementCache().heatmapLoc, getWrapper().defaultWaitForPage);
-        }
-        else
-        {
-            elementCache().applyButton.findElement(this).click();
-        }
+        doAndWaitForElementToRefresh(() -> elementCache().applyButton.findElement(this).click(),
+                elementCache().heatmapLoc, getWrapper().defaultWaitForPage);
+        return this;
+    }
 
+    public PeptideSummaryWebPart applyExpectingError(String error)
+    {
+        elementCache().applyButton.findElement(this).click();
+        getWrapper().assertTextPresent(error);
         return this;
     }
 

--- a/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
@@ -678,6 +678,7 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
     public enum DateRangeOffset
     {
         ALL(0, "All dates"),
+        LAST_7_DAYS(180, "Last 7 days"),
         LAST_180_DAYS(180, "Last 180 days"),
         CUSTOM(-1, "Custom range");
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSPeptideSummaryHeatmapTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSPeptideSummaryHeatmapTest.java
@@ -87,15 +87,13 @@ public class TargetedMSPeptideSummaryHeatmapTest extends TargetedMSTest
 
         log("Verify invalid date combos produce helpful errors");
         peptideSummaryHeatMap.setCustomDateRange("2013-08-15", "2013-08-01");
-        peptideSummaryHeatMap.apply(false);
-        assertTextPresent("Please choose a start date that is before the end date.");
+        peptideSummaryHeatMap.applyExpectingError("Please choose a start date that is before the end date.");
         peptideSummaryHeatMap.setCustomDateRange(null, "2013-08-01");
-        peptideSummaryHeatMap.apply(false);
-        assertTextPresent("Please select both start and end dates.");
+        peptideSummaryHeatMap.applyExpectingError("Please select both start and end dates.");
 
         log("Verify Custom date range");
         peptideSummaryHeatMap.setCustomDateRange("2013-08-01", "2013-08-15");
-        peptideSummaryHeatMap.apply(true);
+        peptideSummaryHeatMap.apply();
         verifyDataCustomRange(peptideSummaryHeatMap);
 
         log("Verify Custom -> standard -> custom toggling");

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSPeptideSummaryHeatmapTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSPeptideSummaryHeatmapTest.java
@@ -5,6 +5,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.Locator;
 import org.labkey.test.components.targetedms.PeptideSummaryWebPart;
 import org.labkey.test.components.targetedms.QCPlotsWebPart;
 import org.labkey.test.pages.panoramapremium.ConfigureMetricsUIPage;
@@ -13,6 +14,8 @@ import org.labkey.test.util.PortalHelper;
 
 import java.util.Arrays;
 import java.util.List;
+
+import static org.junit.Assert.assertEquals;
 
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
@@ -61,13 +64,59 @@ public class TargetedMSPeptideSummaryHeatmapTest extends TargetedMSTest
                 .clickSave();
 
         clickPortalTab(PEPTIDE_MOLECULE_SUMMARY);
-        PeptideSummaryWebPart peptideSummaryHeatMap = new PeptideSummaryWebPart(getDriver());
-        Assert.assertEquals("Incorrect outlier count", "2",
-                peptideSummaryHeatMap.getCellElement(1, QCPlotsWebPart.MetricType.FWHM).getText());
-        Assert.assertEquals("Incorrect total replicate count", "47", peptideSummaryHeatMap.getTotalReplicateCount().trim());
+        verifyDataAllDates();
 
         log("Verify data range: " + PeptideSummaryWebPart.HeatmapDateRange.Last_7_Days);
+        PeptideSummaryWebPart peptideSummaryHeatMap = new PeptideSummaryWebPart(getDriver());
         peptideSummaryHeatMap.setDateRange(PeptideSummaryWebPart.HeatmapDateRange.Last_7_Days);
+        verifyDataLast7Days();
+
+        // Go back to the dashboard and make sure the date range matches
+        goToProjectHome();
+        qcPlotsWebPart = new PanoramaDashboard(this).getQcPlotsWebPart();
+        qcPlotsWebPart.waitForReady();
+        assertEquals("Date Range Offset not set to default value", QCPlotsWebPart.DateRangeOffset.LAST_7_DAYS, qcPlotsWebPart.getCurrentDateRangeOffset());
+        qcPlotsWebPart.filterQCPlots("2013-08-10", "2013-08-15", 7);
+
+        // Now navigate through the link instead of the custom tab and webpart
+        waitAndClickAndWait(Locator.linkContainingText("View all 47 replicates"));
+        // Make sure the custom date range matches the other plot's
+        peptideSummaryHeatMap = new PeptideSummaryWebPart(getDriver());
+        assertEquals("2013-08-10", peptideSummaryHeatMap.getStartDate());
+        assertEquals("2013-08-15", peptideSummaryHeatMap.getEndDate());
+
+        log("Verify invalid date combos produce helpful errors");
+        peptideSummaryHeatMap.setCustomDateRange("2013-08-15", "2013-08-01");
+        peptideSummaryHeatMap.apply(false);
+        assertTextPresent("Please choose a start date that is before the end date.");
+        peptideSummaryHeatMap.setCustomDateRange(null, "2013-08-01");
+        peptideSummaryHeatMap.apply(false);
+        assertTextPresent("Please select both start and end dates.");
+
+        log("Verify Custom date range");
+        peptideSummaryHeatMap.setCustomDateRange("2013-08-01", "2013-08-15");
+        peptideSummaryHeatMap.apply(true);
+        verifyDataCustomRange(peptideSummaryHeatMap);
+
+        log("Verify Custom -> standard -> custom toggling");
+        peptideSummaryHeatMap.setDateRange(PeptideSummaryWebPart.HeatmapDateRange.Last_7_Days);
+        verifyDataLast7Days();
+
+        peptideSummaryHeatMap.setDateRange(PeptideSummaryWebPart.HeatmapDateRange.Custom_Range);
+        assertEquals("2013-08-01", peptideSummaryHeatMap.getStartDate());
+        assertEquals("2013-08-15", peptideSummaryHeatMap.getEndDate());
+        verifyDataCustomRange(peptideSummaryHeatMap);
+    }
+
+    private static void verifyDataCustomRange(PeptideSummaryWebPart peptideSummaryHeatMap)
+    {
+        Assert.assertEquals("Incorrect outlier count for " + QCPlotsWebPart.MetricType.PRECURSOR_AREA, "11",
+                peptideSummaryHeatMap.getCellElement(1, QCPlotsWebPart.MetricType.PRECURSOR_AREA).getText());
+    }
+
+    private void verifyDataLast7Days()
+    {
+        PeptideSummaryWebPart peptideSummaryHeatMap = new PeptideSummaryWebPart(getDriver());
         Assert.assertEquals("Incorrect outlier count for " + QCPlotsWebPart.MetricType.FWHM, "1",
                 peptideSummaryHeatMap.getCellElement(1, QCPlotsWebPart.MetricType.FWHM).getText());
 
@@ -76,13 +125,15 @@ public class TargetedMSPeptideSummaryHeatmapTest extends TargetedMSTest
                 peptideSummaryHeatMap.getCellElement(1, QCPlotsWebPart.MetricType.PRECURSOR_AREA).getCssValue("background-color"));
         Assert.assertEquals("Incorrect heatmap color for lightest red", "rgb(255, 245, 245)",
                 peptideSummaryHeatMap.getCellElement(1, QCPlotsWebPart.MetricType.FWHM).getCssValue("background-color"));
+    }
 
-        log("Verify Custom date range");
-        peptideSummaryHeatMap.setCustomDateRange("2013-08-01", "2013-08-15");
-        log("hitting apply button");
-        peptideSummaryHeatMap.apply();
-        Assert.assertEquals("Incorrect outlier count for " + QCPlotsWebPart.MetricType.PRECURSOR_AREA, "11",
-                peptideSummaryHeatMap.getCellElement(1, QCPlotsWebPart.MetricType.PRECURSOR_AREA).getText());
+    private void verifyDataAllDates()
+    {
+        PeptideSummaryWebPart peptideSummaryHeatMap = new PeptideSummaryWebPart(getDriver());
+        Assert.assertEquals("Incorrect outlier count", "2",
+                peptideSummaryHeatMap.getCellElement(1, QCPlotsWebPart.MetricType.FWHM).getText());
+        assertTextPresent("Total Ion Chromatogram Area", "VYVEELKPTPEGDLEILLQK", "++, 1,157.1330");
+        Assert.assertEquals("Incorrect total replicate count", "47", peptideSummaryHeatMap.getTotalReplicateCount().trim());
     }
 
     @Test


### PR DESCRIPTION
#### Rationale
We've done a number of bug fixes for the peptide heat map summary report and want to avoid regressions.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/2517

#### Changes
* Check more types of date ranges, including error conditions
* Make sure custom dates are sticky
* Assorted spot checks of peptides and metrics
