### PR TITLE
Constants for many commonly used role names in tests

### DIFF
--- a/test/src/org/labkey/test/tests/panoramapremium/TargetedMSQCPremiumTest.java
+++ b/test/src/org/labkey/test/tests/panoramapremium/TargetedMSQCPremiumTest.java
@@ -35,6 +35,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.labkey.test.components.targetedms.QCPlotsWebPart.QCPlotType.CUSUMm;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 6)
@@ -57,7 +58,7 @@ public class TargetedMSQCPremiumTest extends TargetedMSPremiumTest
     {
         setupFolder(FolderType.QC);
         _userHelper.createUser(USER);
-        new ApiPermissionsHelper(this).setUserPermissions(USER, "Reader");
+        new ApiPermissionsHelper(this).setUserPermissions(USER, READER_ROLE);
         importData(SProCoP_FILE);
     }
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSCalibrationCurveTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSCalibrationCurveTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 /**
  * Tests uploading Skyline documents that contain calibration curve settings. Makes sure that the calculated results
@@ -165,7 +166,7 @@ public class TargetedMSCalibrationCurveTest extends AbstractQuantificationTest
 
         // impersonate a reader, who should be able to change the settings/inputs but those don't get persisted
         pushLocation();
-        impersonateRole("Reader");
+        impersonateRole(READER_ROLE);
         popLocation();
         pkReportPage = new PKReportPage(getDriver(), 10);
         // uncheck all the SB1 and SB2 time inputs

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSInstrumentNicknameTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSInstrumentNicknameTest.java
@@ -32,6 +32,8 @@ import java.io.IOException;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 @Category({})
 public class TargetedMSInstrumentNicknameTest extends TargetedMSTest
@@ -105,8 +107,8 @@ public class TargetedMSInstrumentNicknameTest extends TargetedMSTest
 
         // give user reader permissions to all but FOLDER_1
         ApiPermissionsHelper permissionsHelper = new ApiPermissionsHelper(this);
-        permissionsHelper.addMemberToRole(USER, "Reader", PermissionsHelper.MemberType.user, getProjectName());
-        permissionsHelper.addMemberToRole(USER, "Editor", PermissionsHelper.MemberType.user, getProjectName() + "/" + NON_QC_SUB_FOLDER);
+        permissionsHelper.addMemberToRole(USER, READER_ROLE, PermissionsHelper.MemberType.user, getProjectName());
+        permissionsHelper.addMemberToRole(USER, EDITOR_ROLE, PermissionsHelper.MemberType.user, getProjectName() + "/" + NON_QC_SUB_FOLDER);
     }
 
     private void importInitialData()
@@ -182,7 +184,7 @@ public class TargetedMSInstrumentNicknameTest extends TargetedMSTest
         assertTextPresent(REPLICATE_NAME_WITH_SERIAL, FILE_PATH_WITH_SERIAL);
 
         String postImpersonationUrl = getDriver().getCurrentUrl();
-        impersonateRole("Reader");
+        impersonateRole(READER_ROLE);
         assertTextPresent(Q_EXACTIVE_SERIAL_ONLY, 1);  // Just the visible element, no form and hidden inputs for readers
         stopImpersonating();
         beginAt(postImpersonationUrl);
@@ -228,7 +230,7 @@ public class TargetedMSInstrumentNicknameTest extends TargetedMSTest
 
         String postImpersonationUrl = getDriver().getCurrentUrl();
         // Check we don't let readers save
-        impersonateRole("Reader");
+        impersonateRole(READER_ROLE);
         assertTextPresent("Currently saved in");
         assertElementNotPresent(Locator.lkButton("Save"));
         stopImpersonating();

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSLibraryTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSLibraryTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
@@ -308,7 +309,7 @@ public class TargetedMSLibraryTest extends TargetedMSTest
 
     private void verifyConflictsAsReadOnlyUser()
     {
-        impersonateRole("Reader");
+        impersonateRole(READER_ROLE);
         String[] conflictText = new String[] {"The chromatogram library in this folder is in a conflicted state and is awaiting action from a folder administrator to resolve the conflicts",
                 "The download link below is for the last stable version of the library."};
         assertTextPresent(conflictText);

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCSummaryTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCSummaryTest.java
@@ -54,6 +54,7 @@ import java.util.stream.Collectors;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 12)
@@ -147,10 +148,10 @@ public class TargetedMSQCSummaryTest extends TargetedMSTest
 
         // give user reader permissions to all but FOLDER_1
         ApiPermissionsHelper permissionsHelper = new ApiPermissionsHelper(this);
-        permissionsHelper.addMemberToRole(USER, "Reader", PermissionsHelper.MemberType.user, getProjectName());
-        permissionsHelper.addMemberToRole(USER, "Reader", PermissionsHelper.MemberType.user, getProjectName() + "/" + FOLDER_2);
-        permissionsHelper.addMemberToRole(USER, "Reader", PermissionsHelper.MemberType.user, getProjectName() + "/" + FOLDER_2 + "/" + FOLDER_2A);
-        permissionsHelper.addMemberToRole(USER, "Reader", PermissionsHelper.MemberType.user, getProjectName() + "/" + FOLDER_3);
+        permissionsHelper.addMemberToRole(USER, READER_ROLE, PermissionsHelper.MemberType.user, getProjectName());
+        permissionsHelper.addMemberToRole(USER, READER_ROLE, PermissionsHelper.MemberType.user, getProjectName() + "/" + FOLDER_2);
+        permissionsHelper.addMemberToRole(USER, READER_ROLE, PermissionsHelper.MemberType.user, getProjectName() + "/" + FOLDER_2 + "/" + FOLDER_2A);
+        permissionsHelper.addMemberToRole(USER, READER_ROLE, PermissionsHelper.MemberType.user, getProjectName() + "/" + FOLDER_3);
 
         // impersonate user and check that the project QC Summary doesn't include the FOLDER_1 details
         goToProjectHome();

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -64,6 +64,7 @@ import static org.labkey.test.components.targetedms.QCPlotsWebPart.QCPlotType.Me
 import static org.labkey.test.components.targetedms.QCPlotsWebPart.QCPlotType.MovingRange;
 import static org.labkey.test.components.targetedms.QCPlotsWebPart.QCPlotType.TrailingCV;
 import static org.labkey.test.components.targetedms.QCPlotsWebPart.QCPlotType.TrailingMean;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 35)
@@ -180,7 +181,7 @@ public class TargetedMSQCTest extends TargetedMSTest
     {
         setupFolder(FolderType.QC);
         _userHelper.createUser(USER);
-        new ApiPermissionsHelper(this).setUserPermissions(USER, "Reader");
+        new ApiPermissionsHelper(this).setUserPermissions(USER, READER_ROLE);
         importData(SProCoP_FILE);
         createAndInsertAnnotations();
     }

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSUtilizationCalendarTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSUtilizationCalendarTest.java
@@ -14,6 +14,8 @@ import org.openqa.selenium.NoSuchElementException;
 import java.sql.Timestamp;
 import java.util.Arrays;
 
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
+
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class TargetedMSUtilizationCalendarTest extends TargetedMSTest
@@ -89,7 +91,7 @@ public class TargetedMSUtilizationCalendarTest extends TargetedMSTest
     public void testReaderRoleAccessibility()
     {
         goToProjectHome();
-        impersonateRole("Reader");
+        impersonateRole(READER_ROLE);
         UtilizationCalendarWebPart utilizationCalendar = new PanoramaDashboard(this)
                 .getQcSummaryWebPart()
                 .gotoUtilizationCalendar();

--- a/test/src/org/labkey/test/tests/targetedms/passport/PassportTestPart.java
+++ b/test/src/org/labkey/test/tests/targetedms/passport/PassportTestPart.java
@@ -29,6 +29,8 @@ import org.openqa.selenium.WebElement;
 
 import java.nio.file.Paths;
 
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
+
 
 public abstract class PassportTestPart extends BaseWebDriverTest
 {
@@ -45,7 +47,7 @@ public abstract class PassportTestPart extends BaseWebDriverTest
     {
         _containerHelper.createProject(getProjectName(), "Collaboration");
         ApiPermissionsHelper h = new ApiPermissionsHelper(this);
-        h.addMemberToRole(NORMAL_USER, "Reader", PermissionsHelper.MemberType.user);
+        h.addMemberToRole(NORMAL_USER, READER_ROLE, PermissionsHelper.MemberType.user);
 
         goToFolderManagement().
                 goToFolderTypeTab().


### PR DESCRIPTION
#### Rationale
There's an exciting new computer science concept - using constants instead of many copies of hard-code values. Let's give it a try with our most commonly used role names in automated tests.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/2703

#### Changes
- Common role names available in PermissionsHelper
- Update tests to use them