### PR TITLE
Wait longer for QC metrics page to load

### DIFF
--- a/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/QCPlotsWebPart.java
@@ -744,7 +744,6 @@ public final class QCPlotsWebPart extends BodyWebPart<QCPlotsWebPart.Elements>
     public ConfigureMetricsUIPage clickConfigureQCMetrics()
     {
         clickMenuItem("Configure QC Metrics");
-        getWrapper().waitForElement(Locator.tagWithText("button", ConfigureMetricsUIPage.ADD_NEW_CUSTOM_METRIC));
         return new ConfigureMetricsUIPage(getDriver());
     }
 

--- a/test/src/org/labkey/test/components/targetedms/QCSummaryWebPart.java
+++ b/test/src/org/labkey/test/components/targetedms/QCSummaryWebPart.java
@@ -103,7 +103,6 @@ public final class QCSummaryWebPart extends BodyWebPart<QCSummaryWebPart.Element
     public ConfigureMetricsUIPage clickConfigureQCMetrics()
     {
         clickMenuItem("Configure QC Metrics");
-        getWrapper().waitForElement(Locator.tagWithText("button", ConfigureMetricsUIPage.ADD_NEW_CUSTOM_METRIC));
         return new ConfigureMetricsUIPage(getDriver());
 
     }

--- a/test/src/org/labkey/test/pages/panoramapremium/ConfigureMetricsUIPage.java
+++ b/test/src/org/labkey/test/pages/panoramapremium/ConfigureMetricsUIPage.java
@@ -2,7 +2,6 @@ package org.labkey.test.pages.panoramapremium;
 
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
-import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.components.ext4.Window;
 import org.labkey.test.components.targetedms.QCPlotsWebPart;
@@ -21,6 +20,12 @@ public class ConfigureMetricsUIPage extends PortalBodyPanel
     public ConfigureMetricsUIPage(WebDriver driver)
     {
         super(driver);
+    }
+
+    @Override
+    protected void waitForPage()
+    {
+        waitForElement(Locator.tagWithText("button", ConfigureMetricsUIPage.ADD_NEW_CUSTOM_METRIC), 15_000);
     }
 
     public ConfigureMetricsUIPage setLeveyJennings(String metric, @Nullable String lowerBound, @Nullable String upperBound)

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCConfigureMetricTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCConfigureMetricTest.java
@@ -11,7 +11,6 @@ import org.labkey.test.components.targetedms.QCSummaryWebPart;
 import org.labkey.test.pages.panoramapremium.ConfigureMetricsUIPage;
 import org.labkey.test.pages.targetedms.PanoramaDashboard;
 import org.labkey.test.tests.panoramapremium.TargetedMSPremiumTest;
-import org.labkey.test.util.DataRegion;
 import org.labkey.test.util.DataRegionTable;
 import org.openqa.selenium.WebElement;
 
@@ -114,6 +113,8 @@ public class TargetedMSQCConfigureMetricTest extends TargetedMSPremiumTest
     @Test
     public void testFixedDeviationFromMeanOption()
     {
+        goToProjectHome();
+
         QCPlotsWebPart.MetricType metricType = QCPlotsWebPart.MetricType.TRANSITION_AREA;
         ConfigureMetricsUIPage configureQCMetrics = goToDashboard().getQcSummaryWebPart().clickConfigureQCMetrics();
 
@@ -153,6 +154,8 @@ public class TargetedMSQCConfigureMetricTest extends TargetedMSPremiumTest
     @Test
     public void testFixedValueCutOffOption()
     {
+        goToProjectHome();
+
         QCPlotsWebPart.MetricType metric = QCPlotsWebPart.MetricType.TRANSITION_MASS_ERROR;
         ConfigureMetricsUIPage configureQCMetrics = goToDashboard().getQcSummaryWebPart().clickConfigureQCMetrics();
 
@@ -185,6 +188,8 @@ public class TargetedMSQCConfigureMetricTest extends TargetedMSPremiumTest
     @Test
     public void testPlotOnlyOption()
     {
+        goToProjectHome();
+
         QCPlotsWebPart.MetricType metric = QCPlotsWebPart.MetricType.ISOTOPE_DOTP;
         ConfigureMetricsUIPage configureQCMetrics = goToDashboard().getQcSummaryWebPart().clickConfigureQCMetrics();
         configureQCMetrics.setShowMetricNoOutlier(metric);


### PR DESCRIPTION
#### Rationale
The QC metrics page sometimes takes longer than 10 seconds to load.
```
org.openqa.selenium.NoSuchElementException: Expected condition failed: waiting for xpath=//button[normalize-space()='Add New Custom Metric'] (tried for 10 second(s) with 100 milliseconds interval)
  [...]
  at app//org.labkey.test.WebDriverWrapper.waitForElement(WebDriverWrapper.java:2504)
  at app//org.labkey.test.components.targetedms.QCSummaryWebPart.clickConfigureQCMetrics(QCSummaryWebPart.java:106)
  at app//org.labkey.test.tests.targetedms.TargetedMSQCConfigureMetricTest.testInconsistentMetricDisplay(TargetedMSQCConfigureMetricTest.java:59)
```

This also causes subsequent tests to fail because they don't navigate to the test project:
```
org.openqa.selenium.NoSuchElementException: Expected condition failed: waiting for id=PanoramaDashboardTab (tried for 10 second(s) with 100 milliseconds interval)
  at app//org.labkey.test.Locator.waitForElement(Locator.java:570)
  at app//org.labkey.test.BaseWebDriverTest.clickTab(BaseWebDriverTest.java:1858)
  at app//org.labkey.test.BaseWebDriverTest.clickTab(BaseWebDriverTest.java:1848)
  at app//org.labkey.test.tests.targetedms.TargetedMSTest.goToDashboard(TargetedMSTest.java:404)
  at app//org.labkey.test.tests.targetedms.TargetedMSQCConfigureMetricTest.testPlotOnlyOption(TargetedMSQCConfigureMetricTest.java:189)
```

#### Related Pull Requests
* N/A

#### Changes
* Wait longer for QC metrics page to load
* Ensure tests start in correct project
