### PR TITLE
Fix upgrade failure on QC exclusions linked to metrics being deleted

### DIFF
--- a/resources/schemas/dbscripts/postgresql/targetedms-25.004-25.005.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-25.004-25.005.sql
@@ -1,3 +1,9 @@
+DELETE FROM targetedms.QCMetricExclusion WHERE MetricId IN
+    (SELECT Id FROM targetedms.QCMetricConfiguration WHERE Series2QueryName IS NOT NULL);
+
+DELETE FROM targetedms.QCTraceMetricValues WHERE Metric IN
+   (SELECT Id FROM targetedms.QCMetricConfiguration WHERE Series2QueryName IS NOT NULL);
+
 DELETE FROM targetedms.QCEnabledMetrics WHERE Metric IN
     (SELECT Id FROM targetedms.QCMetricConfiguration WHERE Series2QueryName IS NOT NULL);
 


### PR DESCRIPTION
#### Rationale
PanoramaWeb had exclusions and trace metric values tied to metrics being consolidated during the upgrade process. We need to delete those rows before we can delete the metric row, or the upgrade fails with a FK violation.

#### Changes
* Delete rows from two additional tables with FKs to targetedms.QCMetricConfiguration