### PR TITLE
Fix data region column name references

### DIFF
--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentTest.java
@@ -397,7 +397,6 @@ public class TargetedMSExperimentTest extends TargetedMSTest
 
         //Look for Small Molecule Precursor List data region
         drt = DataRegion(getDriver()).withName("small_mol_precursors_view").index(1).find();
-        assertEquals("PC aa C30:1", drt.getDataAsText(5, "Custom Ion Name"));
         assertEquals("C38H74NO8P", drt.getDataAsText(5, "Ion Formula"));
         assertEquals("703.9755", drt.getDataAsText(5, "Mass Average"));
         assertEquals("703.5152", drt.getDataAsText(5, "Mass Monoisotopic"));


### PR DESCRIPTION
#### Rationale
My previous DataRegionTable refactor attempted to recreate the previous behavior that would remove spaces when matching field labels. I covered the case where the test passed in an unnecessary space but not when they omitted a space. Rather that duplicating that particular behavior, this updates the handful of tests that are passing incorrect field labels.

For this test in particular, "CustomIonName" and "Precursor" are the same column. I removed one since they are redundant. I picked the label ("Precursor") to be consistent with the rest of the assertions here.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2526

#### Changes
- Remove unnecessary logging parameters from the CustomizeView helper
- Update CustomizeViewHelper to use FieldKey
- Fix problematic data region column name references