### PR TITLE
Fix malformed links on the Passport Details page

### DIFF
--- a/src/org/labkey/targetedms/view/passport/beforeAfterReport.jsp
+++ b/src/org/labkey/targetedms/view/passport/beforeAfterReport.jsp
@@ -2,7 +2,6 @@
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.api.view.template.ClientDependencies" %>
-<%@ page import="org.labkey.targetedms.TargetedMSController" %>
 <%@ page import="org.labkey.targetedms.model.passport.IPeptide" %>
 <%@ page import="org.labkey.targetedms.model.passport.IProtein" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
@@ -52,8 +51,6 @@
     document.addEventListener("DOMContentLoaded", function() {
         protein.initialize();
     });
-    var chromatogramUrl = "<%=h(urlFor(TargetedMSController.PrecursorChromatogramChartAction.class))%>";
-    var showPeptideUrl = "<%=h(urlFor(TargetedMSController.ShowPeptideAction.class))%>";
 </script>
 <!--END IMPORTS-->
 

--- a/webapp/passport/js/beforeAfter/protein.js
+++ b/webapp/passport/js/beforeAfter/protein.js
@@ -155,7 +155,16 @@ protein =
         if (chromatogram) {
             parentElement.empty();
             parentElement.show();
-            LABKEY.targetedms.SVGChart.requestAndRenderSVG(chromatogramUrl + "id=" + chromatogram + "&syncY=true&syncX=false&chartWidth=250&chartHeight=400", parentElement[0], $('#seriesLegend')[0])
+            const chromatogramUrl = LABKEY.ActionURL.buildURL("targetedms", "precursorChromatogramChart",
+                    LABKEY.ActionURL.getContainer(),
+                    {
+                        id: chromatogram,
+                        syncY: true,
+                        syncX: false,
+                        chartWidth: 250,
+                        chartHeight: 400
+                    });
+            LABKEY.targetedms.SVGChart.requestAndRenderSVG(chromatogramUrl, parentElement[0], $('#seriesLegend')[0]);
             return true;
         }
         else {
@@ -193,7 +202,9 @@ protein =
         }
 
         // sets panorama peptide link
-        $('#selectedPeptideLink').attr("href", showPeptideUrl + "id=" + protein.selectedPeptide.PeptideId);
+        const showPeptideUrl = LABKEY.ActionURL.buildURL("targetedms", "showPeptide", LABKEY.ActionURL.getContainer(), {id: protein.selectedPeptide.PeptideId});
+        $('#selectedPeptideLink').attr("href", showPeptideUrl);
+
         // sets basic peptide info (Seq, location, length, etc..
         $('#peptideinfo').empty();
         var value = protein.selectedPeptide["Before Incubation"] ? protein.selectedPeptide["Before Incubation"] : protein.selectedPeptide["Total Area"];


### PR DESCRIPTION
#### Rationale
Chromatogram and peptide detail links were malformed due to a missing `?` before URL query parameters.

#### Changes
- Use LABKEY.ActionURL.buildURL to build the links
