### PR TITLE
Improve QC folder plot controls

### DIFF
--- a/resources/views/configureQCGroups.html
+++ b/resources/views/configureQCGroups.html
@@ -60,12 +60,12 @@
                     LABKEY.QueryWebPart.standardButtons.print,
                     LABKEY.QueryWebPart.standardButtons.pageSize,
                     {
-                        text: 'Mark As Included',
+                        text: 'Include',
                         requiresSelection: 'true',
                         handler: markPrecursorAsIncludedHandler
                     },
                     {
-                        text: 'Mark As Excluded',
+                        text: 'Exclude',
                         requiresSelection: 'true',
                         handler: markPrecursorAsExcludedHandler
                     }

--- a/src/org/labkey/targetedms/view/qcTrendPlotReport.jsp
+++ b/src/org/labkey/targetedms/view/qcTrendPlotReport.jsp
@@ -56,7 +56,8 @@
     String plotPanelId = "tiledPlotPanel-" + uid;
     String plotPaginationPanelId = "plotPaginationPanel-" + uid;
 %>
-
+<!-- Help ExtJS plot controls reliably grab the width they need -->
+<div style="height: 1px; width: 1250px;"></div>
 <div id="<%=h(reportPanelId)%>"></div>
 <div id="<%=h(plotPaginationPanelId)%>" class="plotPaginationHeaderPanel"></div>
 <div id="<%=h(plotPanelId)%>" class="tiledPlotPanel"></div>

--- a/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
@@ -427,7 +427,7 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
             resetInitialQCPlotFields();
         }
 
-        filterQCPlots("2013-08-09", "2013-08-27", expectedPlotCount);
+        filterQCPlots("2013-08-09", "2013-08-27", resetForm);
     }
 
     @LogMethod
@@ -444,14 +444,18 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
     }
 
     @LogMethod
-    public void filterQCPlots(@LoggedParam String startDate, @LoggedParam String endDate, int expectedPlotCount)
+    public void filterQCPlots(@LoggedParam String startDate, @LoggedParam String endDate, boolean waitForPlotsToRefresh)
     {
         setDateRangeOffset(DateRangeOffset.CUSTOM);
         setStartDate(startDate);
-        doAndWaitForUpdate(() ->
+        if (waitForPlotsToRefresh)
+        {
+            doAndWaitForUpdate(() -> setEndDate(endDate));
+        }
+        else
         {
             setEndDate(endDate);
-        });
+        }
     }
 
     public int getGuideSetTrainingRectCount()

--- a/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
@@ -20,8 +20,8 @@ import org.labkey.test.Locator;
 import org.labkey.test.Locators;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.BodyWebPart;
-import org.labkey.test.components.ext4.Checkbox;
 import org.labkey.test.components.ext4.ComboBox;
+import org.labkey.test.components.ext4.RadioButton;
 import org.labkey.test.components.ext4.Window;
 import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.LogMethod;
@@ -280,14 +280,10 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
         // 'check' means show all series combined in a single plot
         try
         {
-            boolean currentlyCombined = elementCache().showPlotsCombined.isSelected();
-            if (currentlyCombined != check)
-            {
-                if (check)
-                    doAndWaitForUpdate(() -> elementCache().showPlotsCombined.click());
-                else
-                    doAndWaitForUpdate(() -> elementCache().showPlotsPerPrecursor.click());
-            }
+            if (check)
+                doAndWaitForUpdate(() -> elementCache().plotsCombinedRadio.check());
+            else
+                doAndWaitForUpdate(() -> elementCache().plotsPerPrecursorRadio.check());
         }
         catch (NoSuchElementException | StaleElementReferenceException e)
         {
@@ -306,34 +302,58 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
 
     public void setShowExcludedPoints(boolean check)
     {
-        elementCache().showExcludedCheckbox.set(check);
+        if (check)
+        {
+            elementCache().excludedReplicatesShow.check();
+        }
+        else
+        {
+            elementCache().excludedReplicatesHide.check();
+        }
     }
 
     public boolean isShowExcludedPointsChecked()
     {
-        return elementCache().showExcludedCheckbox.isChecked();
+        // TODO
+        return elementCache().excludedReplicatesShow.isChecked();
     }
 
     public void setShowReferenceGuideSet(boolean check)
     {
-        elementCache().showReferenceGuideSet.set(check);
+        if (check)
+        {
+            elementCache().referenceGuideSetShow.check();
+        }
+        else
+        {
+            elementCache().referenceGuideSetHide.check();
+        }
     }
 
     public void setShowExcludedPrecursors(boolean check)
     {
-        elementCache().showExcludedPrecursors.set(check);
+        if (check)
+        {
+            elementCache().excludedPrecursorsShow.check();
+        }
+        else
+        {
+            elementCache().excludedPrecursorsHide.check();
+        }
     }
 
     public boolean isShowReferenceGuideSetChecked()
     {
-        return elementCache().showReferenceGuideSet.isChecked();
+        // TODO
+        return elementCache().referenceGuideSetShow.isChecked();
     }
 
     public boolean isShowAllPeptidesInSinglePlotChecked()
     {
         try
         {
-            return elementCache().showPlotsCombined.isSelected();
+            // TODO
+            return elementCache().plotsCombinedRadio.isSelected();
         }
         catch (NoSuchElementException | StaleElementReferenceException e)
         {
@@ -352,11 +372,6 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
     {
         clickMenuItem("Revert to Default View");
         return this;
-    }
-
-    public void applyRange()
-    {
-        doAndWaitForUpdate(() -> elementCache().applyRangeButton.click());
     }
 
     public void waitForPlots(Integer plotCount)
@@ -427,7 +442,6 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
         setDateRangeOffset(DateRangeOffset.CUSTOM);
         setStartDate(startDate);
         setEndDate(endDate);
-        applyRange();
         waitForPlots(expectedPlotCount);
     }
 
@@ -905,14 +919,18 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
         WebElement groupedXPerReplicate = Locator.css("#grouped-x-field input[value=replicate]").findWhenNeeded(this);
         WebElement groupedXPerDate = Locator.css("#grouped-x-field input[value=date]").findWhenNeeded(this);
         WebElement showPlotsPerPrecursor = Locator.css("#peptides-single-plot input[value=per-precursor]").findWhenNeeded(this);
-        WebElement showPlotsCombined = Locator.css("#peptides-single-plot input[value=combined]").findWhenNeeded(this);
-        Checkbox showExcludedCheckbox = new Checkbox(Locator.css("#show-excluded-points input")
-                .findWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT));
-        Checkbox showReferenceGuideSet = new Checkbox(Locator.css("#show-oorange-gs input")
-                .findWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT));
-        Checkbox showExcludedPrecursors = new Checkbox(Locator.css("#show-excluded-precursors input")
-                .findWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT));
 
+        RadioButton plotsCombinedRadio = new RadioButton(Locator.id("plots-combined").findWhenNeeded(getDriver()));
+        RadioButton plotsPerPrecursorRadio = new RadioButton(Locator.id("plots-per-precursor").findWhenNeeded(getDriver()));
+
+        RadioButton excludedReplicatesShow = new RadioButton(Locator.id("excluded-replicates-show").findWhenNeeded(getDriver()));
+        RadioButton excludedReplicatesHide = new RadioButton(Locator.id("excluded-replicates-hide").findWhenNeeded(getDriver()));
+
+        RadioButton excludedPrecursorsShow = new RadioButton(Locator.id("excluded-precursors-show").findWhenNeeded(getDriver()));
+        RadioButton excludedPrecursorsHide = new RadioButton(Locator.id("excluded-precursors-hide").findWhenNeeded(getDriver()));
+
+        RadioButton referenceGuideSetShow = new RadioButton(Locator.id("reference-guide-set-show").findWhenNeeded(getDriver()));
+        RadioButton referenceGuideSetHide = new RadioButton(Locator.id("reference-guide-set-hide").findWhenNeeded(getDriver()));
 
         WebElement plotPanel = Locator.css("div.tiledPlotPanel").findWhenNeeded(this);
         WebElement paginationPanel = Locator.css("div.plotPaginationHeaderPanel").findWhenNeeded(this);

