### PR TITLE
Make TargetedMSModule unavailable when not active in container

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -240,6 +240,12 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
         return true;
     }
 
+    @Override
+    public boolean isAvailable(Container container)
+    {
+        return container.isRoot() || container.getActiveModules().contains(this);
+    }
+
     @NotNull
     @Override
     protected Collection<WebPartFactory> createWebPartFactories()


### PR DESCRIPTION
#### Rationale
Modules like TargetedMS don't work very well when they're not active in a container. Specifically, their schema isn't available, so many actions (export, plotting, etc) break.

#### Changes
* Check if active (or we're in the root)