### PR TITLE
Ticket 53573: Formatting adjustments to the Peptide Map report

### DIFF
--- a/resources/queries/targetedms/PeptideIds.query.xml
+++ b/resources/queries/targetedms/PeptideIds.query.xml
@@ -17,6 +17,7 @@
                                 <property name="showNextAndPrevious">true</property>
                                 <property name="useParens">true</property>
                                 <property name="exportFormatted">true</property>
+                                <property name="highlightFixed">false</property>
                             </properties>
                         </displayColumnFactory>
                     </column>

--- a/src/org/labkey/targetedms/parser/PeptideSettings.java
+++ b/src/org/labkey/targetedms/parser/PeptideSettings.java
@@ -493,7 +493,7 @@ public class PeptideSettings
 
         public boolean isModExplicit()
         {
-            return _explicitMod == null ? false : _explicitMod;
+            return _explicitMod != null && _explicitMod;
         }
 
         public void setExplicitMod(Boolean explicitMod)

--- a/src/org/labkey/targetedms/query/CrossLinkedPeptideDisplayColumn.java
+++ b/src/org/labkey/targetedms/query/CrossLinkedPeptideDisplayColumn.java
@@ -173,13 +173,13 @@ public class CrossLinkedPeptideDisplayColumn extends DataColumn
             return new CrossLinkedPeptideDisplayColumn(colInfo, (match, sequence, modification) ->
             {
                 String label = match.protein().getLabel();
-                String suffix = getChainAbbreviation(label);
-                return (match.index() + 1) + "-" + (match.index() + getPeptideLength(sequence.getUnmodified(), modification)) + suffix;
+                String prefix = getChainPrefix(label);
+                return prefix + (match.index() + 1) + "-" + (match.index() + getPeptideLength(sequence.getUnmodified(), modification));
             });
         }
     }
 
-    public static @NotNull String getChainAbbreviation(String label)
+    public static @NotNull String getChainPrefix(String label)
     {
         String result = "";
         if (label != null)
@@ -187,15 +187,15 @@ public class CrossLinkedPeptideDisplayColumn extends DataColumn
             label = label.toLowerCase();
             if (label.endsWith("_hc"))
             {
-                result = "HC";
+                result = "H";
             }
             if (label.endsWith("_hcstar"))
             {
-                result = "HC*";
+                result = "*";
             }
             if (label.endsWith("_lc"))
             {
-                result = "LC";
+                result = "L";
             }
         }
         return result;
@@ -221,7 +221,7 @@ public class CrossLinkedPeptideDisplayColumn extends DataColumn
                         {
                             for (int linkIndex : sequence.getLinkIndices())
                             {
-                                bonds.add(Character.toString(sequence.getUnmodified().charAt(linkIndex)) + (match.index() + linkIndex + 1) + getChainAbbreviation(match.protein().getLabel()));
+                                bonds.add(Character.toString(sequence.getUnmodified().charAt(linkIndex)) + (match.index() + linkIndex + 1) + getChainPrefix(match.protein().getLabel()));
                             }
                         }
                         allBonds.add(bonds);

--- a/src/org/labkey/targetedms/query/ModificationManager.java
+++ b/src/org/labkey/targetedms/query/ModificationManager.java
@@ -265,12 +265,14 @@ public class ModificationManager
     /**
      * @return    PeptideId -> (Set of indexes where the peptide has structural modifications)
      */
-    private static Map<Long, Set<Pair<Integer, Integer>>> getPeptideStructuralModIndexMap(long runId)
+    private static Map<Long, Set<Pair<Integer, Integer>>> getPeptideStructuralModIndexMap(long runId, boolean includeFixedMods)
     {
         SQLFragment sql = new SQLFragment();
         sql.append(" SELECT mod.PeptideId AS peptideId, mod.IndexAA AS indexAA, mod.PeptideIndex AS peptideIndex");
         sql.append(" FROM ");
         sql.append(TargetedMSManager.getTableInfoPeptideStructuralModification(), "mod");
+        sql.append(" , ");
+        sql.append(TargetedMSManager.getTableInfoRunStructuralModification(), "runmod");
         sql.append(" , ");
         sql.append(TargetedMSManager.getTableInfoGeneralMolecule(), "gm");
         sql.append(" , ");
@@ -285,6 +287,15 @@ public class ModificationManager
         sql.append(" gm.peptideGroupId = pg.id ");
         sql.append(" AND ");
         sql.append(" mod.peptideId = gm.id ");
+        sql.append(" AND ");
+        sql.append(" runmod.StructuralModId = mod.StructuralModId");
+        sql.append(" AND ");
+        sql.append(" runmod.RunId = run.Id");
+        if (!includeFixedMods)
+        {
+            sql.append(" AND (runmod.variable = ? OR runmod.ExplicitMod IS NOT NULL)");
+            sql.add(true);
+        }
 
         final Map<Long, Set<Pair<Integer, Integer>>> peptideModIndexMap = new HashMap<>();
 
@@ -342,17 +353,25 @@ public class ModificationManager
         return Collections.unmodifiableMap(peptideModIndexMap);
     }
 