--- a/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
@@ -252,17 +252,19 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
 
     public void setGroupXAxisValuesByDate(boolean check)
     {
-        if (check)
-            doAndWaitForUpdate(() -> elementCache().xAxisGroupingDateRadio.check());
-        else
-            doAndWaitForUpdate(() -> elementCache().xAxisGroupingReplicateRadio.check());
+        if (isGroupXAxisValuesByDateChecked() != check)
+        {
+            if (check)
+                doAndWaitForUpdate(() -> elementCache().xAxisGroupingDateRadio.check());
+            else
+                doAndWaitForUpdate(() -> elementCache().xAxisGroupingReplicateRadio.check());
+        }
     }
 
     public boolean isGroupXAxisValuesByDateChecked()
     {
         try
         {
-            // TODO
             return elementCache().xAxisGroupingDateRadio.isSelected();
         }
         catch (NoSuchElementException | StaleElementReferenceException e)
@@ -277,10 +279,13 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
         // 'check' means show all series combined in a single plot
         try
         {
-            if (check)
-                doAndWaitForUpdate(() -> elementCache().plotsCombinedRadio.check());
-            else
-                doAndWaitForUpdate(() -> elementCache().plotsPerPrecursorRadio.check());
+            if (isShowAllPeptidesInSinglePlotChecked() != check)
+            {
+                if (check)
+                    doAndWaitForUpdate(() -> elementCache().plotsCombinedRadio.check());
+                else
+                    doAndWaitForUpdate(() -> elementCache().plotsPerPrecursorRadio.check());
+            }
         }
         catch (NoSuchElementException | StaleElementReferenceException e)
         {
@@ -311,19 +316,21 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
 
     public boolean isShowExcludedPointsChecked()
     {
-        // TODO
         return elementCache().excludedReplicatesShow.isChecked();
     }
 
     public void setShowReferenceGuideSet(boolean check)
     {
-        if (check)
+        if (isShowExcludedPointsChecked() != check)
         {
-            elementCache().referenceGuideSetShow.check();
-        }
-        else
-        {
-            elementCache().referenceGuideSetHide.check();
+            if (check)
+            {
+                elementCache().referenceGuideSetShow.check();
+            }
+            else
+            {
+                elementCache().referenceGuideSetHide.check();
+            }
         }
     }
 
@@ -341,7 +348,6 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
 
     public boolean isShowReferenceGuideSetChecked()
     {
-        // TODO
         return elementCache().referenceGuideSetShow.isChecked();
     }
 
@@ -349,7 +355,6 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
     {
         try
         {
-            // TODO
             return elementCache().plotsCombinedRadio.isSelected();
         }
         catch (NoSuchElementException | StaleElementReferenceException e)
@@ -915,20 +920,22 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
                 .findWhenNeeded(this).setMatcher(Ext4Helper.TextMatchTechnique.CONTAINS).setMultiSelect(true);
         WebElement groupedXPerReplicate = Locator.css("#grouped-x-field input[value=replicate]").findWhenNeeded(this);
 
-        RadioButton xAxisGroupingReplicateRadio = new RadioButton(Locator.id("x-axis-grouping-replicate").findWhenNeeded(getDriver()));
-        RadioButton xAxisGroupingDateRadio = new RadioButton(Locator.id("x-axis-grouping-date").findWhenNeeded(getDriver()));
+        RadioButton xAxisGroupingReplicateRadio = new RadioButton.RadioButtonFinder().withLabel("per replicate").findWhenNeeded(getDriver());
+        RadioButton xAxisGroupingDateRadio = new RadioButton.RadioButtonFinder().withLabel("per date").findWhenNeeded(getDriver());
 
-        RadioButton plotsCombinedRadio = new RadioButton(Locator.id("plots-combined").findWhenNeeded(getDriver()));
-        RadioButton plotsPerPrecursorRadio = new RadioButton(Locator.id("plots-per-precursor").findWhenNeeded(getDriver()));
+        RadioButton plotsCombinedRadio = new RadioButton.RadioButtonFinder().withLabel("combined").findWhenNeeded(getDriver());
+        RadioButton plotsPerPrecursorRadio = new RadioButton.RadioButtonFinder().withLabel("per precursor").findWhenNeeded(getDriver());
 
-        RadioButton excludedReplicatesShow = new RadioButton(Locator.id("excluded-replicates-show").findWhenNeeded(getDriver()));
-        RadioButton excludedReplicatesHide = new RadioButton(Locator.id("excluded-replicates-hide").findWhenNeeded(getDriver()));
+        // These have the same label as another group, but are first in the page
+        RadioButton excludedReplicatesShow = new RadioButton.RadioButtonFinder().withLabel("show").findWhenNeeded(getDriver());
+        RadioButton excludedReplicatesHide = new RadioButton.RadioButtonFinder().withLabel("hide").findWhenNeeded(getDriver());
 
+        // Note that these two won't work with the isChecked() call but they have the same labels as the ones above so we can't simply check by label
         RadioButton excludedPrecursorsShow = new RadioButton(Locator.id("excluded-precursors-show").findWhenNeeded(getDriver()));
         RadioButton excludedPrecursorsHide = new RadioButton(Locator.id("excluded-precursors-hide").findWhenNeeded(getDriver()));
 
-        RadioButton referenceGuideSetShow = new RadioButton(Locator.id("reference-guide-set-show").findWhenNeeded(getDriver()));
-        RadioButton referenceGuideSetHide = new RadioButton(Locator.id("reference-guide-set-hide").findWhenNeeded(getDriver()));
+        RadioButton referenceGuideSetShow = new RadioButton.RadioButtonFinder().withLabel("always show").findWhenNeeded(getDriver());
+        RadioButton referenceGuideSetHide = new RadioButton.RadioButtonFinder().withLabel("when in date range").findWhenNeeded(getDriver());
 
         WebElement plotPanel = Locator.css("div.tiledPlotPanel").findWhenNeeded(this);
         WebElement paginationPanel = Locator.css("div.plotPaginationHeaderPanel").findWhenNeeded(this);

--- a/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
@@ -446,10 +446,10 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
     @LogMethod
     public void filterQCPlots(@LoggedParam String startDate, @LoggedParam String endDate, int expectedPlotCount)
     {
+        setDateRangeOffset(DateRangeOffset.CUSTOM);
+        setStartDate(startDate);
         doAndWaitForUpdate(() ->
         {
-            setDateRangeOffset(DateRangeOffset.CUSTOM);
-            setStartDate(startDate);
             setEndDate(endDate);
         });
     }

--- a/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
@@ -321,7 +321,7 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
 
     public void setShowReferenceGuideSet(boolean check)
     {
-        if (isShowExcludedPointsChecked() != check)
+        if (isShowReferenceGuideSetChecked() != check)
         {
             if (check)
             {

--- a/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
@@ -252,22 +252,46 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
 
     public void setGroupXAxisValuesByDate(boolean check)
     {
-        if (elementCache().groupedXCheckbox.get() != check)
+        boolean currentlyByDate = isGroupXAxisValuesByDateChecked();
+        if (currentlyByDate != check)
         {
-            doAndWaitForUpdate(() -> elementCache().groupedXCheckbox.set(check));
+            if (check)
+                doAndWaitForUpdate(() -> elementCache().groupedXPerDate.click());
+            else
+                doAndWaitForUpdate(() -> elementCache().groupedXPerReplicate.click());
         }
     }
 
     public boolean isGroupXAxisValuesByDateChecked()
     {
-        return elementCache().groupedXCheckbox.isChecked();
+        try
+        {
+            return elementCache().groupedXPerDate.isSelected();
+        }
+        catch (NoSuchElementException | StaleElementReferenceException e)
+        {
+            // Fallback: if radios are not present yet, assume unchecked
+            return false;
+        }
     }
 
     public void setShowAllPeptidesInSinglePlot(boolean check)
     {
-        if (elementCache().singlePlotCheckbox.get() != check)
+        // 'check' means show all series combined in a single plot
+        try
         {
-            doAndWaitForUpdate(() -> elementCache().singlePlotCheckbox.set(check));
+            boolean currentlyCombined = elementCache().showPlotsCombined.isSelected();
+            if (currentlyCombined != check)
+            {
+                if (check)
+                    doAndWaitForUpdate(() -> elementCache().showPlotsCombined.click());
+                else
+                    doAndWaitForUpdate(() -> elementCache().showPlotsPerPrecursor.click());
+            }
+        }
+        catch (NoSuchElementException | StaleElementReferenceException e)
+        {
+            // Fallback: ignore if control not present yet
         }
     }
 
@@ -307,7 +331,14 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
 
     public boolean isShowAllPeptidesInSinglePlotChecked()
     {
-        return elementCache().singlePlotCheckbox.isChecked();
+        try
+        {
+            return elementCache().showPlotsCombined.isSelected();
+        }
+        catch (NoSuchElementException | StaleElementReferenceException e)
+        {
+            return false;
+        }
     }
 
     public QCPlotsWebPart saveAsDefaultView()
@@ -871,10 +902,10 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
 
         ComboBox qcPlotTypeCombo = new ComboBox.ComboBoxFinder(getDriver()).withIdPrefix("qc-plot-type-with-y-options")
                 .findWhenNeeded(this).setMatcher(Ext4Helper.TextMatchTechnique.CONTAINS).setMultiSelect(true);
-        Checkbox groupedXCheckbox = new Checkbox(Locator.css("#grouped-x-field input")
-                .findWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT));
-        Checkbox singlePlotCheckbox = new Checkbox(Locator.css("#peptides-single-plot input")
-                .findWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT));
+        WebElement groupedXPerReplicate = Locator.css("#grouped-x-field input[value=replicate]").findWhenNeeded(this);
+        WebElement groupedXPerDate = Locator.css("#grouped-x-field input[value=date]").findWhenNeeded(this);
+        WebElement showPlotsPerPrecursor = Locator.css("#peptides-single-plot input[value=per-precursor]").findWhenNeeded(this);
+        WebElement showPlotsCombined = Locator.css("#peptides-single-plot input[value=combined]").findWhenNeeded(this);
         Checkbox showExcludedCheckbox = new Checkbox(Locator.css("#show-excluded-points input")
                 .findWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT));
         Checkbox showReferenceGuideSet = new Checkbox(Locator.css("#show-oorange-gs input")

--- a/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
@@ -389,6 +389,11 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
         }
     }
 
+    public boolean isCombinedPlotControlVisible()
+    {
+        return elementCache().plotsCombinedRadio.isDisplayed();
+    }
+
     public List<QCPlot> getPlots()
     {
         return elementCache().findSeriesPanels().stream().map(QCPlot::new).toList();
@@ -441,10 +446,12 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
     @LogMethod
     public void filterQCPlots(@LoggedParam String startDate, @LoggedParam String endDate, int expectedPlotCount)
     {
-        setDateRangeOffset(DateRangeOffset.CUSTOM);
-        setStartDate(startDate);
-        setEndDate(endDate);
-        waitForPlots(expectedPlotCount);
+        doAndWaitForUpdate(() ->
+        {
+            setDateRangeOffset(DateRangeOffset.CUSTOM);
+            setStartDate(startDate);
+            setEndDate(endDate);
+        });
     }
 
     public int getGuideSetTrainingRectCount()

--- a/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
@@ -252,21 +252,18 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
 
     public void setGroupXAxisValuesByDate(boolean check)
     {
-        boolean currentlyByDate = isGroupXAxisValuesByDateChecked();
-        if (currentlyByDate != check)
-        {
-            if (check)
-                doAndWaitForUpdate(() -> elementCache().groupedXPerDate.click());
-            else
-                doAndWaitForUpdate(() -> elementCache().groupedXPerReplicate.click());
-        }
+        if (check)
+            doAndWaitForUpdate(() -> elementCache().xAxisGroupingDateRadio.check());
+        else
+            doAndWaitForUpdate(() -> elementCache().xAxisGroupingReplicateRadio.check());
     }
 
     public boolean isGroupXAxisValuesByDateChecked()
     {
         try
         {
-            return elementCache().groupedXPerDate.isSelected();
+            // TODO
+            return elementCache().xAxisGroupingDateRadio.isSelected();
         }
         catch (NoSuchElementException | StaleElementReferenceException e)
         {
@@ -917,8 +914,9 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
         ComboBox qcPlotTypeCombo = new ComboBox.ComboBoxFinder(getDriver()).withIdPrefix("qc-plot-type-with-y-options")
                 .findWhenNeeded(this).setMatcher(Ext4Helper.TextMatchTechnique.CONTAINS).setMultiSelect(true);
         WebElement groupedXPerReplicate = Locator.css("#grouped-x-field input[value=replicate]").findWhenNeeded(this);
-        WebElement groupedXPerDate = Locator.css("#grouped-x-field input[value=date]").findWhenNeeded(this);
-        WebElement showPlotsPerPrecursor = Locator.css("#peptides-single-plot input[value=per-precursor]").findWhenNeeded(this);
+
+        RadioButton xAxisGroupingReplicateRadio = new RadioButton(Locator.id("x-axis-grouping-replicate").findWhenNeeded(getDriver()));
+        RadioButton xAxisGroupingDateRadio = new RadioButton(Locator.id("x-axis-grouping-date").findWhenNeeded(getDriver()));
 
         RadioButton plotsCombinedRadio = new RadioButton(Locator.id("plots-combined").findWhenNeeded(getDriver()));
         RadioButton plotsPerPrecursorRadio = new RadioButton(Locator.id("plots-per-precursor").findWhenNeeded(getDriver()));

--- a/test/src/org/labkey/test/tests/panoramapremium/TargetedMSHidePeptidesAndMolecules.java
+++ b/test/src/org/labkey/test/tests/panoramapremium/TargetedMSHidePeptidesAndMolecules.java
@@ -128,9 +128,9 @@ public class TargetedMSHidePeptidesAndMolecules extends TargetedMSTest
         DataRegionTable table = gotoIncludeExcludeMenu();
         table.checkCheckbox(rowIndex);
         if (action.equals("Excluded"))
-            table.doAndWaitForUpdate(() -> table.clickHeaderButton("Mark As Excluded"));
+            table.doAndWaitForUpdate(() -> table.clickHeaderButton("Exclude"));
         else
-            table.doAndWaitForUpdate(() -> table.clickHeaderButton("Mark As Included"));
+            table.doAndWaitForUpdate(() -> table.clickHeaderButton("Include"));
         checker().withScreenshot("MarkedAsColumnUpdate_" + folderName).verifyEquals("Marked As column not updated with selection of action", action, table.getDataAsText(rowIndex, "markedAs"));
 
         log("Verifying targetedms.ExcludedPrecursors table gets updated with action");

--- a/test/src/org/labkey/test/tests/panoramapremium/TargetedMSQCFolderImportExport.java
+++ b/test/src/org/labkey/test/tests/panoramapremium/TargetedMSQCFolderImportExport.java
@@ -153,6 +153,6 @@ public class TargetedMSQCFolderImportExport extends TargetedMSPremiumTest
         qcSummaryWebPart.clickMenuItem("Configure Included and Excluded Precursors");
         DataRegionTable table = new DataRegionTable.DataRegionFinder(getDriver()).waitFor();
         table.checkCheckbox(rowNum);
-        table.clickHeaderButton("Mark As Excluded");
+        table.clickHeaderButton("Exclude");
     }
 }

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentalQCLinkTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentalQCLinkTest.java
@@ -153,7 +153,7 @@ public class TargetedMSExperimentalQCLinkTest extends TargetedMSTest
 
         String testStartDate = "2013-08-18";
         String testEndDate = "2013-08-27";
-        qcPlotsWebPart.filterQCPlots(testStartDate, testEndDate, 7);
+        qcPlotsWebPart.filterQCPlots(testStartDate, testEndDate, true);
 
         checker().verifyTrue("The graph is not divided by line separator",
                 isElementPresent(Locator.tagWithAttribute("line", "class", "separator")));

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSIrtTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSIrtTest.java
@@ -33,7 +33,7 @@ public abstract class TargetedMSIrtTest extends TargetedMSTest
     private static final String SCHEMA = "targetedms";
     private static final String QUERY = "iRTPeptide";
 
-    // All tests use varations of this test dataset.
+    // All tests use variations of this test dataset.
     protected static final String SKY_FILE = "iRT Human+Standard Calibrate.zip";
     protected static final int PEPTIDE_COUNT = 716;
     protected static final double DELTA = 0.00001;

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSPeptideSummaryHeatmapTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSPeptideSummaryHeatmapTest.java
@@ -76,7 +76,7 @@ public class TargetedMSPeptideSummaryHeatmapTest extends TargetedMSTest
         qcPlotsWebPart = new PanoramaDashboard(this).getQcPlotsWebPart();
         qcPlotsWebPart.waitForReady();
         assertEquals("Date Range Offset not set to default value", QCPlotsWebPart.DateRangeOffset.LAST_7_DAYS, qcPlotsWebPart.getCurrentDateRangeOffset());
-        qcPlotsWebPart.filterQCPlots("2013-08-10", "2013-08-15", 7);
+        qcPlotsWebPart.filterQCPlots("2013-08-10", "2013-08-15", true);
 
         // Now navigate through the link instead of the custom tab and webpart
         waitAndClickAndWait(Locator.linkContainingText("View all 47 replicates"));

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCGuideSetTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCGuideSetTest.java
@@ -208,6 +208,7 @@ public class TargetedMSQCGuideSetTest extends TargetedMSTest
         qcPlotsWebPart.filterQCPlots("2013-08-19", "2013-08-19", PRECURSORS.length);
         shapeCounts = new ArrayList<>();
         shapeCounts.add(Pair.of(SvgShapes.CIRCLE.getPathPrefix(), 14));
+        qcPlotsWebPart = new QCPlotsWebPart(getDriver());
         verifyGuideSetRelatedElementsForPlots(qcPlotsWebPart, 0, shapeCounts, 2);
     }
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCGuideSetTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCGuideSetTest.java
@@ -205,7 +205,7 @@ public class TargetedMSQCGuideSetTest extends TargetedMSTest
         qcPlotsWebPart.setGroupXAxisValuesByDate(false);
 
         // filter plot by start/end date to check reference points without training points in view
-        qcPlotsWebPart.filterQCPlots("2013-08-19", "2013-08-19", PRECURSORS.length);
+        qcPlotsWebPart.filterQCPlots("2013-08-19", "2013-08-19", true);
         shapeCounts = new ArrayList<>();
         shapeCounts.add(Pair.of(SvgShapes.CIRCLE.getPathPrefix(), 14));
         qcPlotsWebPart = new QCPlotsWebPart(getDriver());

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -63,7 +63,6 @@ import static org.labkey.test.components.targetedms.QCPlotsWebPart.QCPlotType.CU
 import static org.labkey.test.components.targetedms.QCPlotsWebPart.QCPlotType.MetricValue;
 import static org.labkey.test.components.targetedms.QCPlotsWebPart.QCPlotType.MovingRange;
 import static org.labkey.test.components.targetedms.QCPlotsWebPart.QCPlotType.TrailingCV;
-import static org.labkey.test.components.targetedms.QCPlotsWebPart.QCPlotType.TrailingMean;
 import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 @Category({})
@@ -349,7 +348,7 @@ public class TargetedMSQCTest extends TargetedMSTest
         qcPlotsWebPart.setScale(QCPlotsWebPart.Scale.PERCENT_OF_MEAN);
         qcPlotsWebPart.setGroupXAxisValuesByDate(true);
         qcPlotsWebPart.setShowAllPeptidesInSinglePlot(true, 1);
-        qcPlotsWebPart.filterQCPlots(testDateStr, testDateStr, 1);
+        qcPlotsWebPart.filterQCPlots(testDateStr, testDateStr, true);
         int count = qcPlotsWebPart.getPointElements("d", SvgShapes.CIRCLE.getPathPrefix(), true).size();
         assertEquals("Unexpected number of points for '" + testDateStr + "'", 21, count);
 
@@ -546,10 +545,10 @@ public class TargetedMSQCTest extends TargetedMSTest
         QCPlotsWebPart qcPlotsWebPart = qcDashboard.getQcPlotsWebPart();
         qcPlotsWebPart.filterQCPlotsToInitialData(PRECURSORS.length, true);
 
-        qcPlotsWebPart.filterQCPlots("2014-08-09", "2014-08-27", 0);
-
-        // reset to avoid test case dependency
-        qcPlotsWebPart.resetInitialQCPlotFields();
+        qcPlotsWebPart.filterQCPlots("2015-08-09", "2014-08-27", false);
+        waitForText("Please enter an end date that does not occur before the start date.");
+        qcPlotsWebPart.filterQCPlots("2014-08-09", "2014-08-27", false);
+        waitForText("There were no records found");
     }
 
     @Test

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -190,6 +190,9 @@ public class TargetedMSQCTest extends TargetedMSTest
     public void preTest()
     {
         goToProjectHome();
+        PanoramaDashboard qcDashboard = new PanoramaDashboard(this);
+        QCPlotsWebPart qcPlotsWebPart = qcDashboard.getQcPlotsWebPart();
+        qcPlotsWebPart.revertToDefaultView();
     }
 
     @Test

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -697,10 +697,10 @@ public class TargetedMSQCTest extends TargetedMSTest
         String ticPlotSVGText = qcPlotsWebPart.getSVGPlotText("precursorPlot0");
         assertFalse(ticPlotSVGText.isEmpty());
 
-        log("Verifying Show All Series Checkbox");
-        assertElementNotVisible(Locator.tagContainingText("label", "Show All Series in a Single Plot"));
+        log("Verifying combined/per-precursor plot controls");
+        assertFalse(qcPlotsWebPart.isCombinedPlotControlVisible());
         qcPlotsWebPart.setMetric1Type(QCPlotsWebPart.MetricType.RETENTION);
-        assertElementVisible(Locator.tagContainingText("label", "Show All Series in a Single Plot"));
+        assertTrue(qcPlotsWebPart.isCombinedPlotControlVisible());
 
         log("Verifying tic_area information in hover plot");
         qcPlotsWebPart.setMetric1Type(QCPlotsWebPart.MetricType.TIC_AREA);

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSTrailingMeanAndCVTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSTrailingMeanAndCVTest.java
@@ -69,8 +69,6 @@ public class TargetedMSTrailingMeanAndCVTest extends TargetedMSTest
         qcPlotsWebPart.setQCPlotTypes(QCPlotsWebPart.QCPlotType.MetricValue, QCPlotsWebPart.QCPlotType.TrailingMean);
         waitForText("TrailingMean - The number you entered is larger than the number of available runs. Only 47 runs are used for calculation");
         checker().verifyEquals("Incorrect plot count", REPLICATE_COUNT , qcPlotsWebPart.getPlots().size());
-        checker().verifyEquals("Incorrect number of times error message was displayed", REPLICATE_COUNT,
-                Locators.labkeyError.findElements(getDriver()).size());
 
         log("Verifying y-axis value based on metric type");
         trailingLast = "3";
@@ -150,8 +148,6 @@ public class TargetedMSTrailingMeanAndCVTest extends TargetedMSTest
         qcPlotsWebPart.setQCPlotTypes(QCPlotsWebPart.QCPlotType.MetricValue, QCPlotsWebPart.QCPlotType.TrailingCV);
         waitForText("TrailingCV - The number you entered is larger than the number of available runs. Only 47 runs are used for calculation");
         checker().verifyEquals("Incorrect plot count", REPLICATE_COUNT , qcPlotsWebPart.getPlots().size());
-        checker().verifyEquals("Incorrect number of times error message was displayed", REPLICATE_COUNT,
-                Locators.labkeyError.findElements(getDriver()).size());
 
         trailingLast = "3";
         qcPlotsWebPart.setQCPlotTypes(QCPlotsWebPart.QCPlotType.TrailingCV);

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSTrailingMeanAndCVTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSTrailingMeanAndCVTest.java
@@ -62,14 +62,12 @@ public class TargetedMSTrailingMeanAndCVTest extends TargetedMSTest
         log("Verifying error checking on trailing last number");
         trailingLast = "-1";
         qcPlotsWebPart.setTrailingLast(trailingLast);
-        longWait().until(ExpectedConditions.textToBePresentInElement(Locators.labkeyError.findWhenNeeded(getDriver()),
-                "TrailingMean - Please enter a positive integer (>2) that is less than or equal to the total number of available runs - 47"));
+        waitForText("TrailingMean - Please enter a positive integer (>2) that is less than or equal to the total number of available runs - 47");
 
         trailingLast = "48";
         qcPlotsWebPart.setTrailingLast(trailingLast);
         qcPlotsWebPart.setQCPlotTypes(QCPlotsWebPart.QCPlotType.MetricValue, QCPlotsWebPart.QCPlotType.TrailingMean);
-        longWait().until(ExpectedConditions.textToBePresentInElement(Locators.labkeyError.findWhenNeeded(getDriver()),
-                "TrailingMean - The number you entered is larger than the number of available runs. Only 47 runs are used for calculation"));
+        waitForText("TrailingMean - The number you entered is larger than the number of available runs. Only 47 runs are used for calculation");
         checker().verifyEquals("Incorrect plot count", REPLICATE_COUNT , qcPlotsWebPart.getPlots().size());
         checker().verifyEquals("Incorrect number of times error message was displayed", REPLICATE_COUNT,
                 Locators.labkeyError.findElements(getDriver()).size());
@@ -145,14 +143,12 @@ public class TargetedMSTrailingMeanAndCVTest extends TargetedMSTest
         log("Verifying error checking on trailing last number");
         trailingLast = "-1";
         qcPlotsWebPart.setTrailingLast(trailingLast);
-        longWait().until(ExpectedConditions.textToBePresentInElement(Locators.labkeyError.findWhenNeeded(getDriver()),
-                "TrailingCV - Please enter a positive integer (>2) that is less than or equal to the total number of available runs - 47"));
+        waitForText("TrailingCV - Please enter a positive integer (>2) that is less than or equal to the total number of available runs - 47");
 
         trailingLast = "48";
         qcPlotsWebPart.setTrailingLast(trailingLast);
         qcPlotsWebPart.setQCPlotTypes(QCPlotsWebPart.QCPlotType.MetricValue, QCPlotsWebPart.QCPlotType.TrailingCV);
-        longWait().until(ExpectedConditions.textToBePresentInElement(Locators.labkeyError.findWhenNeeded(getDriver()),
-                "TrailingCV - The number you entered is larger than the number of available runs. Only 47 runs are used for calculation"));
+        waitForText("TrailingCV - The number you entered is larger than the number of available runs. Only 47 runs are used for calculation");
         checker().verifyEquals("Incorrect plot count", REPLICATE_COUNT , qcPlotsWebPart.getPlots().size());
         checker().verifyEquals("Incorrect number of times error message was displayed", REPLICATE_COUNT,
                 Locators.labkeyError.findElements(getDriver()).size());

--- a/webapp/TargetedMS/css/qcTrendPlotReport.css
+++ b/webapp/TargetedMS/css/qcTrendPlotReport.css
@@ -103,3 +103,7 @@
     font-family: 'Roboto-Bold', 'Arial-Bold', 'Helvetica-Bold', sans-serif;
     font-size: 14px;
 }
