### PR TITLE
Add link to "Register" for a new account

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -133,6 +133,7 @@ import org.labkey.api.reports.model.ViewCategoryManager;
 import org.labkey.api.reports.report.RedirectReport;
 import org.labkey.api.reports.report.ReportDescriptor;
 import org.labkey.api.security.ActionNames;
+import org.labkey.api.security.AuthenticationManager;
 import org.labkey.api.security.Group;
 import org.labkey.api.security.LoginUrls;
 import org.labkey.api.security.RequiresLogin;
@@ -2309,10 +2310,9 @@ public class TargetedMSController extends SpringActionController
         @Override
         public void addNavTrail(NavTree root)
         {
+            root.addChild("Targeted MS Runs", getShowListURL(getContainer()));
             if (null != _run)
             {
-                root.addChild("Targeted MS Runs", getShowListURL(getContainer()));
-
                 root.addChild(_run.getDescription(), getShowRunURL(getContainer(), _run.getId()));
 
                 ActionURL pepDetailsUrl = new ActionURL(ShowPeptideAction.class, getContainer());
@@ -4461,20 +4461,20 @@ public class TargetedMSController extends SpringActionController
     @NotNull
     private static HtmlView getLoginView(ViewContext context, Container container)
     {
-        ActionURL registerUrl = new ActionURL("login", "register", container);
-        registerUrl.addReturnUrl(context.getActionURL());
+        ActionURL loginUrl = PageFlowUtil.urlProvider(LoginUrls.class).getLoginURL(container, context.getActionURL());
+        ActionURL registerUrl = PageFlowUtil.urlProvider(LoginUrls.class).getRegisterURL(container, context.getActionURL());
+        HtmlString loginLink = DOM.createHtmlFragment(
+                                DOM.A(at(style, "font-weight: bold;", href, loginUrl),"Login"),
+                                " to view this data");
+        HtmlString registerLink = DOM.createHtmlFragment(
+                                    DOM.BR(),
+                                    "Don't have an account? ",
+                                    DOM.A(at(style, "font-weight: bold;", href, registerUrl), "Register"));
 
         return new HtmlView(DOM.createHtmlFragment(
                 DOM.DIV(cl("alert alert-info"),
-                        DOM.A(at(style, "font-weight: bold;",
-                                 href, PageFlowUtil.urlProvider(LoginUrls.class).getLoginURL(container, context.getActionURL())),
-                                "Login"),
-                        " to view this data.",
-                       DOM.BR(),
-                       "Don't have an account? ",
-                        DOM.A(at(style, "font-weight: bold;",
-                                        href, registerUrl),
-                                "Register"))));
+                        loginLink,
+                        AuthenticationManager.isRegistrationEnabled() ? registerLink : "")));
     }
 
     @RequiresPermission(ReadPermission.class)

--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -4461,13 +4461,20 @@ public class TargetedMSController extends SpringActionController
     @NotNull
     private static HtmlView getLoginView(ViewContext context, Container container)
     {
+        ActionURL registerUrl = new ActionURL("login", "register", container);
+        registerUrl.addReturnUrl(context.getActionURL());
+
         return new HtmlView(DOM.createHtmlFragment(
                 DOM.DIV(cl("alert alert-info"),
-                        "Please ",
                         DOM.A(at(style, "font-weight: bold;",
                                  href, PageFlowUtil.urlProvider(LoginUrls.class).getLoginURL(container, context.getActionURL())),
-                                "login"),
-                        " to view this data")));
+                                "Login"),
+                        " to view this data.",
+                       DOM.BR(),
+                       "Don't have an account? ",
+                        DOM.A(at(style, "font-weight: bold;",
+                                        href, registerUrl),
+                                "Register"))));
     }
 
     @RequiresPermission(ReadPermission.class)

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentTest.java
@@ -30,6 +30,9 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.components.FilesWebPart;
+import org.labkey.test.pages.core.admin.ShowAdminPage;
+import org.labkey.test.pages.core.login.LoginConfigurePage;
+import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.FileBrowserHelper;
@@ -47,9 +50,11 @@ import java.util.List;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.labkey.test.util.DataRegionTable.DataRegion;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 8)
@@ -96,6 +101,9 @@ public class TargetedMSExperimentTest extends TargetedMSTest
         // Verify product ion labels
         importData(SKY_FILE3, ++jobCount);
         verifyFragmentIonLabels(SKY_FILE3);
