### PR TITLE
Ticket 53573: H* adjust to the Peptide Map report

### DIFF
--- a/src/org/labkey/targetedms/query/CrossLinkedPeptideDisplayColumn.java
+++ b/src/org/labkey/targetedms/query/CrossLinkedPeptideDisplayColumn.java
@@ -191,7 +191,7 @@ public class CrossLinkedPeptideDisplayColumn extends DataColumn
             }
             if (label.endsWith("_hcstar"))
             {
-                result = "*";
+                result = "H*";
             }
             if (label.endsWith("_lc"))
             {


### PR DESCRIPTION
#### Rationale
The previous change incorrectly collapsed "HC*" to just "*". During a demo, the customer clarified that it should be "H*"

#### Changes
* "H*" for the win