-    /** Pair is the index of the cross-linked peptide (or 0 for non-cross-linked peptides) and the amino acid index */
-    public static Set<Pair<Integer, Integer>> getStructuralModIndexes(long peptideId, Long runId)
+    /**
+     * Pair is the index of the cross-linked peptide (or 0 for non-cross-linked peptides) and the amino acid index
+     * @param includeFixedMods Whether to include fixed modifications
+     * @return Set of pairs of peptide index and amino acid index
+     */
+    public static Set<Pair<Integer, Integer>> getStructuralModIndexes(long peptideId, Long runId, boolean includeFixedMods)
     {
-        if(runId == null)
+        if (runId == null)
         {
+            if (!includeFixedMods)
+            {
+                throw new UnsupportedOperationException();
+            }
             Map<Pair<Integer, Integer>, Double> modMap = getPeptideStructuralModsMap(peptideId);
             return new HashSet<>(modMap.keySet());
         }
         else
         {
-            Map<Long, Set<Pair<Integer, Integer>>> modIndexesForRun = PEPTIDE_STR_MOD_INDEXES.get(String.valueOf(runId), null, (runId1, argument) -> getPeptideStructuralModIndexMap(Long.valueOf(runId1)));
+            Map<Long, Set<Pair<Integer, Integer>>> modIndexesForRun = PEPTIDE_STR_MOD_INDEXES.get(runId + "-" + includeFixedMods, null, (runId1, argument) -> getPeptideStructuralModIndexMap(runId, includeFixedMods));
             return modIndexesForRun.getOrDefault(peptideId, Collections.emptySet());
         }
     }

--- a/src/org/labkey/targetedms/query/ModifiedSequenceDisplayColumn.java
+++ b/src/org/labkey/targetedms/query/ModifiedSequenceDisplayColumn.java
@@ -65,9 +65,14 @@ public abstract class ModifiedSequenceDisplayColumn extends IconColumn
 
     public ModifiedSequenceDisplayColumn(ColumnInfo colInfo)
     {
+        this(colInfo, true);
+    }
+
+    public ModifiedSequenceDisplayColumn(ColumnInfo colInfo, boolean highlightFixed)
+    {
         super(colInfo);
 
-        _htmlMaker = new ModifiedPeptideHtmlMaker();
+        _htmlMaker = new ModifiedPeptideHtmlMaker(highlightFixed);
     }
 
     ModifiedPeptideHtmlMaker getHtmlMaker()
@@ -147,6 +152,7 @@ public abstract class ModifiedSequenceDisplayColumn extends IconColumn
         private boolean _exportStrippedHtml = false;
         private boolean _showNextAndPrevious = false;
         private boolean _useParens = false;
+        private boolean _highlightFixed = true;
         /** Optionally, the name of the column that identifies the animo acid and index within the protein to highlight as modified */
         private String _modificationSite;
 
@@ -161,6 +167,7 @@ public abstract class ModifiedSequenceDisplayColumn extends IconColumn
             _useParens = getBooleanProperty(map, "useParens", _useParens);
             _exportStrippedHtml = getBooleanProperty(map, "exportFormatted", _exportStrippedHtml);
             _modificationSite = map == null || map.get("modificationSite").isEmpty() ? null : map.get("modificationSite").iterator().next();
+            _highlightFixed = getBooleanProperty(map, "highlightFixed", _highlightFixed);
         }
 
         private boolean getBooleanProperty(MultiValuedMap<String, String> map, String propertyName, boolean defaultValue)
@@ -176,7 +183,7 @@ public abstract class ModifiedSequenceDisplayColumn extends IconColumn
         @Override
         public DisplayColumn createRenderer(ColumnInfo colInfo)
         {
-            return new ModifiedSequenceDisplayColumn.PeptideCol(colInfo, _showNextAndPrevious, _useParens, _exportStrippedHtml, _modificationSite);
+            return new ModifiedSequenceDisplayColumn.PeptideCol(colInfo, _showNextAndPrevious, _useParens, _exportStrippedHtml, _highlightFixed, _modificationSite);
         }
     }
 
@@ -190,12 +197,12 @@ public abstract class ModifiedSequenceDisplayColumn extends IconColumn
 
         public PeptideCol(ColumnInfo colInfo)
         {
-            this(colInfo, false, false, false, null);
+            this(colInfo, false, false, false, true, null);
         }
 
