### PR TITLE
Require a login to protect public folders against aggressive bots

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -2217,6 +2217,7 @@ public class TargetedMSController extends SpringActionController
     }
 
 
+    @RequiresLogin
     @RequiresPermission(ReadPermission.class)
     public class PrecursorAllChromatogramsChartAction extends SimpleViewAction<ChromatogramForm>
     {
@@ -2351,6 +2352,7 @@ public class TargetedMSController extends SpringActionController
         // No match found so no need to redirect
     }
 
+    @RequiresLogin
     @RequiresPermission(ReadPermission.class)
     public class MoleculePrecursorAllChromatogramsChartAction extends SimpleViewAction<ChromatogramForm>
     {

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -134,6 +134,7 @@ import org.labkey.api.reports.report.RedirectReport;
 import org.labkey.api.reports.report.ReportDescriptor;
 import org.labkey.api.security.ActionNames;
 import org.labkey.api.security.Group;
+import org.labkey.api.security.LoginUrls;
 import org.labkey.api.security.RequiresLogin;
 import org.labkey.api.security.RequiresPermission;
 import org.labkey.api.security.SecurityManager;
@@ -2217,7 +2218,6 @@ public class TargetedMSController extends SpringActionController
     }
 
 
-    @RequiresLogin // Require a login to protect public folders against aggressive bots hitting this page on very large documents
     @RequiresPermission(ReadPermission.class)
     public class PrecursorAllChromatogramsChartAction extends SimpleViewAction<ChromatogramForm>
     {
@@ -2228,6 +2228,12 @@ public class TargetedMSController extends SpringActionController
         @Override
         public ModelAndView getView(ChromatogramForm form, BindException errors)
         {
+            if (getViewContext().getUser().isGuest())
+            {
+                // Require a login to protect public folders against aggressive bots hitting this page on very large documents
+                return TargetedMSController.getLoginView(getViewContext(), getContainer());
+            }
+
             long precursorId = form.getId();
             _precursor = PrecursorManager.getPrecursor(getContainer(), precursorId, getUser());
             if (_precursor == null)
@@ -2352,7 +2358,6 @@ public class TargetedMSController extends SpringActionController
         // No match found so no need to redirect
     }
 
-    @RequiresLogin // Require a login to protect public folders against aggressive bots hitting this page on very large documents
     @RequiresPermission(ReadPermission.class)
     public class MoleculePrecursorAllChromatogramsChartAction extends SimpleViewAction<ChromatogramForm>
     {
@@ -2363,6 +2368,12 @@ public class TargetedMSController extends SpringActionController
         @Override
         public ModelAndView getView(ChromatogramForm form, BindException errors)
         {
+            if (getViewContext().getUser().isGuest())
+            {
+                // Require a login to protect public folders against aggressive bots hitting this page on very large documents
+                return TargetedMSController.getLoginView(getViewContext(), getContainer());
+            }
+
             long precursorId = form.getId();
             _precursor = MoleculePrecursorManager.getPrecursor(getContainer(), precursorId, getUser());
             if (_precursor == null)
@@ -4400,10 +4411,18 @@ public class TargetedMSController extends SpringActionController
         public abstract String getDataRegionNameSmallMolecule();
     }
 
-    @RequiresLogin // Require a login to protect public folders against aggressive bots hitting this page on very large documents
     @RequiresPermission(ReadPermission.class)
     public class ShowTransitionListAction extends ShowRunSplitDetailsAction<DocumentTransitionsView>
     {
+        @Override
+        public ModelAndView getHtmlView(final RunDetailsForm form, BindException errors) throws Exception
+        {
+            return getViewContext().getUser().isGuest()
+                    // Require a login to protect public folders against aggressive bots hitting this page on very large documents
+                    ? TargetedMSController.getLoginView(getViewContext(), getContainer())
+                    : super.getHtmlView(form, errors);
+        }
+
         @Override
         protected DocumentTransitionsView createQueryView(RunDetailsForm form, BindException errors, boolean forExport, String dataRegion)
         {
@@ -4437,6 +4456,18 @@ public class TargetedMSController extends SpringActionController
         {
             return SmallMoleculeTransitionsView.DATAREGION_NAME;
         }
+    }
+
+    @NotNull
+    private static HtmlView getLoginView(ViewContext context, Container container)
+    {
+        return new HtmlView(DOM.createHtmlFragment(
+                DOM.DIV(cl("alert alert-info"),
+                        "Please ",
+                        DOM.A(at(style, "font-weight: bold;",
+                                 href, PageFlowUtil.urlProvider(LoginUrls.class).getLoginURL(container, context.getActionURL())),
+                                "login"),
+                        " to view this data")));
     }
 
     @RequiresPermission(ReadPermission.class)

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -4398,6 +4398,7 @@ public class TargetedMSController extends SpringActionController
         public abstract String getDataRegionNameSmallMolecule();
     }
 
+    @RequiresLogin // Require a login to protect public folders against aggressive bots hitting this page on very large documents
     @RequiresPermission(ReadPermission.class)
     public class ShowTransitionListAction extends ShowRunSplitDetailsAction<DocumentTransitionsView>
     {

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -2217,7 +2217,7 @@ public class TargetedMSController extends SpringActionController
     }
 
 
-    @RequiresLogin
+    @RequiresLogin // Require a login to protect public folders against aggressive bots hitting this page on very large documents
     @RequiresPermission(ReadPermission.class)
     public class PrecursorAllChromatogramsChartAction extends SimpleViewAction<ChromatogramForm>
     {
@@ -2352,7 +2352,7 @@ public class TargetedMSController extends SpringActionController
         // No match found so no need to redirect
     }
 
-    @RequiresLogin
+    @RequiresLogin // Require a login to protect public folders against aggressive bots hitting this page on very large documents
     @RequiresPermission(ReadPermission.class)
     public class MoleculePrecursorAllChromatogramsChartAction extends SimpleViewAction<ChromatogramForm>
     {

--- a/src/org/labkey/targetedms/query/ChromatogramGridQuerySettings.java
+++ b/src/org/labkey/targetedms/query/ChromatogramGridQuerySettings.java
@@ -27,11 +27,13 @@ import org.labkey.api.view.ViewContext;
 public class ChromatogramGridQuerySettings extends QuerySettings
 {
     private int _maxRowSize;
+    private static final int DEFAULT_ROWS = 10;
+    private static final int MAX_ROWS_FOR_GUESTS = 50;
 
     public ChromatogramGridQuerySettings(ViewContext context, String dataRegionName, boolean replicateChromatogramsGrouped)
     {
         super(dataRegionName);
-        setMaxRows(10);
+        setMaxRows(DEFAULT_ROWS);
         // On the peptide / molecule details page all the chromatograms from a replicate are displayed together. These are
         // the total precursor ion chromatogram and the fragment ion chromatograms from all the peptide / molecule precursors
         // In this case we set the default row size to 1 so that each row displays the chromatograms from a single replicate.
@@ -46,6 +48,13 @@ public class ChromatogramGridQuerySettings extends QuerySettings
     public void init(ViewContext context)
     {
         super.init(context);
+
+        if (context.getUser().isGuest())
+        {
+            // Multiple chart rendering requests are triggered per row. Cap guest users at 50 rows to prevent bot abuse on large documents
+            setMaxRows(Math.min(MAX_ROWS_FOR_GUESTS, getMaxRows()));
+        }
+
         String param = _getParameter("maxRowSize");
         if (param != null)
         {


### PR DESCRIPTION
#### Rationale
The transition list is an expensive page to render for very large Skyline documents. A bot has been hitting public pages on PanoramaWeb over 28,000 times in 24 hours, causing perf problems.

#### Changes
* Require a login to view the transition list, even when guests have read access to the container