### PR TITLE
Return Set<Class<?>> from Module "get test" methods

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -686,9 +686,8 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
         TargetedMSService.get().registerSkylineDocumentImportListener(QCNotificationSender.get());
     }
 
-    @NotNull
     @Override
-    public Set<Class> getIntegrationTests()
+    public @NotNull Set<Class<?>> getIntegrationTests()
     {
         return Set.of(
             MsDataSourceUtil.TestCase.class,
@@ -696,9 +695,8 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
         );
     }
 
-    @NotNull
     @Override
-    public Set<Class> getUnitTests()
+    public @NotNull Set<Class<?>> getUnitTests()
     {
         return Set.of(
             ComparisonCategory.TestCase.class,

--- a/src/org/labkey/targetedms/TargetedMsRepresentativeStateAuditProvider.java
+++ b/src/org/labkey/targetedms/TargetedMsRepresentativeStateAuditProvider.java
@@ -40,8 +40,8 @@ public class TargetedMsRepresentativeStateAuditProvider extends AbstractAuditTyp
 
     static final List<FieldKey> defaultVisibleColumns = new ArrayList<>();
 
-    static {
-
+    static
+    {
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_CREATED));
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_CREATED_BY));
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_IMPERSONATED_BY));
@@ -50,10 +50,9 @@ public class TargetedMsRepresentativeStateAuditProvider extends AbstractAuditTyp
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_COMMENT));
     }
 
-    @Override
-    protected AbstractAuditDomainKind getDomainKind()
+    public TargetedMsRepresentativeStateAuditProvider()
     {
-        return new TargetedMsRepresentativeStateAuditDomainKind();
+        super(new TargetedMsRepresentativeStateAuditDomainKind());
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Eliminate IntelliJ warnings caused by `Module` methods `getUnitTests()` and `getIntegrationTests()` returning raw `Set<Class>`; they now return `Set<Class<?>>`.

Also, eliminate use of the deprecated `AbstractAuditTypeProvider()` constructor and overrides of `getDomainKind()` in its subclasses; we now always call the constructor that passes in a `DomainKind`.