-        public PeptideCol(ColumnInfo colInfo, boolean showNextAndPrevious, boolean useParens, boolean exportStrippedHtml, String modificationSite)
+        public PeptideCol(ColumnInfo colInfo, boolean showNextAndPrevious, boolean useParens, boolean exportStrippedHtml, boolean highlightFixed, String modificationSite)
         {
-            super(colInfo);
+            super(colInfo, highlightFixed);
             _showNextAndPrevious = showNextAndPrevious;
             _useParens = useParens;
             _modificationSite = modificationSite;

--- a/src/org/labkey/targetedms/query/SiteLocationDisplayColumnFactory.java
+++ b/src/org/labkey/targetedms/query/SiteLocationDisplayColumnFactory.java
@@ -76,7 +76,7 @@ public class SiteLocationDisplayColumnFactory implements DisplayColumnFactory
                 };
 
                 String chain = _col.getChainLabel(ctx);
-                String chainPrefix = CrossLinkedPeptideDisplayColumn.getChainAbbreviation(chain);
+                String chainPrefix = CrossLinkedPeptideDisplayColumn.getChainPrefix(chain);
                 if (!chainPrefix.isEmpty())
                 {
                     chainPrefix = chainPrefix + " ";

--- a/src/org/labkey/targetedms/view/ModifiedPeptideHtmlMaker.java
+++ b/src/org/labkey/targetedms/view/ModifiedPeptideHtmlMaker.java
@@ -54,6 +54,9 @@ public class ModifiedPeptideHtmlMaker
 
     /** RunId -> all proteins in that run */
     private final Map<Long, List<Protein>> _proteins = new HashMap<>();
+    
+    /** Whether to include fixed modifications in the formatting */
+    private final boolean _highlightFixedMods;
 
     private final static String[] HEX_PADDING = new String[] {
                                                         "",
@@ -67,7 +70,16 @@ public class ModifiedPeptideHtmlMaker
 
     public ModifiedPeptideHtmlMaker()
     {
+        this(true);
+    }
+    
+    /**
+     * @param highlightFixedMods Whether to include fixed modifications in the formatting
+     */
+    public ModifiedPeptideHtmlMaker(boolean highlightFixedMods)
+    {
         _firstIsotopeLabelIdInDocMap = new HashMap<>();
+        _highlightFixedMods = highlightFixedMods;
     }
 
     public Pair<HtmlString, List<List<SequencePart>>> getPrecursorHtml(Precursor precursor, Long runId, TargetedMSSchema schema)
@@ -147,7 +159,7 @@ public class ModifiedPeptideHtmlMaker
 
         if (strModIndices == null)
         {
-            strModIndices = ModificationManager.getStructuralModIndexes(peptideId, runId);
+            strModIndices = ModificationManager.getStructuralModIndexes(peptideId, runId, _highlightFixedMods);
         }
         Set<Integer> isotopeModIndices = null;
         if(isotopeLabelId != null)

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSMAMTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSMAMTest.java
@@ -20,6 +20,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.Locator;
 
+import static org.junit.Assert.assertTrue;
+
 @Category({})
 public class TargetedMSMAMTest extends TargetedMSTest
 {
@@ -60,6 +62,9 @@ public class TargetedMSMAMTest extends TargetedMSTest
         assertTextPresentInThisOrder("70-84", "325-333", "28-41", "190-196; 26-32");
         assertTextPresentInThisOrder("(K)ASTEGVAIQGQQGTR(L)", "(K)AQYEDIANR(S)", "(K)SVTEQGAELSNEER(N)");
         assertTextPresentInThisOrder("Carbamidomethyl Cysteine @ C157", "Carbamidomethyl Cysteine @ C245", "Carbamidomethyl Cysteine @ C94");
+
+        // Ensure that the Cystine isn't highlighted, as it's a fixed modification and that report doesn't want to call it out
+        assertTrue(getHtmlSource().contains("(K)YLECSALTQR(G)"));
     }
 
     @Test
@@ -77,5 +82,8 @@ public class TargetedMSMAMTest extends TargetedMSTest
         // Disulfide bonds
         assertTextPresentInThisOrder("Q364-T369-D364/\nN366-T369-D364", "V121-S345-Q142/\nQ124-S345-Q142");
         assertTextPresentInThisOrder("(A)LKPLALV(D)", "(G)AVVQDPA(Y)", "(F)YGEATSR(E)");
+
+        // Ensure that the highlighting is as expected for both crosslinking and modification
+        assertTrue(getHtmlSource().contains("(Y)<span style=\"font-weight:bold;color:green;text-decoration:underline;\">Q</span><span style=\"font-weight:bold;text-decoration:underline;\">M</span><span style=\"font-weight:bold;color:green;\">N</span>(D)"));
     }
 }


### PR DESCRIPTION
#### Rationale
Users have requested changes to the Peptide Map report to better match the existing report they are looking to replace.

#### Changes
* For the Peptide Identify column, use a single-character prefix to identify the chain instead of a 2-3 character suffix.
* For the peptide sequence, don't highlight fixed modifications