### PR TITLE
Ticket 54342: PanoramaWeb overwhelmed by groupChromatogramChart.view plots

### DIFF
--- a/src/org/labkey/targetedms/chart/ChromatogramDataset.java
+++ b/src/org/labkey/targetedms/chart/ChromatogramDataset.java
@@ -1462,6 +1462,7 @@ public abstract class ChromatogramDataset
 
     public static class GroupDataset extends RtRangeDataset
     {
+        private static final int SERIES_LIMIT = 25;
         private final PeptideGroup _group;
         private final SampleFile _sampleFile;
         private final ViewContext _context;
@@ -1568,6 +1569,12 @@ public abstract class ChromatogramDataset
                     _allMolecules = filtered;
                     break;
                 }
+            }
+
+            // Ticket 54342: PanoramaWeb overwhelmed with requests for massive targetedms-groupChromatogramChart.view plots
+            if (_allMolecules.size() > SERIES_LIMIT)
+            {
+                _allMolecules = _allMolecules.entrySet().stream().limit(SERIES_LIMIT).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
             }
 
             List<PrecursorChromInfoPlus> nonOptimizationPeaks = new ArrayList<>();


### PR DESCRIPTION
#### Rationale
The server and client can get overwhelmed by chromatogram plots with massive number of molecules. The user would too if they finished rendering.

#### Changes
* Limit to 25 molecules as a series. User can still select individual molecules from the list if they want to customize the selection