+
+        // Verify that guests access is blocked on some actions
+        verifyGuestAccess();
     }
 
     @LogMethod
@@ -798,5 +806,90 @@ public class TargetedMSExperimentTest extends TargetedMSTest
         List<String> missing = expectedLegendTexts.stream().filter(l -> !svgTexts.contains(l)).toList();
 
         assertTrue("Missing legend items in chromatogram plot - " + missing, missing.isEmpty());
+    }
+
+    @LogMethod
+    private void verifyGuestAccess()
+    {
+        // Enable self sign up
+        ShowAdminPage adminPage = goToAdminConsole();
+        LoginConfigurePage loginConfigurePage = adminPage.clickAuthentication();
+        loginConfigurePage.setSelfSignup(true);
+        loginConfigurePage.clickSaveAndFinish();
+
+        // Make folder public
+        goToProjectHome(getProjectName());
+        ApiPermissionsHelper permissionsHelper = new ApiPermissionsHelper(this);
+        permissionsHelper.setSiteGroupPermissions("Guests", READER_ROLE);
+
+        // Signout
+        signOut();
+        verifyGuestAccess(true);
+
+        // Disable self-signup
+        signIn();
+        adminPage = goToAdminConsole();
+        loginConfigurePage = adminPage.clickAuthentication();
+        loginConfigurePage.setSelfSignup(false);
+        loginConfigurePage.clickSaveAndFinish();
+
+        // Message on blocked pages should not include link to register
+        signOut();
+        verifyGuestAccess(false);
+    }
+
+    private void verifyGuestAccess(boolean selfSignupEnabled)
+    {
+        goToProjectHome(getProjectName());
+        goToDashboard();
+
+        // Verify guest CAN view the document details page (ShowPrecursorListAction)
+        clickAndWait(Locator.linkWithText(SKY_FILE));
+        assertTextPresent("Document Summary");
+
+        // Verify guest CAN view the protein details page (ShowProteinAction)
+        String targetProtein = "YAL038W";
+        clickAndWait(Locator.linkWithText(targetProtein));
+        assertTextPresentInThisOrder(targetProtein,
+                "Protein",
+                "Sequence Coverage",
+                "Annotations for " + targetProtein,
+                "Peptides",
+                "Chromatograms",
+                "Summary Charts");
+
+        // Verify guest CAN view the peptide details page (ShowPeptideAction)
+        String targetPeptide = "LTSLNVVAGSDLR";
+        clickAndWait(Locator.linkWithText(targetPeptide));
+        assertTextPresentInThisOrder(targetPeptide,
+                "Peptide Summary",
+                "Chromatograms",
+                "Summary Charts",
+                "LTSLNVVAGSDLR, Charge 2"); // Title of the MS/MS spectrum viewer panel
+
+        // Verify guest CANNOT view the precursor details page (PrecursorAllChromatogramsChartAction)
+        clickAndWait(Locator.linkWithImage("TransitionGroupLib.png"));
+        verifyNoGuestAccessMessage(selfSignupEnabled);
+
+        // Go back to the document details page and in Document Summary click the transitions link
+        // Verify guest CANNOT view the transitions list (ShowTransitionListAction)
+        goToDashboard();
+        clickAndWait(Locator.linkWithText(SKY_FILE));
+        clickAndWait(Locator.linkWithText("296 transitions"));
+        verifyNoGuestAccessMessage(selfSignupEnabled);
+    }
+
+    private void verifyNoGuestAccessMessage(boolean selfSignupEnabled)
+    {
+        String fullBodyText = getBodyText();
+        if (selfSignupEnabled)
+        {
+            assertTrue(fullBodyText.contains("Login to view this data" + "\n" + "Don't have an account? Register"));
+        }
+        else
+        {
+            assertTrue(fullBodyText.contains("Login to view this data"));
+            assertFalse(fullBodyText.contains("Don't have an account? Register"));
+        }
     }
 }


### PR DESCRIPTION
#### Rationale
We will enable self-sign-up on PanoramaWeb.  For pages that don't allow guest access, add a link to "Register" for an account in case the user does not have one.
<img width="475" height="149" alt="image" src="https://github.com/user-attachments/assets/1c60baa7-668b-4f71-83dc-0303ce343826" />


#### Related Pull Requests
* https://github.com/LabKey/targetedms/pull/1169