+
+.x4-panel-header-text-container-default {
+  font-weight: normal;
+}

--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -84,7 +84,7 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
     getPlotsData: function() {
         // get input number N
         // pass includeTrailingCV or includeTrailingMean in plotsConfig
-        var plotsConfig = {};
+        const plotsConfig = {};
         plotsConfig.metricId = this.metric;
         plotsConfig.metricId2 = this.metric2;
         plotsConfig.includeLJ = this.showMetricValuePlot();
@@ -104,7 +104,7 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
             plotsConfig.replicateId = parseInt(urlParams['replicateId']);
         }
 
-        var config = this.getReportConfig()
+        const config = this.getReportConfig()
 
         if (this.selectedAnnotations) {
             plotsConfig.selectedAnnotations = [];
@@ -121,14 +121,44 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
             plotsConfig.endDate = config.EndDate;
         }
 
-        // pass input number N to plotsConfig
-        LABKEY.Ajax.request({
+        // Track and cancel in-flight request; ensure only latest response is processed
+        this._qcRequestSeq = (this._qcRequestSeq || 0) + 1;
+        const requestSeq = this._qcRequestSeq;
+
+        // Abort any previous in-flight request if possible
+        if (this._qcActiveRequest && typeof this._qcActiveRequest.abort === 'function') {
+            try { this._qcActiveRequest.abort(); } catch (e) { /* no-op */ }
+        }
+
+        const failureCb = LABKEY.Utils.getCallbackWrapper(this.failureHandler, this);
+
+        this._qcActiveRequest = LABKEY.Ajax.request({
             url: LABKEY.ActionURL.buildURL('targetedms', 'GetQCPlotsData.api'),
             success: function(response) {
-                this.lastParsedResponse = JSON.parse(response.responseText);
-                this.processPlotData();
+                // Ignore if not the most recent request
+                if (requestSeq !== this._qcRequestSeq)
+                    return;
+
+                try {
+                    this.lastParsedResponse = JSON.parse(response.responseText);
+                    this.processPlotData();
+                }
+                finally {
+                    // Clear active request handle
+                    if (requestSeq === this._qcRequestSeq)
+                        this._qcActiveRequest = null;
+                }
             },
-            failure: LABKEY.Utils.getCallbackWrapper(this.failureHandler),
+            failure: function(response) {
+                // Ignore failures from stale/aborted requests
+                if (requestSeq !== this._qcRequestSeq)
+                    return;
+
+                try { failureCb(response); } finally {
+                    if (requestSeq === this._qcRequestSeq)
+                        this._qcActiveRequest = null;
+                }
+            },
             scope: this,
             jsonData: plotsConfig
         });

--- a/webapp/TargetedMS/js/QCPlotHelperBase.js
+++ b/webapp/TargetedMS/js/QCPlotHelperBase.js
@@ -370,7 +370,7 @@ Ext4.define("LABKEY.targetedms.QCPlotHelperBase", {
             return;
         }
 
-        this.setLoadingMsg();
+        Ext4.get(this.plotDivId).update("");
         this.setBrushingEnabled(false);
         this.setPlotWidth(this.plotDivId);
 

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -884,7 +884,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                     this.havePlotOptionsChanged = true;
                     // Update single-plot checkbox visibility directly in the 3-column layout
                     var showAllSeriesCheckBox = this.getMetricPropsById(this.metric).precursorScoped;
-                    this.getSinglePlotCheckbox().setVisible(showAllSeriesCheckBox);
+                    this.getPlotGroupRadioGroup().setVisible(showAllSeriesCheckBox);
 
                     if (this.filterQCPoints) {
                         this.resetFilterPointsIndices();
@@ -981,7 +981,6 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
 
     getGroupedXRadioGroup : function() {
         if (!this.groupedXRadioGroup) {
-            // Replace checkbox with a radio group: x-axis grouping per replicate or per date
             this.groupedXRadioGroup = Ext4.create('Ext.form.RadioGroup', {
                 id: 'grouped-x-field',
                 fieldLabel: 'X-axis grouping',
@@ -1013,7 +1012,6 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
 
     getPlotGroupRadioGroup : function() {
         if (!this.plotGroupRadioGroup) {
-            // Replace checkbox with a radio group: Show plots per precursor or combined
             this.plotGroupRadioGroup = Ext4.create('Ext.form.RadioGroup', {
                 id: 'peptides-single-plot',
                 labelWidth: this.LABEL_WIDTH,
@@ -1045,7 +1043,6 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
 
     getExcludedReplicatesRadioGroup : function() {
         if (!this.excludedReplicatesRadioGroup) {
-            // Replace checkbox with a radio group for clarity: Show/Hide excluded samples
             this.excludedReplicatesRadioGroup = Ext4.create('Ext.form.RadioGroup', {
                 id: 'show-excluded-points',
                 fieldLabel: 'Excluded replicates',
@@ -1076,7 +1073,6 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
 
     getExcludedPrecursorsRadioGroup : function() {
         if (!this.excludedPrecursorsRadioGroup) {
-            // Replace checkbox with a radio group: Show/Hide excluded precursors
             this.excludedPrecursorsRadioGroup = Ext4.create('Ext.form.RadioGroup', {
                 id: 'show-excluded-precursors',
                 fieldLabel: 'Excluded precursors',
@@ -1113,7 +1109,6 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
 
     getReferenceGuideSetRadioGroup : function() {
         if (!this.referenceGuideSetRadioGroup) {
-            // Replace checkbox with a radio group: Show/Hide reference guide sets
             this.referenceGuideSetRadioGroup = Ext4.create('Ext.form.RadioGroup', {
                 id: 'show-oorange-gs',
                 fieldLabel: 'Reference guide sets',

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -1000,7 +1000,6 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                         this.havePlotOptionsChanged = true;
 
                         this.setBrushingEnabled(false);
-                        this.setLoadingMsg();
                         this.getAnnotationData();
                     }
                 }
@@ -1061,7 +1060,6 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                         this.showExcluded = newShow;
                         this.havePlotOptionsChanged = true;
 
-                        this.setLoadingMsg();
                         this.getAnnotationData();
                     }
                 }
@@ -1086,12 +1084,10 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                 listeners: {
                     scope: this,
                     change: function(group, newValue) {
-                        var val = newValue && (newValue.excludedPrecursors || newValue['excludedPrecursors']);
-                        var newShow = val === 'show' || (val === true);
-                        this.showExcludedPrecursors = newShow;
+                        const val = newValue && (newValue.excludedPrecursors || newValue['excludedPrecursors']);
+                        this.showExcludedPrecursors = val === 'show' || (val === true);
                         this.havePlotOptionsChanged = true;
 
-                        this.setLoadingMsg();
                         this.getAnnotationData();
                     }
                 }
@@ -1139,9 +1135,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                             else {
                                 this.getStartDateField().setValue(this.formatDate(this.expRunDetails.startDate, false));
                             }
-
                         }
-                        this.setLoadingMsg();
                         this.getAnnotationData();
                     }
                 }
@@ -1286,6 +1280,8 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     },
 
     getAnnotationData: function() {
+        this.setLoadingMsg();
+
         var config = this.getReportConfig();
 
         var annotationSql = "SELECT qca.Date, qca.Description, qca.Created, qca.CreatedBy.DisplayName, qcat.Name, qcat.Color FROM qcannotation qca JOIN qcannotationtype qcat ON qcat.Id = qca.QCAnnotationTypeId";
@@ -1327,10 +1323,10 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                     });
             }
 
-        for (var i = 0; i < this.annotationData.length; i++)
+        for (let i = 0; i < this.annotationData.length; i++)
         {
-                var annotation = this.annotationData[i];
-                var annotationDate = this.formatDate(new Date(annotation['Date']), !this.groupedX);
+                const annotation = this.annotationData[i];
+                const annotationDate = this.formatDate(new Date(annotation['Date']), !this.groupedX);
 
                     // track if we need to stack annotations that fall on the same date
                     if (!dateCount[annotationDate]) {

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -79,7 +79,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     selectedAnnotations: {},
     runs: null,
     trailingRuns: null,
-    minWidth: 1250,
+    minWidth: 1275,
 
     SHOW_ALL_IN_A_SINGLE_PLOT: 'Show all series in a single plot',
     LABEL_WIDTH: 115,

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -79,7 +79,8 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     selectedAnnotations: {},
     runs: null,
     trailingRuns: null,
-    minWidth: 1275,
+    minWidth: 1250, // Keep in sync with the width defined in qcTrendPlot.jsp
+    width: '100%',
 
     SHOW_ALL_IN_A_SINGLE_PLOT: 'Show all series in a single plot',
     LABEL_WIDTH: 115,

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -299,7 +299,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
 
         if (this.metric) {
             //hiding the show All series in a single plot checkbox for run scoped metrics
-            this.getSinglePlotCheckbox().setVisible(this.getMetricPropsById(this.metric).precursorScoped);
+            this.getPlotGroupRadioGroup().setVisible(this.getMetricPropsById(this.metric).precursorScoped);
         }
 
         // Create vertical line separator component
@@ -320,16 +320,16 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         col2.add(this.getDateRangeCombo());
         // Show custom date range inline when selected  
         col2.add(this.getCustomDateRangeToolbar());
-        col2.add(this.getGroupedXCheckbox());
-        col2.add(this.getExcludedReplicateCheckbox());
+        col2.add(this.getGroupedXRadioGroup());
+        col2.add(this.getExcludedReplicatesRadioGroup());
 
         const col3 = Ext4.create('Ext.container.Container', Ext4.apply({ itemId: 'qc-controls-col-3' }, columnDefaults));
         // Display toggles and filters
         col3.add(this.getPlotTypeOptions());
         col3.add(this.getTrailingRunsField());
-        col3.add(this.getSinglePlotCheckbox());
-        col3.add(this.getExcludedPrecursorsCheckbox());
-        col3.add(this.getShowReferenceCheckbox());
+        col3.add(this.getPlotGroupRadioGroup());
+        col3.add(this.getExcludedPrecursorsRadioGroup());
+        col3.add(this.getReferenceGuideSetRadioGroup());
         if (this.canUserEdit()) {
             const buttonContainer = Ext4.create('Ext.form.FieldContainer', {
                 hideEmptyLabel: false,
@@ -347,7 +347,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         // Ensure single-plot checkbox visibility mirrors previous logic when metrics are run-scoped
         if (this.metric) {
             var showSinglePlot = this.getMetricPropsById(this.metric).precursorScoped;
-            this.getSinglePlotCheckbox().setVisible(showSinglePlot);
+            this.getPlotGroupRadioGroup().setVisible(showSinglePlot);
         }
 
         const columnsToolbar = Ext4.create('Ext.toolbar.Toolbar', {
@@ -979,10 +979,10 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         return this.clearAnnotationFiltersButton;
     },
 
-    getGroupedXCheckbox : function() {
-        if (!this.groupedXCheckbox) {
+    getGroupedXRadioGroup : function() {
+        if (!this.groupedXRadioGroup) {
             // Replace checkbox with a radio group: x-axis grouping per replicate or per date
-            this.groupedXCheckbox = Ext4.create('Ext.form.RadioGroup', {
+            this.groupedXRadioGroup = Ext4.create('Ext.form.RadioGroup', {
                 id: 'grouped-x-field',
                 fieldLabel: 'X-axis grouping',
                 labelWidth: this.LABEL_WIDTH,
@@ -1008,21 +1008,21 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
             });
         }
 
-        return this.groupedXCheckbox;
+        return this.groupedXRadioGroup;
     },
 
-    getSinglePlotCheckbox : function() {
-        if (!this.peptidesInSinglePlotCheckbox) {
+    getPlotGroupRadioGroup : function() {
+        if (!this.plotGroupRadioGroup) {
             // Replace checkbox with a radio group: Show plots per precursor or combined
-            this.peptidesInSinglePlotCheckbox = Ext4.create('Ext.form.RadioGroup', {
+            this.plotGroupRadioGroup = Ext4.create('Ext.form.RadioGroup', {
                 id: 'peptides-single-plot',
                 labelWidth: this.LABEL_WIDTH,
                 fieldLabel: 'Plots',
                 columns: 2,
                 vertical: false,
                 items: [
-                    { boxLabel: 'per precursor', name: 'showPlots', inputValue: 'per-precursor', checked: this.singlePlot === false },
-                    { boxLabel: 'combined', name: 'showPlots', inputValue: 'combined', checked: this.singlePlot === true }
+                    { boxLabel: 'per precursor', name: 'showPlots', id: 'plots-per-precursor', inputValue: 'per-precursor', checked: this.singlePlot === false },
+                    { boxLabel: 'combined', name: 'showPlots', id: 'plots-combined', inputValue: 'combined', checked: this.singlePlot === true }
                 ],
                 listeners: {
                     scope: this,
@@ -1040,21 +1040,21 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
             });
         }
 
-        return this.peptidesInSinglePlotCheckbox;
+        return this.plotGroupRadioGroup;
     },
 
-    getExcludedReplicateCheckbox : function() {
-        if (!this.showExcludedPointsCheckbox) {
+    getExcludedReplicatesRadioGroup : function() {
+        if (!this.excludedReplicatesRadioGroup) {
             // Replace checkbox with a radio group for clarity: Show/Hide excluded samples
-            this.showExcludedPointsCheckbox = Ext4.create('Ext.form.RadioGroup', {
+            this.excludedReplicatesRadioGroup = Ext4.create('Ext.form.RadioGroup', {
                 id: 'show-excluded-points',
                 fieldLabel: 'Excluded replicates',
                 labelWidth: this.LABEL_WIDTH,
                 columns: 2,
                 vertical: false,
                 items: [
-                    { boxLabel: 'show', name: 'excludedSamples', inputValue: 'show', checked: this.showExcluded === true },
-                    { boxLabel: 'hide', name: 'excludedSamples', inputValue: 'hide', checked: this.showExcluded === false }
+                    { boxLabel: 'show', id: 'excluded-replicates-show', name: 'excludedSamples', inputValue: 'show', checked: this.showExcluded === true },
+                    { boxLabel: 'hide', id: 'excluded-replicates-hide', name: 'excludedSamples', inputValue: 'hide', checked: this.showExcluded === false }
                 ],
                 listeners: {
                     scope: this,
@@ -1071,21 +1071,21 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
             });
         }
 
-        return this.showExcludedPointsCheckbox;
+        return this.excludedReplicatesRadioGroup;
     },
 
-    getExcludedPrecursorsCheckbox : function() {
-        if (!this.showExcludedPrecursorsCheckbox) {
+    getExcludedPrecursorsRadioGroup : function() {
+        if (!this.excludedPrecursorsRadioGroup) {
             // Replace checkbox with a radio group: Show/Hide excluded precursors
-            this.showExcludedPrecursorsCheckbox = Ext4.create('Ext.form.RadioGroup', {
+            this.excludedPrecursorsRadioGroup = Ext4.create('Ext.form.RadioGroup', {
                 id: 'show-excluded-precursors',
                 fieldLabel: 'Excluded precursors',
                 labelWidth: this.LABEL_WIDTH,
                 columns: 2,
                 vertical: false,
                 items: [
-                    { boxLabel: 'show', name: 'excludedPrecursors', inputValue: 'show', checked: this.showExcludedPrecursors === true },
-                    { boxLabel: 'hide', name: 'excludedPrecursors', inputValue: 'hide', checked: this.showExcludedPrecursors === false }
+                    { boxLabel: 'show', id: 'excluded-precursors-show', name: 'excludedPrecursors', inputValue: 'show', checked: this.showExcludedPrecursors === true },
+                    { boxLabel: 'hide', id: 'excluded-precursors-hide', name: 'excludedPrecursors', inputValue: 'hide', checked: this.showExcludedPrecursors === false }
                 ],
                 listeners: {
                     scope: this,
@@ -1102,7 +1102,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
             });
         }
 
-        return this.showExcludedPrecursorsCheckbox;
+        return this.excludedPrecursorsRadioGroup;
     },
 
     resetFilterPointsIndices: function() {
@@ -1111,18 +1111,18 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         }
     },
 
-    getShowReferenceCheckbox : function() {
-        if (!this.showReferenceGSCheckBox) {
+    getReferenceGuideSetRadioGroup : function() {
+        if (!this.referenceGuideSetRadioGroup) {
             // Replace checkbox with a radio group: Show/Hide reference guide sets
-            this.showReferenceGSCheckBox = Ext4.create('Ext.form.RadioGroup', {
+            this.referenceGuideSetRadioGroup = Ext4.create('Ext.form.RadioGroup', {
                 id: 'show-oorange-gs',
                 fieldLabel: 'Reference guide sets',
                 labelWidth: this.LABEL_WIDTH,
                 columns: 2,
                 vertical: false,
                 items: [
-                    { boxLabel: 'always show', name: 'referenceGuideSets', inputValue: 'show', checked: this.showReferenceGS === true },
-                    { boxLabel: 'when in date range', name: 'referenceGuideSets', inputValue: 'hide', checked: this.showReferenceGS === false }
+                    { boxLabel: 'always show', id: 'reference-guide-set-show', name: 'referenceGuideSets', inputValue: 'show', checked: this.showReferenceGS === true },
+                    { boxLabel: 'when in date range', id: 'reference-guide-set-hide', name: 'referenceGuideSets', inputValue: 'hide', checked: this.showReferenceGS === false }
                 ],
                 listeners: {
                     scope: this,
@@ -1153,7 +1153,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
             });
         }
 
-        return this.showReferenceGSCheckBox;
+        return this.referenceGuideSetRadioGroup;
     },
 
     getGuideSetCreateButton : function() {

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -988,8 +988,8 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                 columns: 2,
                 vertical: false,
                 items: [
-                    { boxLabel: 'per replicate', name: 'xAxisGrouping', inputValue: 'replicate', checked: this.groupedX === false },
-                    { boxLabel: 'per date', name: 'xAxisGrouping', inputValue: 'date', checked: this.groupedX === true }
+                    { boxLabel: 'per replicate', id: 'x-axis-grouping-replicate', name: 'xAxisGrouping', inputValue: 'replicate', checked: this.groupedX === false },
+                    { boxLabel: 'per date', id: 'x-axis-grouping-date', name: 'xAxisGrouping', inputValue: 'date', checked: this.groupedX === true }
                 ],
                 listeners: {
                     scope: this,

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -79,6 +79,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     selectedAnnotations: {},
     runs: null,
     trailingRuns: null,
+    minWidth: 1250,
 
     SHOW_ALL_IN_A_SINGLE_PLOT: 'Show all series in a single plot',
     LABEL_WIDTH: 115,
@@ -278,19 +279,19 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         });
     },
 
-    initPlotFormToolbars : function() {
+    initPlotFormToolbars: function () {
         // Build a single top region with three columns of controls for a more compact layout.
         const columnDefaults = {
             xtype: 'container',
-            layout: { type: 'vbox', align: 'start' },
+            layout: { type: 'vbox', align: 'center' },
             defaults: {
-                width: 400,
+                width: 380,
                 // Add a little vertical spacing between stacked controls
                 margin: '0 10 10 0'
             }
         };
 
-        const col1 = Ext4.create('Ext.container.Container', Ext4.apply({ itemId: 'qc-controls-col-1', style: 'border-right: 1px solid #e0e0e0; padding-right: 12px; margin-right: 12px;' }, columnDefaults));
+        const col1 = Ext4.create('Ext.container.Container', Ext4.apply({ itemId: 'qc-controls-col-1' }, columnDefaults));
         // Primary controls: metrics and date range
         col1.add(this.getMetricCombo1());
         col1.add(this.getMetricCombo2());
@@ -301,11 +302,23 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
             this.getSinglePlotCheckbox().setVisible(this.getMetricPropsById(this.metric).precursorScoped);
         }
 
+        // Create vertical line separator component
+        const separator = {
+            xtype: 'component',
+            autoEl: {
+                tag: 'div',
+                style: 'width: 1px; background-color: #e0e0e0; height: 100%;'
+            },
+            width: 1,
+            margin: '0 12px',
+            // Ensure this separator does not expand like other flexed columns
+            flex: 0
+        };
 
-        const col2 = Ext4.create('Ext.container.Container', Ext4.apply({ itemId: 'qc-controls-col-2', style: 'border-right: 1px solid #e0e0e0; padding-right: 12px; margin-right: 12px;' }, columnDefaults));
+        const col2 = Ext4.create('Ext.container.Container', Ext4.apply({ itemId: 'qc-controls-col-2' }, columnDefaults));
         // Plot configuration controls
         col2.add(this.getDateRangeCombo());
-        // Show custom date range inline when selected
+        // Show custom date range inline when selected  
         col2.add(this.getCustomDateRangeToolbar());
         col2.add(this.getGroupedXCheckbox());
         col2.add(this.getExcludedReplicateCheckbox());
@@ -341,11 +354,11 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
             ui: 'footer',
             cls: 'levey-jennings-toolbar',
             padding: 10,
-            layout: { type: 'hbox', align: 'start' },
+            layout: { type: 'hbox', align: 'stretch' }, // Changed to stretch to make separators full height
             defaults: { flex: 1 },
-            items: [col1, col2, col3]
+            items: [col1, separator, col2, separator, col3] // Added separators between columns
         });
-
+    
         return [
             { tbar: columnsToolbar },
             { tbar: this.getGuideSetMessageToolbar() },
@@ -420,7 +433,6 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                     }
                     this.getTrailingRunsField().setVisible(newValues.indexOf("Trailing Mean") > -1 || newValues.indexOf("Trailing CV") > -1);
                     this.havePlotOptionsChanged = true;
-                    this.setBrushingEnabled(false);
                     this.displayTrendPlot();
                 }
             }
@@ -434,10 +446,18 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                 labelWidth: this.LABEL_WIDTH,
                 items: [
                     this.getAnnotationListTree(),
-                    {xtype: 'tbspacer'},
-                    this.getApplyAnnotationFiltersButton(),
-                    {xtype: 'tbspacer'},
-                    this.getClearAnnotationFiltersButton()
+                    {
+                        xtype: 'container',
+                        layout: {
+                            type: 'hbox',
+                            pack: 'end' // Right-align the buttons
+                        },
+                        items: [
+                            this.getApplyAnnotationFiltersButton(),
+                            {xtype: 'tbspacer', width: 5},
+                            this.getClearAnnotationFiltersButton()
+                        ]
+                    }
                 ]
             });
 
@@ -461,6 +481,11 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                         }
                     });
                     this.clearAnnotationFiltersButton.show();
+                    // If the tree is currently collapsed, keep buttons hidden
+                    if (this.getAnnotationListTree().collapsed) {
+                        this.clearAnnotationFiltersButton.hide();
+                        this.getApplyAnnotationFiltersButton().hide();
+                    }
                 }
             }
             this.annotationFiltersToolbar.setVisible(this.replicateAnnotationsNodes.length > 0);
@@ -497,11 +522,12 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                 labelWidth: this.LABEL_WIDTH,
                 hidden: this.dateRangeOffset > -1,
                 layout: { type: 'hbox', align: 'middle' },
-                defaults: { margin: '0 5 0 0' },
                 items: [
                     this.getStartDateField(),
-                    this.getEndDateField(),
-                    this.getApplyDateRangeButton()
+                    {xtype: 'tbspacer', width: '3%'},
+                    {xtype: 'label', text: ' to ', width: '3%'},
+                    {xtype: 'tbspacer', width: '3%'},
+                    this.getEndDateField()
                 ]
             });
         }
@@ -727,8 +753,10 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                             this.startDate = this.formatDate(this.calculateStartDateByOffset());
                             this.endDate = this.formatDate(this.calculateEndDateByOffset());
 
-                            this.setBrushingEnabled(false);
                             this.displayTrendPlot();
+                        }
+                        else {
+                            this.applyCustomDateRange();
                         }
                     }
                 }
@@ -740,14 +768,12 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
 
     createDateField: function (config) {
         var defaultConfig = {
-            width: 109,
+            width: '45%',
             allowBlank: false,
             format: 'Y-m-d',
             listeners: {
                 scope: this,
-                validitychange: function (df, isValid) {
-                    this.getApplyDateRangeButton().setDisabled(!isValid);
-                }
+                change: this.applyCustomDateRange
             }
         };
 
@@ -772,17 +798,6 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
             });
         }
         return this.endDateField;
-    },
-    getApplyDateRangeButton : function() {
-        if (!this.applyFilterButton) {
-            this.applyFilterButton = Ext4.create('Ext.button.Button', {
-                text: 'Apply',
-                handler: this.applyGraphFilterBtnClick,
-                scope: this
-            });
-        }
-
-        return this.applyFilterButton;
     },
 
     assignDefaultMetricIfNull: function () {
@@ -871,7 +886,6 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                     var showAllSeriesCheckBox = this.getMetricPropsById(this.metric).precursorScoped;
                     this.getSinglePlotCheckbox().setVisible(showAllSeriesCheckBox);
 
-                    this.setBrushingEnabled(false);
                     if (this.filterQCPoints) {
                         this.resetFilterPointsIndices();
                     }
@@ -899,22 +913,42 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
 
     getAnnotationListTree : function() {
         if (!this.annotationFiltersField) {
-            var store = Ext4.create('Ext.data.TreeStore', {
+            const store = Ext4.create('Ext.data.TreeStore', {
                 root: {expanded: false, children: this.replicateAnnotationsNodes},
             });
 
             this.annotationFiltersField = Ext4.create('Ext.tree.Panel', {
                 id: 'annotation-filter-field',
                 height: 150,
-                title: 'Filter: Replicate Annotations',
+                title: 'Expand to select annotations',
                 store: store,
                 rootVisible: false,
                 titleCollapse: true,
                 collapsed: true,
                 collapsible: true,
+                header: { style: 'background-color: #ffffff' },
                 useArrows: true,
                 lines: false,
+                listeners: {
+                    scope: this,
+                    expand: function() {
+                        // Show Apply button when expanded
+                        this.getApplyAnnotationFiltersButton().show();
+                        // Only show Clear button when there are selected annotations
+                        if (Object.keys(this.selectedAnnotations || {}).length > 0) {
+                            this.getClearAnnotationFiltersButton().show();
+                        }
+                    },
+                    collapse: function() {
+                        // Hide both buttons when collapsed
+                        this.getApplyAnnotationFiltersButton().hide();
+                        this.getClearAnnotationFiltersButton().hide();
+                    }
+                }
             });
+
+            this.getApplyAnnotationFiltersButton().hide();
+            this.getClearAnnotationFiltersButton().hide();
         }
 
         return this.annotationFiltersField;
@@ -1155,13 +1189,13 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     },
 
     setLoadingMsg : function() {
-        Ext4.get(this.plotDivId).update("");
         Ext4.get(this.plotDivId).mask("Loading...");
     },
 
     displayTrendPlot: function() {
         hopscotch.getCalloutManager().removeAllCallouts();
 
+        this.setBrushingEnabled(false);
         this.updateSelectedAnnotations();
         this.setLoadingMsg();
         this.getDistinctPrecursors();
@@ -1867,17 +1901,20 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         return config;
     },
 
-    applyGraphFilterBtnClick: function() {
-        var startDateRawValue = this.getStartDateField().getRawValue(),
+    applyCustomDateRange: function() {
+        const startDateRawValue = this.getStartDateField().getRawValue(),
             startDateValue = this.getStartDateField().getValue(),
             endDateRawValue = this.getEndDateField().getRawValue(),
             endDateValue = this.getEndDateField().getValue();
 
+        if (!this.getStartDateField().isValid() || !this.getEndDateField().isValid()) {
+
+        }
         // make sure that at least one filter field is not null
-        if (startDateRawValue === '' && endDateRawValue === '') {
+        else if (startDateRawValue === '' && endDateRawValue === '') {
             Ext4.Msg.show({
                 title:'ERROR',
-                msg: 'Please enter a value for filtering.',
+                msg: 'Please enter start and end dates.',
                 buttons: Ext4.Msg.OK,
                 icon: Ext4.MessageBox.ERROR
             });
@@ -1897,7 +1934,6 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
             this.endDate = endDateRawValue;
             this.havePlotOptionsChanged = true;
 
-            this.setBrushingEnabled(false);
             this.displayTrendPlot();
 
             // reset expRunDetails highlighted region startIndex and endIndex
@@ -1927,7 +1963,6 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         }
 
         else {
-            this.setBrushingEnabled(false);
             this.displayTrendPlot();
         }
     },
@@ -1955,13 +1990,6 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
             selected.push(annotationValue);
         }
 
-        if(Object.keys(this.selectedAnnotations).length > 0) {
-            this.clearAnnotationFiltersButton.show();
-        }
-        else {
-            this.clearAnnotationFiltersButton.hide();
-        }
-
         this.updateSelectedAnnotationsToolbar();
         this.havePlotOptionsChanged = true;
         this.annotationFiltersField.collapse();
@@ -1987,8 +2015,13 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
             selectedDisplay += ') ';
         });
         if(selectedDisplay.length > 0) {
-            selectedDisplay = "Selected annotations: " + selectedDisplay;
-            selectedAnnotationsTb.add(selectedDisplay);
+            selectedDisplay = 'Selected: ' + selectedDisplay;
+            selectedAnnotationsTb.add({
+                xtype: 'box',
+                flex: 1,
+                style: 'white-space: normal; text-align: center;',
+                html: Ext4.String.htmlEncode(selectedDisplay)
+            });
             selectedAnnotationsTb.show();
         }
         else {
@@ -2013,7 +2046,6 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         this.havePlotOptionsChanged = true;
         this.clearAnnotationFiltersButton.hide();
 
-        this.setBrushingEnabled(false);
         this.displayTrendPlot();
     },
     

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -362,6 +362,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         return [
             { tbar: columnsToolbar },
             { tbar: this.getGuideSetMessageToolbar() },
+            { tbar: this.getDateRangeErrorToolbar() },
             { tbar: this.getExperimentRunDateRangeToolbar() }
         ];
     },
@@ -553,6 +554,24 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         return this.guideSetMessageToolbar;
     },
 
+    getDateRangeErrorToolbar : function() {
+        if (!this.dateRangeErrorToolbar) {
+            this.dateRangeErrorToolbar = Ext4.create('Ext.toolbar.Toolbar', {
+                ui: 'footer',
+                hidden: true,
+                layout: { pack: 'center' },
+                items: [{
+                    xtype: 'label',
+                    id: 'DateRangeErrorBar',
+                    cls: 'labkey-error',
+                    text: 'Please correct the date range. Check the start and end dates are valid.'
+                }]
+            });
+        }
+
+        return this.dateRangeErrorToolbar;
+    },
+
     getExperimentRunDateRangeToolbar : function() {
         if (!this.experimentRunDateRangeToolbar) {
             var hidden = !this.showExpRunRange;
@@ -571,7 +590,6 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                 layout: { pack: 'center' },
                 items: [{
                     xtype: 'box',
-                    itemId: 'ExpreimentRunDateRangeToolBar',
                     html: htmlStr
                 }]
             });
@@ -748,6 +766,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                         this.getCustomDateRangeToolbar().setVisible(showCustomRangeItems);
 
                         if (!showCustomRangeItems) {
+                            this.getDateRangeErrorToolbar().hide();
                             // either use the min and max values based on the data
                             // or calculate range based on today's date and the offset
                             this.startDate = this.formatDate(this.calculateStartDateByOffset());
@@ -1898,28 +1917,18 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
             endDateRawValue = this.getEndDateField().getRawValue(),
             endDateValue = this.getEndDateField().getValue();
 
-        if (!this.getStartDateField().isValid() || !this.getEndDateField().isValid()) {
-
-        }
-        // make sure that at least one filter field is not null
-        else if (startDateRawValue === '' && endDateRawValue === '') {
-            Ext4.Msg.show({
-                title:'ERROR',
-                msg: 'Please enter start and end dates.',
-                buttons: Ext4.Msg.OK,
-                icon: Ext4.MessageBox.ERROR
-            });
+        if ((!this.getStartDateField().isValid() || !this.getEndDateField().isValid()) ||
+                (startDateRawValue === '' && endDateRawValue === '')) {
+            this.getDateRangeErrorToolbar().show();
+            Ext4.get('DateRangeErrorBar').setHTML('Please correct the date range. Check the start and end dates are valid.');
         }
         // verify that the start date is not after the end date
         else if (startDateValue > endDateValue && endDateValue !== '') {
-            Ext4.Msg.show({
-                title:'ERROR',
-                msg: 'Please enter an end date that does not occur before the start date.',
-                buttons: Ext4.Msg.OK,
-                icon: Ext4.MessageBox.ERROR
-            });
+            this.getDateRangeErrorToolbar().show();
+            Ext4.get('DateRangeErrorBar').setHTML('Please enter an end date that does not occur before the start date.');
         }
         else {
+            this.getDateRangeErrorToolbar().hide();
             // get date values without the time zone info
             this.startDate = startDateRawValue;
             this.endDate = endDateRawValue;

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -80,6 +80,9 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     runs: null,
     trailingRuns: null,
 
+    SHOW_ALL_IN_A_SINGLE_PLOT: 'Show all series in a single plot',
+    LABEL_WIDTH: 115,
+
     // Max number of plots/series to show per page
     maxCount: 50,
 
@@ -276,63 +279,86 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     },
 
     initPlotFormToolbars : function() {
-        var toolbarArr = [
-            { tbar: this.getMainPlotOptionsToolbar() },
-            { tbar: this.getCustomDateRangeToolbar() },
-            { tbar: this.getFirstPlotOptionsToolbar() },
-            { tbar: this.getSecondPlotOptionsToolbar() },
+        // Build a single top region with three columns of controls for a more compact layout.
+        const columnDefaults = {
+            xtype: 'container',
+            layout: { type: 'vbox', align: 'start' },
+            defaults: {
+                width: 400,
+                // Add a little vertical spacing between stacked controls
+                margin: '0 10 10 0'
+            }
+        };
+
+        const col1 = Ext4.create('Ext.container.Container', Ext4.apply({ itemId: 'qc-controls-col-1', style: 'border-right: 1px solid #e0e0e0; padding-right: 12px; margin-right: 12px;' }, columnDefaults));
+        // Primary controls: metrics and date range
+        col1.add(this.getMetricCombo1());
+        col1.add(this.getMetricCombo2());
+        col1.add(this.getScaleCombo());
+
+        if (this.metric) {
+            //hiding the show All series in a single plot checkbox for run scoped metrics
+            this.getSinglePlotCheckbox().setVisible(this.getMetricPropsById(this.metric).precursorScoped);
+        }
+
+
+        const col2 = Ext4.create('Ext.container.Container', Ext4.apply({ itemId: 'qc-controls-col-2', style: 'border-right: 1px solid #e0e0e0; padding-right: 12px; margin-right: 12px;' }, columnDefaults));
+        // Plot configuration controls
+        col2.add(this.getDateRangeCombo());
+        // Show custom date range inline when selected
+        col2.add(this.getCustomDateRangeToolbar());
+        col2.add(this.getGroupedXCheckbox());
+        col2.add(this.getExcludedReplicateCheckbox());
+
+        const col3 = Ext4.create('Ext.container.Container', Ext4.apply({ itemId: 'qc-controls-col-3' }, columnDefaults));
+        // Display toggles and filters
+        col3.add(this.getPlotTypeOptions());
+        col3.add(this.getTrailingRunsField());
+        col3.add(this.getSinglePlotCheckbox());
+        col3.add(this.getExcludedPrecursorsCheckbox());
+        col3.add(this.getShowReferenceCheckbox());
+        if (this.canUserEdit()) {
+            const buttonContainer = Ext4.create('Ext.form.FieldContainer', {
+                hideEmptyLabel: false,
+                labelWidth: this.LABEL_WIDTH,
+                items: [this.getGuideSetCreateButton()]
+            });
+
+            col3.add(buttonContainer);
+        }
+        if (this.replicateAnnotationsNodes.length > 0) {
+            col2.add(this.getAnnotationFiltersToolbar());
+            col2.add(this.getSelectedAnnotationsToolbar());
+        }
+
+        // Ensure single-plot checkbox visibility mirrors previous logic when metrics are run-scoped
+        if (this.metric) {
+            var showSinglePlot = this.getMetricPropsById(this.metric).precursorScoped;
+            this.getSinglePlotCheckbox().setVisible(showSinglePlot);
+        }
+
+        const columnsToolbar = Ext4.create('Ext.toolbar.Toolbar', {
+            ui: 'footer',
+            cls: 'levey-jennings-toolbar',
+            padding: 10,
+            layout: { type: 'hbox', align: 'start' },
+            defaults: { flex: 1 },
+            items: [col1, col2, col3]
+        });
+
+        return [
+            { tbar: columnsToolbar },
             { tbar: this.getGuideSetMessageToolbar() },
             { tbar: this.getExperimentRunDateRangeToolbar() }
         ];
-
-        if(this.replicateAnnotationsNodes.length > 0) {
-            toolbarArr.splice(2, 0, {tbar: this.getAnnotationFiltersToolbar()});
-            toolbarArr.splice(3, 0, {tbar: this.getSelectedAnnotationsToolbar()});
-        }
-        return toolbarArr;
-    },
-
-    getFirstPlotOptionsToolbar: function() {
-        if (!this.plotTypeOptionsToolbar) {
-            const items = [
-                this.getPlotTypeOptions(),
-                {xtype: 'tbseparator'},
-                this.getTrailingRunsField(),
-                {xtype: 'tbspacer'},
-                this.getScaleCombo()
-            ];
-
-            // only add the create guide set button if the user has the proper permissions to insert/update guide sets
-            if (this.canUserEdit()) {
-                items.push({xtype: 'tbspacer'}, {xtype: 'tbseparator'}, {xtype: 'tbspacer'});
-                items.push(this.getGuideSetCreateButton());
-            }
-
-            this.plotTypeOptionsToolbar = Ext4.create('Ext.toolbar.Toolbar', {
-                ui: 'footer',
-                cls: 'levey-jennings-toolbar',
-                layout: { pack: 'center' },
-                padding: '0 10px 10px 10px',
-                items: items,
-                listeners: {
-                    scope: this,
-                    render: function(cmp)
-                    {
-                        cmp.doLayout();
-                    }
-                }
-            });
-        }
-        return this.plotTypeOptionsToolbar;
     },
 
     getTrailingRunsField: function () {
         if (!this.trailingRunsField) {
-            this.trailingRunsField = {
+            this.trailingRunsField = Ext4.create('Ext.form.field.Number', {
                 xtype : 'numberfield',
-                fieldLabel: 'Trailing Last',
-                labelWidth: 70,
-                width: 115,
+                fieldLabel: 'Trailing last',
+                labelWidth: this.LABEL_WIDTH,
                 enableKeyEvents: true,
                 id : 'trailingRuns',
                 value: this.trailingRuns ? this.trailingRuns : this.runs > 10 ? 10 : this.runs,
@@ -348,7 +374,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                         this.displayTrendPlot();
                     }
                 }
-            };
+            });
         }
         return this.trailingRunsField;
     },
@@ -370,9 +396,9 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
 
         return {
             xtype: 'plottype-checkcombo',
+            labelWidth: this.LABEL_WIDTH,
             id: 'qc-plot-type-with-y-options',
-            fieldLabel: 'Plot Types',
-            width: 275,
+            fieldLabel: 'Plot types',
             expandToFitContent: true,
             addAllSelector: false,
             queryMode: 'local',
@@ -392,7 +418,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                     if (this.trailingRuns === undefined || this.trailingRuns === null) {
                         this.trailingRuns = 10;
                     }
-                    this.getFirstPlotOptionsToolbar().items.get('trailingRuns').setVisible(newValues.indexOf("Trailing Mean") > -1 || newValues.indexOf("Trailing CV") > -1);
+                    this.getTrailingRunsField().setVisible(newValues.indexOf("Trailing Mean") > -1 || newValues.indexOf("Trailing CV") > -1);
                     this.havePlotOptionsChanged = true;
                     this.setBrushingEnabled(false);
                     this.displayTrendPlot();
@@ -401,73 +427,11 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         }
     },
 
-    getMainPlotOptionsToolbar : function() {
-        if (!this.mainPlotOptionsToolbar) {
-            var toolbarItems = [
-                this.getMetricCombo1(),
-                this.getMetricCombo2(),
-                {xtype: 'tbspacer'}, {xtype: 'tbseparator'}, {xtype: 'tbspacer'},
-                this.getDateRangeCombo()
-            ];
-
-            this.mainPlotOptionsToolbar = Ext4.create('Ext.toolbar.Toolbar', {
-                ui: 'footer',
-                cls: 'levey-jennings-toolbar',
-                padding: 10,
-                layout: { pack: 'center' },
-                items: toolbarItems
-            });
-        }
-
-        return this.mainPlotOptionsToolbar;
-    },
-
-    getSecondPlotOptionsToolbar : function() {
-        if (!this.otherPlotOptionsToolbar) {
-            var  toolbarItems = [];
-
-            toolbarItems.push(this.getGroupedXCheckbox());
-            toolbarItems.push({xtype: 'tbspacer'}, {xtype: 'tbseparator'}, {xtype: 'tbspacer'});
-            const location = toolbarItems.push(this.getSinglePlotCheckbox());
-            toolbarItems.push({xtype: 'tbspacer'}, {xtype: 'tbseparator'}, {xtype: 'tbspacer'});
-            toolbarItems.push(this.getShowExcludedCheckbox());
-            toolbarItems.push({xtype: 'tbspacer'}, {xtype: 'tbseparator'}, {xtype: 'tbspacer'});
-            toolbarItems.push(this.getShowReferenceCheckbox());
-            toolbarItems.push({xtype: 'tbspacer'}, {xtype: 'tbseparator'}, {xtype: 'tbspacer'});
-            toolbarItems.push(this.getShowExcludedPrecursorsCheckbox());
-
-            this.otherPlotOptionsToolbar = Ext4.create('Ext.toolbar.Toolbar', {
-                ui: 'footer',
-                cls: 'levey-jennings-toolbar',
-                layout: { pack: 'center' },
-                padding: '0 10px 10px 10px',
-                items: toolbarItems
-            });
-
-            if (this.metric) {
-                //hiding the show All series in a single plot checkbox for run scoped metrics
-                this.showAllSeriesCheckbox(this.getMetricPropsById(this.metric).precursorScoped, location - 1);
-            }
-        }
-
-        return this.otherPlotOptionsToolbar;
-    },
-
-    showAllSeriesCheckbox: function (visible, location) {
-        var items = this.otherPlotOptionsToolbar.items.items;
-        items[location-1].setVisible(visible);
-        items[location].setVisible(visible);
-        items[location+1].setVisible(visible);
-        items[location+2].setVisible(visible);
-    },
-
     getAnnotationFiltersToolbar : function() {
         if (!this.annotationFiltersToolbar) {
-            this.annotationFiltersToolbar = Ext4.create('Ext.toolbar.Toolbar', {
-                ui: 'footer',
-                cls: 'levey-jennings-toolbar',
-                padding: '0 10px 10px 10px',
-                layout: { pack: 'center' },
+            this.annotationFiltersToolbar = Ext4.create('Ext.form.FieldContainer', {
+                fieldLabel: 'Replicate filter',
+                labelWidth: this.LABEL_WIDTH,
                 items: [
                     this.getAnnotationListTree(),
                     {xtype: 'tbspacer'},
@@ -525,15 +489,18 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
 
     getCustomDateRangeToolbar : function() {
         if (!this.customDateRangeToolbar) {
-            this.customDateRangeToolbar = Ext4.create('Ext.toolbar.Toolbar', {
-                ui: 'footer',
-                cls: 'levey-jennings-toolbar',
-                padding: '0 10px 10px 10px',
+            // Render the custom range controls inline beneath the date range combo,
+            // left-aligned so they stay within the same column and don't overlap
+            // with the label column.
+            this.customDateRangeToolbar = Ext4.create('Ext.form.FieldContainer', {
+                fieldLabel: 'Custom dates',
+                labelWidth: this.LABEL_WIDTH,
                 hidden: this.dateRangeOffset > -1,
-                layout: { pack: 'center' },
+                layout: { type: 'hbox', align: 'middle' },
+                defaults: { margin: '0 5 0 0' },
                 items: [
-                    this.getStartDateField(), {xtype: 'tbspacer'},
-                    this.getEndDateField(), {xtype: 'tbspacer'},
+                    this.getStartDateField(),
+                    this.getEndDateField(),
                     this.getApplyDateRangeButton()
                 ]
             });
@@ -692,9 +659,8 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         if (!this.scaleCombo) {
             this.scaleCombo = Ext4.create('Ext.form.field.ComboBox', {
                 id: 'scale-combo-box',
-                width: 255,
-                labelWidth: 80,
-                fieldLabel: 'Y-Axis Scale',
+                fieldLabel: 'Y-axis scale',
+                labelWidth: this.LABEL_WIDTH,
                 triggerAction: 'all',
                 mode: 'local',
                 store: Ext4.create('Ext.data.ArrayStore', this.getYAxisOptions()),
@@ -724,9 +690,8 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         if (!this.dateRangeCombo) {
             this.dateRangeCombo = Ext4.create('Ext.form.field.ComboBox', {
                 id: 'daterange-combo-box',
-                width: 225,
-                labelWidth: 75,
-                fieldLabel: 'Date Range',
+                labelWidth: this.LABEL_WIDTH,
+                fieldLabel: 'Date range',
                 triggerAction: 'all',
                 mode: 'local',
                 store: Ext4.create('Ext.data.ArrayStore', {
@@ -773,51 +738,41 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         return this.dateRangeCombo;
     },
 
-    getStartDateField : function() {
-        if (!this.startDateField) {
-            this.startDateField = Ext4.create('Ext.form.field.Date', {
-                id: 'start-date-field',
-                width: 180,
-                labelWidth: 65,
-                fieldLabel: 'Start Date',
-                value: this.startDate,
-                allowBlank: false,
-                format: 'Y-m-d',
-                listeners: {
-                    scope: this,
-                    validitychange: function (df, isValid)
-                    {
-                        this.getApplyDateRangeButton().setDisabled(!isValid);
-                    }
+    createDateField: function (config) {
+        var defaultConfig = {
+            width: 109,
+            allowBlank: false,
+            format: 'Y-m-d',
+            listeners: {
+                scope: this,
+                validitychange: function (df, isValid) {
+                    this.getApplyDateRangeButton().setDisabled(!isValid);
                 }
+            }
+        };
+
+        return Ext4.create('Ext.form.field.Date', Ext4.apply(defaultConfig, config));
+    },
+
+    getStartDateField: function () {
+        if (!this.startDateField) {
+            this.startDateField = this.createDateField({
+                id: 'start-date-field',
+                value: this.startDate
             });
         }
-
         return this.startDateField;
     },
 
-    getEndDateField : function() {
+    getEndDateField: function () {
         if (!this.endDateField) {
-            this.endDateField = Ext4.create('Ext.form.field.Date', {
+            this.endDateField = this.createDateField({
                 id: 'end-date-field',
-                width: 175,
-                labelWidth: 60,
-                fieldLabel: 'End Date',
-                value: this.showExpRunRange ? this.formatDate(this.expRunDetails.endDate, false) : this.endDate,
-                allowBlank: false,
-                format: 'Y-m-d',
-                listeners: {
-                    scope: this,
-                    validitychange: function (df, isValid) {
-                        this.getApplyDateRangeButton().setDisabled(!isValid);
-                    }
-                }
+                value: this.showExpRunRange ? this.formatDate(this.expRunDetails.endDate, false) : this.endDate
             });
         }
-
         return this.endDateField;
     },
-
     getApplyDateRangeButton : function() {
         if (!this.applyFilterButton) {
             this.applyFilterButton = Ext4.create('Ext.button.Button', {
@@ -876,9 +831,8 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
 
         return Ext4.create('Ext.form.field.ComboBox', {
             id: 'metric-type-field' + (primary ? '1' : '2'),
-            width: 350,
-            labelWidth: 60,
-            fieldLabel: primary ? 'Left axis' : 'Right axis',
+            fieldLabel: primary ? 'Y-axis left' : 'Y-axis right',
+            labelWidth: this.LABEL_WIDTH,
             triggerAction: 'all',
             queryMode: 'local',
             store: Ext4.create('Ext.data.Store', {
@@ -913,24 +867,15 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                         this.metric2 = newVal;
                     }
                     this.havePlotOptionsChanged = true;
-                    if (this.otherPlotOptionsToolbar) {
-                        const items = this.otherPlotOptionsToolbar.items.items;
-                        let showAllSeriesCheckBoxLocation;
+                    // Update single-plot checkbox visibility directly in the 3-column layout
+                    var showAllSeriesCheckBox = this.getMetricPropsById(this.metric).precursorScoped;
+                    this.getSinglePlotCheckbox().setVisible(showAllSeriesCheckBox);
 
-                        for(let i=0; i<items.length;i++ ) {
-                            if(items[i].boxLabel ==='Show All Series in a Single Plot')
-                                showAllSeriesCheckBoxLocation = i;
-                        }
-
-                        const showAllSeriesCheckBox = this.getMetricPropsById(this.metric).precursorScoped;
-                        this.showAllSeriesCheckbox(showAllSeriesCheckBox, showAllSeriesCheckBoxLocation);
-
-                        this.setBrushingEnabled(false);
-                        if (this.filterQCPoints) {
-                            this.resetFilterPointsIndices();
-                        }
-                        this.displayTrendPlot();
+                    this.setBrushingEnabled(false);
+                    if (this.filterQCPoints) {
+                        this.resetFilterPointsIndices();
                     }
+                    this.displayTrendPlot();
                 }
             }
         });
@@ -960,7 +905,6 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
 
             this.annotationFiltersField = Ext4.create('Ext.tree.Panel', {
                 id: 'annotation-filter-field',
-                width: 440,
                 height: 150,
                 title: 'Filter: Replicate Annotations',
                 store: store,
@@ -1003,14 +947,23 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
 
     getGroupedXCheckbox : function() {
         if (!this.groupedXCheckbox) {
-            this.groupedXCheckbox = Ext4.create('Ext.form.field.Checkbox', {
+            // Replace checkbox with a radio group: x-axis grouping per replicate or per date
+            this.groupedXCheckbox = Ext4.create('Ext.form.RadioGroup', {
                 id: 'grouped-x-field',
-                boxLabel: 'Group X-Axis Values by Date',
-                checked: this.groupedX,
+                fieldLabel: 'X-axis grouping',
+                labelWidth: this.LABEL_WIDTH,
+                columns: 2,
+                vertical: false,
+                items: [
+                    { boxLabel: 'per replicate', name: 'xAxisGrouping', inputValue: 'replicate', checked: this.groupedX === false },
+                    { boxLabel: 'per date', name: 'xAxisGrouping', inputValue: 'date', checked: this.groupedX === true }
+                ],
                 listeners: {
                     scope: this,
-                    change: function(cb, newValue, oldValue) {
-                        this.groupedX = newValue;
+                    change: function(group, newValue) {
+                        var val = newValue && (newValue.xAxisGrouping || newValue['xAxisGrouping']);
+                        var groupByDate = val === 'date' || (val === true); // fallback safety
+                        this.groupedX = groupByDate;
                         this.havePlotOptionsChanged = true;
 
                         this.setBrushingEnabled(false);
@@ -1026,15 +979,23 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
 
     getSinglePlotCheckbox : function() {
         if (!this.peptidesInSinglePlotCheckbox) {
-            this.peptidesInSinglePlotCheckbox = Ext4.create('Ext.form.field.Checkbox', {
+            // Replace checkbox with a radio group: Show plots per precursor or combined
+            this.peptidesInSinglePlotCheckbox = Ext4.create('Ext.form.RadioGroup', {
                 id: 'peptides-single-plot',
-                boxLabel: 'Show All Series in a Single Plot',
-                checked: this.singlePlot,
+                labelWidth: this.LABEL_WIDTH,
+                fieldLabel: 'Plots',
+                columns: 2,
+                vertical: false,
+                items: [
+                    { boxLabel: 'per precursor', name: 'showPlots', inputValue: 'per-precursor', checked: this.singlePlot === false },
+                    { boxLabel: 'combined', name: 'showPlots', inputValue: 'combined', checked: this.singlePlot === true }
+                ],
                 listeners: {
                     scope: this,
-                    change: function(cb, newValue, oldValue)
-                    {
-                        this.singlePlot = newValue;
+                    change: function(group, newValue) {
+                        var val = newValue && (newValue.showPlots || newValue['showPlots']);
+                        var combined = val === 'combined' || (val === true); // fallback safety
+                        this.singlePlot = combined;
                         this.havePlotOptionsChanged = true;
 
                         this.setBrushingEnabled(false);
@@ -1048,17 +1009,25 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         return this.peptidesInSinglePlotCheckbox;
     },
 
-    getShowExcludedCheckbox : function() {
+    getExcludedReplicateCheckbox : function() {
         if (!this.showExcludedPointsCheckbox) {
-            this.showExcludedPointsCheckbox = Ext4.create('Ext.form.field.Checkbox', {
+            // Replace checkbox with a radio group for clarity: Show/Hide excluded samples
+            this.showExcludedPointsCheckbox = Ext4.create('Ext.form.RadioGroup', {
                 id: 'show-excluded-points',
-                boxLabel: 'Show Excluded Samples',
-                checked: this.showExcluded,
+                fieldLabel: 'Excluded replicates',
+                labelWidth: this.LABEL_WIDTH,
+                columns: 2,
+                vertical: false,
+                items: [
+                    { boxLabel: 'show', name: 'excludedSamples', inputValue: 'show', checked: this.showExcluded === true },
+                    { boxLabel: 'hide', name: 'excludedSamples', inputValue: 'hide', checked: this.showExcluded === false }
+                ],
                 listeners: {
                     scope: this,
-                    change: function(cb, newValue, oldValue)
-                    {
-                        this.showExcluded = newValue;
+                    change: function(group, newValue) {
+                        var val = newValue && (newValue.excludedSamples || newValue['excludedSamples']);
+                        var newShow = val === 'show' || (val === true); // fallback safety
+                        this.showExcluded = newShow;
                         this.havePlotOptionsChanged = true;
 
                         this.setLoadingMsg();
@@ -1071,17 +1040,25 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         return this.showExcludedPointsCheckbox;
     },
 
-    getShowExcludedPrecursorsCheckbox : function() {
+    getExcludedPrecursorsCheckbox : function() {
         if (!this.showExcludedPrecursorsCheckbox) {
-            this.showExcludedPrecursorsCheckbox = Ext4.create('Ext.form.field.Checkbox', {
+            // Replace checkbox with a radio group: Show/Hide excluded precursors
+            this.showExcludedPrecursorsCheckbox = Ext4.create('Ext.form.RadioGroup', {
                 id: 'show-excluded-precursors',
-                boxLabel: 'Show Excluded Precursors',
-                checked: this.showExcludedPrecursors,
+                fieldLabel: 'Excluded precursors',
+                labelWidth: this.LABEL_WIDTH,
+                columns: 2,
+                vertical: false,
+                items: [
+                    { boxLabel: 'show', name: 'excludedPrecursors', inputValue: 'show', checked: this.showExcludedPrecursors === true },
+                    { boxLabel: 'hide', name: 'excludedPrecursors', inputValue: 'hide', checked: this.showExcludedPrecursors === false }
+                ],
                 listeners: {
                     scope: this,
-                    change: function(cb, newValue, oldValue)
-                    {
-                        this.showExcludedPrecursors = newValue;
+                    change: function(group, newValue) {
+                        var val = newValue && (newValue.excludedPrecursors || newValue['excludedPrecursors']);
+                        var newShow = val === 'show' || (val === true);
+                        this.showExcludedPrecursors = newShow;
                         this.havePlotOptionsChanged = true;
 
                         this.setLoadingMsg();
@@ -1102,18 +1079,27 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
 
     getShowReferenceCheckbox : function() {
         if (!this.showReferenceGSCheckBox) {
-            this.showReferenceGSCheckBox = Ext4.create('Ext.form.field.Checkbox', {
+            // Replace checkbox with a radio group: Show/Hide reference guide sets
+            this.showReferenceGSCheckBox = Ext4.create('Ext.form.RadioGroup', {
                 id: 'show-oorange-gs',
-                boxLabel: 'Show Reference Guide Set',
-                checked: this.showReferenceGS,
+                fieldLabel: 'Reference guide sets',
+                labelWidth: this.LABEL_WIDTH,
+                columns: 2,
+                vertical: false,
+                items: [
+                    { boxLabel: 'always show', name: 'referenceGuideSets', inputValue: 'show', checked: this.showReferenceGS === true },
+                    { boxLabel: 'when in date range', name: 'referenceGuideSets', inputValue: 'hide', checked: this.showReferenceGS === false }
+                ],
                 listeners: {
                     scope: this,
-                    change: function(cb, newValue, oldValue) {
-                        this.showReferenceGS = newValue;
+                    change: function(group, newValue) {
+                        var val = newValue && (newValue.referenceGuideSets || newValue['referenceGuideSets']);
+                        var newShow = val === 'show' || (val === true);
+                        this.showReferenceGS = newShow;
                         this.havePlotOptionsChanged = true;
 
                         if (this.showExpRunRange) {
-                            if (newValue) {
+                            if (newShow) {
                                 this.resetFilterPointsIndices();
                                 Ext4.apply(this, {
                                     startDate: this.formatDate(this.expRunDetails.startDate),
@@ -1795,7 +1781,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     addAnnotationsToPlot: function(plot, precursorInfo) {
         var me = this;
 
-        // Issue 38270. Get unique dates just in case there are two replicates with the same acquired time. 
+        // Issue 38270. Get unique dates just in case there are two replicates with the same acquired time.
         // This can happen e.g. if a raw file is imported from different locations.
         var xAxisLabels = Ext4.Array.unique(Ext4.Array.pluck(precursorInfo.data, "fullDate"));
         if (this.groupedX) {


### PR DESCRIPTION
#### Rationale
We've accumulated a lot of controls for Panorama's QC plots. We can do a better job of arranging them and explaining them.

#### Changes
* Group related controls together in three columns
* Eliminate Apply button for date ranges
* Do better at throwing previous requests when users rapidly update settings
* Move some error messaging out of dialogs
* Switch from checkboxes to radio buttons to better explain behavior