### PR TITLE
Issue 53623: Improve QC metrics config UI

### DIFF
--- a/resources/views/configureQCMetric.html
+++ b/resources/views/configureQCMetric.html
@@ -11,9 +11,9 @@
         LABKEY.internal = {};
 
     LABKEY.internal.ConfigureQCMetrics = new function () {
-        var qcMetrics;
-        var qcMetricsTable ='';
-        var configRows = [];
+        let qcMetrics;
+        let qcMetricsTable ='';
+        let configRows = [];
 
         function showQCMetrics() {
             qcMetricsTable += '<form id="qcMetricsForm" >';
@@ -37,7 +37,11 @@
                 qcMetricsTable += '<td>' + (editLock ? '<a id="editLink' + row.id + '" href="#">' : '' ) + LABKEY.Utils.encodeHtml(row.name) + '</td>' + (editLock ? '</a>' : '' );
                 qcMetricsTable += '<td>' + (row.PrecursorScoped ? 'Precursor' : 'Run') + '</td>';
 
-                if (row.EffectiveStatus === 'NoData') {
+                // remove all paired metric configs
+                if (row.Series2QueryName !== null) {
+                    qcMetricsTable += '<td id=\"' + LABKEY.Utils.encodeHtml(row.name) + '\">Dual-metrics cannot be configured</td>';
+                }
+                else if (row.EffectiveStatus === 'NoData') {
                     qcMetricsTable += '<td id=\"' + LABKEY.Utils.encodeHtml(row.name) + '\">No data in this folder</td>';
                 }
                 else {
@@ -121,10 +125,6 @@
                     sort: 'name',
                     scope: this,
                     success: function (result) {
-                        // remove all paired metric configs
-                        result.rows = result.rows.filter(function(row) {
-                            return row.Series2QueryName === null;
-                        });
                         result.rows.sort(function(row1, row2) { return row1.name.toLowerCase().localeCompare(row2.name.toLowerCase()); });
                         qcMetrics = result.rows;
                         showQCMetrics();

--- a/resources/web/PanoramaPremium/window/AddNewMetricWindow.js
+++ b/resources/web/PanoramaPremium/window/AddNewMetricWindow.js
@@ -14,6 +14,9 @@ Ext4.define('Panorama.Window.AddCustomMetricWindow', {
     update: 'update',
     insert: 'insert',
 
+    SCHEMA_NAME: 'targetedms',
+
+
     initComponent: function() {
         var title = this.operation === this.insert ? 'Add New Metric' : 'Edit Metric';
         this.setTitle(title);
@@ -28,41 +31,27 @@ Ext4.define('Panorama.Window.AddCustomMetricWindow', {
         }]
 
         this.callParent();
-        if(this.operation === this.update) {
-            if(this.metric.Series1SchemaName) {
-                this.getQueriesForSchema(this.metric.Series1SchemaName, function (queries, scope) {
-                    scope.series1queries = queries;
-                    scope.queries1Combo.bindStore(scope.getQueriesStore());
 
-                });
+        LABKEY.Query.getQueries({
+            scope: this,
+            schemaName: this.SCHEMA_NAME,
+            success: function(queriesInfo) {
+                this.series1queries = queriesInfo.queries;
+                this.series2queries = queriesInfo.queries;
+                this.enabledqueries = queriesInfo.queries;
             }
-            if(this.metric.Series2SchemaName) {
-                this.getQueriesForSchema(this.metric.Series2SchemaName, function (queries, scope) {
-                    scope.series2queries = queries;
-                    scope.queries2Combo.bindStore(scope.getQueriesStore());
-                });
-            }
-            if(this.metric.EnabledSchemaName) {
-                this.getQueriesForSchema(this.metric.EnabledSchemaName, function (queries, scope) {
-                    scope.enabledqueries = queries;
-                    scope.enabledQueriesCombo.bindStore(scope.getQueriesStore());
-                });
-            }
-        }
+        });
 
     },
 
     getItems: function() {
         return [
                 this.getMetricNameField(),
-                this.getSchema1Combo(),
                 this.getQueries1Combo(),
                 this.getSeries1AxisLabelField(),
-                this.getSchema2Combo(),
                 this.getQueries2Combo(),
                 this.getSeries2AxisLabelField(),
                 this.getMetricTypeCombo(),
-                this.getEnabledSchemaCombo(),
                 this.getEnabledQueriesCombo(),
             this.getQueryError(),
         ];
@@ -107,38 +96,6 @@ Ext4.define('Panorama.Window.AddCustomMetricWindow', {
         };
     },
 
-    getSchema1Combo: function() {
-        if(!this.schema1Combo) {
-            var config = Ext4.apply(this.getSchemaConfig('Series 1', 'series1'), {
-                listeners: {
-                    scope: this,
-                    select: function(combo, recs){
-                        var rec = recs[0];
-                        this.series1schema = rec.data.field1;
-                        this.queries1Combo.setValue(null);
-
-                        LABKEY.Query.getQueries({
-                            scope: this,
-                            schemaName: this.series1schema,
-                            success: function(queriesInfo) {
-                                this.series1queries = queriesInfo.queries;
-                            }
-                        });
-                    }
-                }
-            });
-
-            this.schema1Combo = Ext4.create('Ext.form.field.ComboBox', config);
-
-            if(this.operation === this.update) {
-                this.schema1Combo.setValue(this.metric.Series1SchemaName);
-                this.schema1Combo.bindStore(this.schemas);
-            }
-        }
-
-        return this.schema1Combo;
-    },
-
     getQueriesConfig: function(label, name) {
         return {
             fieldLabel: label + ' Query',
@@ -146,8 +103,7 @@ Ext4.define('Panorama.Window.AddCustomMetricWindow', {
             labelWidth: 150,
             width: 400,
             displayField : 'title',
-            valueField : 'name',
-            emptyText: 'Please select ' + label + ' Schema.'
+            valueField : 'name'
         };
     },
 
@@ -224,37 +180,6 @@ Ext4.define('Panorama.Window.AddCustomMetricWindow', {
         return this.series2AxisLabelField;
     },
 
-    getSchema2Combo: function() {
-        if(!this.schema2Combo) {
-            var config = Ext4.apply(this.getSchemaConfig('Series 2', 'series2'), {
-                listeners: {
-                    scope: this,
-                    select: function(combo, recs){
-                        var rec = recs[0];
-                        this.series2schema = rec.data.field1;
-                        this.queries2Combo.setValue(null);
-
-                        LABKEY.Query.getQueries({
-                            scope: this,
-                            schemaName: this.series2schema,
-                            success: function(queriesInfo) {
-                                this.series2queries = queriesInfo.queries;
-                            }
-                        });
-                    }
-                }
-            });
-
-            this.schema2Combo = Ext4.create('Ext.form.field.ComboBox', config);
-
-            if(this.operation === this.update) {
-                this.schema2Combo.setValue(this.metric.Series2SchemaName);
-            }
-        }
-
-        return this.schema2Combo;
-    },
-
     getQueries2Combo: function() {
         if(!this.queries2Combo) {
             var config = Ext4.apply(this.getQueriesConfig('Series 2', 'series2'), {
@@ -278,37 +203,6 @@ Ext4.define('Panorama.Window.AddCustomMetricWindow', {
         }
 
         return this.queries2Combo;
-    },
-
-    getEnabledSchemaCombo: function() {
-        if(!this.enabledSchemaCombo) {
-            var config = Ext4.apply(this.getSchemaConfig('Enabled', 'enabled'), {
-                listeners: {
-                    scope: this,
-                    select: function(combo, recs){
-                        var rec = recs[0];
-                        this.enabledschema = rec.data.field1;
-                        this.enabledQueriesCombo.setValue(null);
-
-                        LABKEY.Query.getQueries({
-                            scope: this,
-                            schemaName: this.enabledschema,
-                            success: function(queriesInfo) {
-                                this.enabledqueries = queriesInfo.queries;
-                            }
-                        });
-                    }
-                }
-            });
-
-            this.enabledSchemaCombo = Ext4.create('Ext.form.field.ComboBox', config);
-
-            if(this.operation === this.update) {
-                this.enabledSchemaCombo.setValue(this.metric.EnabledSchemaName);
-            }
-        }
-
-        return this.enabledSchemaCombo;
     },
 
     getEnabledQueriesCombo: function() {
@@ -426,32 +320,17 @@ Ext4.define('Panorama.Window.AddCustomMetricWindow', {
             isValid = false;
         }
 
-        if(!this.schema1Combo.getValue()) {
-            this.schema1Combo.setActiveError(errorText);
-            isValid = false;
-        }
-
-        if(this.schema1Combo.getValue() && !this.queries1Combo.getValue()) {
+        if(!this.queries1Combo.getValue()) {
             this.queries1Combo.setActiveError(errorText);
             isValid = false;
         }
 
-        if(this.schema1Combo.getValue() && !this.series1AxisLabelField.getValue().length > 0) {
+        if(!this.series1AxisLabelField.getValue().length > 0) {
             this.series1AxisLabelField.setActiveError(errorText);
             isValid = false;
         }
 
-        if(this.schema2Combo.getValue() && !this.queries2Combo.getValue()) {
-            this.queries2Combo.setActiveError("Required when series 2 schema is provided.");
-            isValid = false;
-        }
-
-        if(this.schema2Combo.getValue() && !this.series2AxisLabelField.getValue().length > 0) {
-            this.series2AxisLabelField.setActiveError("Required when series 2 schema is provided.");
-            isValid = false;
-        }
-
-        if(this.schema1Combo.getValue() && this.metricTypeCombo.getValue() == null) {
+        if(this.metricTypeCombo.getValue() == null) {
             this.metricTypeCombo.setActiveError(errorText);
             isValid = false;
         }
@@ -510,17 +389,17 @@ Ext4.define('Panorama.Window.AddCustomMetricWindow', {
             var records = [];
             var newMetric = {};
             newMetric.Name = this.metricNameField.getValue();
-            newMetric.Series1SchemaName = this.schema1Combo.getValue();
+            newMetric.Series1SchemaName = this.SCHEMA_NAME;
             newMetric.Series1QueryName = this.queries1Combo.getValue();
             newMetric.Series1Label = this.series1AxisLabelField.getValue();
             newMetric.PrecursorScoped = this.metricTypeCombo.getValue();
 
 
-            newMetric.Series2SchemaName = this.schema2Combo.getValue();
+            newMetric.Series2SchemaName = this.SCHEMA_NAME;
             newMetric.Series2QueryName = this.queries2Combo.getValue();
             newMetric.Series2Label = this.series2AxisLabelField.getValue();
 
-            newMetric.EnabledSchemaName = this.enabledSchemaCombo.getValue();
+            newMetric.EnabledSchemaName = this.SCHEMA_NAME;
             newMetric.EnabledQueryName = this.enabledQueriesCombo.getValue();
 
             if(this.operation === this.update) {

--- a/src/org/labkey/targetedms/TargetedMSDataHandler.java
+++ b/src/org/labkey/targetedms/TargetedMSDataHandler.java
@@ -30,6 +30,7 @@ import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.pipeline.PipeRoot;
+import org.labkey.api.pipeline.PipelineJob;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.security.User;
@@ -105,7 +106,14 @@ public class TargetedMSDataHandler extends AbstractExperimentDataHandler
 
             TargetedMSManager.updateRun(run, info.getUser());
 
-            TargetedMSService.get().getSkylineDocumentImportListener().forEach(listener -> listener.onDocumentImport(context.getContainer(), info.getUser(), run));
+            try
+            {
+                TargetedMSService.get().getSkylineDocumentImportListener().forEach(listener -> listener.onDocumentImport(context.getContainer(), info.getUser(), run));
+            }
+            catch (RuntimeException e)
+            {
+                context.getJob().warn("Error calling SkylineDocumentImportListener.onDocumentImport", e);
+            }
 
             transaction.commit();
         }

--- a/src/org/labkey/targetedms/outliers/OutlierGenerator.java
+++ b/src/org/labkey/targetedms/outliers/OutlierGenerator.java
@@ -504,12 +504,13 @@ public class OutlierGenerator
     public String getMetricLabel(Map<Integer, QCMetricConfiguration> metrics, RawMetricDataSet dataRow)
     {
         QCMetricConfiguration metric = metrics.get(dataRow.getMetricId());
-        return switch (dataRow.getMetricSeriesIndex())
+        String result = switch (dataRow.getMetricSeriesIndex())
                 {
                     case 1 -> metric.getSeries1Label();
                     case 2 -> metric.getSeries2Label();
                     default -> throw new IllegalArgumentException("Unexpected metric series index: " + dataRow.getMetricSeriesIndex());
                 };
+        return result == null ? "Unlabeled" : result;
     }
     /**
      * returns the separated plots data per peptide

--- a/src/org/labkey/targetedms/query/CalibrationCurveTable.java
+++ b/src/org/labkey/targetedms/query/CalibrationCurveTable.java
@@ -57,6 +57,8 @@ public class CalibrationCurveTable extends TargetedMSTable
         public PeptideCalibrationCurveTable(TargetedMSSchema schema, ContainerFilter cf)
         {
             super(schema, cf);
+            setName(TargetedMSSchema.TABLE_PEPTIDE_CALIBRATION_CURVE);
+            setTitle(TargetedMSSchema.TABLE_PEPTIDE_CALIBRATION_CURVE);
             var generalMoleculeId = getMutableColumn("GeneralMoleculeId");
             generalMoleculeId.setFk(new TargetedMSForeignKey(_userSchema, TargetedMSSchema.TABLE_PEPTIDE, cf));
             generalMoleculeId.setLabel("Peptide");
@@ -73,6 +75,8 @@ public class CalibrationCurveTable extends TargetedMSTable
         public MoleculeCalibrationCurveTable(TargetedMSSchema schema, ContainerFilter cf)
         {
             super(schema, cf);
+            setName(TargetedMSSchema.TABLE_MOLECULE_CALIBRATION_CURVE);
+            setTitle(TargetedMSSchema.TABLE_MOLECULE_CALIBRATION_CURVE);
             var generalMoleculeId = getMutableColumn("GeneralMoleculeId");
             generalMoleculeId.setFk(new TargetedMSForeignKey(_userSchema, TargetedMSSchema.TABLE_MOLECULE, cf));
             generalMoleculeId.setLabel("Molecule");

--- a/test/src/org/labkey/test/pages/panoramapremium/ConfigureMetricsUIPage.java
+++ b/test/src/org/labkey/test/pages/panoramapremium/ConfigureMetricsUIPage.java
@@ -127,10 +127,23 @@ public class ConfigureMetricsUIPage extends PortalBodyPanel
 
     public void editMetric(String metric, Map<CustomMetricProperties, String> metricProperties)
     {
+        Window<?> metricWindow = openForEdit(metric);
+        editCustomMetricValues(metricWindow, metricProperties);
+    }
+
+    public void deleteMetric(String metric)
+    {
+        openForEdit(metric);
+        clickButton("Delete", 0);
+        clickButton("Yes");
+        waitForPage();
+    }
+
+    private Window<?> openForEdit(String metric)
+    {
         waitAndClick(Locator.linkWithText(metric));
         waitForElement(Ext4Helper.Locators.window("Edit Metric"));
-        Window<?> metricWindow = new Window.WindowFinder(getDriver()).withTitle("Edit Metric").waitFor();
-        editCustomMetricValues(metricWindow, metricProperties);
+        return new Window.WindowFinder(getDriver()).withTitle("Edit Metric").waitFor();
     }
 
     private void editCustomMetricValues(Window<?> metricWindow, Map<CustomMetricProperties, String> metricProperties)
@@ -186,8 +199,6 @@ public class ConfigureMetricsUIPage extends PortalBodyPanel
     public enum CustomMetricProperties
     {
         metricName("Name", false),
-        series1Schema("Series 1 Schema", true),
-        series2Schema("Series 2 Schema", true),
         series1Query("Series 1 Query", true),
         series2Query("Series 2 Query", true),
         series1AxisLabel("Series 1 Axis Label", false),

--- a/test/src/org/labkey/test/pages/panoramapremium/ConfigureMetricsUIPage.java
+++ b/test/src/org/labkey/test/pages/panoramapremium/ConfigureMetricsUIPage.java
@@ -8,6 +8,7 @@ import org.labkey.test.components.ext4.Window;
 import org.labkey.test.components.targetedms.QCPlotsWebPart;
 import org.labkey.test.pages.PortalBodyPanel;
 import org.labkey.test.util.Ext4Helper;
+import org.openqa.selenium.NoSuchElementException;
 
 import java.util.Map;
 
@@ -155,10 +156,15 @@ public class ConfigureMetricsUIPage extends PortalBodyPanel
             else
             {
                 String label = prop.formLabel;
-
-                click(Ext4Helper.Locators.formItemWithLabel(label)); // Focus to make combo box open on the first try
-
-                _ext4Helper.selectComboBoxItem(label, val);
+                //adding waits does not help here, however it passes in catch block
+                try
+                {
+                    _ext4Helper.selectComboBoxItem(label, val);
+                }
+                catch (NoSuchElementException e)
+                {
+                    _ext4Helper.selectComboBoxItem(label, val);
+                }
             }
         });
         clickAndWait(Ext4Helper.Locators.ext4Button("Save").findElement(metricWindow));

--- a/test/src/org/labkey/test/pages/panoramapremium/ConfigureMetricsUIPage.java
+++ b/test/src/org/labkey/test/pages/panoramapremium/ConfigureMetricsUIPage.java
@@ -8,7 +8,6 @@ import org.labkey.test.components.ext4.Window;
 import org.labkey.test.components.targetedms.QCPlotsWebPart;
 import org.labkey.test.pages.PortalBodyPanel;
 import org.labkey.test.util.Ext4Helper;
-import org.openqa.selenium.NoSuchElementException;
 
 import java.util.Map;
 
@@ -156,15 +155,10 @@ public class ConfigureMetricsUIPage extends PortalBodyPanel
             else
             {
                 String label = prop.formLabel;
-                //adding waits does not help here, however it passes in catch block
-                try
-                {
-                    _ext4Helper.selectComboBoxItem(label, val);
-                }
-                catch (NoSuchElementException e)
-                {
-                    _ext4Helper.selectComboBoxItem(label, val);
-                }
+
+                click(Ext4Helper.Locators.formItemWithLabel(label)); // Focus to make combo box open on the first try
+
+                _ext4Helper.selectComboBoxItem(label, val);
             }
         });
         clickAndWait(Ext4Helper.Locators.ext4Button("Save").findElement(metricWindow));

--- a/test/src/org/labkey/test/pages/panoramapremium/ConfigureMetricsUIPage.java
+++ b/test/src/org/labkey/test/pages/panoramapremium/ConfigureMetricsUIPage.java
@@ -204,7 +204,6 @@ public class ConfigureMetricsUIPage extends PortalBodyPanel
         series1AxisLabel("Series 1 Axis Label", false),
         series2AxisLabel("Series 2 Axis Label", false),
         metricType("Metric Type", true),
-        enabledSchema("Enabled Schema", true),
         enabledQuery("Enabled Query", true);
 
         private final String formLabel;

--- a/test/src/org/labkey/test/tests/panoramapremium/TargetedMSIsotopologueTest.java
+++ b/test/src/org/labkey/test/tests/panoramapremium/TargetedMSIsotopologueTest.java
@@ -8,6 +8,7 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.components.ext4.Window;
 import org.labkey.test.components.targetedms.QCPlotsWebPart;
+import org.labkey.test.pages.panoramapremium.ConfigureMetricsUIPage;
 import org.labkey.test.pages.targetedms.PanoramaDashboard;
 
 import static org.junit.Assert.assertTrue;
@@ -67,9 +68,8 @@ public class TargetedMSIsotopologueTest extends TargetedMSPremiumTest
 
         log("Verifying that two new metric properties are added");
         clickButton("Add New Custom Metric", 0);
-        Window metricWindow = new Window.WindowFinder(getDriver()).withTitle("Add New Metric").waitFor();
-        assertElementPresent(Locator.name("enabledSchema"));
-        assertElementPresent(Locator.name("enabledQuery"));
+        Window<?> metricWindow = new Window.WindowFinder(getDriver()).withTitle("Add New Metric").waitFor();
+        assertElementPresent(Locator.name(ConfigureMetricsUIPage.CustomMetricProperties.enabledQuery.name()));
 
     }
 }

--- a/test/src/org/labkey/test/tests/panoramapremium/TargetedMSQCFolderImportExport.java
+++ b/test/src/org/labkey/test/tests/panoramapremium/TargetedMSQCFolderImportExport.java
@@ -64,7 +64,7 @@ public class TargetedMSQCFolderImportExport extends TargetedMSPremiumTest
         String annotationType = "Test QC Annotation type";
         log("Updating the folder to be exported with data points");
         createGuideSet(getProjectName());
-        addCustomMetric(getProjectName(), customMetricName, "targetedms", "AQCTest_Metric");
+        addCustomMetric(getProjectName(), customMetricName, "AQCTest_Metric");
         addAnnotationType(getProjectName(), annotationType);
         excludePrecursors(getProjectName(), 0);
 
@@ -118,12 +118,11 @@ public class TargetedMSQCFolderImportExport extends TargetedMSPremiumTest
         Assert.assertEquals("Guide Set was not added correctly", 1, table.getDataRowCount());
     }
 
-    private void addCustomMetric(String projectName, String metricName, String schema1Name, String series1Query)
+    private void addCustomMetric(String projectName, String metricName, String series1Query)
     {
         goToProjectHome(projectName);
         Map<ConfigureMetricsUIPage.CustomMetricProperties, String> metricProperties = new LinkedHashMap<>();
         metricProperties.put(ConfigureMetricsUIPage.CustomMetricProperties.metricName, metricName);
-        metricProperties.put(ConfigureMetricsUIPage.CustomMetricProperties.series1Schema, schema1Name);
         metricProperties.put(ConfigureMetricsUIPage.CustomMetricProperties.series1Query, series1Query);
         metricProperties.put(ConfigureMetricsUIPage.CustomMetricProperties.series1AxisLabel, metricName);
         metricProperties.put(ConfigureMetricsUIPage.CustomMetricProperties.metricType, ConfigureMetricsUIPage.MetricType.Precursor.name());

--- a/test/src/org/labkey/test/tests/panoramapremium/TargetedMSQCPremiumTest.java
+++ b/test/src/org/labkey/test/tests/panoramapremium/TargetedMSQCPremiumTest.java
@@ -77,7 +77,7 @@ public class TargetedMSQCPremiumTest extends TargetedMSPremiumTest
         // these tests use the UIContainerHelper for project creation, but we can use the APIContainerHelper for deletion
         APIContainerHelper apiContainerHelper = new APIContainerHelper(this);
         apiContainerHelper.deleteProject(getProjectName(), afterTest);
-        apiContainerHelper.deleteProject("PressureTraceQC", afterTest);
+        apiContainerHelper.deleteProject("PressureTraceQC", false);
         _userHelper.deleteUsers(false, USER);
     }
 
@@ -147,14 +147,12 @@ public class TargetedMSQCPremiumTest extends TargetedMSPremiumTest
     public void testAddNewMetric()
     {
         String metricName = "Test Custom Metric";
-        String schema1Name = "targetedms";
         String series1Query = "AQCTest_Metric"; //starting the query name with A to make it appear top in the list
 
         log("Adding new test custom metric");
         //need to preserve the insertion order
         Map<ConfigureMetricsUIPage.CustomMetricProperties, String > metricProperties = new LinkedHashMap<>();
         metricProperties.put(ConfigureMetricsUIPage.CustomMetricProperties.metricName, metricName);
-        metricProperties.put(ConfigureMetricsUIPage.CustomMetricProperties.series1Schema, schema1Name);
         metricProperties.put(ConfigureMetricsUIPage.CustomMetricProperties.series1Query, series1Query);
         metricProperties.put(ConfigureMetricsUIPage.CustomMetricProperties.series1AxisLabel, metricName);
         metricProperties.put(ConfigureMetricsUIPage.CustomMetricProperties.metricType, ConfigureMetricsUIPage.MetricType.Precursor.name());
@@ -178,13 +176,28 @@ public class TargetedMSQCPremiumTest extends TargetedMSPremiumTest
 
         configureUI = goToConfigureMetricsUI();
         metricProperties.clear();
-        metricProperties.put(ConfigureMetricsUIPage.CustomMetricProperties.metricName, metricName+"-Edited");
+        String metricName2 = metricName + "-Edited";
+        metricProperties.put(ConfigureMetricsUIPage.CustomMetricProperties.metricName, metricName2);
         configureUI.editMetric(metricName, metricProperties);
 
         log("Verifying new metric got edited");
         qcPlotsWebPart.clickMenuItem("Configure QC Metrics");
-        waitForElement(Locator.linkWithText(metricName + "-Edited"));
-        assertTextPresent(metricName + "-Edited");
+        waitForElement(Locator.linkWithText(metricName2));
+        assertTextPresent(metricName2);
+
+        configureUI = goToConfigureMetricsUI();
+        metricProperties.clear();
+        metricProperties.put(ConfigureMetricsUIPage.CustomMetricProperties.series2Query, "QCMetric_fwb");
+        configureUI.editMetric(metricName2, metricProperties);
+
+        qcPlotsWebPart.clickMenuItem("Configure QC Metrics");
+        waitForElement(Locator.linkWithText(metricName2));
+        assertTextPresent(metricName2, "Dual-metrics cannot be configured");
+        configureUI = goToConfigureMetricsUI();
+        configureUI.deleteMetric(metricName2);
+
+        configureUI = goToConfigureMetricsUI();
+        assertTextNotPresent(metricName2);
     }
 
     @Test


### PR DESCRIPTION
#### Rationale
We can simplify the setup for QC metrics, make it possible to edit or delete dual-series configurations, and prevent errors from being as fatal.

#### Changes
* Assume all metric queries are in the `targetedms` schema
* Tolerate series without a label
* Don't let a bad query prevent imports of new documents
* Allow editing of metrics that define two different series

- [x] Automated tests
- [x] Manual testing @labkey-tchad 
