### PR TITLE
 Support BIGINT Primary Keys

### DIFF
--- a/api-src/org/labkey/api/targetedms/ITargetedMSRun.java
+++ b/api-src/org/labkey/api/targetedms/ITargetedMSRun.java
@@ -33,8 +33,8 @@ public interface ITargetedMSRun
     String getDescription();
     Date getCreated();
     long getId();
-    Integer getDataId();
-    Integer getSkydDataId();
+    Long getDataId();
+    Long getSkydDataId();
     String getSoftwareVersion();
     RunRepresentativeDataState getRepresentativeDataState();
 }

--- a/api-src/org/labkey/api/targetedms/TargetedMSService.java
+++ b/api-src/org/labkey/api/targetedms/TargetedMSService.java
@@ -130,7 +130,7 @@ public interface TargetedMSService
     List<TableCustomizer> getModificationSearchResultCustomizers();
 
     /** @return rowId for pipeline job that will perform the import asynchronously */
-    Integer importSkylineDocument(ViewBackgroundInfo info, Path skylinePath) throws XarFormatException, PipelineValidationException;
+    Long importSkylineDocument(ViewBackgroundInfo info, Path skylinePath) throws XarFormatException, PipelineValidationException;
 
     /**
      * @param sampleFiles list of sample files for which we should do a path lookup on the server

--- a/src/org/labkey/panoramapremium/PanoramaPremiumController.java
+++ b/src/org/labkey/panoramapremium/PanoramaPremiumController.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public class PanoramaPremiumController extends SpringActionController
 {
@@ -54,7 +53,7 @@ public class PanoramaPremiumController extends SpringActionController
         public Object execute(QueryForm queryForm, BindException errors) throws Exception
         {
             //get selected rows
-            Set<Integer> selectedRowsKeys = DataRegionSelection.getSelectedIntegers(queryForm.getViewContext(),true);
+            Set<Long> selectedRowsKeys = DataRegionSelection.getSelectedIntegers(queryForm.getViewContext(),true);
 
             UserSchema us = QueryService.get().getUserSchema(getUser(), getContainer(), "targetedms");
             TableInfo excludedPrecursorsTableInfo = us.getTable("ExcludedPrecursors");
@@ -84,7 +83,7 @@ public class PanoramaPremiumController extends SpringActionController
         }
     }
 
-    public List<Map<String, Object>> getPrecursorsToExcludeOrInclude(Set<Integer> selectedRowsKeys, String query, boolean isExcluding, boolean isIncluding)
+    public List<Map<String, Object>> getPrecursorsToExcludeOrInclude(Set<Long> selectedRowsKeys, String query, boolean isExcluding, boolean isIncluding)
     {
         final boolean isPeptide = query.equalsIgnoreCase("QCGroupingPrecursorPeptides");
         final boolean isMolecule = query.equalsIgnoreCase("QCGroupingPrecursorMolecules");
@@ -163,7 +162,7 @@ public class PanoramaPremiumController extends SpringActionController
             BatchValidationException batchValidationErrors = new BatchValidationException();
 
             //get selected rows
-            Set<Integer> selectedRowsKeys = DataRegionSelection.getSelectedIntegers(queryForm.getViewContext(), true);
+            Set<Long> selectedRowsKeys = DataRegionSelection.getSelectedIntegers(queryForm.getViewContext(), true);
 
             //get selected precursors that are not already excluded (i.e. not in targetedms.excludedPrecursors table)
             List<Map<String, Object>> precursorsToExclude = getPrecursorsToExcludeOrInclude(selectedRowsKeys, queryForm.getQueryName(), true, false);

--- a/src/org/labkey/targetedms/SkylineBinaryDataHandler.java
+++ b/src/org/labkey/targetedms/SkylineBinaryDataHandler.java
@@ -71,7 +71,7 @@ public class SkylineBinaryDataHandler extends AbstractExperimentDataHandler
     }
 
     @Override
-    public void runMoved(ExpData newData, Container container, Container targetContainer, String oldRunLSID, String newRunLSID, User user, int oldDataRowID) throws ExperimentException
+    public void runMoved(ExpData newData, Container container, Container targetContainer, String oldRunLSID, String newRunLSID, User user, long oldDataRowID) throws ExperimentException
     {
         super.runMoved(newData, container, targetContainer, oldRunLSID, newRunLSID, user, oldDataRowID);
         // Update the file path in the new ExpData

--- a/src/org/labkey/targetedms/SkylineDocImporter.java
+++ b/src/org/labkey/targetedms/SkylineDocImporter.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.LongArrayList;
 import org.labkey.api.collections.LongHashMap;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
@@ -693,7 +694,7 @@ public class SkylineDocImporter
         _log.debug("Found data for the following old sample files in the QC folder:");
         replicateInfo.oldSamplesToDelete.keySet().forEach(key -> _log.debug(String.format("  %s", key)));
 
-        List<Long> existingSamples = new ArrayList<>(total);
+        List<Long> existingSamples = new LongArrayList(total);
         replicateInfo.oldSamplesToDelete.forEach((key, value) -> value.forEach(existingSample -> existingSamples.add(existingSample.getId())));
 
         List<String> srcFiles = TargetedMSManager.deleteSampleFilesAndDependencies(existingSamples);

--- a/src/org/labkey/targetedms/SkylineDocImporter.java
+++ b/src/org/labkey/targetedms/SkylineDocImporter.java
@@ -102,6 +102,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.locks.ReentrantLock;
 
+import static org.labkey.api.exp.api.ExperimentService.asInteger;
 import static org.labkey.targetedms.TargetedMSManager.getTableInfoTransitionChromInfo;
 
 /**
@@ -1090,7 +1091,7 @@ public class SkylineDocImporter
                 Map<String, Object> iRTScaleRow = new CaseInsensitiveHashMap<>();
                 iRTScaleRow.put("container", _container);
                 Map<String, Object> iRTScaleResult = Table.insert(_user, TargetedMSManager.getTableInfoiRTScale(), iRTScaleRow);
-                iRTScaleId = (int) iRTScaleResult.get("id");
+                iRTScaleId = asInteger(iRTScaleResult.get("id"));
             }
 
             // insert any new iRT Peptides into the database

--- a/src/org/labkey/targetedms/SkylineDocImporter.java
+++ b/src/org/labkey/targetedms/SkylineDocImporter.java
@@ -567,7 +567,7 @@ public class SkylineDocImporter
             sql.append(TargetedMSManager.getTableInfoGeneralMoleculeChromInfo(), "gmci");
             sql.append(" WHERE gmci.SampleFileId = ? AND RetentionTime IS NOT NULL");
             sql.add(sampleFile.getId());
-            Map<Long, Float> rtValuesMap = new SqlSelector(TargetedMSManager.getSchema(), sql).getValueMap();
+            Map<Long, Float> rtValuesMap = new SqlSelector(TargetedMSManager.getSchema(), sql).getValueMap(Long.class);
 
             for (IrtPeptide irtPeptide : matchedIrts)
             {

--- a/src/org/labkey/targetedms/SkylineDocImporter.java
+++ b/src/org/labkey/targetedms/SkylineDocImporter.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.LongHashMap;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DbScope;
@@ -757,7 +758,7 @@ public class SkylineDocImporter
         private final Map<String, Long> isotopeLabelIdMap = new HashMap<>();
         private final Set<Long> internalStandardLabelIds = new HashSet<>();
         private final Map<String, Long> structuralModNameIdMap = new HashMap<>();
-        private final Map<Long, List<PeptideSettings.PotentialLoss>> structuralModLossesMap = new HashMap<>();
+        private final Map<Long, List<PeptideSettings.PotentialLoss>> structuralModLossesMap = new LongHashMap<>();
         private final Map<String, Long> isotopeModNameIdMap = new HashMap<>();
     }
 
@@ -1867,7 +1868,7 @@ public class SkylineDocImporter
     private Map<Long, Long> insertGeneralMoleculeChromInfos(long gmId, List<GeneralMoleculeChromInfo> generalMoleculeChromInfos,
                                                                   Map<SampleFileKey, SampleFile> skylineIdSampleFileIdMap)
     {
-        Map<Long, Long> sampleFileIdGeneralMolChromInfoIdMap = new HashMap<>();
+        Map<Long, Long> sampleFileIdGeneralMolChromInfoIdMap = new LongHashMap<>();
 
         for (GeneralMoleculeChromInfo generalMoleculeChromInfo : generalMoleculeChromInfos)
         {
@@ -2314,7 +2315,7 @@ public class SkylineDocImporter
 
     private void copyExtractedFilesToCloud(TargetedMSRun run)
     {
-        Integer skyDataId = run.getDataId();
+        var skyDataId = run.getDataId();
         if (skyDataId != null)
         {
             ExpData skyData = ExperimentService.get().getExpData(skyDataId);

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -27,6 +27,7 @@ import org.apache.batik.svggen.SVGGeneratorContext;
 import org.apache.batik.svggen.SVGGraphics2D;
 import org.apache.batik.svggen.SVGGraphics2DIOException;
 import org.apache.batik.svggen.SVGIDGenerator;
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
@@ -72,6 +73,7 @@ import org.labkey.api.attachments.DocumentConversionService;
 import org.labkey.api.attachments.SvgSource;
 import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.audit.provider.SiteSettingsAuditProvider;
+import org.labkey.api.collections.LongHashMap;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
@@ -313,6 +315,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static org.labkey.api.exp.api.ExperimentService.asLong;
 import static org.labkey.api.targetedms.TargetedMSService.FOLDER_TYPE_PROP_NAME;
 import static org.labkey.api.targetedms.TargetedMSService.FolderType;
 import static org.labkey.api.targetedms.TargetedMSService.MODULE_NAME;
@@ -4017,7 +4020,7 @@ public class TargetedMSController extends SpringActionController
                 ViewBackgroundInfo info = getViewBackgroundInfo();
                 try
                 {
-                    Integer jobId = TargetedMSManager.addRunToQueue(info, path);
+                    Long jobId = TargetedMSManager.addRunToQueue(info, path);
                     Map<String, Object> detailsMap = new HashMap<>(4);
                     detailsMap.put("Path", form.getPath());
                     detailsMap.put("File", FileUtil.getFileName(path));
@@ -4060,7 +4063,7 @@ public class TargetedMSController extends SpringActionController
             throw new NotFoundException("Document is not fully loaded and initialized");
         }
 
-        Set<Integer> ids = Collections.singleton(expRun.getRowId());
+        Set<Long> ids = Collections.singleton(expRun.getRowId());
 
         RunDetailsBean bean = new RunDetailsBean();
         bean.setForm(form);
@@ -7600,10 +7603,10 @@ public class TargetedMSController extends SpringActionController
         @Override
         public Object execute(SelectedRowIdsForm form, BindException errors)
         {
-            Collection<Integer> linkedRowIds = new ArrayList<>();
+            Collection<Long> linkedRowIds = new ArrayList<>();
 
             //get selectedRowIds params
-            List<Integer> selectedRowIds = form.getSelectedRowIds();
+            List<Long> selectedRowIds = form.getSelectedRowIds();
             if (form.isIncludeSelected())
                 linkedRowIds.addAll(selectedRowIds);
 
@@ -7618,15 +7621,15 @@ public class TargetedMSController extends SpringActionController
 
     public static class SelectedRowIdsForm
     {
-        List<Integer> selectedRowIds;
+        List<Long> selectedRowIds;
         boolean includeSelected;
 
-        public List<Integer> getSelectedRowIds()
+        public List<Long> getSelectedRowIds()
         {
             return selectedRowIds;
         }
 
-        public void setSelectedRowIds(List<Integer> selectedRowIds)
+        public void setSelectedRowIds(List<Long> selectedRowIds)
         {
             this.selectedRowIds = selectedRowIds;
         }
@@ -7715,7 +7718,7 @@ public class TargetedMSController extends SpringActionController
         public void validateForm(ChainedVersions form, Errors errors)
         {
             // verify that the run and replacedByRun rowIds are valid and match an existing run
-            for (Map.Entry<Integer, Integer> entry : form.getRuns().entrySet())
+            for (var entry : form.getRuns().entrySet())
             {
                 if (entry.getKey() == null)
                     errors.reject(ERROR_MSG, "No run found for id " + entry.getKey());
@@ -7737,10 +7740,10 @@ public class TargetedMSController extends SpringActionController
         {
             DbScope scope = ExperimentService.get().getSchema().getScope();
 
-            Set<Integer> ids = new HashSet<>(form.getRuns().keySet());
+            Set<Long> ids = new HashSet<>(form.getRuns().keySet());
             ids.addAll(form.getRuns().values());
 
-            Collection<Integer> allLinkedIds = TargetedMSManager.getLinkedVersions(getUser(), getContainer(), ids, ids);
+            var allLinkedIds = TargetedMSManager.getLinkedVersions(getUser(), getContainer(), ids, ids);
 
             try (DbScope.Transaction transaction = scope.ensureTransaction())
             {
@@ -7762,7 +7765,7 @@ public class TargetedMSController extends SpringActionController
                     }
                 });
 
-                for (Map.Entry<Integer, Integer> entry : form._runs.entrySet())
+                for (var entry : form._runs.entrySet())
                 {
                     ExpRun run = ExperimentService.get().getExpRun(entry.getKey());
                     ExpRun replacedByRun = ExperimentService.get().getExpRun(entry.getValue());
@@ -7780,10 +7783,10 @@ public class TargetedMSController extends SpringActionController
             return new ApiSimpleResponse("success", true);
         }
 
-        private List<Integer> getLinkedListOfChainedDocuments(Set<Map.Entry<Integer, Integer>> entries)
+        private List<Long> getLinkedListOfChainedDocuments(Set<Map.Entry<Integer, Integer>> entries)
         {
             int index = 0;
-            List<Integer> chainedDocumentsList = new LinkedList<>();
+            List<Long> chainedDocumentsList = new LinkedList<>();
 
 
             for (Map.Entry<Integer, Integer> entry : entries)
@@ -7804,11 +7807,11 @@ public class TargetedMSController extends SpringActionController
             return chainedDocumentsList;
         }
 
-        private void addToDocumentChainAtCorrectIndex(ExpRun run, ExpRun replacedByRun, List<Integer> list)
+        private void addToDocumentChainAtCorrectIndex(ExpRun run, ExpRun replacedByRun, List<Long> list)
         {
             for (int i = 0; i < list.size(); i++)
             {
-                final Integer rowid = list.get(i);
+                final var rowid = list.get(i);
                 if (rowid == run.getRowId())
                 {
                     list.add(i + 1, replacedByRun.getRowId());
@@ -7826,7 +7829,7 @@ public class TargetedMSController extends SpringActionController
 
     public static class ChainedVersions implements ApiJsonForm
     {
-        private final Map<Integer, Integer> _runs = new HashMap<>();
+        private final Map<Long, Long> _runs = new LongHashMap<>();
 
         @Override
         public void bindJson(JSONObject json)
@@ -7834,13 +7837,13 @@ public class TargetedMSController extends SpringActionController
             List<Map<String, Object>> list = JsonUtil.toMapList(json.getJSONArray("runs"));
             for (Map<String, Object> entry : list)
             {
-                Integer rowId = (Integer) entry.get("RowId");
-                Integer replacedByRunId = (Integer) entry.get("ReplacedByRun");
+                Long rowId = MapUtils.getLong(entry, "RowId");
+                Long replacedByRunId = MapUtils.getLong(entry, "ReplacedByRun");
                 _runs.put(rowId, replacedByRunId);
             }
         }
 
-        public Map<Integer, Integer> getRuns()
+        public Map<Long, Long> getRuns()
         {
             return _runs;
         }

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -73,6 +73,7 @@ import org.labkey.api.attachments.DocumentConversionService;
 import org.labkey.api.attachments.SvgSource;
 import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.audit.provider.SiteSettingsAuditProvider;
+import org.labkey.api.collections.LongArrayList;
 import org.labkey.api.collections.LongHashMap;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
@@ -6312,8 +6313,8 @@ public class TargetedMSController extends SpringActionController
             if(!StringUtils.isBlank(selectedInputValues))
             {
                 String[] vals = selectedInputValues.split(",");
-                _selectedIds = new ArrayList<>(vals.length);
-                _deselectedIds = new ArrayList<>(vals.length);
+                _selectedIds = new LongArrayList(vals.length);
+                _deselectedIds = new LongArrayList(vals.length);
 
                 for(String value: vals)
                 {

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -27,7 +27,7 @@ import org.apache.batik.svggen.SVGGeneratorContext;
 import org.apache.batik.svggen.SVGGraphics2D;
 import org.apache.batik.svggen.SVGGraphics2DIOException;
 import org.apache.batik.svggen.SVGIDGenerator;
-import org.apache.commons.collections.MapUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;

--- a/src/org/labkey/targetedms/TargetedMSDataHandler.java
+++ b/src/org/labkey/targetedms/TargetedMSDataHandler.java
@@ -160,7 +160,7 @@ public class TargetedMSDataHandler extends AbstractExperimentDataHandler
     }
 
     @Override
-    public void runMoved(ExpData newData, Container container, Container targetContainer, String oldRunLSID, String newRunLSID, User user, int oldDataRowID) throws ExperimentException
+    public void runMoved(ExpData newData, Container container, Container targetContainer, String oldRunLSID, String newRunLSID, User user, long oldDataRowID) throws ExperimentException
     {
         super.runMoved(newData, container, targetContainer, oldRunLSID, newRunLSID, user, oldDataRowID);
         TargetedMSService.FolderType sourceFolderType = TargetedMSManager.getFolderType(container);

--- a/src/org/labkey/targetedms/TargetedMSManager.java
+++ b/src/org/labkey/targetedms/TargetedMSManager.java
@@ -2567,7 +2567,8 @@ public class TargetedMSManager
         TableSelector selector = new TableSelector(runsTable, idColumnNames, filter, null);
 
         //get RowId -> ReplacedByRun key value pairs and also populate the opposite direction to get ReplacedByRun -> RowId
-        Map<Long, Long> replacedByMap = selector.getValueMap();
+        Map<Long, Long> replacedByMap = new LongHashMap<>();
+        selector.forEach(rs -> {replacedByMap.put(rs.getLong(1), rs.getLong(2));});
         Map<Long, Long> replacesMap = new LongHashMap<>();
         for (Map.Entry<Long, Long> entry : replacedByMap.entrySet())
             replacesMap.put(entry.getValue(), entry.getKey());

--- a/src/org/labkey/targetedms/TargetedMSManager.java
+++ b/src/org/labkey/targetedms/TargetedMSManager.java
@@ -26,6 +26,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.cache.Cache;
 import org.labkey.api.cache.CacheManager;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.LongHashMap;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
@@ -650,7 +651,7 @@ public class TargetedMSManager
     }
 
     /** @return rowId for pipeline job that will perform the import asynchronously */
-    public static Integer addRunToQueue(ViewBackgroundInfo info,
+    public static Long addRunToQueue(ViewBackgroundInfo info,
                                         final Path path) throws XarFormatException, PipelineValidationException
     {
         String description = "Skyline document import - " + FileUtil.getFileName(path);
@@ -708,7 +709,7 @@ public class TargetedMSManager
         return PipelineService.get().getJobId(user, container, job.getJobGUID());
     }
 
-    public static void ensureWrapped(TargetedMSRun run, User user, Integer jobId) throws ExperimentException
+    public static void ensureWrapped(TargetedMSRun run, User user, Long jobId) throws ExperimentException
     {
         ExpRun expRun;
         if (run.getExperimentRunLSID() != null)
@@ -722,7 +723,7 @@ public class TargetedMSManager
         wrapRun(run, user, jobId);
     }
 
-    private static void wrapRun(TargetedMSRun run, User user, Integer jobId) throws ExperimentException
+    private static void wrapRun(TargetedMSRun run, User user, Long jobId) throws ExperimentException
     {
         try (DbScope.Transaction transaction = ExperimentService.get().getSchema().getScope().ensureTransaction())
         {
@@ -840,12 +841,12 @@ public class TargetedMSManager
         deleteiRTscales(container);
     }
 
-    public static TargetedMSRun getRunByDataId(int dataId)
+    public static TargetedMSRun getRunByDataId(long dataId)
     {
         return getRunByDataId(dataId, null);
     }
 
-    public static TargetedMSRun getRunByDataId(int dataId, Container c)
+    public static TargetedMSRun getRunByDataId(long dataId, Container c)
     {
         TargetedMSRun[] runs;
         if(c != null)
@@ -867,12 +868,12 @@ public class TargetedMSManager
         throw new IllegalStateException("There is more than one non-deleted Targeted MS Run for dataId " + dataId);
     }
 
-    public static TargetedMSRun getRunBySkydDataId(int skydDataId)
+    public static TargetedMSRun getRunBySkydDataId(long skydDataId)
     {
         return getRunBySkydDataId(skydDataId, null);
     }
 
-    public static TargetedMSRun getRunBySkydDataId(int skydDataId, Container c)
+    public static TargetedMSRun getRunBySkydDataId(long skydDataId, Container c)
     {
         TargetedMSRun[] runs;
         if(c != null)
@@ -2486,7 +2487,7 @@ public class TargetedMSManager
         return maxCount != null ? maxCount.intValue() : 0;
     }
 
-    static void moveRun(TargetedMSRun run, Container newContainer, String newRunLSID, int newDataRowId, User user)
+    static void moveRun(TargetedMSRun run, Container newContainer, String newRunLSID, long newDataRowId, User user)
     {
         // MoveRunsTask.moveRun ensures a transaction
         SQLFragment updatePrecChromInfoSql = new SQLFragment("UPDATE ");
@@ -2506,10 +2507,10 @@ public class TargetedMSManager
         updateRun(run, user);
     }
 
-    private static void addParentRunsToChain(ArrayDeque<Integer> chainRowIds, Map<Integer, Integer> replacedByMap, Integer rowId)
+    private static void addParentRunsToChain(ArrayDeque<Long> chainRowIds, Map<Long, Long> replacedByMap, Long rowId)
     {
         // add all runs rowIds up the chain to the end of the list, recursively
-        Integer replacedBy = replacedByMap.get(rowId);
+        var replacedBy = replacedByMap.get(rowId);
         int originalSize = chainRowIds.size();
         if (replacedBy != null)
         {
@@ -2525,10 +2526,10 @@ public class TargetedMSManager
         }
     }
 
-    private static void addChildRunsToChain(ArrayDeque<Integer> chainRowIds, Map<Integer, Integer> replacesMap, Integer rowId)
+    private static void addChildRunsToChain(ArrayDeque<Long> chainRowIds, Map<Long, Long> replacesMap, Long rowId)
     {
         // add all runs rowIds down the chain to the front of the list, recursively
-        Integer replaces = replacesMap.get(rowId);
+        var replaces = replacesMap.get(rowId);
         int originalSize = chainRowIds.size();
         if (replaces != null)
         {
@@ -2544,14 +2545,14 @@ public class TargetedMSManager
         }
     }
 
-    public static Collection<Integer> getLinkedVersions(User u, Container c, Collection<Integer> selectedRowIds, Collection<Integer> linkedRowIds)
+    public static Collection<Long> getLinkedVersions(User u, Container c, Collection<Long> selectedRowIds, Collection<Long> linkedRowIds)
     {
         return getLinkedVersions(new TargetedMSSchema(u, c), selectedRowIds, linkedRowIds);
     }
 
-    public static Collection<Integer> getLinkedVersions(@NotNull TargetedMSSchema schema, Collection<Integer> selectedRowIds, Collection<Integer> linkedRowIds)
+    public static Collection<Long> getLinkedVersions(@NotNull TargetedMSSchema schema, Collection<Long> selectedRowIds, Collection<Long> linkedRowIds)
     {
-        Set<Integer> result = new HashSet<>(linkedRowIds);
+        Set<Long> result = new HashSet<>(linkedRowIds);
         //get related/linked RowIds from TargetedMSRuns table
 
         //create a filter for non-null ReplacedByRun value
@@ -2566,15 +2567,15 @@ public class TargetedMSManager
         TableSelector selector = new TableSelector(runsTable, idColumnNames, filter, null);
 
         //get RowId -> ReplacedByRun key value pairs and also populate the opposite direction to get ReplacedByRun -> RowId
-        Map<Integer, Integer> replacedByMap = selector.getValueMap();
-        Map<Integer, Integer> replacesMap = new HashMap<>();
-        for (Map.Entry<Integer, Integer> entry : replacedByMap.entrySet())
+        Map<Long, Long> replacedByMap = selector.getValueMap();
+        Map<Long, Long> replacesMap = new LongHashMap<>();
+        for (Map.Entry<Long, Long> entry : replacedByMap.entrySet())
             replacesMap.put(entry.getValue(), entry.getKey());
 
         //get full chain for the selected runs to be added to the linkedRowIds list
-        for (Integer rowId : selectedRowIds)
+        for (var rowId : selectedRowIds)
         {
-            ArrayDeque<Integer> chainRowIds = new ArrayDeque<>();
+            ArrayDeque<Long> chainRowIds = new ArrayDeque<>();
             addParentRunsToChain(chainRowIds, replacedByMap, rowId);
             addChildRunsToChain(chainRowIds, replacesMap, rowId);
 

--- a/src/org/labkey/targetedms/TargetedMSRun.java
+++ b/src/org/labkey/targetedms/TargetedMSRun.java
@@ -60,8 +60,8 @@ public class TargetedMSRun implements Serializable, ITargetedMSRun
     protected int _auditLogEntriesCount;
     protected int _listCount;
 
-    protected Integer _dataId; // FK to exp.data's RowId column for the .sky file
-    protected Integer _skydDataId; // FK to exp.data's RowId column for the .skyd file
+    protected Long _dataId; // FK to exp.data's RowId column for the .sky file
+    protected Long _skydDataId; // FK to exp.data's RowId column for the .skyd file
     protected Integer _iRTscaleId;
 
     private String _softwareVersion;
@@ -331,23 +331,23 @@ public class TargetedMSRun implements Serializable, ITargetedMSRun
     }
 
     @Override
-    public Integer getDataId()
+    public Long getDataId()
     {
         return _dataId;
     }
 
-    public void setDataId(Integer dataId)
+    public void setDataId(Long dataId)
     {
         _dataId = dataId;
     }
 
     @Override
-    public Integer getSkydDataId()
+    public Long getSkydDataId()
     {
         return _skydDataId;
     }
 
-    public void setSkydDataId(Integer dataId)
+    public void setSkydDataId(Long dataId)
     {
         _skydDataId = dataId;
     }

--- a/src/org/labkey/targetedms/TargetedMSSchema.java
+++ b/src/org/labkey/targetedms/TargetedMSSchema.java
@@ -22,6 +22,7 @@ import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
+import org.labkey.api.collections.LongHashMap;
 import org.labkey.api.data.AJAXDetailsDisplayColumn;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
@@ -879,16 +880,16 @@ public class TargetedMSSchema extends UserSchema
                 versionsCol.setDisplayColumnFactory(colInfo -> new DataColumn(colInfo) {
 
                     /** exp.ExperimentRun.RowId -> number of associated runs */
-                    private final Map<Integer, Integer> _counts = new HashMap<>();
+                    private final Map<Long, Integer> _counts = new LongHashMap<>();
 
                     @Override
                     public Object getValue(RenderContext ctx)
                     {
-                        Integer expRunId = ctx.get(getExpRunIdFieldKey(), Integer.class);
+                        Long expRunId = ctx.get(getExpRunIdFieldKey(), Long.class);
 
                         return expRunId == null ? null : _counts.computeIfAbsent(expRunId, x ->
                         {
-                            Set<Integer> rowIds = Collections.singleton(x);
+                            Set<Long> rowIds = Collections.singleton(x);
                             return TargetedMSManager.getLinkedVersions(TargetedMSSchema.this, rowIds, rowIds).size();
                         });
                     }

--- a/src/org/labkey/targetedms/TargetedMSServiceImpl.java
+++ b/src/org/labkey/targetedms/TargetedMSServiceImpl.java
@@ -346,7 +346,7 @@ public class TargetedMSServiceImpl implements TargetedMSService
     }
 
     @Override
-    public Integer importSkylineDocument(ViewBackgroundInfo info, Path skylinePath) throws XarFormatException, PipelineValidationException
+    public Long importSkylineDocument(ViewBackgroundInfo info, Path skylinePath) throws XarFormatException, PipelineValidationException
     {
         return TargetedMSManager.addRunToQueue(info, skylinePath);
     }

--- a/src/org/labkey/targetedms/calculations/GeneralMoleculeResultDataSet.java
+++ b/src/org/labkey/targetedms/calculations/GeneralMoleculeResultDataSet.java
@@ -14,6 +14,7 @@
  */
 package org.labkey.targetedms.calculations;
 
+import org.labkey.api.collections.LongHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableSelector;
@@ -52,7 +53,7 @@ public class GeneralMoleculeResultDataSet<TransitionType extends GeneralTransiti
 {
     private final MoleculeType _generalMolecule;
     private final ReplicateDataSet _replicateSet;
-    private final Map<Long, List<ChromInfoRecord>> _chromInfoRecordsByReplicateId = new HashMap<>();
+    private final Map<Long, List<ChromInfoRecord>> _chromInfoRecordsByReplicateId = new LongHashMap<>();
 
     public GeneralMoleculeResultDataSet(User user, Container container, ReplicateDataSet replicateSet, MoleculeType peptide)
     {

--- a/src/org/labkey/targetedms/calculations/RunQuantifier.java
+++ b/src/org/labkey/targetedms/calculations/RunQuantifier.java
@@ -15,6 +15,7 @@
 package org.labkey.targetedms.calculations;
 
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.collections.LongHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableSelector;
@@ -191,7 +192,7 @@ public class RunQuantifier
         Collection<GeneralMoleculeChromInfo> moleculeChromInfos
                 = generalMoleculeResultDataSet.getGeneralMoleculeChromInfos();
         Set<Long> excludedReplicateIds = getExcludedReplicateIds(moleculeChromInfos);
-        Map<Long, CalibrationCurveDataSet.Replicate> calibrationCurveReplicates = new HashMap<>();
+        Map<Long, CalibrationCurveDataSet.Replicate> calibrationCurveReplicates = new LongHashMap<>();
         for (Replicate replicate : _replicateDataSet.listReplicates())
         {
             Double moleculeConcentration = replicate.getAnalyteConcentration();

--- a/src/org/labkey/targetedms/chart/ChromatogramDataset.java
+++ b/src/org/labkey/targetedms/chart/ChromatogramDataset.java
@@ -21,6 +21,7 @@ import org.jfree.chart.ChartColor;
 import org.jfree.data.xy.XYDataItem;
 import org.jfree.data.xy.XYSeries;
 import org.jfree.data.xy.XYSeriesCollection;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DataRegionSelection;
 import org.labkey.api.pipeline.PipeRoot;
@@ -418,7 +419,7 @@ public abstract class ChromatogramDataset
         private final List<ChartAnnotation> _annotations = new ArrayList<>();
 
         /** Create a map of colors to be used for drawing the peaks. */
-        protected final Map<Integer, Color> _seriesColors = new HashMap<>();
+        protected final Map<Integer, Color> _seriesColors = new IntHashMap<>();
 
         public RtRangeDataset(User u, Container c)
         {

--- a/src/org/labkey/targetedms/chart/ComparisonChartInputMaker.java
+++ b/src/org/labkey/targetedms/chart/ComparisonChartInputMaker.java
@@ -16,6 +16,7 @@
 package org.labkey.targetedms.chart;
 
 import org.apache.commons.lang3.StringUtils;
+import org.labkey.api.collections.LongHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.security.User;
 import org.labkey.targetedms.TargetedMSSchema;
@@ -208,7 +209,7 @@ public class ComparisonChartInputMaker
     private List<PrecursorChromInfoLitePlus> filterInputList()
     {
         List<SampleFile> sampleFileList = ReplicateManager.getSampleFilesForRun(_runId);
-        Map<Long, Long> sampleFileReplicateMap = new HashMap<>();
+        Map<Long, Long> sampleFileReplicateMap = new LongHashMap<>();
         for(SampleFile file: sampleFileList)
         {
             sampleFileReplicateMap.put(file.getId(), file.getReplicateId());
@@ -237,10 +238,10 @@ public class ComparisonChartInputMaker
 
     private Map<Long, Replicate> getSampleFileReplicateMap()
     {
-        Map<Long, Replicate> sampleFileReplicateMap = new HashMap<>();
+        Map<Long, Replicate> sampleFileReplicateMap = new LongHashMap<>();
         List<SampleFile> sampleFiles = ReplicateManager.getSampleFilesForRun(_runId);
         List<Replicate> replicates = ReplicateManager.getReplicatesForRun(_runId);
-        Map<Long, Replicate> replicateMap = new HashMap<>();
+        Map<Long, Replicate> replicateMap = new LongHashMap<>();
         for(Replicate replicate: replicates)
         {
             replicateMap.put(replicate.getId(), replicate);
@@ -254,11 +255,11 @@ public class ComparisonChartInputMaker
 
     private Map<Long, String> getSampleAnnotationMap()
     {
-        Map<Long, String> sampleFileAnnotMap = new HashMap<>();
+        Map<Long, String> sampleFileAnnotMap = new LongHashMap<>();
         if(_groupByAnnotationName != null)
         {
             List<ReplicateAnnotation> replicateAnnotationList = ReplicateManager.getReplicateAnnotationsForRun(_runId);
-            Map<Long, String> replicateAnnotationMap = new HashMap<>();
+            Map<Long, String> replicateAnnotationMap = new LongHashMap<>();
             for(ReplicateAnnotation annot: replicateAnnotationList)
             {
                 if(!annot.getName().equals(_groupByAnnotationName))

--- a/src/org/labkey/targetedms/chromlib/ContainerChromatogramLibraryWriter.java
+++ b/src/org/labkey/targetedms/chromlib/ContainerChromatogramLibraryWriter.java
@@ -16,6 +16,7 @@
 package org.labkey.targetedms.chromlib;
 
 import org.labkey.api.collections.CaseInsensitiveHashSet;
+import org.labkey.api.collections.LongHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableSelector;
@@ -496,7 +497,7 @@ public class ContainerChromatogramLibraryWriter
         // Get the isotope modifications for the peptide.
         List<Peptide.IsotopeModification> pepIsotopeMods = ModificationManager.getPeptideIsotopelModifications(peptide.getId());
         // IsotopeLabelId(Panorama) -> List<Peptide.IsotopeModification>
-        Map<Long, List<Peptide.IsotopeModification>> precIsotopeModMap = new HashMap<>();
+        Map<Long, List<Peptide.IsotopeModification>> precIsotopeModMap = new LongHashMap<>();
         for(Peptide.IsotopeModification isotopeMod: pepIsotopeMods)
         {
             Long isotopeLabelId = _isotopeModificationAndLabelMap.get(isotopeMod.getIsotopeModId());

--- a/src/org/labkey/targetedms/datasource/MsDataSourceUtil.java
+++ b/src/org/labkey/targetedms/datasource/MsDataSourceUtil.java
@@ -188,10 +188,10 @@ public class MsDataSourceUtil
         filter.addCondition(FieldKey.fromParts("datafileurl"), encodedName, CompareType.CONTAINS);
 
         // Get the rowId and name of matching rows.
-        Map<Integer, String> expDatas = new TableSelector(expDataTInfo,
-                expDataTInfo.getColumns("RowId", "DataFileUrl"), filter, null).getValueMap();
+        Map<Long, String> expDatas = new TableSelector(expDataTInfo,
+                expDataTInfo.getColumns("RowId", "DataFileUrl"), filter, null).getValueMap(Long.class);
 
-        List<Integer> expDataIds = new ArrayList<>();
+        List<Long> expDataIds = new ArrayList<>();
         expDatas.entrySet().forEach(e -> e.setValue(org.labkey.api.util.Path.parse(e.getValue()).getName())); // Replace path with file name
         // Look for the file and file.zip (e.g. sample_1.raw and sample_1.raw.zip)
         expDatas.entrySet().stream()
@@ -415,7 +415,7 @@ public class MsDataSourceUtil
             run.setContainer(_container);
             run.setFileName(SKY_FILE_NAME);
             Table.insert(_user, TargetedMSManager.getTableInfoRuns(), run);
-            assertNotEquals("Id for saved run should not be 0", 0, run.getId());
+            assertNotEquals("Id for saved run should not be 0", 0L, run.getId());
             return run;
         }
 

--- a/src/org/labkey/targetedms/outliers/OutlierGenerator.java
+++ b/src/org/labkey/targetedms/outliers/OutlierGenerator.java
@@ -18,6 +18,8 @@ package org.labkey.targetedms.outliers;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.collections.IntHashMap;
+import org.labkey.api.collections.LongHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.RuntimeSQLException;
 import org.labkey.api.data.SQLFragment;
@@ -265,7 +267,7 @@ public class OutlierGenerator
         TableInfo sampleFileForQC = schema.getTable("SampleFileForQC");
         List<SampleFileQCMetadata> sfs = new TableSelector(sampleFileForQC).getArrayList(SampleFileQCMetadata.class);
 
-        Map<Long, SampleFileQCMetadata> sampleFiles = new HashMap<>();
+        Map<Long, SampleFileQCMetadata> sampleFiles = new LongHashMap<>();
         for (SampleFileQCMetadata sf : sfs)
         {
             sampleFiles.put(sf.getId(), sf);
@@ -285,10 +287,10 @@ public class OutlierGenerator
 
         try
         {
-            Map<Long, Object> excludedPrecursorIds = new HashMap<>();
+            Map<Long, Object> excludedPrecursorIds = new LongHashMap<>();
             Map<Long, RawMetricDataSet.PrecursorInfo> precursors = loadPrecursors(schema, excludedPrecursorIds, showExcludedPrecursors);
 
-            Map<Integer, QCMetricConfiguration> metrics = new HashMap<>();
+            Map<Integer, QCMetricConfiguration> metrics = new IntHashMap<>();
             configurations.forEach(m -> metrics.put(m.getId(), m));
 
             try (ResultSet rs = new SqlSelector(TargetedMSManager.getSchema(), sql).getResultSet(false))
@@ -343,7 +345,7 @@ public class OutlierGenerator
     @NotNull
     private Map<Long, RawMetricDataSet.PrecursorInfo> loadPrecursors(TargetedMSSchema schema, Map<Long, Object> excludedPrecursorsIds, boolean showExcludedPrecursors) throws SQLException
     {
-        Map<Long, RawMetricDataSet.PrecursorInfo> precursors = new HashMap<>();
+        Map<Long, RawMetricDataSet.PrecursorInfo> precursors = new LongHashMap<>();
 
         DecimalFormat format = new DecimalFormat();
         format.setMinimumFractionDigits(4);

--- a/src/org/labkey/targetedms/parser/PeakAreaRatioCalculator.java
+++ b/src/org/labkey/targetedms/parser/PeakAreaRatioCalculator.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.targetedms.parser;
 
+import org.labkey.api.collections.LongHashMap;
 import org.labkey.targetedms.query.IsotopeLabelManager;
 import org.labkey.targetedms.query.ReplicateManager;
 
@@ -32,7 +33,7 @@ public class PeakAreaRatioCalculator<TransitionType extends GeneralTransition, P
     private final MoleculeType _peptide;
     private final TransitionSettings _transitionSettings;
 
-    private final Map<Long, PeptideAreaRatioCalculator> _peptideAreaRatioCalculatorMap = new HashMap<>();
+    private final Map<Long, PeptideAreaRatioCalculator> _peptideAreaRatioCalculatorMap = new LongHashMap<>();
 
     // All the precursors and transitions and chrom infos for this peptide must already have database IDs.
     public PeakAreaRatioCalculator(MoleculeType molecule, TransitionSettings transitionSettings)

--- a/src/org/labkey/targetedms/passport/PassportController.java
+++ b/src/org/labkey/targetedms/passport/PassportController.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.action.SimpleViewAction;
 import org.labkey.api.action.SpringActionController;
+import org.labkey.api.collections.LongHashMap;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
@@ -280,7 +281,7 @@ public class PassportController extends SpringActionController
         if (p == null)
             return;
 
-        Map<Long, IPeptide> peptideMap = new HashMap<>();
+        Map<Long, IPeptide> peptideMap = new LongHashMap<>();
 
         UserSchema schema = QueryService.get().getUserSchema(getUser(), getContainer(), "targetedms");
         TableInfo tinfo = schema.getTable("Passport_TotalPrecursorArea");

--- a/src/org/labkey/targetedms/pipeline/TargetedMSImportTask.java
+++ b/src/org/labkey/targetedms/pipeline/TargetedMSImportTask.java
@@ -62,7 +62,7 @@ public class TargetedMSImportTask extends PipelineJob.Task<TargetedMSImportTask.
                                                                  job.getLocalDirectory(), job.getPipeRoot());
             TargetedMSRun run = importer.importRun(job.getRunInfo(), job);
 
-            Integer jobId = PipelineService.get().getJobId(getJob().getUser(), getJob().getContainer(), getJob().getJobGUID());
+            Long jobId = PipelineService.get().getJobId(getJob().getUser(), getJob().getContainer(), getJob().getJobGUID());
             TargetedMSManager.ensureWrapped(run, job.getUser(), jobId);
             TargetedMSService.get().getSkylineDocumentImportListener().forEach(listener -> listener.onDocumentImport(job.getContainer(), job.getUser(), run));
             transaction.commit();

--- a/src/org/labkey/targetedms/query/CrossLinkedPeptideDisplayColumn.java
+++ b/src/org/labkey/targetedms/query/CrossLinkedPeptideDisplayColumn.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.Test;
+import org.labkey.api.collections.LongHashMap;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.DataColumn;
 import org.labkey.api.data.DisplayColumn;
@@ -27,7 +28,7 @@ import java.util.Set;
 public class CrossLinkedPeptideDisplayColumn extends DataColumn
 {
     // Cache the proteins for a given run to avoid many redundant queries
-    private final Map<Long, List<Protein>> _proteins = new HashMap<>();
+    private final Map<Long, List<Protein>> _proteins = new LongHashMap<>();
     private final Formatter _formatter;
 
     private CrossLinkedPeptideDisplayColumn(ColumnInfo col, Formatter formatter)

--- a/src/org/labkey/targetedms/query/ModificationManager.java
+++ b/src/org/labkey/targetedms/query/ModificationManager.java
@@ -17,6 +17,8 @@ package org.labkey.targetedms.query;
 
 import org.labkey.api.cache.Cache;
 import org.labkey.api.cache.CacheManager;
+import org.labkey.api.collections.IntHashMap;
+import org.labkey.api.collections.LongHashMap;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.Selector;
 import org.labkey.api.data.SimpleFilter;
@@ -99,7 +101,7 @@ public class ModificationManager
      */
     public static Map<Integer, Double> getPeptideIsotopeModsMap(long peptideId, long isotopeLabelId)
     {
-        final Map<Integer, Double> isotopeModIndexMassDiff = new HashMap<>();
+        final Map<Integer, Double> isotopeModIndexMassDiff = new IntHashMap<>();
         String sql = "SELECT pm.IndexAa, pm.MassDiff "+
                      "FROM "+
                      TargetedMSManager.getTableInfoPeptideIsotopeModification()+" AS pm, "+
@@ -286,7 +288,7 @@ public class ModificationManager
         sql.append(" AND ");
         sql.append(" mod.peptideId = gm.id ");
 
-        final Map<Long, Set<Pair<Integer, Integer>>> peptideModIndexMap = new HashMap<>();
+        final Map<Long, Set<Pair<Integer, Integer>>> peptideModIndexMap = new LongHashMap<>();
 
         new SqlSelector(getSchema(), sql).forEach(rs -> {
             long peptideId = rs.getLong("peptideId");
@@ -297,7 +299,7 @@ public class ModificationManager
             modIndexes.add(Pair.of(peptideIndex, indexAA));
         });
 
-        Map<Long, Set<Pair<Integer, Integer>>> immutableMap = new HashMap<>();
+        Map<Long, Set<Pair<Integer, Integer>>> immutableMap = new LongHashMap<>();
         peptideModIndexMap.forEach((k, v) -> immutableMap.put(k, Collections.unmodifiableSet(v)));
 
         return Collections.unmodifiableMap(immutableMap);

--- a/src/org/labkey/targetedms/query/ModifiedSequenceDisplayColumn.java
+++ b/src/org/labkey/targetedms/query/ModifiedSequenceDisplayColumn.java
@@ -25,6 +25,7 @@ import org.apache.poi.ss.usermodel.RichTextString;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.DisplayColumnFactory;
@@ -412,7 +413,7 @@ public abstract class ModifiedSequenceDisplayColumn extends IconColumn
             ModifiedSequenceDisplayColumn.this.initialize(ctx);
 
             StringBuilder builder = new StringBuilder();
-            Map<Integer, Font> highlights = new HashMap<>();
+            Map<Integer, Font> highlights = new IntHashMap<>();
             int i = 0;
             String separator = "";
             for (List<ModifiedPeptideHtmlMaker.SequencePart> parts : _parsedParts)

--- a/src/org/labkey/targetedms/query/PTMPercentsGroupedCustomizer.java
+++ b/src/org/labkey/targetedms/query/PTMPercentsGroupedCustomizer.java
@@ -1,6 +1,7 @@
 package org.labkey.targetedms.query;
 
 import org.apache.commons.collections4.MultiValuedMap;
+import org.labkey.api.collections.LongHashMap;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DisplayColumn;
@@ -209,7 +210,7 @@ public class PTMPercentsGroupedCustomizer extends PTMPercentsCustomizer
     /** Look up proteins on demand by peptideGroupId, caching them for reuse */
     public static class PeptideGroupIdProteinGetter implements Function<Long, Protein>
     {
-        private final Map<Long, Protein> _proteins = new HashMap<>();
+        private final Map<Long, Protein> _proteins = new LongHashMap<>();
         @Override
         public Protein apply(Long peptideGroupId)
         {

--- a/src/org/labkey/targetedms/query/PeptideGroupManager.java
+++ b/src/org/labkey/targetedms/query/PeptideGroupManager.java
@@ -17,6 +17,7 @@ package org.labkey.targetedms.query;
 
 
 import org.apache.commons.lang3.StringUtils;
+import org.labkey.api.collections.LongArrayList;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
@@ -174,7 +175,7 @@ public class PeptideGroupManager
     {
         if(peptideGroupIds == null || peptideGroupIds.length == 0)
             return;
-        List<Long> peptideGroupIdList = new ArrayList<>(peptideGroupIds.length);
+        List<Long> peptideGroupIdList = new LongArrayList(peptideGroupIds.length);
         for(int i = 0; i < peptideGroupIds.length; i++)
         {
             peptideGroupIdList.add(peptideGroupIds[i]);

--- a/src/org/labkey/targetedms/query/QCMetricConfigurationTable.java
+++ b/src/org/labkey/targetedms/query/QCMetricConfigurationTable.java
@@ -46,6 +46,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.labkey.api.exp.api.ExperimentService.asInteger;
+
 public class QCMetricConfigurationTable extends FilteredTable<TargetedMSSchema>
 {
     public QCMetricConfigurationTable(TargetedMSSchema schema, ContainerFilter cf)
@@ -105,7 +107,7 @@ public class QCMetricConfigurationTable extends FilteredTable<TargetedMSSchema>
         {
             var insertedRow = super.insertRow(user, container, row);
             TargetedMSManager.get().clearCachedEnabledQCMetrics(container);
-            calculateAndInsertTraceValuesForMetric((int) insertedRow.get("Id"), container, user);
+            calculateAndInsertTraceValuesForMetric(asInteger(insertedRow.get("Id")), container, user);
             return insertedRow;
         }
 
@@ -113,7 +115,7 @@ public class QCMetricConfigurationTable extends FilteredTable<TargetedMSSchema>
         protected Map<String, Object> updateRow(User user, Container container, Map<String, Object> row, @NotNull Map<String, Object> oldRow, @Nullable Map<Enum, Object> configParameters) throws InvalidKeyException, ValidationException, QueryUpdateServiceException, SQLException
         {
             var updatedRow = super.updateRow(user, container, row, oldRow, configParameters);
-            var metricId = (int) updatedRow.get("Id");
+            int metricId = asInteger(updatedRow.get("Id"));
             deleteTraceValueForMetric(metricId, container);
             TargetedMSManager.get().clearCachedEnabledQCMetrics(container);
             calculateAndInsertTraceValuesForMetric(metricId, container, user);
@@ -124,29 +126,29 @@ public class QCMetricConfigurationTable extends FilteredTable<TargetedMSSchema>
         protected Map<String, Object> deleteRow(User user, Container container, Map<String, Object> oldRow) throws InvalidKeyException, QueryUpdateServiceException, SQLException
         {
             TargetedMSManager.get().clearCachedEnabledQCMetrics(container);
-            deleteTraceValueForMetric((Integer) oldRow.get("id"), container);
+            deleteTraceValueForMetric(asInteger(oldRow.get("id")), container);
             return super.deleteRow(user, container, oldRow);
         }
 
         private void deleteTraceValueForMetric(int metricId, Container container)
         {
             var sql = new SQLFragment(" DELETE FROM " + TargetedMSManager.getTableQCTraceMetricValues() + " WHERE metric IN ("+
-                    " SELECT qc.Id FROM " + TargetedMSManager.getTableInfoQCMetricConfiguration() + " qc" +
-                    " INNER JOIN " + TargetedMSManager.getTableInfoSampleFileChromInfo() + " sfi ON sfi.TextId = qc.TraceName" +
-                    " INNER JOIN " + TargetedMSManager.getTableInfoSampleFile() + " sf ON sf.id = sfi.SampleFileId" +
-                    " INNER JOIN " + TargetedMSManager.getTableInfoReplicate() + " rep ON rep.Id = sf.ReplicateId" +
-                    " INNER JOIN " + TargetedMSManager.getTableInfoRuns() + " r ON rep.RunId = r.Id" +
-                    " WHERE qc.Id = ? AND r.container = ? ) ").add(metricId).add(container.getId());
+                " SELECT qc.Id FROM " + TargetedMSManager.getTableInfoQCMetricConfiguration() + " qc" +
+                " INNER JOIN " + TargetedMSManager.getTableInfoSampleFileChromInfo() + " sfi ON sfi.TextId = qc.TraceName" +
+                " INNER JOIN " + TargetedMSManager.getTableInfoSampleFile() + " sf ON sf.id = sfi.SampleFileId" +
+                " INNER JOIN " + TargetedMSManager.getTableInfoReplicate() + " rep ON rep.Id = sf.ReplicateId" +
+                " INNER JOIN " + TargetedMSManager.getTableInfoRuns() + " r ON rep.RunId = r.Id" +
+                " WHERE qc.Id = ? AND r.container = ? ) ").add(metricId).add(container.getId());
             new SqlExecutor(TargetedMSManager.getSchema()).execute(sql);
         }
 
         private void calculateAndInsertTraceValuesForMetric(int metricId, Container container, User user)
         {
             var qcMetricConfigurations = TargetedMSManager
-                    .getEnabledQCMetricConfigurations(_queryTable.getUserSchema())
-                    .stream()
-                    .filter(qcMetricConfiguration -> qcMetricConfiguration.getId() == metricId)
-                    .collect(Collectors.toList());
+                .getEnabledQCMetricConfigurations(_queryTable.getUserSchema())
+                .stream()
+                .filter(qcMetricConfiguration -> qcMetricConfiguration.getId() == metricId)
+                .collect(Collectors.toList());
             var runsInContainer = TargetedMSManager.getRunsInContainer(container);
 
             for (TargetedMSRun run : runsInContainer)
@@ -155,6 +157,5 @@ public class QCMetricConfigurationTable extends FilteredTable<TargetedMSSchema>
                 qcTraceMetricValues.forEach(qcTraceMetricValue -> Table.insert(user, TargetedMSManager.getTableQCTraceMetricValues(), qcTraceMetricValue));
             }
         }
-
     }
 }

--- a/src/org/labkey/targetedms/view/ModifiedPeptideHtmlMaker.java
+++ b/src/org/labkey/targetedms/view/ModifiedPeptideHtmlMaker.java
@@ -17,6 +17,7 @@ package org.labkey.targetedms.view;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.collections.LongHashMap;
 import org.labkey.api.util.DOM;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.Pair;
@@ -53,7 +54,7 @@ public class ModifiedPeptideHtmlMaker
     private final Map<Long, Long> _firstIsotopeLabelIdInDocMap;
 
     /** RunId -> all proteins in that run */
-    private final Map<Long, List<Protein>> _proteins = new HashMap<>();
+    private final Map<Long, List<Protein>> _proteins = new LongHashMap<>();
 
     private final static String[] HEX_PADDING = new String[] {
                                                         "",

--- a/src/org/labkey/targetedms/view/peptideSummaryView.jsp
+++ b/src/org/labkey/targetedms/view/peptideSummaryView.jsp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 %>
+<%@ page import="org.labkey.api.collections.LongHashMap" %>
 <%@ page import="org.labkey.api.util.Formats" %>
 <%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
@@ -26,14 +27,13 @@
 <%@ page import="org.labkey.targetedms.view.IconFactory" %>
 <%@ page import="org.labkey.targetedms.view.ModifiedPeptideHtmlMaker" %>
 <%@ page import="org.labkey.targetedms.view.PrecursorHtmlMaker" %>
-<%@ page import="java.util.HashMap" %>
 <%@ page import="java.util.Map" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
     JspView<TargetedMSController.PeptideChromatogramsViewBean> me = HttpView.currentView();
     TargetedMSController.PeptideChromatogramsViewBean bean = me.getModelBean();
     TargetedMSRun run = bean.getRun();
-    Map<Long, String> labelIdMap = new HashMap<>();
+    Map<Long, String> labelIdMap = new LongHashMap<>();
     for(PeptideSettings.IsotopeLabel label: bean.getLabels())
     {
         labelIdMap.put(label.getId(), label.getName());

--- a/src/org/labkey/targetedms/view/spectrum/LibrarySpectrumMatchGetter.java
+++ b/src/org/labkey/targetedms/view/spectrum/LibrarySpectrumMatchGetter.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.cache.BlockingCache;
 import org.labkey.api.cache.CacheManager;
+import org.labkey.api.collections.LongHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.security.User;
 import org.labkey.api.util.FileUtil;
@@ -214,7 +215,7 @@ public class LibrarySpectrumMatchGetter
 
         List<Peptide.StructuralModification> structuralModifications= ModificationManager.getPeptideStructuralModifications(peptide.getId());
         List<PeptideSettings.RunStructuralModification> runStrMods = ModificationManager.getStructuralModificationsForRun(run.getId());
-        Map<Long, List<PeptideSettings.PotentialLoss>> potentialLossMap = new HashMap<>();
+        Map<Long, List<PeptideSettings.PotentialLoss>> potentialLossMap = new LongHashMap<>();
         for(Peptide.StructuralModification mod: structuralModifications)
         {
             List<PeptideSettings.PotentialLoss> losses = ModificationManager.getPotentialLossesForStructuralMod(mod.getStructuralModId());


### PR DESCRIPTION
#### Rationale
Implement support for tables with BIGINT primary keys.  E.g. RowId/ObjectId BIGSERIAL
Because of the large number of shared classes, utilities, services, etc, a lot of code was migrated to used Long.  Code should now assume that an generic integer object key (as opposed to a known table PK), could be a Long.

This PR is aimed at a) Supporting ObjectID BIGSERIAL b) making it possible (but not automatic) to migrate tables that want to use RowId BIGSERIAL.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
New safer collection classes
  class Int/LongHashMap
  class Int/LongHashSet
explicit Class for key values in Map Objects returned by BaseSelector
  Selector.getValueMap(Class key)
safe "cast" using asInteger or asLong, as opposed to (Integer) and (Long)

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->