### PR TITLE
Share instrument annotations across QC folders

### DIFF
--- a/resources/queries/targetedms/qcannotation/.qview.xml
+++ b/resources/queries/targetedms/qcannotation/.qview.xml
@@ -4,6 +4,8 @@
         <column name="Date" />
         <column name="EndDate" />
         <column name="QCAnnotationTypeId" />
+        <column name="instrumentModel" />
+        <column name="instrumentSerialNumber" />
         <column name="Container" />
         <column name="Created" />
         <column name="Modified" />

--- a/resources/queries/targetedms/qcannotationtype/.qview.xml
+++ b/resources/queries/targetedms/qcannotationtype/.qview.xml
@@ -4,6 +4,7 @@
         <column name="Description" />
         <column name="Color" />
         <column name="Container" />
+        <column name="IsShareable"/>
         <column name="Created" />
         <column name="Modified" />
     </columns>

--- a/resources/queries/targetedms/qcannotationtype/.qview.xml
+++ b/resources/queries/targetedms/qcannotationtype/.qview.xml
@@ -4,7 +4,7 @@
         <column name="Description" />
         <column name="Color" />
         <column name="Container" />
-        <column name="IsShareable"/>
+        <column name="Shareable"/>
         <column name="Created" />
         <column name="Modified" />
     </columns>

--- a/resources/schemas/dbscripts/postgresql/targetedms-26.002-26.003.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-26.002-26.003.sql
@@ -1,2 +1,3 @@
 ALTER TABLE targetedms.QCAnnotationType ADD COLUMN isShareable BOOLEAN DEFAULT FALSE;
-ALTER TABLE targetedms.QCAnnotation ADD COLUMN instrument VARCHAR(255);
+ALTER TABLE targetedms.QCAnnotation ADD COLUMN instrumentModel VARCHAR(255);
+ALTER TABLE targetedms.QCAnnotation ADD COLUMN instrumentSerialNumber VARCHAR(255);

--- a/resources/schemas/dbscripts/postgresql/targetedms-26.002-26.003.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-26.002-26.003.sql
@@ -1,3 +1,5 @@
-ALTER TABLE targetedms.QCAnnotationType ADD COLUMN isShareable BOOLEAN DEFAULT FALSE;
+ALTER TABLE targetedms.QCAnnotationType ADD COLUMN Shareable BOOLEAN DEFAULT FALSE;
 ALTER TABLE targetedms.QCAnnotation ADD COLUMN instrumentModel VARCHAR(255);
 ALTER TABLE targetedms.QCAnnotation ADD COLUMN instrumentSerialNumber VARCHAR(255);
+
+UPDATE targetedms.QCAnnotationType SET Shareable = TRUE WHERE Name = 'Instrumentation Change';

--- a/resources/schemas/dbscripts/postgresql/targetedms-26.002-26.003.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-26.002-26.003.sql
@@ -1,0 +1,2 @@
+ALTER TABLE targetedms.QCAnnotationType ADD COLUMN isShareable BOOLEAN DEFAULT FALSE;
+ALTER TABLE targetedms.QCAnnotation ADD COLUMN instrument VARCHAR(255);

--- a/resources/schemas/targetedms.xml
+++ b/resources/schemas/targetedms.xml
@@ -1308,7 +1308,8 @@
                 <columnTitle>Annotation Type</columnTitle>
                 <description>The category of the event</description>
             </column>
-            <column columnName="instrument"/>
+            <column columnName="instrumentModel"/>
+            <column columnName="instrumentSerialNumber"/>
         </columns>
     </table>
     <table tableName="QCMetricConfiguration" tableDbType="TABLE">

--- a/resources/schemas/targetedms.xml
+++ b/resources/schemas/targetedms.xml
@@ -1262,6 +1262,7 @@
             <column columnName="Name"/>
             <column columnName="Description"/>
             <column columnName="Color"/>
+            <column columnName="IsShareable"/>
         </columns>
     </table>
 
@@ -1307,6 +1308,7 @@
                 <columnTitle>Annotation Type</columnTitle>
                 <description>The category of the event</description>
             </column>
+            <column columnName="instrument"/>
         </columns>
     </table>
     <table tableName="QCMetricConfiguration" tableDbType="TABLE">

--- a/resources/schemas/targetedms.xml
+++ b/resources/schemas/targetedms.xml
@@ -1262,7 +1262,7 @@
             <column columnName="Name"/>
             <column columnName="Description"/>
             <column columnName="Color"/>
-            <column columnName="IsShareable"/>
+            <column columnName="Shareable"/>
         </columns>
     </table>
 

--- a/src/org/labkey/targetedms/TargetedMSManager.java
+++ b/src/org/labkey/targetedms/TargetedMSManager.java
@@ -207,7 +207,8 @@ public class TargetedMSManager
 
     public static List<SampleFileChromInfo> getSampleFileChromInfos(SampleFile sampleFile)
     {
-        return new TableSelector(getTableInfoSampleFileChromInfo(), new SimpleFilter(FieldKey.fromParts("SampleFileId"), sampleFile.getId()), new Sort("TextId")).getArrayList(SampleFileChromInfo.class);    }
+        return new TableSelector(getTableInfoSampleFileChromInfo(), new SimpleFilter(FieldKey.fromParts("SampleFileId"), sampleFile.getId()), new Sort("TextId")).getArrayList(SampleFileChromInfo.class);
+    }
 
     public static SampleFileChromInfo getSampleFileChromInfo(int id, Container c)
     {
@@ -356,7 +357,7 @@ public class TargetedMSManager
 
     public static TableInfo getTableInfoPeptideAreaRatio()
     {
-       return getSchema().getTable(TargetedMSSchema.TABLE_PEPTIDE_AREA_RATIO);
+        return getSchema().getTable(TargetedMSSchema.TABLE_PEPTIDE_AREA_RATIO);
     }
 
     public static TableInfo getTableInfoInstrument()
@@ -499,6 +500,7 @@ public class TargetedMSManager
     {
         return getSchema().getTable(TargetedMSSchema.TABLE_QC_EMAIL_NOTIFICATIONS);
     }
+
     public static TableInfo getTableInfoAnnotationSettings()
     {
         return getSchema().getTable(TargetedMSSchema.TABLE_ANNOTATION_SETTINGS);
@@ -543,12 +545,14 @@ public class TargetedMSManager
     {
         return getSchema().getTable(TargetedMSSchema.TABLE_QC_ANNOTATION);
     }
+
     public static TableInfo getTableInfoQuantificationSettings()
     {
         return getSchema().getTable(TargetedMSSchema.TABLE_QUANTIIFICATION_SETTINGS);
     }
 
-    public static TableInfo getTableInfoCalibrationCurve() {
+    public static TableInfo getTableInfoCalibrationCurve()
+    {
         return getSchema().getTable(TargetedMSSchema.TABLE_CALIBRATION_CURVE);
     }
 
@@ -612,7 +616,9 @@ public class TargetedMSManager
         return getSchema().getTable(TargetedMSSchema.TABLE_SKYLINE_RUN_AUDITLOG_ENTRY);
     }
 
-    /** View that's a CTE to pull in the RunId */
+    /**
+     * View that's a CTE to pull in the RunId
+     */
     public static TableInfo getTableInfoSkylineAuditLog()
     {
         return getSchema().getTable(TargetedMSSchema.TABLE_SKYLINE_AUDITLOG);
@@ -623,19 +629,23 @@ public class TargetedMSManager
         return getSchema().getTable(TargetedMSSchema.TABLE_SKYLINE_AUDITLOG_MESSAGE);
     }
 
-    public static TableInfo getTableInfoListDefinition() {
+    public static TableInfo getTableInfoListDefinition()
+    {
         return getSchema().getTable(TargetedMSSchema.TABLE_LIST_DEFINITION);
     }
 
-    public static TableInfo getTableInfoListColumnDefinition() {
+    public static TableInfo getTableInfoListColumnDefinition()
+    {
         return getSchema().getTable(TargetedMSSchema.TABLE_LIST_COLUMN_DEFINITION);
     }
 
-    public static TableInfo getTableInfoListItem() {
+    public static TableInfo getTableInfoListItem()
+    {
         return getSchema().getTable(TargetedMSSchema.TABLE_LIST_ITEM);
     }
 
-    public static TableInfo getTableInfoListItemValue() {
+    public static TableInfo getTableInfoListItemValue()
+    {
         return getSchema().getTable(TargetedMSSchema.TABLE_LIST_ITEM_VALUE);
     }
 
@@ -704,20 +714,22 @@ public class TargetedMSManager
         return getSchema().getTable(TargetedMSSchema.TABLE_INSTRUMENT_USAGE_PAYMENT);
     }
 
-    /** @return rowId for pipeline job that will perform the import asynchronously */
+    /**
+     * @return rowId for pipeline job that will perform the import asynchronously
+     */
     public static Long addRunToQueue(ViewBackgroundInfo info,
-                                        final Path path) throws XarFormatException, PipelineValidationException
+                                     final Path path) throws XarFormatException, PipelineValidationException
     {
         String description = "Skyline document import - " + FileUtil.getFileName(path);
         XarContext xarContext = new XarContext(description, info.getContainer(), info.getUser());
-        User user =  info.getUser();
+        User user = info.getUser();
         Container container = info.getContainer();
 
         // If an entry does not already exist for this data file in exp.data create it now.
-		// This should happen only if a file was copied to the pipeline directory instead
-		// of being uploaded via the files browser.
+        // This should happen only if a file was copied to the pipeline directory instead
+        // of being uploaded via the files browser.
         ExpData expData = ExperimentService.get().getExpDataByURL(path, container);
-        if(expData == null)
+        if (expData == null)
         {
             XarSource source = new AbstractFileXarSource("Wrap Targeted MS Run", container, user)
             {
@@ -785,7 +797,7 @@ public class TargetedMSManager
 
             // Make sure that we have a protocol in this folder
             String protocolPrefix = run.isZipFile() ? TargetedMSModule.IMPORT_SKYZIP_PROTOCOL_OBJECT_PREFIX :
-                                                      TargetedMSModule.IMPORT_SKYDOC_PROTOCOL_OBJECT_PREFIX;
+                    TargetedMSModule.IMPORT_SKYDOC_PROTOCOL_OBJECT_PREFIX;
 
             Lsid lsid = new Lsid("Protocol.Folder-" + container.getRowId(), protocolPrefix);
             ExpProtocol protocol = ExperimentService.get().getExpProtocol(lsid.toString());
@@ -810,11 +822,11 @@ public class TargetedMSManager
             outputDatas.put(expData, "sky");
 
             ExpData expSkydData = null;
-            if(run.getSkydDataId() != null)
+            if (run.getSkydDataId() != null)
             {
                 expSkydData = ExperimentService.get().getExpData(run.getSkydDataId());
             }
-            if(expSkydData != null)
+            if (expSkydData != null)
             {
                 outputDatas.put(expSkydData, "skyd");
             }
@@ -831,12 +843,12 @@ public class TargetedMSManager
             }
 
             expRun = ExperimentService.get().saveSimpleExperimentRun(expRun,
-                                                                     Collections.emptyMap(),
-                                                                     inputDatas,
-                                                                     Collections.emptyMap(),
-                                                                     outputDatas,
-                                                                     Collections.emptyMap(),
-                                                                     info, _log, false);
+                    Collections.emptyMap(),
+                    inputDatas,
+                    Collections.emptyMap(),
+                    outputDatas,
+                    Collections.emptyMap(),
+                    info, _log, false);
 
             run.setExperimentRunLSID(expRun.getLSID());
             TargetedMSManager.updateRun(run, user);
@@ -903,7 +915,7 @@ public class TargetedMSManager
     public static TargetedMSRun getRunByDataId(long dataId, Container c)
     {
         TargetedMSRun[] runs;
-        if(c != null)
+        if (c != null)
         {
             runs = getRuns("DataId = ? AND Deleted = ? AND Container = ?", dataId, Boolean.FALSE, c.getId());
         }
@@ -911,11 +923,11 @@ public class TargetedMSManager
         {
             runs = getRuns("DataId = ? AND Deleted = ?", dataId, Boolean.FALSE);
         }
-        if(runs.length == 0)
+        if (runs.length == 0)
         {
             return null;
         }
-        if(runs.length == 1)
+        if (runs.length == 1)
         {
             return runs[0];
         }
@@ -930,7 +942,7 @@ public class TargetedMSManager
     public static TargetedMSRun getRunBySkydDataId(long skydDataId, Container c)
     {
         TargetedMSRun[] runs;
-        if(c != null)
+        if (c != null)
         {
             runs = getRuns("SkydDataId = ? AND Deleted = ? AND Container = ?", skydDataId, Boolean.FALSE, c.getId());
         }
@@ -938,11 +950,11 @@ public class TargetedMSManager
         {
             runs = getRuns("SkydDataId = ? AND Deleted = ?", skydDataId, Boolean.FALSE);
         }
-        if(runs.length == 0)
+        if (runs.length == 0)
         {
             return null;
         }
-        if(runs.length == 1)
+        if (runs.length == 1)
         {
             return runs[0];
         }
@@ -953,15 +965,15 @@ public class TargetedMSManager
     public static TargetedMSRun getRunByLsid(String lsid, Container c)
     {
         TargetedMSRun[] runs = getRuns("experimentrunlsid = ? AND container = ?", lsid, c.getId());
-        if(runs.length == 0)
+        if (runs.length == 0)
         {
             return null;
         }
-        if(runs.length == 1)
+        if (runs.length == 1)
         {
             return runs[0];
         }
-        throw new IllegalArgumentException("More than one TargetedMS runs found for LSID "+lsid);
+        throw new IllegalArgumentException("More than one TargetedMS runs found for LSID " + lsid);
     }
 
     public static boolean updateSkydDataId(ITargetedMSRun run, ExpData newSkydData, User user)
@@ -1046,11 +1058,11 @@ public class TargetedMSManager
     {
         Collection<Long> representativeRunIds = Collections.emptyList();
 
-        if(representativeState == RunRepresentativeDataState.Representative_Protein)
+        if (representativeState == RunRepresentativeDataState.Representative_Protein)
         {
             representativeRunIds = getProteinRepresentativeRunIds(container);
         }
-        else if(representativeState == RunRepresentativeDataState.Representative_Peptide)
+        else if (representativeState == RunRepresentativeDataState.Representative_Peptide)
         {
             representativeRunIds = getPeptideRepresentativeRunIds(container);
         }
@@ -1061,7 +1073,7 @@ public class TargetedMSManager
         }
 
         SQLFragment updateSql = new SQLFragment();
-        updateSql.append("UPDATE "+TargetedMSManager.getTableInfoRuns());
+        updateSql.append("UPDATE " + TargetedMSManager.getTableInfoRuns());
         updateSql.append(" SET RepresentativeDataState = ?");
         updateSql.add(RunRepresentativeDataState.NotRepresentative.ordinal());
         updateSql.append(" WHERE Container = ?");
@@ -1073,7 +1085,7 @@ public class TargetedMSManager
         // for the documents not yet imported.
         updateSql.append(" AND StatusId = ? ");
         updateSql.add(SkylineDocImporter.STATUS_SUCCESS);
-        updateSql.append(" AND Id NOT IN ("+StringUtils.join(representativeRunIds, ",")+")");
+        updateSql.append(" AND Id NOT IN (" + StringUtils.join(representativeRunIds, ",") + ")");
 
         new SqlExecutor(TargetedMSManager.getSchema()).execute(updateSql);
     }
@@ -1081,11 +1093,11 @@ public class TargetedMSManager
     public static List<Long> getCurrentRepresentativeRunIds(Container container)
     {
         List<Long> representativeRunIds = null;
-        if(getFolderType(container) == TargetedMSService.FolderType.LibraryProtein)
+        if (getFolderType(container) == TargetedMSService.FolderType.LibraryProtein)
         {
             representativeRunIds = getCurrentProteinRepresentativeRunIds(container);
         }
-        else if(getFolderType(container) == TargetedMSService.FolderType.Library)
+        else if (getFolderType(container) == TargetedMSService.FolderType.Library)
         {
             representativeRunIds = getCurrentPeptideRepresentativeRunIds(container);
         }
@@ -1101,8 +1113,8 @@ public class TargetedMSManager
     private static List<Long> getProteinRepresentativeRunIds(Container container)
     {
         return getProteinRepresentativeRunIds(container, RepresentativeDataState.Representative.ordinal(),
-                                                         RepresentativeDataState.Deprecated.ordinal(),
-                                                         RepresentativeDataState.Conflicted.ordinal());
+                RepresentativeDataState.Deprecated.ordinal(),
+                RepresentativeDataState.Conflicted.ordinal());
     }
 
     private static List<Long> getProteinRepresentativeRunIds(Container container, int... stateArray)
@@ -1130,8 +1142,8 @@ public class TargetedMSManager
     private static List<Long> getPeptideRepresentativeRunIds(Container container)
     {
         return getPeptideRepresentativeRunIds(container, RepresentativeDataState.Representative.ordinal(),
-                                                         RepresentativeDataState.Deprecated.ordinal(),
-                                                         RepresentativeDataState.Conflicted.ordinal());
+                RepresentativeDataState.Deprecated.ordinal(),
+                RepresentativeDataState.Conflicted.ordinal());
     }
 
     private static List<Long> getPeptideRepresentativeRunIds(Container container, int... stateArray)
@@ -1164,7 +1176,9 @@ public class TargetedMSManager
         Table.update(user, getTableInfoRuns(), run, run.getRunId());
     }
 
-    /** Delete all of the TargetedMS runs in the container, including their experiment run wrappers */
+    /**
+     * Delete all of the TargetedMS runs in the container, including their experiment run wrappers
+     */
     public static void deleteIncludingExperimentWrapper(Container c, User user)
     {
         List<Long> runIds = new SqlSelector(getSchema(), "SELECT Id FROM " + getTableInfoRuns() + " WHERE Container = ?", c).getArrayList(Long.class);
@@ -1210,9 +1224,13 @@ public class TargetedMSManager
         return name;
     }
 
-    private record NicknameKey(String serialNumber, String model) {}
+    private record NicknameKey(String serialNumber, String model)
+    {
+    }
 
-    /** @return the matches in order of closest to furthest match, injecting a virtual option if the list is empty */
+    /**
+     * @return the matches in order of closest to furthest match, injecting a virtual option if the list is empty
+     */
     public List<InstrumentNickname> getNickname(String name, TargetedMSSchema schema)
     {
         TableInfo info = schema.getTableOrThrow(TABLE_INSTRUMENT_NICKNAME, new ContainerFilter.CurrentPlusProjectAndShared(schema.getContainer(), schema.getUser()));
@@ -1235,7 +1253,7 @@ public class TargetedMSManager
         }
 
         List<InstrumentNickname> result = new ArrayList<>(dedupeAcrossContainers.values());
-        
+
         if (matches.isEmpty())
         {
             String sql = "SELECT DISTINCT InstrumentNickname, " +
@@ -1283,13 +1301,14 @@ public class TargetedMSManager
     /**
      * Delete just the targetedms run and its child tables
      * Pulled out into separate method so could be called by itself from data handlers
+     *
      * @param runIds targetedms.run.id values
      */
     public static void deleteRuns(List<Long> runIds, Container c, User user, boolean containerDeletion)
     {
         List<Long> cantDelete = new ArrayList<>();
         List<TargetedMSRun> runsToDelete = new ArrayList<>();
-        for (long runId: runIds)
+        for (long runId : runIds)
         {
             TargetedMSRun run = getRun(runId);
             if (run == null || run.isDeleted())
@@ -1298,7 +1317,7 @@ public class TargetedMSManager
             }
             if (!run.getContainer().equals(c) && !run.getContainer().hasPermission(user, DeletePermission.class))
             {
-               cantDelete.add(runId);
+                cantDelete.add(runId);
             }
             runsToDelete.add(run);
         }
@@ -1371,22 +1390,22 @@ public class TargetedMSManager
 
     public static TargetedMSRun getRunForPrecursor(long precursorId)
     {
-        String sql = "SELECT run.* FROM "+
-                     getTableInfoRuns()+" AS run, "+
-                     getTableInfoPeptideGroup()+" AS pg, "+
-                     getTableInfoGeneralMolecule()+" AS gm, "+
-                     getTableInfoGeneralPrecursor()+" AS gp "+
-                     "WHERE run.Id=pg.RunId "+
-                     "AND pg.Id=gm.PeptideGroupId "+
-                     "AND gm.Id=gp.GeneralMoleculeId "+
-                     "AND gp.Id=?";
+        String sql = "SELECT run.* FROM " +
+                getTableInfoRuns() + " AS run, " +
+                getTableInfoPeptideGroup() + " AS pg, " +
+                getTableInfoGeneralMolecule() + " AS gm, " +
+                getTableInfoGeneralPrecursor() + " AS gp " +
+                "WHERE run.Id=pg.RunId " +
+                "AND pg.Id=gm.PeptideGroupId " +
+                "AND gm.Id=gp.GeneralMoleculeId " +
+                "AND gp.Id=?";
         SQLFragment sf = new SQLFragment(sql);
         sf.add(precursorId);
 
         TargetedMSRun run = new SqlSelector(getSchema(), sf).getObject(TargetedMSRun.class);
-        if(run == null)
+        if (run == null)
         {
-            throw new NotFoundException("No run found for precursor: "+precursorId);
+            throw new NotFoundException("No run found for precursor: " + precursorId);
         }
         return run;
     }
@@ -1394,18 +1413,18 @@ public class TargetedMSManager
     @NotNull
     public static TargetedMSRun getRunForGeneralMolecule(long id)
     {
-        String sql = "SELECT run.* FROM "+
-                     getTableInfoRuns()+" AS run, "+
-                     getTableInfoPeptideGroup()+" AS pg, "+
-                     getTableInfoGeneralMolecule()+" AS gm "+
-                     "WHERE run.Id=pg.RunId "+
-                     "AND pg.Id=gm.PeptideGroupId "+
-                     "AND gm.Id=?";
+        String sql = "SELECT run.* FROM " +
+                getTableInfoRuns() + " AS run, " +
+                getTableInfoPeptideGroup() + " AS pg, " +
+                getTableInfoGeneralMolecule() + " AS gm " +
+                "WHERE run.Id=pg.RunId " +
+                "AND pg.Id=gm.PeptideGroupId " +
+                "AND gm.Id=?";
         SQLFragment sf = new SQLFragment(sql);
         sf.add(id);
 
         TargetedMSRun run = new SqlSelector(getSchema(), sf).getObject(TargetedMSRun.class);
-        if(run == null)
+        if (run == null)
         {
             throw new NotFoundException("No run found for general molecule: " + id);
         }
@@ -1506,7 +1525,7 @@ public class TargetedMSManager
         sql.append(getTableInfoRuns(), "r");
         sql.append(", ");
         sql.append(ExperimentService.get().getTinfoData(), "d");
-        sql.append( " WHERE rep.Id = sf.ReplicateId AND rep.RunId = r.Id AND d.RowId = r.DataId AND d.DataFileUrl = ?");
+        sql.append(" WHERE rep.Id = sf.ReplicateId AND rep.RunId = r.Id AND d.RowId = r.DataId AND d.DataFileUrl = ?");
         sql.add(FileUtil.uriToString(uri));
 
         return new SqlSelector(getSchema(), sql).exists();
@@ -1648,7 +1667,7 @@ public class TargetedMSManager
 
         var map = new SqlSelector(getSchema(), sql).getMap();
         String filePath = null;
-        if(map != null)
+        if (map != null)
         {
             filePath = (String) map.get("dataFileUrl");
         }
@@ -1735,7 +1754,7 @@ public class TargetedMSManager
     private static String createTempChromInfoIdsTable(TableInfo tableInfo, String tempTableNamePrefix, SQLFragment whereClause)
     {
         final String suffix = StringUtilsLabKey.getPaddedUniquifier(9);
-        final String tempTableName = TargetedMSManager.getSqlDialect().getTempTablePrefix() +  tempTableNamePrefix + suffix;
+        final String tempTableName = TargetedMSManager.getSqlDialect().getTempTablePrefix() + tempTableNamePrefix + suffix;
         new SqlExecutor(TargetedMSSchema.getSchema()).execute("CREATE " +
                 TargetedMSManager.getSqlDialect().getTempTableKeyword() + " TABLE " + tempTableName +
                 " ( Id BIGINT NOT NULL PRIMARY KEY )");
@@ -1759,7 +1778,9 @@ public class TargetedMSManager
         return new SQLFragment("DELETE FROM " + fromTable + " WHERE " + fromFk + " IN (SELECT Id FROM " + tempIdsTable).append(")");
     }
 
-    /** Actually delete runs that have been marked as deleted from the database */
+    /**
+     * Actually delete runs that have been marked as deleted from the database
+     */
     private static void purgeDeletedRuns()
     {
         // Delete from FoldChange
@@ -1918,7 +1939,7 @@ public class TargetedMSManager
         // Get a list of deleted runs
         SQLFragment sql = new SQLFragment("SELECT Id FROM " + getTableInfoRuns() + " WHERE Deleted =  ?", true);
         List<Long> deletedRunIds = new SqlSelector(getSchema(), sql).getArrayList(Long.class);
-        if(!deletedRunIds.isEmpty())
+        if (!deletedRunIds.isEmpty())
         {
             ModificationManager.removeRunCachedResults(deletedRunIds);
             PeptideManager.removeRunCachedResults(deletedRunIds);
@@ -1940,7 +1961,7 @@ public class TargetedMSManager
     public static void deletePrecursorChromInfoDependent(TableInfo tableInfo)
     {
         execute(" DELETE FROM " + tableInfo +
-                " WHERE PrecursorChromInfoId IN (SELECT pci.Id FROM " + getTableInfoPrecursorChromInfo() + " pci "+
+                " WHERE PrecursorChromInfoId IN (SELECT pci.Id FROM " + getTableInfoPrecursorChromInfo() + " pci " +
                 " INNER JOIN " + getTableInfoSampleFile() + " s ON pci.SampleFileId = s.Id " +
                 " INNER JOIN " + getTableInfoReplicate() + " rep ON s.ReplicateId = rep.Id " +
                 " INNER JOIN " + getTableInfoRuns() + " r ON rep.RunId = r.Id " +
@@ -1950,7 +1971,7 @@ public class TargetedMSManager
     public static void deleteGeneralMoleculeChromInfoDependent(TableInfo tableInfo)
     {
         execute(" DELETE FROM " + tableInfo +
-                " WHERE PeptideChromInfoId IN (SELECT mci.Id FROM " + getTableInfoGeneralMoleculeChromInfo() + " mci "+
+                " WHERE PeptideChromInfoId IN (SELECT mci.Id FROM " + getTableInfoGeneralMoleculeChromInfo() + " mci " +
                 " INNER JOIN " + getTableInfoSampleFile() + " s ON mci.SampleFileId = s.Id " +
                 " INNER JOIN " + getTableInfoReplicate() + " rep ON s.ReplicateId = rep.Id " +
                 " INNER JOIN " + getTableInfoRuns() + " r ON rep.RunId = r.Id " +
@@ -1960,8 +1981,8 @@ public class TargetedMSManager
     public static void deleteGeneralTransitionDependent(TableInfo tableInfo, String colName, SQLFragment whereClause)
     {
         execute(new SQLFragment(" DELETE FROM " + tableInfo +
-                " WHERE " + colName + " IN (SELECT gt.Id FROM " + getTableInfoGeneralTransition() + " gt "+
-                " INNER JOIN " + getTableInfoGeneralPrecursor() + " gp ON gt.GeneralPrecursorId = gp.Id "+
+                " WHERE " + colName + " IN (SELECT gt.Id FROM " + getTableInfoGeneralTransition() + " gt " +
+                " INNER JOIN " + getTableInfoGeneralPrecursor() + " gp ON gt.GeneralPrecursorId = gp.Id " +
                 " INNER JOIN " + getTableInfoGeneralMolecule() + " gm ON gp.GeneralMoleculeId = gm.Id " +
                 " INNER JOIN " + getTableInfoPeptideGroup() + " pg ON gm.PeptideGroupId = pg.Id " +
                 " INNER JOIN " + getTableInfoRuns() + " r ON pg.RunId = r.Id ").append(whereClause).append(")"));
@@ -1979,7 +2000,7 @@ public class TargetedMSManager
     private static void deleteGeneralPrecursorDependent(TableInfo tableInfo, String colName)
     {
         execute(" DELETE FROM " + tableInfo +
-                " WHERE " + colName + " IN (SELECT gp.Id FROM " + getTableInfoGeneralPrecursor() + " gp "+
+                " WHERE " + colName + " IN (SELECT gp.Id FROM " + getTableInfoGeneralPrecursor() + " gp " +
                 " INNER JOIN " + getTableInfoGeneralMolecule() + " gm ON gp.GeneralMoleculeId = gm.Id " +
                 " INNER JOIN " + getTableInfoPeptideGroup() + " pg ON gm.PeptideGroupId = pg.Id " +
                 " INNER JOIN " + getTableInfoRuns() + " r ON pg.RunId = r.Id " +
@@ -1989,7 +2010,7 @@ public class TargetedMSManager
     private static void deleteGeneralMoleculeDependent(TableInfo tableInfo, String colName)
     {
         execute(" DELETE FROM " + tableInfo +
-                " WHERE " + colName + " IN (SELECT gm.Id FROM " + getTableInfoGeneralMolecule() + " gm "+
+                " WHERE " + colName + " IN (SELECT gm.Id FROM " + getTableInfoGeneralMolecule() + " gm " +
                 " INNER JOIN " + getTableInfoPeptideGroup() + " pg ON gm.PeptideGroupId = pg.Id " +
                 " INNER JOIN " + getTableInfoRuns() + " r ON pg.RunId = r.Id " +
                 " WHERE r.Deleted = ?)", true);
@@ -1998,7 +2019,7 @@ public class TargetedMSManager
     private static void deletePeptideGroupDependent(TableInfo tableInfo)
     {
         execute(" DELETE FROM " + tableInfo +
-                " WHERE PeptideGroupId IN (SELECT pg.Id FROM " + getTableInfoPeptideGroup() + " pg "+
+                " WHERE PeptideGroupId IN (SELECT pg.Id FROM " + getTableInfoPeptideGroup() + " pg " +
                 " INNER JOIN " + getTableInfoRuns() + " r ON pg.RunId = r.Id " +
                 " WHERE r.Deleted = ?)", true);
     }
@@ -2012,7 +2033,7 @@ public class TargetedMSManager
     private static void deleteReplicateDependent(TableInfo tableInfo)
     {
         execute(" DELETE FROM " + tableInfo +
-                " WHERE ReplicateId IN (SELECT rep.Id FROM " + getTableInfoReplicate() + " rep "+
+                " WHERE ReplicateId IN (SELECT rep.Id FROM " + getTableInfoReplicate() + " rep " +
                 " INNER JOIN " + getTableInfoRuns() + " r ON rep.RunId = r.Id " +
                 " WHERE r.Deleted = ?)", true);
     }
@@ -2025,9 +2046,9 @@ public class TargetedMSManager
     private static void deleteTransitionPredictionSettingsDependent()
     {
         execute("DELETE FROM " + getTableInfoPredictorSettings() + " WHERE PredictorId IN (SELECT Id FROM " +
-                getTableInfoPredictor() + " WHERE " +
-                "Id IN (SELECT CePredictorId FROM " + getTableInfoTransitionPredictionSettings() + " tps, " + getTableInfoRuns() + " r WHERE r.Id = tps.RunId AND r.Deleted = ?)" +
-                "OR Id IN (SELECT DpPredictorId FROM " + getTableInfoTransitionPredictionSettings() + " tps, " + getTableInfoRuns() + " r WHERE r.Id = tps.RunId AND r.Deleted = ?))"
+                        getTableInfoPredictor() + " WHERE " +
+                        "Id IN (SELECT CePredictorId FROM " + getTableInfoTransitionPredictionSettings() + " tps, " + getTableInfoRuns() + " r WHERE r.Id = tps.RunId AND r.Deleted = ?)" +
+                        "OR Id IN (SELECT DpPredictorId FROM " + getTableInfoTransitionPredictionSettings() + " tps, " + getTableInfoRuns() + " r WHERE r.Id = tps.RunId AND r.Deleted = ?))"
                 , true, true);
 
         List<Long> predictorsToDelete = getPredictorsToDelete();
@@ -2101,7 +2122,7 @@ public class TargetedMSManager
     public static List<Integer> getIrtScaleIds(Container c)
     {
         SimpleFilter conFil = SimpleFilter.createContainerFilter(c);
-        return new TableSelector(TargetedMSManager.getTableInfoiRTScale().getColumn(FieldKey.fromParts("id")), conFil , null).getArrayList(Integer.class);
+        return new TableSelector(TargetedMSManager.getTableInfoiRTScale().getColumn(FieldKey.fromParts("id")), conFil, null).getArrayList(Integer.class);
     }
 
     // return the ModuleProperty value for "TARGETED_MS_FOLDER_TYPE"
@@ -2144,7 +2165,7 @@ public class TargetedMSManager
             return;
 
         new SqlExecutor(getSchema()).execute("UPDATE " + getTableInfoRuns() + " SET Description=? WHERE Id = ?",
-                            newDescription, runId);
+                newDescription, runId);
         TargetedMSRun run = getRun(runId);
         if (run != null)
         {
@@ -2158,7 +2179,9 @@ public class TargetedMSManager
         }
     }
 
-    /** @return the sample file if it has already been imported in the container */
+    /**
+     * @return the sample file if it has already been imported in the container
+     */
     @Nullable
     public static Replicate getReplicate(long replicateId, Container container)
     {
@@ -2166,19 +2189,23 @@ public class TargetedMSManager
         sql.append(getTableInfoReplicate(), "rep");
         sql.append(", ");
         sql.append(getTableInfoRuns(), "r");
-        sql.append( " WHERE r.Id = rep.RunId AND rep.Id = ? AND r.Container = ? ");
+        sql.append(" WHERE r.Id = rep.RunId AND rep.Id = ? AND r.Container = ? ");
         sql.add(replicateId);
         sql.add(container);
         return new SqlSelector(getSchema(), sql).getObject(Replicate.class);
     }
 
-    /** @return the sample file if it has already been imported in the container */
+    /**
+     * @return the sample file if it has already been imported in the container
+     */
     public static List<SampleFile> getSampleFile(String filePath, Date acquiredTime, Container container)
     {
         return getSampleFile(filePath, acquiredTime, container, true);
     }
 
-    /** @return the sample file if it has already been imported in the container */
+    /**
+     * @return the sample file if it has already been imported in the container
+     */
     @Nullable
     public static SampleFile getSampleFile(long id, Container container)
     {
@@ -2225,13 +2252,13 @@ public class TargetedMSManager
      */
     public static List<SampleFile> getMatchingSampleFiles(@NotNull SampleFile sampleFile, Container container)
     {
-        if(sampleFile.getAcquiredTime() != null)
+        if (sampleFile.getAcquiredTime() != null)
         {
             // Issue 38270. A file may have been imported from a different path in a previous document.  
             // If SampleFile has an acquired time check for a file with same name and acquired time.
             String filePath = sampleFile.getFilePath();
             String fileName = FilenameUtils.getName(filePath);
-            if(!StringUtils.isBlank(fileName) && fileName.length() < filePath.length())
+            if (!StringUtils.isBlank(fileName) && fileName.length() < filePath.length())
             {
                 fileName = filePath.substring(filePath.indexOf(fileName) - 1); // Include the separator char
             }
@@ -2246,7 +2273,7 @@ public class TargetedMSManager
     private static List<SampleFile> getSampleFile(String filePath, Date acquiredTime, Container container, boolean fullPath)
     {
         SQLFragment sql = new SQLFragment();
-        if(fullPath)
+        if (fullPath)
         {
             sql.append(" sf.FilePath = ? ");
             sql.add(filePath);
@@ -2256,7 +2283,7 @@ public class TargetedMSManager
             sql.append(" sf.FilePath LIKE ? ");
             sql.add("%" + getSqlDialect().encodeLikeOpSearchString(filePath));
         }
-        if(acquiredTime == null)
+        if (acquiredTime == null)
             sql.append(" AND sf.AcquiredTime IS NULL");
         else
         {
@@ -2326,13 +2353,13 @@ public class TargetedMSManager
 
         Map<String, Map<String, Double>> intensities = new HashMap<>();
 
-        for (Map<String, Object> rowMap:new TableSelector(table).getMapArray())
+        for (Map<String, Object> rowMap : new TableSelector(table).getMapArray())
         {
-            List <ColumnInfo> columns = table.getColumns();
+            List<ColumnInfo> columns = table.getColumns();
 
             List<Double> values = new ArrayList<>();
 
-            for(ColumnInfo column : columns)
+            for (ColumnInfo column : columns)
             {
                 //Skip pivot column and row name column
                 String colName = column.getName();
@@ -2355,10 +2382,10 @@ public class TargetedMSManager
 
             MathStat stats = StatsService.get().getStats(primitiveValues);
 
-            String proteinName = (String)rowMap.get(rowHeadingColumnName);
+            String proteinName = (String) rowMap.get(rowHeadingColumnName);
             Map<String, Double> intensityMap = new TreeMap<>();
             boolean hasValue = false;
-            for(ColumnInfo column : columns)
+            for (ColumnInfo column : columns)
             {
                 String colName = column.getName();
                 if (colName.compareToIgnoreCase(intensityColumnName) == 0 || colName.compareToIgnoreCase(rowHeadingColumnName) == 0)
@@ -2397,7 +2424,7 @@ public class TargetedMSManager
 
     private static Double getValue(Object o)
     {
-        Double value = (Double)JdbcType.DOUBLE.convert(o);
+        Double value = (Double) JdbcType.DOUBLE.convert(o);
         if (value == null || value == 0.0)
         {
             return null;
@@ -2410,6 +2437,7 @@ public class TargetedMSManager
     {
         return _metricCache.get(schema.getContainer(), schema, null);
     }
+
     public static List<QCMetricConfiguration> getEnabledQCMetricConfigurations(TargetedMSSchema schema)
     {
         List<QCMetricConfiguration> result = new ArrayList<>();
@@ -2427,7 +2455,7 @@ public class TargetedMSManager
     {
         TargetedMSSchema schema = new TargetedMSSchema(user, container);
         List<QCMetricConfiguration> enabledQCMetricConfigurations = getEnabledQCMetricConfigurations(schema);
-        if(!enabledQCMetricConfigurations.isEmpty())
+        if (!enabledQCMetricConfigurations.isEmpty())
         {
             List<GuideSet> guideSets = TargetedMSManager.getGuideSets(container, user);
             Map<Integer, QCMetricConfiguration> metricMap = enabledQCMetricConfigurations.stream().collect(Collectors.toMap(QCMetricConfiguration::getId, Function.identity()));
@@ -2633,7 +2661,7 @@ public class TargetedMSManager
     public static boolean containerHasDocVersions(Container container)
     {
         ExperimentService svc = ExperimentService.get();
-        return new SqlSelector(svc.getSchema(), new SQLFragment("SELECT r.rowId FROM ", Boolean.FALSE, container )
+        return new SqlSelector(svc.getSchema(), new SQLFragment("SELECT r.rowId FROM ", Boolean.FALSE, container)
                 .append(svc.getTinfoExperimentRun(), "r")
                 .append(" INNER JOIN ").append(TargetedMSManager.getTableInfoRuns(), "tRuns")
                 .append(" ON (tRuns.ExperimentRunLSID = r.lsid AND tRuns.Deleted = ?)")
@@ -2645,7 +2673,7 @@ public class TargetedMSManager
         final String suffix = StringUtilsLabKey.getPaddedUniquifier(9);
         final String precursorGroupingsTableName = getSqlDialect().getTempTablePrefix() + "PrecursorGroupings" + suffix;
         final String moleculeGroupingsTableName = getSqlDialect().getTempTablePrefix() + "MoleculeGroupings" + suffix;
-        final String areasTableName = getSqlDialect().getTempTablePrefix() +  "Areas" + suffix;
+        final String areasTableName = getSqlDialect().getTempTablePrefix() + "Areas" + suffix;
 
         if (log != null)
         {
@@ -2697,7 +2725,7 @@ public class TargetedMSManager
                 .append("WHERE g.PrecursorId = targetedms.precursorchrominfo.PrecursorId AND \n")
                 .append("a.SampleFileId = targetedms.precursorchrominfo.SampleFileId) X) ");
         updatePrecursorSQL.append(" WHERE PrecursorId IN \n")
-            .append("(SELECT PrecursorId FROM ").append(precursorGroupingsTableName).append(")");
+                .append("(SELECT PrecursorId FROM ").append(precursorGroupingsTableName).append(")");
 
         if (log != null)
         {
@@ -2714,7 +2742,7 @@ public class TargetedMSManager
                 .append("WHERE g.GeneralMoleculeId = targetedms.generalmoleculechrominfo.GeneralMoleculeId AND \n")
                 .append("a.SampleFileId = targetedms.generalmoleculechrominfo.SampleFileId) X)");
         updateMoleculeSQL.append(" WHERE GeneralMoleculeId IN \n")
-            .append("(SELECT GeneralMoleculeId FROM ").append(moleculeGroupingsTableName).append(")");
+                .append("(SELECT GeneralMoleculeId FROM ").append(moleculeGroupingsTableName).append(")");
 
         if (log != null)
         {
@@ -2901,7 +2929,7 @@ public class TargetedMSManager
 
                 if (!valuesToStore.isEmpty())
                 {
-                    valuesToStore.forEach((key,val) -> {
+                    valuesToStore.forEach((key, val) -> {
                         QCTraceMetricValues qcTraceMetricValues = new QCTraceMetricValues();
                         qcTraceMetricValues.setMetric(qcMetricConfiguration.getId());
                         qcTraceMetricValues.setSampleFileId(key.getSampleFileId());
@@ -2940,7 +2968,7 @@ public class TargetedMSManager
         return keywords;
     }
 
-    public static Map<String,Object> getQCFolderDateRange(Container container)
+    public static Map<String, Object> getQCFolderDateRange(Container container)
     {
         var sql = new SQLFragment("SELECT MIN(sf.AcquiredTime) AS startDate, MAX(sf.AcquiredTime) AS endDate ");
         sql.append(" FROM ").append(getTableInfoSampleFile(), "sf");
@@ -2977,6 +3005,18 @@ public class TargetedMSManager
         return Objects.requireNonNull(table.getUpdateService());
     }
 
+
+    public static String getInstrumentNickName(Container container)
+    {
+        SimpleFilter filter = SimpleFilter.createContainerFilter(container);
+        List<InstrumentNickname> nicknames = new TableSelector(getTableInfoInstrumentNickname(), filter, null).getArrayList(InstrumentNickname.class);
+        return nicknames.stream()
+                .map(InstrumentNickname::getNickname)
+                .distinct()
+                .collect(Collectors.joining(","));
+    }
+
+
     public void deleteNickname(InstrumentNickname name, User user) throws SQLException, BatchValidationException, QueryUpdateServiceException, InvalidKeyException
     {
         getNicknameUpdateService(user, name.getContainer()).
@@ -3001,5 +3041,16 @@ public class TargetedMSManager
             getNicknameUpdateService(user, name.getContainer()).
                     insertRows(user, name.getContainer(), Arrays.asList(row), errors, null, null);
         }
+    }
+
+    public static boolean isQCAnnotationTypeShareable(int qcAnnotationTypeId)
+    {
+        SQLFragment sql = new SQLFragment("SELECT IsShareable FROM ");
+        sql.append(getTableInfoQCAnnotationType());
+        sql.append(" WHERE Id = ?");
+        sql.add(qcAnnotationTypeId);
+
+        Boolean isShareable = new SqlSelector(getSchema(), sql).getObject(Boolean.class);
+        return isShareable != null && isShareable;
     }
 }

--- a/src/org/labkey/targetedms/TargetedMSManager.java
+++ b/src/org/labkey/targetedms/TargetedMSManager.java
@@ -359,7 +359,7 @@ public class TargetedMSManager
 
     public static TableInfo getTableInfoPeptideAreaRatio()
     {
-        return getSchema().getTable(TargetedMSSchema.TABLE_PEPTIDE_AREA_RATIO);
+       return getSchema().getTable(TargetedMSSchema.TABLE_PEPTIDE_AREA_RATIO);
     }
 
     public static TableInfo getTableInfoInstrument()
@@ -502,7 +502,6 @@ public class TargetedMSManager
     {
         return getSchema().getTable(TargetedMSSchema.TABLE_QC_EMAIL_NOTIFICATIONS);
     }
-
     public static TableInfo getTableInfoAnnotationSettings()
     {
         return getSchema().getTable(TargetedMSSchema.TABLE_ANNOTATION_SETTINGS);
@@ -547,7 +546,6 @@ public class TargetedMSManager
     {
         return getSchema().getTable(TargetedMSSchema.TABLE_QC_ANNOTATION);
     }
-
     public static TableInfo getTableInfoQuantificationSettings()
     {
         return getSchema().getTable(TargetedMSSchema.TABLE_QUANTIIFICATION_SETTINGS);
@@ -623,9 +621,7 @@ public class TargetedMSManager
         return getSchema().getTable(TargetedMSSchema.TABLE_SKYLINE_RUN_AUDITLOG_ENTRY);
     }
 
-    /**
-     * View that's a CTE to pull in the RunId
-     */
+    /** View that's a CTE to pull in the RunId */
     public static TableInfo getTableInfoSkylineAuditLog()
     {
         return getSchema().getTable(TargetedMSSchema.TABLE_SKYLINE_AUDITLOG);
@@ -721,22 +717,20 @@ public class TargetedMSManager
         return getSchema().getTable(TargetedMSSchema.TABLE_INSTRUMENT_USAGE_PAYMENT);
     }
 
-    /**
-     * @return rowId for pipeline job that will perform the import asynchronously
-     */
+    /** @return rowId for pipeline job that will perform the import asynchronously */
     public static Long addRunToQueue(ViewBackgroundInfo info,
-                                     final Path path) throws XarFormatException, PipelineValidationException
+                                        final Path path) throws XarFormatException, PipelineValidationException
     {
         String description = "Skyline document import - " + FileUtil.getFileName(path);
         XarContext xarContext = new XarContext(description, info.getContainer(), info.getUser());
-        User user = info.getUser();
+        User user =  info.getUser();
         Container container = info.getContainer();
 
         // If an entry does not already exist for this data file in exp.data create it now.
-        // This should happen only if a file was copied to the pipeline directory instead
-        // of being uploaded via the files browser.
+		// This should happen only if a file was copied to the pipeline directory instead
+		// of being uploaded via the files browser.
         ExpData expData = ExperimentService.get().getExpDataByURL(path, container);
-        if (expData == null)
+        if(expData == null)
         {
             XarSource source = new AbstractFileXarSource("Wrap Targeted MS Run", container, user)
             {
@@ -804,7 +798,7 @@ public class TargetedMSManager
 
             // Make sure that we have a protocol in this folder
             String protocolPrefix = run.isZipFile() ? TargetedMSModule.IMPORT_SKYZIP_PROTOCOL_OBJECT_PREFIX :
-                    TargetedMSModule.IMPORT_SKYDOC_PROTOCOL_OBJECT_PREFIX;
+                                                      TargetedMSModule.IMPORT_SKYDOC_PROTOCOL_OBJECT_PREFIX;
 
             Lsid lsid = new Lsid("Protocol.Folder-" + container.getRowId(), protocolPrefix);
             ExpProtocol protocol = ExperimentService.get().getExpProtocol(lsid.toString());
@@ -829,11 +823,11 @@ public class TargetedMSManager
             outputDatas.put(expData, "sky");
 
             ExpData expSkydData = null;
-            if (run.getSkydDataId() != null)
+            if(run.getSkydDataId() != null)
             {
                 expSkydData = ExperimentService.get().getExpData(run.getSkydDataId());
             }
-            if (expSkydData != null)
+            if(expSkydData != null)
             {
                 outputDatas.put(expSkydData, "skyd");
             }
@@ -850,12 +844,12 @@ public class TargetedMSManager
             }
 
             expRun = ExperimentService.get().saveSimpleExperimentRun(expRun,
-                    Collections.emptyMap(),
-                    inputDatas,
-                    Collections.emptyMap(),
-                    outputDatas,
-                    Collections.emptyMap(),
-                    info, _log, false);
+                                                                     Collections.emptyMap(),
+                                                                     inputDatas,
+                                                                     Collections.emptyMap(),
+                                                                     outputDatas,
+                                                                     Collections.emptyMap(),
+                                                                     info, _log, false);
 
             run.setExperimentRunLSID(expRun.getLSID());
             TargetedMSManager.updateRun(run, user);
@@ -922,7 +916,7 @@ public class TargetedMSManager
     public static TargetedMSRun getRunByDataId(long dataId, Container c)
     {
         TargetedMSRun[] runs;
-        if (c != null)
+        if(c != null)
         {
             runs = getRuns("DataId = ? AND Deleted = ? AND Container = ?", dataId, Boolean.FALSE, c.getId());
         }
@@ -930,11 +924,11 @@ public class TargetedMSManager
         {
             runs = getRuns("DataId = ? AND Deleted = ?", dataId, Boolean.FALSE);
         }
-        if (runs.length == 0)
+        if(runs.length == 0)
         {
             return null;
         }
-        if (runs.length == 1)
+        if(runs.length == 1)
         {
             return runs[0];
         }
@@ -949,7 +943,7 @@ public class TargetedMSManager
     public static TargetedMSRun getRunBySkydDataId(long skydDataId, Container c)
     {
         TargetedMSRun[] runs;
-        if (c != null)
+        if(c != null)
         {
             runs = getRuns("SkydDataId = ? AND Deleted = ? AND Container = ?", skydDataId, Boolean.FALSE, c.getId());
         }
@@ -957,11 +951,11 @@ public class TargetedMSManager
         {
             runs = getRuns("SkydDataId = ? AND Deleted = ?", skydDataId, Boolean.FALSE);
         }
-        if (runs.length == 0)
+        if(runs.length == 0)
         {
             return null;
         }
-        if (runs.length == 1)
+        if(runs.length == 1)
         {
             return runs[0];
         }
@@ -972,15 +966,15 @@ public class TargetedMSManager
     public static TargetedMSRun getRunByLsid(String lsid, Container c)
     {
         TargetedMSRun[] runs = getRuns("experimentrunlsid = ? AND container = ?", lsid, c.getId());
-        if (runs.length == 0)
+        if(runs.length == 0)
         {
             return null;
         }
-        if (runs.length == 1)
+        if(runs.length == 1)
         {
             return runs[0];
         }
-        throw new IllegalArgumentException("More than one TargetedMS runs found for LSID " + lsid);
+        throw new IllegalArgumentException("More than one TargetedMS runs found for LSID "+lsid);
     }
 
     public static boolean updateSkydDataId(ITargetedMSRun run, ExpData newSkydData, User user)
@@ -1071,11 +1065,11 @@ public class TargetedMSManager
     {
         Collection<Long> representativeRunIds = Collections.emptyList();
 
-        if (representativeState == RunRepresentativeDataState.Representative_Protein)
+        if(representativeState == RunRepresentativeDataState.Representative_Protein)
         {
             representativeRunIds = getProteinRepresentativeRunIds(container);
         }
-        else if (representativeState == RunRepresentativeDataState.Representative_Peptide)
+        else if(representativeState == RunRepresentativeDataState.Representative_Peptide)
         {
             representativeRunIds = getPeptideRepresentativeRunIds(container);
         }
@@ -1086,7 +1080,7 @@ public class TargetedMSManager
         }
 
         SQLFragment updateSql = new SQLFragment();
-        updateSql.append("UPDATE " + TargetedMSManager.getTableInfoRuns());
+        updateSql.append("UPDATE "+TargetedMSManager.getTableInfoRuns());
         updateSql.append(" SET RepresentativeDataState = ?");
         updateSql.add(RunRepresentativeDataState.NotRepresentative.ordinal());
         updateSql.append(" WHERE Container = ?");
@@ -1098,7 +1092,7 @@ public class TargetedMSManager
         // for the documents not yet imported.
         updateSql.append(" AND StatusId = ? ");
         updateSql.add(SkylineDocImporter.STATUS_SUCCESS);
-        updateSql.append(" AND Id NOT IN (" + StringUtils.join(representativeRunIds, ",") + ")");
+        updateSql.append(" AND Id NOT IN ("+StringUtils.join(representativeRunIds, ",")+")");
 
         new SqlExecutor(TargetedMSManager.getSchema()).execute(updateSql);
     }
@@ -1106,11 +1100,11 @@ public class TargetedMSManager
     public static List<Long> getCurrentRepresentativeRunIds(Container container)
     {
         List<Long> representativeRunIds = null;
-        if (getFolderType(container) == TargetedMSService.FolderType.LibraryProtein)
+        if(getFolderType(container) == TargetedMSService.FolderType.LibraryProtein)
         {
             representativeRunIds = getCurrentProteinRepresentativeRunIds(container);
         }
-        else if (getFolderType(container) == TargetedMSService.FolderType.Library)
+        else if(getFolderType(container) == TargetedMSService.FolderType.Library)
         {
             representativeRunIds = getCurrentPeptideRepresentativeRunIds(container);
         }
@@ -1126,8 +1120,8 @@ public class TargetedMSManager
     private static List<Long> getProteinRepresentativeRunIds(Container container)
     {
         return getProteinRepresentativeRunIds(container, RepresentativeDataState.Representative.ordinal(),
-                RepresentativeDataState.Deprecated.ordinal(),
-                RepresentativeDataState.Conflicted.ordinal());
+                                                         RepresentativeDataState.Deprecated.ordinal(),
+                                                         RepresentativeDataState.Conflicted.ordinal());
     }
 
     private static List<Long> getProteinRepresentativeRunIds(Container container, int... stateArray)
@@ -1155,8 +1149,8 @@ public class TargetedMSManager
     private static List<Long> getPeptideRepresentativeRunIds(Container container)
     {
         return getPeptideRepresentativeRunIds(container, RepresentativeDataState.Representative.ordinal(),
-                RepresentativeDataState.Deprecated.ordinal(),
-                RepresentativeDataState.Conflicted.ordinal());
+                                                         RepresentativeDataState.Deprecated.ordinal(),
+                                                         RepresentativeDataState.Conflicted.ordinal());
     }
 
     private static List<Long> getPeptideRepresentativeRunIds(Container container, int... stateArray)
@@ -1189,9 +1183,7 @@ public class TargetedMSManager
         Table.update(user, getTableInfoRuns(), run, run.getRunId());
     }
 
-    /**
-     * Delete all of the TargetedMS runs in the container, including their experiment run wrappers
-     */
+    /** Delete all of the TargetedMS runs in the container, including their experiment run wrappers */
     public static void deleteIncludingExperimentWrapper(Container c, User user)
     {
         List<Long> runIds = new SqlSelector(getSchema(), "SELECT Id FROM " + getTableInfoRuns() + " WHERE Container = ?", c).getArrayList(Long.class);
@@ -1237,13 +1229,9 @@ public class TargetedMSManager
         return name;
     }
 
-    private record NicknameKey(String serialNumber, String model)
-    {
-    }
+    private record NicknameKey(String serialNumber, String model) {}
 
-    /**
-     * @return the matches in order of closest to furthest match, injecting a virtual option if the list is empty
-     */
+    /** @return the matches in order of closest to furthest match, injecting a virtual option if the list is empty */
     public List<InstrumentNickname> getNickname(String name, TargetedMSSchema schema)
     {
         TableInfo info = schema.getTableOrThrow(TABLE_INSTRUMENT_NICKNAME, new ContainerFilter.CurrentPlusProjectAndShared(schema.getContainer(), schema.getUser()));
@@ -1314,14 +1302,13 @@ public class TargetedMSManager
     /**
      * Delete just the targetedms run and its child tables
      * Pulled out into separate method so could be called by itself from data handlers
-     *
      * @param runIds targetedms.run.id values
      */
     public static void deleteRuns(List<Long> runIds, Container c, User user, boolean containerDeletion)
     {
         List<Long> cantDelete = new ArrayList<>();
         List<TargetedMSRun> runsToDelete = new ArrayList<>();
-        for (long runId : runIds)
+        for (long runId: runIds)
         {
             TargetedMSRun run = getRun(runId);
             if (run == null || run.isDeleted())
@@ -1330,7 +1317,7 @@ public class TargetedMSManager
             }
             if (!run.getContainer().equals(c) && !run.getContainer().hasPermission(user, DeletePermission.class))
             {
-                cantDelete.add(runId);
+               cantDelete.add(runId);
             }
             runsToDelete.add(run);
         }
@@ -1403,22 +1390,22 @@ public class TargetedMSManager
 
     public static TargetedMSRun getRunForPrecursor(long precursorId)
     {
-        String sql = "SELECT run.* FROM " +
-                getTableInfoRuns() + " AS run, " +
-                getTableInfoPeptideGroup() + " AS pg, " +
-                getTableInfoGeneralMolecule() + " AS gm, " +
-                getTableInfoGeneralPrecursor() + " AS gp " +
-                "WHERE run.Id=pg.RunId " +
-                "AND pg.Id=gm.PeptideGroupId " +
-                "AND gm.Id=gp.GeneralMoleculeId " +
-                "AND gp.Id=?";
+        String sql = "SELECT run.* FROM "+
+                     getTableInfoRuns()+" AS run, "+
+                     getTableInfoPeptideGroup()+" AS pg, "+
+                     getTableInfoGeneralMolecule()+" AS gm, "+
+                     getTableInfoGeneralPrecursor()+" AS gp "+
+                     "WHERE run.Id=pg.RunId "+
+                     "AND pg.Id=gm.PeptideGroupId "+
+                     "AND gm.Id=gp.GeneralMoleculeId "+
+                     "AND gp.Id=?";
         SQLFragment sf = new SQLFragment(sql);
         sf.add(precursorId);
 
         TargetedMSRun run = new SqlSelector(getSchema(), sf).getObject(TargetedMSRun.class);
-        if (run == null)
+        if(run == null)
         {
-            throw new NotFoundException("No run found for precursor: " + precursorId);
+            throw new NotFoundException("No run found for precursor: "+precursorId);
         }
         return run;
     }
@@ -1426,18 +1413,18 @@ public class TargetedMSManager
     @NotNull
     public static TargetedMSRun getRunForGeneralMolecule(long id)
     {
-        String sql = "SELECT run.* FROM " +
-                getTableInfoRuns() + " AS run, " +
-                getTableInfoPeptideGroup() + " AS pg, " +
-                getTableInfoGeneralMolecule() + " AS gm " +
-                "WHERE run.Id=pg.RunId " +
-                "AND pg.Id=gm.PeptideGroupId " +
-                "AND gm.Id=?";
+        String sql = "SELECT run.* FROM "+
+                     getTableInfoRuns()+" AS run, "+
+                     getTableInfoPeptideGroup()+" AS pg, "+
+                     getTableInfoGeneralMolecule()+" AS gm "+
+                     "WHERE run.Id=pg.RunId "+
+                     "AND pg.Id=gm.PeptideGroupId "+
+                     "AND gm.Id=?";
         SQLFragment sf = new SQLFragment(sql);
         sf.add(id);
 
         TargetedMSRun run = new SqlSelector(getSchema(), sf).getObject(TargetedMSRun.class);
-        if (run == null)
+        if(run == null)
         {
             throw new NotFoundException("No run found for general molecule: " + id);
         }
@@ -1538,7 +1525,7 @@ public class TargetedMSManager
         sql.append(getTableInfoRuns(), "r");
         sql.append(", ");
         sql.append(ExperimentService.get().getTinfoData(), "d");
-        sql.append(" WHERE rep.Id = sf.ReplicateId AND rep.RunId = r.Id AND d.RowId = r.DataId AND d.DataFileUrl = ?");
+        sql.append( " WHERE rep.Id = sf.ReplicateId AND rep.RunId = r.Id AND d.RowId = r.DataId AND d.DataFileUrl = ?");
         sql.add(FileUtil.uriToString(uri));
 
         return new SqlSelector(getSchema(), sql).exists();
@@ -1680,7 +1667,7 @@ public class TargetedMSManager
 
         var map = new SqlSelector(getSchema(), sql).getMap();
         String filePath = null;
-        if (map != null)
+        if(map != null)
         {
             filePath = (String) map.get("dataFileUrl");
         }
@@ -1767,7 +1754,7 @@ public class TargetedMSManager
     private static String createTempChromInfoIdsTable(TableInfo tableInfo, String tempTableNamePrefix, SQLFragment whereClause)
     {
         final String suffix = StringUtilsLabKey.getPaddedUniquifier(9);
-        final String tempTableName = TargetedMSManager.getSqlDialect().getTempTablePrefix() + tempTableNamePrefix + suffix;
+        final String tempTableName = TargetedMSManager.getSqlDialect().getTempTablePrefix() +  tempTableNamePrefix + suffix;
         new SqlExecutor(TargetedMSSchema.getSchema()).execute("CREATE " +
                 TargetedMSManager.getSqlDialect().getTempTableKeyword() + " TABLE " + tempTableName +
                 " ( Id BIGINT NOT NULL PRIMARY KEY )");
@@ -1791,9 +1778,7 @@ public class TargetedMSManager
         return new SQLFragment("DELETE FROM " + fromTable + " WHERE " + fromFk + " IN (SELECT Id FROM " + tempIdsTable).append(")");
     }
 
-    /**
-     * Actually delete runs that have been marked as deleted from the database
-     */
+    /** Actually delete runs that have been marked as deleted from the database */
     private static void purgeDeletedRuns()
     {
         deleteRunDependent(getTableInfoPTMPercentsGroupedPrepivotCache());
@@ -1953,7 +1938,7 @@ public class TargetedMSManager
         // Get a list of deleted runs
         SQLFragment sql = new SQLFragment("SELECT Id FROM " + getTableInfoRuns() + " WHERE Deleted =  ?", true);
         List<Long> deletedRunIds = new SqlSelector(getSchema(), sql).getArrayList(Long.class);
-        if (!deletedRunIds.isEmpty())
+        if(!deletedRunIds.isEmpty())
         {
             ModificationManager.removeRunCachedResults(deletedRunIds);
             PeptideManager.removeRunCachedResults(deletedRunIds);
@@ -1975,7 +1960,7 @@ public class TargetedMSManager
     public static void deletePrecursorChromInfoDependent(TableInfo tableInfo)
     {
         execute(" DELETE FROM " + tableInfo +
-                " WHERE PrecursorChromInfoId IN (SELECT pci.Id FROM " + getTableInfoPrecursorChromInfo() + " pci " +
+                " WHERE PrecursorChromInfoId IN (SELECT pci.Id FROM " + getTableInfoPrecursorChromInfo() + " pci "+
                 " INNER JOIN " + getTableInfoSampleFile() + " s ON pci.SampleFileId = s.Id " +
                 " INNER JOIN " + getTableInfoReplicate() + " rep ON s.ReplicateId = rep.Id " +
                 " INNER JOIN " + getTableInfoRuns() + " r ON rep.RunId = r.Id " +
@@ -1985,7 +1970,7 @@ public class TargetedMSManager
     public static void deleteGeneralMoleculeChromInfoDependent(TableInfo tableInfo)
     {
         execute(" DELETE FROM " + tableInfo +
-                " WHERE PeptideChromInfoId IN (SELECT mci.Id FROM " + getTableInfoGeneralMoleculeChromInfo() + " mci " +
+                " WHERE PeptideChromInfoId IN (SELECT mci.Id FROM " + getTableInfoGeneralMoleculeChromInfo() + " mci "+
                 " INNER JOIN " + getTableInfoSampleFile() + " s ON mci.SampleFileId = s.Id " +
                 " INNER JOIN " + getTableInfoReplicate() + " rep ON s.ReplicateId = rep.Id " +
                 " INNER JOIN " + getTableInfoRuns() + " r ON rep.RunId = r.Id " +
@@ -1995,8 +1980,8 @@ public class TargetedMSManager
     public static void deleteGeneralTransitionDependent(TableInfo tableInfo, String colName, SQLFragment whereClause)
     {
         execute(new SQLFragment(" DELETE FROM " + tableInfo +
-                " WHERE " + colName + " IN (SELECT gt.Id FROM " + getTableInfoGeneralTransition() + " gt " +
-                " INNER JOIN " + getTableInfoGeneralPrecursor() + " gp ON gt.GeneralPrecursorId = gp.Id " +
+                " WHERE " + colName + " IN (SELECT gt.Id FROM " + getTableInfoGeneralTransition() + " gt "+
+                " INNER JOIN " + getTableInfoGeneralPrecursor() + " gp ON gt.GeneralPrecursorId = gp.Id "+
                 " INNER JOIN " + getTableInfoGeneralMolecule() + " gm ON gp.GeneralMoleculeId = gm.Id " +
                 " INNER JOIN " + getTableInfoPeptideGroup() + " pg ON gm.PeptideGroupId = pg.Id " +
                 " INNER JOIN " + getTableInfoRuns() + " r ON pg.RunId = r.Id ").append(whereClause).append(")"));
@@ -2014,7 +1999,7 @@ public class TargetedMSManager
     private static void deleteGeneralPrecursorDependent(TableInfo tableInfo, String colName)
     {
         execute(" DELETE FROM " + tableInfo +
-                " WHERE " + colName + " IN (SELECT gp.Id FROM " + getTableInfoGeneralPrecursor() + " gp " +
+                " WHERE " + colName + " IN (SELECT gp.Id FROM " + getTableInfoGeneralPrecursor() + " gp "+
                 " INNER JOIN " + getTableInfoGeneralMolecule() + " gm ON gp.GeneralMoleculeId = gm.Id " +
                 " INNER JOIN " + getTableInfoPeptideGroup() + " pg ON gm.PeptideGroupId = pg.Id " +
                 " INNER JOIN " + getTableInfoRuns() + " r ON pg.RunId = r.Id " +
@@ -2024,7 +2009,7 @@ public class TargetedMSManager
     private static void deleteGeneralMoleculeDependent(TableInfo tableInfo, String colName)
     {
         execute(" DELETE FROM " + tableInfo +
-                " WHERE " + colName + " IN (SELECT gm.Id FROM " + getTableInfoGeneralMolecule() + " gm " +
+                " WHERE " + colName + " IN (SELECT gm.Id FROM " + getTableInfoGeneralMolecule() + " gm "+
                 " INNER JOIN " + getTableInfoPeptideGroup() + " pg ON gm.PeptideGroupId = pg.Id " +
                 " INNER JOIN " + getTableInfoRuns() + " r ON pg.RunId = r.Id " +
                 " WHERE r.Deleted = ?)", true);
@@ -2033,7 +2018,7 @@ public class TargetedMSManager
     private static void deletePeptideGroupDependent(TableInfo tableInfo)
     {
         execute(" DELETE FROM " + tableInfo +
-                " WHERE PeptideGroupId IN (SELECT pg.Id FROM " + getTableInfoPeptideGroup() + " pg " +
+                " WHERE PeptideGroupId IN (SELECT pg.Id FROM " + getTableInfoPeptideGroup() + " pg "+
                 " INNER JOIN " + getTableInfoRuns() + " r ON pg.RunId = r.Id " +
                 " WHERE r.Deleted = ?)", true);
     }
@@ -2047,7 +2032,7 @@ public class TargetedMSManager
     private static void deleteReplicateDependent(TableInfo tableInfo)
     {
         execute(" DELETE FROM " + tableInfo +
-                " WHERE ReplicateId IN (SELECT rep.Id FROM " + getTableInfoReplicate() + " rep " +
+                " WHERE ReplicateId IN (SELECT rep.Id FROM " + getTableInfoReplicate() + " rep "+
                 " INNER JOIN " + getTableInfoRuns() + " r ON rep.RunId = r.Id " +
                 " WHERE r.Deleted = ?)", true);
     }
@@ -2060,9 +2045,9 @@ public class TargetedMSManager
     private static void deleteTransitionPredictionSettingsDependent()
     {
         execute("DELETE FROM " + getTableInfoPredictorSettings() + " WHERE PredictorId IN (SELECT Id FROM " +
-                        getTableInfoPredictor() + " WHERE " +
-                        "Id IN (SELECT CePredictorId FROM " + getTableInfoTransitionPredictionSettings() + " tps, " + getTableInfoRuns() + " r WHERE r.Id = tps.RunId AND r.Deleted = ?)" +
-                        "OR Id IN (SELECT DpPredictorId FROM " + getTableInfoTransitionPredictionSettings() + " tps, " + getTableInfoRuns() + " r WHERE r.Id = tps.RunId AND r.Deleted = ?))"
+                getTableInfoPredictor() + " WHERE " +
+                "Id IN (SELECT CePredictorId FROM " + getTableInfoTransitionPredictionSettings() + " tps, " + getTableInfoRuns() + " r WHERE r.Id = tps.RunId AND r.Deleted = ?)" +
+                "OR Id IN (SELECT DpPredictorId FROM " + getTableInfoTransitionPredictionSettings() + " tps, " + getTableInfoRuns() + " r WHERE r.Id = tps.RunId AND r.Deleted = ?))"
                 , true, true);
 
         List<Long> predictorsToDelete = getPredictorsToDelete();
@@ -2136,7 +2121,7 @@ public class TargetedMSManager
     public static List<Integer> getIrtScaleIds(Container c)
     {
         SimpleFilter conFil = SimpleFilter.createContainerFilter(c);
-        return new TableSelector(TargetedMSManager.getTableInfoiRTScale().getColumn(FieldKey.fromParts("id")), conFil, null).getArrayList(Integer.class);
+        return new TableSelector(TargetedMSManager.getTableInfoiRTScale().getColumn(FieldKey.fromParts("id")), conFil , null).getArrayList(Integer.class);
     }
 
     // return the ModuleProperty value for "TARGETED_MS_FOLDER_TYPE"
@@ -2179,7 +2164,7 @@ public class TargetedMSManager
             return;
 
         new SqlExecutor(getSchema()).execute("UPDATE " + getTableInfoRuns() + " SET Description=? WHERE Id = ?",
-                newDescription, runId);
+                            newDescription, runId);
         TargetedMSRun run = getRun(runId);
         if (run != null)
         {
@@ -2193,9 +2178,7 @@ public class TargetedMSManager
         }
     }
 
-    /**
-     * @return the sample file if it has already been imported in the container
-     */
+    /** @return the sample file if it has already been imported in the container */
     @Nullable
     public static Replicate getReplicate(long replicateId, Container container)
     {
@@ -2203,23 +2186,19 @@ public class TargetedMSManager
         sql.append(getTableInfoReplicate(), "rep");
         sql.append(", ");
         sql.append(getTableInfoRuns(), "r");
-        sql.append(" WHERE r.Id = rep.RunId AND rep.Id = ? AND r.Container = ? ");
+        sql.append( " WHERE r.Id = rep.RunId AND rep.Id = ? AND r.Container = ? ");
         sql.add(replicateId);
         sql.add(container);
         return new SqlSelector(getSchema(), sql).getObject(Replicate.class);
     }
 
-    /**
-     * @return the sample file if it has already been imported in the container
-     */
+    /** @return the sample file if it has already been imported in the container */
     public static List<SampleFile> getSampleFile(String filePath, Date acquiredTime, Container container)
     {
         return getSampleFile(filePath, acquiredTime, container, true);
     }
 
-    /**
-     * @return the sample file if it has already been imported in the container
-     */
+    /** @return the sample file if it has already been imported in the container */
     @Nullable
     public static SampleFile getSampleFile(long id, Container container)
     {
@@ -2266,13 +2245,13 @@ public class TargetedMSManager
      */
     public static List<SampleFile> getMatchingSampleFiles(@NotNull SampleFile sampleFile, Container container)
     {
-        if (sampleFile.getAcquiredTime() != null)
+        if(sampleFile.getAcquiredTime() != null)
         {
             // Issue 38270. A file may have been imported from a different path in a previous document.  
             // If SampleFile has an acquired time check for a file with same name and acquired time.
             String filePath = sampleFile.getFilePath();
             String fileName = FilenameUtils.getName(filePath);
-            if (!StringUtils.isBlank(fileName) && fileName.length() < filePath.length())
+            if(!StringUtils.isBlank(fileName) && fileName.length() < filePath.length())
             {
                 fileName = filePath.substring(filePath.indexOf(fileName) - 1); // Include the separator char
             }
@@ -2287,7 +2266,7 @@ public class TargetedMSManager
     private static List<SampleFile> getSampleFile(String filePath, Date acquiredTime, Container container, boolean fullPath)
     {
         SQLFragment sql = new SQLFragment();
-        if (fullPath)
+        if(fullPath)
         {
             sql.append(" sf.FilePath = ? ");
             sql.add(filePath);
@@ -2297,7 +2276,7 @@ public class TargetedMSManager
             sql.append(" sf.FilePath LIKE ? ");
             sql.add("%" + getSqlDialect().encodeLikeOpSearchString(filePath));
         }
-        if (acquiredTime == null)
+        if(acquiredTime == null)
             sql.append(" AND sf.AcquiredTime IS NULL");
         else
         {
@@ -2367,13 +2346,13 @@ public class TargetedMSManager
 
         Map<String, Map<String, Double>> intensities = new HashMap<>();
 
-        for (Map<String, Object> rowMap : new TableSelector(table).getMapArray())
+        for (Map<String, Object> rowMap:new TableSelector(table).getMapArray())
         {
-            List<ColumnInfo> columns = table.getColumns();
+            List <ColumnInfo> columns = table.getColumns();
 
             List<Double> values = new ArrayList<>();
 
-            for (ColumnInfo column : columns)
+            for(ColumnInfo column : columns)
             {
                 //Skip pivot column and row name column
                 String colName = column.getName();
@@ -2396,10 +2375,10 @@ public class TargetedMSManager
 
             MathStat stats = StatsService.get().getStats(primitiveValues);
 
-            String proteinName = (String) rowMap.get(rowHeadingColumnName);
+            String proteinName = (String)rowMap.get(rowHeadingColumnName);
             Map<String, Double> intensityMap = new TreeMap<>();
             boolean hasValue = false;
-            for (ColumnInfo column : columns)
+            for(ColumnInfo column : columns)
             {
                 String colName = column.getName();
                 if (colName.compareToIgnoreCase(intensityColumnName) == 0 || colName.compareToIgnoreCase(rowHeadingColumnName) == 0)
@@ -2438,7 +2417,7 @@ public class TargetedMSManager
 
     private static Double getValue(Object o)
     {
-        Double value = (Double) JdbcType.DOUBLE.convert(o);
+        Double value = (Double)JdbcType.DOUBLE.convert(o);
         if (value == null || value == 0.0)
         {
             return null;
@@ -2451,7 +2430,6 @@ public class TargetedMSManager
     {
         return _metricCache.get(schema.getContainer(), schema, null);
     }
-
     public static List<QCMetricConfiguration> getEnabledQCMetricConfigurations(TargetedMSSchema schema)
     {
         List<QCMetricConfiguration> result = new ArrayList<>();
@@ -2469,7 +2447,7 @@ public class TargetedMSManager
     {
         TargetedMSSchema schema = new TargetedMSSchema(user, container);
         List<QCMetricConfiguration> enabledQCMetricConfigurations = getEnabledQCMetricConfigurations(schema);
-        if (!enabledQCMetricConfigurations.isEmpty())
+        if(!enabledQCMetricConfigurations.isEmpty())
         {
             List<GuideSet> guideSets = TargetedMSManager.getGuideSets(container, user);
             Map<Integer, QCMetricConfiguration> metricMap = enabledQCMetricConfigurations.stream().collect(Collectors.toMap(QCMetricConfiguration::getId, Function.identity()));
@@ -2675,7 +2653,7 @@ public class TargetedMSManager
     public static boolean containerHasDocVersions(Container container)
     {
         ExperimentService svc = ExperimentService.get();
-        return new SqlSelector(svc.getSchema(), new SQLFragment("SELECT r.rowId FROM ", Boolean.FALSE, container)
+        return new SqlSelector(svc.getSchema(), new SQLFragment("SELECT r.rowId FROM ", Boolean.FALSE, container )
                 .append(svc.getTinfoExperimentRun(), "r")
                 .append(" INNER JOIN ").append(TargetedMSManager.getTableInfoRuns(), "tRuns")
                 .append(" ON (tRuns.ExperimentRunLSID = r.lsid AND tRuns.Deleted = ?)")
@@ -2687,7 +2665,7 @@ public class TargetedMSManager
         final String suffix = StringUtilsLabKey.getPaddedUniquifier(9);
         final String precursorGroupingsTableName = getSqlDialect().getTempTablePrefix() + "PrecursorGroupings" + suffix;
         final String moleculeGroupingsTableName = getSqlDialect().getTempTablePrefix() + "MoleculeGroupings" + suffix;
-        final String areasTableName = getSqlDialect().getTempTablePrefix() + "Areas" + suffix;
+        final String areasTableName = getSqlDialect().getTempTablePrefix() +  "Areas" + suffix;
 
         if (log != null)
         {
@@ -2739,7 +2717,7 @@ public class TargetedMSManager
                 .append("WHERE g.PrecursorId = targetedms.precursorchrominfo.PrecursorId AND \n")
                 .append("a.SampleFileId = targetedms.precursorchrominfo.SampleFileId) X) ");
         updatePrecursorSQL.append(" WHERE PrecursorId IN \n")
-                .append("(SELECT PrecursorId FROM ").append(precursorGroupingsTableName).append(")");
+            .append("(SELECT PrecursorId FROM ").append(precursorGroupingsTableName).append(")");
 
         if (log != null)
         {
@@ -2756,7 +2734,7 @@ public class TargetedMSManager
                 .append("WHERE g.GeneralMoleculeId = targetedms.generalmoleculechrominfo.GeneralMoleculeId AND \n")
                 .append("a.SampleFileId = targetedms.generalmoleculechrominfo.SampleFileId) X)");
         updateMoleculeSQL.append(" WHERE GeneralMoleculeId IN \n")
-                .append("(SELECT GeneralMoleculeId FROM ").append(moleculeGroupingsTableName).append(")");
+            .append("(SELECT GeneralMoleculeId FROM ").append(moleculeGroupingsTableName).append(")");
 
         if (log != null)
         {
@@ -3000,7 +2978,7 @@ public class TargetedMSManager
 
                 if (!valuesToStore.isEmpty())
                 {
-                    valuesToStore.forEach((key, val) -> {
+                    valuesToStore.forEach((key,val) -> {
                         QCTraceMetricValues qcTraceMetricValues = new QCTraceMetricValues();
                         qcTraceMetricValues.setMetric(qcMetricConfiguration.getId());
                         qcTraceMetricValues.setSampleFileId(key.getSampleFileId());
@@ -3039,7 +3017,7 @@ public class TargetedMSManager
         return keywords;
     }
 
-    public static Map<String, Object> getQCFolderDateRange(Container container)
+    public static Map<String,Object> getQCFolderDateRange(Container container)
     {
         var sql = new SQLFragment("SELECT MIN(sf.AcquiredTime) AS startDate, MAX(sf.AcquiredTime) AS endDate ");
         sql.append(" FROM ").append(getTableInfoSampleFile(), "sf");
@@ -3108,131 +3086,6 @@ public class TargetedMSManager
 
         return new SqlSelector(getSchema(), sql).getArrayList(InstrumentDetails.class);
 
-    }
-
-    public static List<String> getInstrumentNickName(Container container)
-    {
-        SimpleFilter filter = SimpleFilter.createContainerFilter(container);
-
-        List<InstrumentNickname> nicknames = new TableSelector(getTableInfoInstrumentNickname(), filter, null).getArrayList(InstrumentNickname.class);
-        return nicknames.stream()
-                .map(InstrumentNickname::getNickname)
-                .distinct()
-                .collect(Collectors.toList());
-    }
-
-    /**
-     * Returns the instrument nickname for the given instrument, similar to the logic in SampleFileTable.
-     * First checks for a custom nickname matching the serial number and model, then falls back to a default name.
-     *
-     * @param container    The container to search in (including project and shared containers)
-     * @param user         The user for permission checking
-     * @param instrumentId The instrument ID
-     * @return The resolved nickname, or null if no instrument is found
-     */
-    @Nullable
-    public static String getInstrumentNickName(@NotNull Container container, @NotNull User user,
-                                               @Nullable Long instrumentId)
-    {
-        if (instrumentId == null)
-        {
-            return null;
-        }
-
-        TargetedMSSchema schema = new TargetedMSSchema(user, container);
-
-        // Get the serial number and model from the sample file table
-        SQLFragment sampleFileSQL = new SQLFragment("SELECT DISTINCT sf.InstrumentSerialNumber, i.Model FROM ");
-        sampleFileSQL.append(getTableInfoSampleFile(), "sf");
-        sampleFileSQL.append(" INNER JOIN ");
-        sampleFileSQL.append(getTableInfoInstrument(), "i");
-        sampleFileSQL.append(" ON sf.InstrumentId = i.Id WHERE i.Id = ?").add(instrumentId);
-
-        Map<String, Object> sampleFileData = new SqlSelector(getSchema(), sampleFileSQL).getMap();
-        String serialNumber = sampleFileData != null ? (String) sampleFileData.get("InstrumentSerialNumber") : null;
-        String instrumentModel = sampleFileData != null ? (String) sampleFileData.get("Model") : null;
-
-        // First, try to find a custom nickname matching the serial number and model
-        // Join conditions match the logic in SampleFileTable:
-        // - SerialNumber matches or both are NULL
-        // - Model matches or both are NULL
-        SimpleFilter filter = new SimpleFilter();
-
-        // Build a filter for nickname lookup with proper NULL handling
-        if (serialNumber != null)
-        {
-            filter.addCondition(FieldKey.fromParts("SerialNumber"), serialNumber);
-        }
-        else
-        {
-            filter.addCondition(FieldKey.fromParts("SerialNumber"), null, CompareType.ISBLANK);
-        }
-
-        if (instrumentModel != null)
-        {
-            filter.addCondition(new SimpleFilter.OrClause(
-                    new CompareType.EqualsCompareClause(FieldKey.fromParts("Model"), CompareType.EQUAL, instrumentModel),
-                    new CompareType.CompareClause(FieldKey.fromParts("Model"), CompareType.ISBLANK, null)
-            ));
-        }
-        else
-        {
-            filter.addCondition(FieldKey.fromParts("Model"), null, CompareType.ISBLANK);
-        }
-
-        // Search in current container, project, and shared containers, prioritizing by container proximity
-        TableInfo nicknameTable = schema.getTableOrThrow(TABLE_INSTRUMENT_NICKNAME,
-                ContainerFilter.Type.CurrentPlusProjectAndShared.create(container, user));
-
-        List<InstrumentNickname> matches = new TableSelector(nicknameTable, filter, null).getArrayList(InstrumentNickname.class);
-
-        // Sort by container proximity: current > project > shared
-        Container shared = ContainerManager.getSharedContainer();
-        Container project = container.getProject();
-
-        matches.sort((a, b) -> {
-            int aScore = getContainerScore(a.getContainer(), container, project, shared);
-            int bScore = getContainerScore(b.getContainer(), container, project, shared);
-            return Integer.compare(bScore, aScore); // Higher score first
-        });
-
-        if (!matches.isEmpty())
-        {
-            return matches.get(0).getNickname();
-        }
-
-        // Fall back to default naming: COALESCE(Model + ' - ' + SerialNumber, SerialNumber, Model)
-        if (instrumentModel != null && serialNumber != null)
-        {
-            return instrumentModel + " - " + serialNumber;
-        }
-        else if (serialNumber != null)
-        {
-            return serialNumber;
-        }
-        else if (instrumentModel != null)
-        {
-            return instrumentModel;
-        }
-
-        return null;
-    }
-
-    private static int getContainerScore(Container c, Container current, Container project, Container shared)
-    {
-        if (c.equals(current))
-        {
-            return 3;
-        }
-        else if (project != null && c.equals(project))
-        {
-            return 2;
-        }
-        else if (shared != null && c.equals(shared))
-        {
-            return 1;
-        }
-        return 0;
     }
 
 

--- a/src/org/labkey/targetedms/TargetedMSManager.java
+++ b/src/org/labkey/targetedms/TargetedMSManager.java
@@ -3117,7 +3117,7 @@ public class TargetedMSManager
 
     public static boolean isQCAnnotationTypeShareable(int qcAnnotationTypeId)
     {
-        SQLFragment sql = new SQLFragment("SELECT IsShareable FROM ");
+        SQLFragment sql = new SQLFragment("SELECT Shareable FROM ");
         sql.append(getTableInfoQCAnnotationType());
         sql.append(" WHERE Id = ?");
         sql.add(qcAnnotationTypeId);

--- a/src/org/labkey/targetedms/TargetedMSManager.java
+++ b/src/org/labkey/targetedms/TargetedMSManager.java
@@ -17,6 +17,8 @@
 package org.labkey.targetedms;
 
 import com.google.common.base.Joiner;
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
@@ -3074,15 +3076,163 @@ public class TargetedMSManager
         return Objects.requireNonNull(table.getUpdateService());
     }
 
+    public static class InstrumentDetails
+    {
+        @Getter @Setter
+        private String instrumentSerialNumber;
+        @Getter @Setter
+        private String model;
+        @Getter @Setter
+        private Long instrumentId;
 
-    public static String getInstrumentNickName(Container container)
+        public InstrumentDetails()
+        {
+        }
+    }
+
+    public static List<InstrumentDetails> getInstrumentDetails(Container container)
+    {
+        SQLFragment sql = new SQLFragment("SELECT DISTINCT sf.InstrumentSerialNumber, i.Model, i.Id AS InstrumentId FROM ");
+        sql.append(getTableInfoSampleFile(), "sf");
+        sql.append(" INNER JOIN ");
+        sql.append(getTableInfoInstrument(), "i");
+        sql.append(" ON sf.InstrumentId = i.Id ");
+        sql.append(" INNER JOIN ");
+        sql.append(getTableInfoReplicate(), "rep");
+        sql.append(" ON sf.ReplicateId = rep.Id ");
+        sql.append(" INNER JOIN ");
+        sql.append(getTableInfoRuns(), "r");
+        sql.append(" ON rep.RunId = r.Id ");
+        sql.append(" WHERE r.Container = ?");
+        sql.add(container);
+
+        return new SqlSelector(getSchema(), sql).getArrayList(InstrumentDetails.class);
+
+    }
+
+    public static List<String> getInstrumentNickName(Container container)
     {
         SimpleFilter filter = SimpleFilter.createContainerFilter(container);
+
         List<InstrumentNickname> nicknames = new TableSelector(getTableInfoInstrumentNickname(), filter, null).getArrayList(InstrumentNickname.class);
         return nicknames.stream()
                 .map(InstrumentNickname::getNickname)
                 .distinct()
-                .collect(Collectors.joining(","));
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns the instrument nickname for the given instrument, similar to the logic in SampleFileTable.
+     * First checks for a custom nickname matching the serial number and model, then falls back to a default name.
+     *
+     * @param container    The container to search in (including project and shared containers)
+     * @param user         The user for permission checking
+     * @param instrumentId The instrument ID
+     * @return The resolved nickname, or null if no instrument is found
+     */
+    @Nullable
+    public static String getInstrumentNickName(@NotNull Container container, @NotNull User user,
+                                               @Nullable Long instrumentId)
+    {
+        if (instrumentId == null)
+        {
+            return null;
+        }
+
+        TargetedMSSchema schema = new TargetedMSSchema(user, container);
+
+        // Get the serial number and model from the sample file table
+        SQLFragment sampleFileSQL = new SQLFragment("SELECT DISTINCT sf.InstrumentSerialNumber, i.Model FROM ");
+        sampleFileSQL.append(getTableInfoSampleFile(), "sf");
+        sampleFileSQL.append(" INNER JOIN ");
+        sampleFileSQL.append(getTableInfoInstrument(), "i");
+        sampleFileSQL.append(" ON sf.InstrumentId = i.Id WHERE i.Id = ?").add(instrumentId);
+
+        Map<String, Object> sampleFileData = new SqlSelector(getSchema(), sampleFileSQL).getMap();
+        String serialNumber = sampleFileData != null ? (String) sampleFileData.get("InstrumentSerialNumber") : null;
+        String instrumentModel = sampleFileData != null ? (String) sampleFileData.get("Model") : null;
+
+        // First, try to find a custom nickname matching the serial number and model
+        // Join conditions match the logic in SampleFileTable:
+        // - SerialNumber matches or both are NULL
+        // - Model matches or both are NULL
+        SimpleFilter filter = new SimpleFilter();
+
+        // Build a filter for nickname lookup with proper NULL handling
+        if (serialNumber != null)
+        {
+            filter.addCondition(FieldKey.fromParts("SerialNumber"), serialNumber);
+        }
+        else
+        {
+            filter.addCondition(FieldKey.fromParts("SerialNumber"), null, CompareType.ISBLANK);
+        }
+
+        if (instrumentModel != null)
+        {
+            filter.addCondition(new SimpleFilter.OrClause(
+                    new CompareType.EqualsCompareClause(FieldKey.fromParts("Model"), CompareType.EQUAL, instrumentModel),
+                    new CompareType.CompareClause(FieldKey.fromParts("Model"), CompareType.ISBLANK, null)
+            ));
+        }
+        else
+        {
+            filter.addCondition(FieldKey.fromParts("Model"), null, CompareType.ISBLANK);
+        }
+
+        // Search in current container, project, and shared containers, prioritizing by container proximity
+        TableInfo nicknameTable = schema.getTableOrThrow(TABLE_INSTRUMENT_NICKNAME,
+                ContainerFilter.Type.CurrentPlusProjectAndShared.create(container, user));
+
+        List<InstrumentNickname> matches = new TableSelector(nicknameTable, filter, null).getArrayList(InstrumentNickname.class);
+
+        // Sort by container proximity: current > project > shared
+        Container shared = ContainerManager.getSharedContainer();
+        Container project = container.getProject();
+
+        matches.sort((a, b) -> {
+            int aScore = getContainerScore(a.getContainer(), container, project, shared);
+            int bScore = getContainerScore(b.getContainer(), container, project, shared);
+            return Integer.compare(bScore, aScore); // Higher score first
+        });
+
+        if (!matches.isEmpty())
+        {
+            return matches.get(0).getNickname();
+        }
+
+        // Fall back to default naming: COALESCE(Model + ' - ' + SerialNumber, SerialNumber, Model)
+        if (instrumentModel != null && serialNumber != null)
+        {
+            return instrumentModel + " - " + serialNumber;
+        }
+        else if (serialNumber != null)
+        {
+            return serialNumber;
+        }
+        else if (instrumentModel != null)
+        {
+            return instrumentModel;
+        }
+
+        return null;
+    }
+
+    private static int getContainerScore(Container c, Container current, Container project, Container shared)
+    {
+        if (c.equals(current))
+        {
+            return 3;
+        }
+        else if (project != null && c.equals(project))
+        {
+            return 2;
+        }
+        else if (shared != null && c.equals(shared))
+        {
+            return 1;
+        }
+        return 0;
     }
 
 

--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -231,7 +231,7 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
     @Override
     public Double getSchemaVersion()
     {
-        return 26.001;
+        return 26.003;
     }
 
     @Override

--- a/src/org/labkey/targetedms/query/QCAnnotationTable.java
+++ b/src/org/labkey/targetedms/query/QCAnnotationTable.java
@@ -15,10 +15,12 @@
  */
 package org.labkey.targetedms.query;
 
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.gwt.client.AuditBehaviorType;
+import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.DefaultQueryUpdateService;
 import org.labkey.api.query.DuplicateKeyException;
 import org.labkey.api.query.QueryForeignKey;
@@ -66,20 +68,51 @@ public class QCAnnotationTable extends SimpleUserSchema.SimpleTable<TargetedMSSc
             return new DefaultQueryUpdateService(this, getRealTable())
             {
                 @Override
-                protected Map<String, Object> insertRow(User user, Container container, Map<String, Object> row) throws SQLException, ValidationException, QueryUpdateServiceException, DuplicateKeyException
+                public List<Map<String, Object>> insertRows(User user, Container container, List<Map<String, Object>> rows, BatchValidationException errors, @Nullable Map<Enum, Object> configParameters, @Nullable Map<String, Object> extraScriptContext) throws SQLException, QueryUpdateServiceException, DuplicateKeyException
                 {
-                    // Check if the QCAnnotationType is shareable
-                    int qcAnnotationTypeId = (Integer) row.get("QCAnnotationTypeId");
-                    boolean isShareable = TargetedMSManager.isQCAnnotationTypeShareable(qcAnnotationTypeId);
-
-                    if (isShareable)
+                    List<Map<String, Object>> resultRows = new java.util.ArrayList<>();
+                    for (Map<String, Object> row : rows)
                     {
-                        // Check if the current container has an instrument and include its nickname
-                        var instrumentNickName = TargetedMSManager.getInstrumentNickName(getContainer());
-                        row.put("instrument", instrumentNickName);
+                        try
+                        {
+                            // Check if the QCAnnotationType is shareable
+                            int qcAnnotationTypeId = (Integer) row.get("QCAnnotationTypeId");
+                            boolean isShareable = TargetedMSManager.isQCAnnotationTypeShareable(qcAnnotationTypeId);
+
+                            if (isShareable)
+                            {
+                                List<TargetedMSManager.InstrumentDetails> instruments = TargetedMSManager.getInstrumentDetails(getContainer());
+                                if (instruments.isEmpty())
+                                {
+                                    resultRows.add(super.insertRow(user, container, row));
+                                }
+                                else
+                                {
+                                    for (TargetedMSManager.InstrumentDetails instrument : instruments)
+                                    {
+                                        Map<String, Object> newRow = new java.util.HashMap<>(row);
+                                        newRow.put("instrumentModel", instrument.getModel());
+                                        newRow.put("instrumentSerialNumber", instrument.getInstrumentSerialNumber());
+                                        newRow.put("Container", getContainer().getId());
+                                        resultRows.add(super.insertRow(user, container, newRow));
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                resultRows.add(super.insertRow(user, container, row));
+                            }
+                        }
+                        catch (ValidationException e)
+                        {
+                            errors.addRowError(e);
+                        }
                     }
 
-                    return super.insertRow(user, container, row);
+                    if (errors.hasErrors())
+                       return null;
+
+                    return resultRows;
                 }
             };
         }

--- a/src/org/labkey/targetedms/query/QCAnnotationTable.java
+++ b/src/org/labkey/targetedms/query/QCAnnotationTable.java
@@ -15,12 +15,24 @@
  */
 package org.labkey.targetedms.query;
 
+import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.TableInfo;
 import org.labkey.api.gwt.client.AuditBehaviorType;
+import org.labkey.api.query.DefaultQueryUpdateService;
+import org.labkey.api.query.DuplicateKeyException;
 import org.labkey.api.query.QueryForeignKey;
+import org.labkey.api.query.QueryUpdateService;
+import org.labkey.api.query.QueryUpdateServiceException;
 import org.labkey.api.query.SimpleUserSchema;
+import org.labkey.api.query.ValidationException;
+import org.labkey.api.security.User;
 import org.labkey.targetedms.TargetedMSManager;
 import org.labkey.targetedms.TargetedMSSchema;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
 
 import static org.labkey.targetedms.query.GuideSetTable.appendFormatLabel;
 
@@ -43,5 +55,34 @@ public class QCAnnotationTable extends SimpleUserSchema.SimpleTable<TargetedMSSc
         appendFormatLabel(getMutableColumn("Date"));
         appendFormatLabel(getMutableColumn("EndDate"));
         setAuditBehavior(AuditBehaviorType.DETAILED);
+    }
+
+    @Override
+    public QueryUpdateService getUpdateService()
+    {
+        TableInfo table = getRealTable();
+        if (table != null)
+        {
+            return new DefaultQueryUpdateService(this, getRealTable())
+            {
+                @Override
+                protected Map<String, Object> insertRow(User user, Container container, Map<String, Object> row) throws SQLException, ValidationException, QueryUpdateServiceException, DuplicateKeyException
+                {
+                    // Check if the QCAnnotationType is shareable
+                    int qcAnnotationTypeId = (Integer) row.get("QCAnnotationTypeId");
+                    boolean isShareable = TargetedMSManager.isQCAnnotationTypeShareable(qcAnnotationTypeId);
+
+                    if (isShareable)
+                    {
+                        // Check if the current container has an instrument and include its nickname
+                        var instrumentNickName = TargetedMSManager.getInstrumentNickName(getContainer());
+                        row.put("instrument", instrumentNickName);
+                    }
+
+                    return super.insertRow(user, container, row);
+                }
+            };
+        }
+        return null;
     }
 }

--- a/test/src/org/labkey/test/components/targetedms/QCPlot.java
+++ b/test/src/org/labkey/test/components/targetedms/QCPlot.java
@@ -27,6 +27,9 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.labkey.test.BaseWebDriverTest.getCurrentTest;
+import static org.labkey.test.util.TestLogger.log;
+
 public class QCPlot
 {
     final WebElement plot;
@@ -64,18 +67,27 @@ public class QCPlot
 
     private QCHelper.Annotation parseAnnotation(WebElement annotationEl)
     {
-        String annotationString = annotationEl.getText();
-        String annotationRegex = "Created By: (.+)\\s*, " +
-                "Date: (\\d\\d\\d\\d-\\d\\d-\\d\\d \\d\\d:\\d\\d:\\d\\d)\\s*, " +
-                "Description: (.+)";
+        getCurrentTest().mouseOver(annotationEl);
+        Locator tippyLocator = Locator.tagWithClass("div", "tippy-content");
+        getCurrentTest().waitForElement(tippyLocator);
+        WebElement tippyContent = tippyLocator.findElement(getCurrentTest().getDriver());
+        String annotationString = tippyContent.getText();
+        
+        String annotationRegex = "(?s)Created By:\\s*(.+?)\\s+" +
+                "Type:\\s*(.+?)\\s+" +
+                "Date:\\s*(\\d\\d\\d\\d-\\d\\d-\\d\\d(?: \\d\\d:\\d\\d:\\d\\d)?)\\s+" +
+                "Description:\\s*(.+?)(?:\\s+Shared From:.*|$)";
         Pattern annotationPattern = Pattern.compile(annotationRegex, Pattern.MULTILINE);
         Matcher annotationMatcher = annotationPattern.matcher(annotationString);
 
-        Assert.assertTrue(annotationString, annotationMatcher.find());
-        String date = annotationMatcher.group(2);
-        String description = annotationMatcher.group(3);
+        Assert.assertTrue("Annotation text did not match regex: " + annotationString, annotationMatcher.find());
+        String description = annotationMatcher.group(4).trim();
         String color = annotationEl.getCssValue("fill");
         QCHelper.AnnotationType type = getAnnotationTypes().get(color);
+
+        // Hide tippy to not interfere with other elements
+        getCurrentTest().mouseOver(Locator.tag("body"));
+        getCurrentTest().waitForElementToDisappear(tippyLocator);
 
         return new QCHelper.Annotation(type.getName(), description);
     }

--- a/test/src/org/labkey/test/components/targetedms/QCPlot.java
+++ b/test/src/org/labkey/test/components/targetedms/QCPlot.java
@@ -16,6 +16,7 @@
 package org.labkey.test.components.targetedms;
 
 import org.junit.Assert;
+import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.util.targetedms.QCHelper;
 import org.openqa.selenium.WebElement;
@@ -67,16 +68,17 @@ public class QCPlot
 
     private QCHelper.Annotation parseAnnotation(WebElement annotationEl)
     {
+        getCurrentTest().scrollIntoView(annotationEl);
         getCurrentTest().mouseOver(annotationEl);
         Locator tippyLocator = Locator.tagWithClass("div", "tippy-content");
         getCurrentTest().waitForElement(tippyLocator);
         WebElement tippyContent = tippyLocator.findElement(getCurrentTest().getDriver());
         String annotationString = tippyContent.getText();
-        
-        String annotationRegex = "(?s)Created By:\\s*(.+?)\\s+" +
-                "Type:\\s*(.+?)\\s+" +
+
+        String annotationRegex = "(?s)Created By:\\s*(.*?)\\s+" +
+                "Type:\\s*(.*?)\\s+" +
                 "Date:\\s*(\\d\\d\\d\\d-\\d\\d-\\d\\d(?: \\d\\d:\\d\\d:\\d\\d)?)\\s+" +
-                "Description:\\s*(.+?)(?:\\s+Shared From:.*|$)";
+                "Description:\\s*(.*?)(?:\\s+Shared From:.*|$)";
         Pattern annotationPattern = Pattern.compile(annotationRegex, Pattern.MULTILINE);
         Matcher annotationMatcher = annotationPattern.matcher(annotationString);
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -234,7 +234,7 @@ public class TargetedMSQCTest extends TargetedMSTest
         goToProjectHome();
         PanoramaDashboard qcDashboard = new PanoramaDashboard(this);
         QCPlotsWebPart qcPlotsWebPart = qcDashboard.getQcPlotsWebPart();
-        scrollIntoView(Locator.tagWithText("span","FFVAPFPEVFGK ++, 692.8686"));
+        scrollIntoView(Locator.tagWithText("span", "FFVAPFPEVFGK ++, 692.8686"));
         qcPlotsWebPart.openExclusionBubble(date);
         clickAndWait(Locator.linkWithText("view chromatogram"));
         assertTrue("Navigated to incorrect replicate", isTextPresent(replicate));
@@ -957,6 +957,30 @@ public class TargetedMSQCTest extends TargetedMSTest
 
         qcPlotsWebPart.waitForPlots(7);
         verifyExclusionButtonSelection(acquiredDate, QCPlotsWebPart.QCPlotExclusionState.Include);
+    }
+
+    @Test
+    public void testShareableAnnotations()
+    {
+        String folderA = "Folder A";
+        String folderB = "Folder B";
+
+        setupSubfolder(getProjectName(), folderA, FolderType.QC);
+        importData(ISOTOPOLOGUE_FILE_ANNOTATED);
+
+        setupSubfolder(getProjectName(), folderB, FolderType.QC);
+        importData(ISOTOPOLOGUE_FILE_ANNOTATED);
+
+        clickFolder(folderA);
+        clickTab("Annotations");
+
+        QCAnnotationWebPart annotationWebPart = new PanoramaAnnotations(this).getQcAnnotationWebPart();
+        QCHelper.Annotation shareableAnnotation = new QCHelper.Annotation("Instrumentation Change", "This is a shareable annotation", "2018-08-25");
+        annotationWebPart.startInsert().insert(shareableAnnotation);
+
+        clickTab("Annotations");
+        annotationWebPart = new PanoramaAnnotations(this).getQcAnnotationWebPart();
+        assertEquals("Expected two annotation rows to be created for shareable annotation", 2, annotationWebPart.getDataRegion().getDataRowCount());
     }
 
     private void verifyQCSummarySampleFileOutliers(String acquiredDate, String outlierInfo)

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -192,6 +192,7 @@ public class TargetedMSQCTest extends TargetedMSTest
         goToProjectHome();
         PanoramaDashboard qcDashboard = new PanoramaDashboard(this);
         QCPlotsWebPart qcPlotsWebPart = qcDashboard.getQcPlotsWebPart();
+        scrollIntoView(qcPlotsWebPart.getComponentElement());
         qcPlotsWebPart.revertToDefaultView();
     }
 
@@ -1111,6 +1112,7 @@ public class TargetedMSQCTest extends TargetedMSTest
         expectedAnnotations.add(candyChange);
         for (QCPlot plot : qcPlots)
         {
+            log("verifying for qc plot - " + plot.getPlot().getText());
             Bag<QCHelper.Annotation> plotAnnotations = new HashBag<>(plot.getAnnotations());
             assertEquals("Wrong annotations in " + plotType + ":" + plot.getPrecursor(), expectedAnnotations, plotAnnotations);
         }

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -980,7 +980,35 @@ public class TargetedMSQCTest extends TargetedMSTest
 
         clickTab("Annotations");
         annotationWebPart = new PanoramaAnnotations(this).getQcAnnotationWebPart();
+        // expect two annotations because the data has association with two instruments
         assertEquals("Expected two annotation rows to be created for shareable annotation", 2, annotationWebPart.getDataRegion().getDataRowCount());
+        
+        clickFolder(folderB);
+        clickTab("Panorama Dashboard");
+        PanoramaDashboard qcDashboard = new PanoramaDashboard(this);
+        QCPlotsWebPart qcPlotsWebPart = qcDashboard.getQcPlotsWebPart();
+        qcPlotsWebPart.waitForPlots(35);
+
+        // Verify the shareable annotation from Folder A appears in Folder B's QC plots
+        List<QCPlot> qcPlots = qcPlotsWebPart.getPlots();
+        boolean shareableAnnotationFound = false;
+        for (QCPlot plot : qcPlots)
+        {
+            List<QCHelper.Annotation> annotations = plot.getAnnotations();
+            for (QCHelper.Annotation annotation : annotations)
+            {
+                if (annotation.getType().equals(shareableAnnotation.getType()) &&
+                        annotation.getDescription().equals(shareableAnnotation.getDescription()))
+                {
+                    shareableAnnotationFound = true;
+                    break;
+                }
+            }
+            if (shareableAnnotationFound)
+                break;
+        }
+        assertTrue("Shareable annotation from Folder A should appear in Folder B QC plots", shareableAnnotationFound);
+
     }
 
     private void verifyQCSummarySampleFileOutliers(String acquiredDate, String outlierInfo)

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSUtilizationCalendarTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSUtilizationCalendarTest.java
@@ -59,7 +59,7 @@ public class TargetedMSUtilizationCalendarTest extends TargetedMSTest
 
         log("Input data validation checks");
         utilizationCalendar.setDisplay("1")
-                .markOfflineExpectingError("2013-08-2", null, null, "Error saving. Missing value for required property: Description")
+                .markOfflineExpectingError("2013-08-2", null, null, "Error saving. A value is required for field 'Description'")
                 .markOfflineExpectingError("2013-08-2", "2013-0802", null, "Error saving. " + getConversionErrorMessage("2013-0802", "EndDate", Timestamp.class))
                 .markOfflineExpectingError("2013-08-2", "2013-08-01", null, "Error saving. End date cannot be before the start date");
 

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -1301,55 +1301,106 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
     getAnnotationData: function() {
         this.setLoadingMsg();
 
-        var config = this.getReportConfig();
+        let config = this.getReportConfig();
 
-        // First, get the current container's instrument nickname to filter shareable annotations
-        LABKEY.Query.executeSql({
-            schemaName: 'targetedms',
-            sql: "SELECT DISTINCT Nickname FROM InstrumentNickname",
-            scope: this,
-            success: function(data) {
-                var instrumentNickname = data.rows.length > 0 ? data.rows[0]['Nickname'] : null;
-                this.fetchAnnotations(config, instrumentNickname);
-            },
-            failure: this.failureHandler
-        });
-    },
-
-    fetchAnnotations: function(config, instrumentNickname) {
-        var annotationSql = "SELECT qca.Id AS qcAnnotationId, qca.Date, qca.Description, qca.Created, qca.CreatedBy.DisplayName, qcat.Id AS qcAnnotationTypeId, qcat.Name, qcat.Color, qca.Container FROM qcannotation qca JOIN qcannotationtype qcat ON qcat.Id = qca.QCAnnotationTypeId";
+        let annotationSql = "SELECT qca.Id AS qcAnnotationId, qca.Date, qca.Description, qca.Created, qca.CreatedBy.DisplayName, qcat.Id AS qcAnnotationTypeId, qcat.Name, qcat.Color FROM qcannotation qca JOIN qcannotationtype qcat ON qcat.Id = qca.QCAnnotationTypeId";
 
         // Filter on start/end dates
-        var separator = " WHERE ";
+        let dateFilter = "";
         if (config.StartDate) {
-            annotationSql += separator + "CAST(Date AS Date) >= '" + config.StartDate + "'";
-            separator = " AND ";
+            dateFilter += " AND CAST(Date AS Date) >= '" + config.StartDate + "'";
         }
         if (config.EndDate) {
-            annotationSql += separator + "CAST(Date AS Date) <= '" + config.EndDate + "'";
-            separator = " AND ";
+            dateFilter += " AND CAST(Date AS Date) <= '" + config.EndDate + "'";
         }
+        annotationSql += " WHERE 1=1 " + dateFilter;
 
-        // Filter logic:
-        // 1. All annotations from the shared container
-        // 2. Annotations from the current container
-        // 3. Shareable annotations from any container with a matching instrument
-        var sharedContainer = LABKEY.Security.getSharedContainer();
+        let handleAnnotationData = function(data) {
+            let annotationData = data ? data.rows : [];
 
-        var containerClause = "qca.Container.Name = '" + sharedContainer + "'";
-        containerClause += " OR (qca.Container = '" + LABKEY.Security.currentContainer.id + "')";
-        if (instrumentNickname) {
-            containerClause += " OR (qcat.IsShareable = TRUE AND qca.instrument = '" + instrumentNickname + "')";
-        }
-        annotationSql += separator + "(" + containerClause + ")";
+            // Check if there is an instrument attached to the current container from samplefile table.
+            LABKEY.Query.executeSql({
+                schemaName: 'targetedms',
+                sql: "SELECT DISTINCT InstrumentId.Model, InstrumentSerialNumber, InstrumentNickname FROM samplefile",
+                scope: this,
+                success: function(instrumentData) {
+                    if (instrumentData && instrumentData.rows && instrumentData.rows.length > 0) {
+                        let instrumentFilter = "";
+                        let separator = "";
+                        for (let i = 0; i < instrumentData.rows.length; i++) {
+                            let row = instrumentData.rows[i];
+                            let model = row["Model"];
+                            let serial = row["InstrumentSerialNumber"];
+                            let nickname = row["InstrumentNickname"];
+
+                            instrumentFilter += separator + "(";
+                            let innerSep = "";
+                            if (model) {
+                                instrumentFilter += "(qca.instrumentModel = '" + model + "'";
+                                innerSep = " AND ";
+                            } else {
+                                instrumentFilter += "(qca.instrumentModel IS NULL";
+                                innerSep = " AND ";
+                            }
+
+                            if (serial) {
+                                instrumentFilter += innerSep + "qca.instrumentSerialNumber = '" + serial + "')";
+                            } else {
+                                instrumentFilter += innerSep + "qca.instrumentSerialNumber IS NULL)";
+                            }
+
+                            if (nickname) {
+                                instrumentFilter += " OR qca.instrumentNickName = '" + nickname + "'";
+                            }
+                            instrumentFilter += ")";
+                            separator = " OR ";
+                        }
+
+                        let sharedAnnotationSql = "SELECT qca.Id AS qcAnnotationId, qca.Date, qca.Description, qca.Created, qca.CreatedBy.DisplayName, qcat.Id AS qcAnnotationTypeId, qcat.Name, qcat.Color " +
+                                "FROM qcannotation qca " +
+                                "JOIN qcannotationtype qcat ON qcat.Id = qca.QCAnnotationTypeId " +
+                                "WHERE qcat.IsShareable = true AND (" + instrumentFilter + ")" + dateFilter;
+
+                        LABKEY.Query.executeSql({
+                            schemaName: 'targetedms',
+                            sql: sharedAnnotationSql,
+                            containerFilter: LABKEY.Query.containerFilter.allFolders,
+                            scope: this,
+                            success: function(sharedData) {
+                                if (sharedData && sharedData.rows) {
+                                    // add shared annotations but avoid duplicates if they were already in the first list
+                                    let existingIds = {};
+                                    for (let j = 0; j < annotationData.length; j++) {
+                                        existingIds[annotationData[j].qcAnnotationId] = true;
+                                    }
+                                    for (let k = 0; k < sharedData.rows.length; k++) {
+                                        if (!existingIds[sharedData.rows[k].qcAnnotationId]) {
+                                            annotationData.push(sharedData.rows[k]);
+                                        }
+                                    }
+                                }
+                                this.processAnnotationData({rows: annotationData});
+                            },
+                            failure: this.failureHandler
+                        });
+                    } else {
+                        this.processAnnotationData({rows: annotationData});
+                    }
+                },
+                failure: function() {
+                    // if instrument fetch fails, just proceed with what we have
+                    this.processAnnotationData({rows: annotationData});
+                }
+            });
+        };
 
         LABKEY.Query.executeSql({
             schemaName: 'targetedms',
             sql: annotationSql,
             sort: 'Date',
-            containerFilter: LABKEY.Query.containerFilter.allFolders,
+            containerFilter: LABKEY.Query.containerFilter.currentPlusProjectAndShared,
             scope: this,
-            success: this.processAnnotationData,
+            success: handleAnnotationData,
             failure: this.failureHandler
         });
     },

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -1364,7 +1364,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                         let sharedAnnotationSql = "SELECT qca.Id AS qcAnnotationId, qca.Date, qca.Description, qca.Created, qca.CreatedBy.DisplayName, qcat.Id AS qcAnnotationTypeId, qcat.Name, qcat.Color, qca.container.Path AS ContainerPath " +
                                 "FROM qcannotation qca " +
                                 "JOIN qcannotationtype qcat ON qcat.Id = qca.QCAnnotationTypeId " +
-                                "WHERE qcat.IsShareable = true AND (" + instrumentFilter + ")" + dateFilter;
+                                "WHERE qcat.Shareable = true AND (" + instrumentFilter + ")" + dateFilter;
 
                         LABKEY.Query.executeSql({
                             schemaName: 'targetedms',
@@ -2163,7 +2163,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                 store: Ext4.create('LABKEY.ext4.data.Store', {
                     schemaName: 'targetedms',
                     queryName: 'QCAnnotationType',
-                    columns: 'Id,Name,IsShareable',
+                    columns: 'Id,Name,Shareable',
                     autoLoad: true,
                     listeners: {
                         load: function() {
@@ -2182,7 +2182,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                 listeners: {
                     change: function (combo, newValue) {
                         const record = combo.getStore().findRecord('Id', newValue);
-                        const isShared = record ? record.get('IsShareable') : false;
+                        const isShared = record ? record.get('Shareable') : false;
                         const field = combo.up('window').down('#shared-annotation-display');
                         field.setVisible(isShared);
                     }
@@ -2199,7 +2199,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                         field.updateVisibility = function() {
                             const combo = field.up('window').down('labkey-combo[name=annotationType]');
                             const record = combo.getStore().findRecord('Id', combo.getValue());
-                            const isShared = record ? record.get('IsShareable') : false;
+                            const isShared = record ? record.get('Shareable') : false;
                             field.setVisible(isShared);
                         };
                         field.updateVisibility();

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -1318,10 +1318,19 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         let handleAnnotationData = function(data) {
             let annotationData = data ? data.rows : [];
 
-            // Check if there is an instrument attached to the current container from samplefile table.
+            
+            // Check if there is an instrument attached to the current container from samplefile table
+            // check the exact instruments in the current container &
+            // any other instruments that share a nickname with an instrument used in the current folder.
+            let getInstrumentsSql = "SELECT DISTINCT Model, SerialNumber AS InstrumentSerialNumber FROM InstrumentNickname " +
+                    "WHERE Nickname IN (SELECT DISTINCT Nickname FROM InstrumentNickname " +
+                    "WHERE (Model || '-' || SerialNumber) IN (SELECT DISTINCT (InstrumentId.Model || '-' || InstrumentSerialNumber) FROM samplefile)) " +
+                    "UNION " +
+                    "SELECT DISTINCT InstrumentId.Model, InstrumentSerialNumber FROM samplefile";
+            
             LABKEY.Query.executeSql({
                 schemaName: 'targetedms',
-                sql: "SELECT DISTINCT InstrumentId.Model, InstrumentSerialNumber, InstrumentNickname FROM samplefile",
+                sql: getInstrumentsSql,
                 scope: this,
                 success: function(instrumentData) {
                     if (instrumentData && instrumentData.rows && instrumentData.rows.length > 0) {

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -1331,7 +1331,6 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                             let row = instrumentData.rows[i];
                             let model = row["Model"];
                             let serial = row["InstrumentSerialNumber"];
-                            let nickname = row["InstrumentNickname"];
 
                             instrumentFilter += separator + "(";
                             let innerSep = "";
@@ -1349,9 +1348,6 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                                 instrumentFilter += innerSep + "qca.instrumentSerialNumber IS NULL)";
                             }
 
-                            if (nickname) {
-                                instrumentFilter += " OR qca.instrumentNickName = '" + nickname + "'";
-                            }
                             instrumentFilter += ")";
                             separator = " OR ";
                         }

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -1412,41 +1412,57 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
 
     processAnnotationData: function(data) {
         if (data) {
-            this.annotationData = data.rows;
             this.annotationShape = LABKEY.vis.Scale.Shape()[4]; // 0: circle, 1: triangle, 2: square, 3: diamond, 4: X
+            this.legendData = [];
+
+            const collapsedData = [];
+            const collapsedMap = {};
+
+            for (let i = 0; i < data.rows.length; i++) {
+                const row = data.rows[i];
+                const key = row['Date'] + '|' + row['Description'] + '|' + row['qcAnnotationTypeId'];
+                if (collapsedMap[key] === undefined) {
+                    collapsedMap[key] = collapsedData.length;
+                    row.qcAnnotationIds = [row.qcAnnotationId];
+                    collapsedData.push(row);
+                }
+                else {
+                    collapsedData[collapsedMap[key]].qcAnnotationIds.push(row.qcAnnotationId);
+                }
+            }
+
+            this.annotationData = collapsedData;
 
             var dateCount = {};
-            this.legendData = [];
 
             // if more than one type of legend present, add a legend header for annotations
             if (this.annotationData.length > 0 && (this.singlePlot || this.showMeanCUSUMPlot() || this.showVariableCUSUMPlot())) {
-                    this.legendData.push({
-                        text: 'Annotations',
-                        separator: true
-                    });
+                this.legendData.push({
+                    text: 'Annotations',
+                    separator: true
+                });
             }
 
-        for (let i = 0; i < this.annotationData.length; i++)
-        {
+            for (let i = 0; i < this.annotationData.length; i++) {
                 const annotation = this.annotationData[i];
                 const annotationDate = this.formatDate(new Date(annotation['Date']), !this.groupedX);
 
-                    // track if we need to stack annotations that fall on the same date
-                    if (!dateCount[annotationDate]) {
-                        dateCount[annotationDate] = 0;
-                    }
-                    annotation.yStepIndex = dateCount[annotationDate];
-                    dateCount[annotationDate]++;
-
-                    // get unique annotation names and colors for the legend
-                if (Ext4.Array.pluck(this.legendData, "text").indexOf(annotation['Name']) === -1) {
-                        this.legendData.push({
-                            text: annotation['Name'],
-                            color: '#' + annotation['Color'],
-                            shape: this.annotationShape
-                        });
-                    }
+                // track if we need to stack annotations that fall on the same date
+                if (!dateCount[annotationDate]) {
+                    dateCount[annotationDate] = 0;
                 }
+                annotation.yStepIndex = dateCount[annotationDate];
+                dateCount[annotationDate]++;
+
+                // get unique annotation names and colors for the legend
+                if (Ext4.Array.pluck(this.legendData, "text").indexOf(annotation['Name']) === -1) {
+                    this.legendData.push({
+                        text: annotation['Name'],
+                        color: '#' + annotation['Color'],
+                        shape: this.annotationShape
+                    });
+                }
+            }
 
             this.getPlotsData();
         }
@@ -2246,7 +2262,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                         return;
                     }
 
-                    me.updateAnnotation(data['qcAnnotationId'], annotationType, description, annotationDate, win);
+                    me.updateAnnotation(data['qcAnnotationIds'], annotationType, description, annotationDate, win);
                 }
             }, {
                 text: 'Delete',
@@ -2256,7 +2272,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                     const win = this.up('window');
                     Ext4.Msg.confirm('Confirm Delete', 'Are you sure you want to delete this annotation?', function (btn) {
                         if (btn === 'yes') {
-                            me.deleteAnnotation(data['qcAnnotationId'], win);
+                            me.deleteAnnotation(data['qcAnnotationIds'], win);
                         }
                     });
                 }
@@ -2301,19 +2317,21 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         });
     },
 
-    updateAnnotation: function (annotationId, annotationType, description, annotationDate, win) {
+    updateAnnotation: function (annotationIds, annotationType, description, annotationDate, win) {
         // Format date as UTC string (YYYY-MM-DD) to avoid timezone conversion
         const dateStr = Ext4.util.Format.date(annotationDate, 'Y-m-d');
+
+        const rows = annotationIds.map(id => ({
+            Id: id,
+            QCAnnotationTypeId: annotationType,
+            Description: description,
+            Date: dateStr
+        }));
 
         LABKEY.Query.updateRows({
             schemaName: 'targetedms',
             queryName: 'QCAnnotation',
-            rows: [{
-                Id: annotationId,
-                QCAnnotationTypeId: annotationType,
-                Description: description,
-                Date: dateStr
-            }],
+            rows: rows,
             success: function () {
                 win.close();
                 this.displayTrendPlot();
@@ -2332,11 +2350,13 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         });
     },
 
-    deleteAnnotation: function (annotationId, win) {
+    deleteAnnotation: function (annotationIds, win) {
+        const rows = annotationIds.map(id => ({ Id: id }));
+
         LABKEY.Query.deleteRows({
             schemaName: 'targetedms',
             queryName: 'QCAnnotation',
-            rows: [{ Id: annotationId }],
+            rows: rows,
             success: function () {
                 win.close();
                 this.displayTrendPlot();

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -1998,25 +1998,42 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
             d3.select(pt).transition().duration(800).attr("stroke-width", strokeWidth).ease("elastic");
 
             if (!pt._tippy) {
-                let content = "Created By: " + d['DisplayName'] + ", "
-                        + "<br/>Type: " + d['Name'] + ", "
-                        + "<br/>Date: " + me.formatDate(new Date(d['Date']), true) + ", "
-                        + "<br/>Description: " + d['Description'];
+                let date = new Date(d['Date']);
+                let dateStr = me.formatDate(date, date.getHours() !== 0 || date.getMinutes() !== 0 || date.getSeconds() !== 0);
+                let content = "<table>"
+                        + "<tr><td style='vertical-align: top; padding-right: 5px;'>Created By:</td><td>" + LABKEY.Utils.encodeHtml(d['DisplayName']) + "</td></tr>"
+                        + "<tr><td style='vertical-align: top; padding-right: 5px;'>Type:</td><td>" + LABKEY.Utils.encodeHtml(d['Name']) + "</td></tr>"
+                        + "<tr><td style='vertical-align: top; padding-right: 5px;'>Date:</td><td>" + dateStr + "</td></tr>"
+                        + "<tr><td style='vertical-align: top; padding-right: 5px;'>Description:</td><td>" + LABKEY.Utils.encodeHtml(d['Description']) + "</td></tr>";
 
                 if (d['ContainerPath'] && d['ContainerPath'] !== LABKEY.ActionURL.getContainer()) {
-                    let containerPath = d['ContainerPath'];
-                    if (containerPath.startsWith('/')) {
-                        containerPath = containerPath.substring(1);
+                    let containerPath = LABKEY.Utils.encodeHtml(d['ContainerPath']);
+                    if (!containerPath.startsWith('/')) {
+                        containerPath = '/' + containerPath;
                     }
-                    content += ",<br/>Shared From: " + containerPath;
+                    content += "<tr><td style='vertical-align: top; padding-right: 5px;'>Shared From:</td><td>" + containerPath + "</td></tr>";
                 }
+                content += "</table>";
 
                 tippy(pt, {
                     content: content,
                     allowHTML: true,
                     arrow: true,
                     theme: 'light-border',
-                    placement: 'top'
+                    placement: 'top',
+                    onMount(instance) {
+                        const tippyBox = instance.popper.querySelector('.tippy-box');
+                        const tippyContent = instance.popper.querySelector('.tippy-content');
+
+                        if (tippyBox) {
+                            tippyBox.style.color = 'black';
+                            tippyBox.style.backgroundColor = 'white';
+                            tippyBox.style.border = '1px solid black';
+                        }
+                        if (tippyContent) {
+                            tippyContent.style.padding = '2px';
+                        }
+                    }
                 });
             }
         };
@@ -2075,7 +2092,15 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                     content: "Add annotation",
                     arrow: true,
                     theme: 'light-border',
-                    placement: 'top'
+                    placement: 'top',
+                    onMount(instance) {
+                        const tippyBox = instance.popper.querySelector('.tippy-box');
+                        if (tippyBox) {
+                            tippyBox.style.color = 'black';
+                            tippyBox.style.backgroundColor = 'white';
+                            tippyBox.style.border = '1px solid black';
+                        }
+                    }
                 });
             }
         });

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -1303,7 +1303,21 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
 
         var config = this.getReportConfig();
 
-        var annotationSql = "SELECT qca.Id AS qcAnnotationId, qca.Date, qca.Description, qca.Created, qca.CreatedBy.DisplayName, qcat.Id AS qcAnnotationTypeId, qcat.Name, qcat.Color FROM qcannotation qca JOIN qcannotationtype qcat ON qcat.Id = qca.QCAnnotationTypeId";
+        // First, get the current container's instrument nickname to filter shareable annotations
+        LABKEY.Query.executeSql({
+            schemaName: 'targetedms',
+            sql: "SELECT DISTINCT Nickname FROM InstrumentNickname",
+            scope: this,
+            success: function(data) {
+                var instrumentNickname = data.rows.length > 0 ? data.rows[0]['Nickname'] : null;
+                this.fetchAnnotations(config, instrumentNickname);
+            },
+            failure: this.failureHandler
+        });
+    },
+
+    fetchAnnotations: function(config, instrumentNickname) {
+        var annotationSql = "SELECT qca.Id AS qcAnnotationId, qca.Date, qca.Description, qca.Created, qca.CreatedBy.DisplayName, qcat.Id AS qcAnnotationTypeId, qcat.Name, qcat.Color, qca.Container FROM qcannotation qca JOIN qcannotationtype qcat ON qcat.Id = qca.QCAnnotationTypeId";
 
         // Filter on start/end dates
         var separator = " WHERE ";
@@ -1313,13 +1327,27 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         }
         if (config.EndDate) {
             annotationSql += separator + "CAST(Date AS Date) <= '" + config.EndDate + "'";
+            separator = " AND ";
         }
+
+        // Filter logic:
+        // 1. All annotations from the shared container
+        // 2. Annotations from the current container
+        // 3. Shareable annotations from any container with a matching instrument
+        var sharedContainer = LABKEY.Security.getSharedContainer();
+
+        var containerClause = "qca.Container.Name = '" + sharedContainer + "'";
+        containerClause += " OR (qca.Container = '" + LABKEY.Security.currentContainer.id + "')";
+        if (instrumentNickname) {
+            containerClause += " OR (qcat.IsShareable = TRUE AND qca.instrument = '" + instrumentNickname + "')";
+        }
+        annotationSql += separator + "(" + containerClause + ")";
 
         LABKEY.Query.executeSql({
             schemaName: 'targetedms',
             sql: annotationSql,
             sort: 'Date',
-            containerFilter: LABKEY.Query.containerFilter.currentPlusProjectAndShared,
+            containerFilter: LABKEY.Query.containerFilter.allFolders,
             scope: this,
             success: this.processAnnotationData,
             failure: this.failureHandler

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -2135,7 +2135,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
         return Ext4.create('Ext.window.Window', {
             title: title,
             width: 400,
-            height: 200,
+            height: 230,
             modal: true,
             items: [{
                 xtype: 'labkey-combo',
@@ -2147,15 +2147,48 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                 store: Ext4.create('LABKEY.ext4.data.Store', {
                     schemaName: 'targetedms',
                     queryName: 'QCAnnotationType',
-                    columns: 'Id,Name',
-                    autoLoad: true
+                    columns: 'Id,Name,IsShareable',
+                    autoLoad: true,
+                    listeners: {
+                        load: function() {
+                            const field = me.sharedAnnotationDisplayField;
+                            if (field && field.rendered) {
+                                field.updateVisibility();
+                            }
+                        }
+                    }
                 }),
                 displayField: 'Name',
                 valueField: 'Id',
                 editable: false,
                 allowBlank: false,
                 value: addNew ? null : data['qcAnnotationTypeId'],
-                
+                listeners: {
+                    change: function (combo, newValue) {
+                        const record = combo.getStore().findRecord('Id', newValue);
+                        const isShared = record ? record.get('IsShareable') : false;
+                        const field = combo.up('window').down('#shared-annotation-display');
+                        field.setVisible(isShared);
+                    }
+                }
+            }, {
+                xtype: 'displayfield',
+                itemId: 'shared-annotation-display',
+                value: '<span style="color: #555;"><i class="fa fa-share-alt"></i> Shared</span>',
+                margin: '0 0 10 165',
+                hidden: true,
+                listeners: {
+                    afterrender: function (field) {
+                        me.sharedAnnotationDisplayField = field;
+                        field.updateVisibility = function() {
+                            const combo = field.up('window').down('labkey-combo[name=annotationType]');
+                            const record = combo.getStore().findRecord('Id', combo.getValue());
+                            const isShared = record ? record.get('IsShareable') : false;
+                            field.setVisible(isShared);
+                        };
+                        field.updateVisibility();
+                    }
+                }
             }, {
                 xtype: 'textarea',
                 labelWidth: 150,

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -1303,7 +1303,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
 
         let config = this.getReportConfig();
 
-        let annotationSql = "SELECT qca.Id AS qcAnnotationId, qca.Date, qca.Description, qca.Created, qca.CreatedBy.DisplayName, qcat.Id AS qcAnnotationTypeId, qcat.Name, qcat.Color FROM qcannotation qca JOIN qcannotationtype qcat ON qcat.Id = qca.QCAnnotationTypeId";
+        let annotationSql = "SELECT qca.Id AS qcAnnotationId, qca.Date, qca.Description, qca.Created, qca.CreatedBy.DisplayName, qcat.Id AS qcAnnotationTypeId, qcat.Name, qcat.Color, qca.container.Path AS ContainerPath FROM qcannotation qca JOIN qcannotationtype qcat ON qcat.Id = qca.QCAnnotationTypeId";
 
         // Filter on start/end dates
         let dateFilter = "";
@@ -1356,7 +1356,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                             separator = " OR ";
                         }
 
-                        let sharedAnnotationSql = "SELECT qca.Id AS qcAnnotationId, qca.Date, qca.Description, qca.Created, qca.CreatedBy.DisplayName, qcat.Id AS qcAnnotationTypeId, qcat.Name, qcat.Color " +
+                        let sharedAnnotationSql = "SELECT qca.Id AS qcAnnotationId, qca.Date, qca.Description, qca.Created, qca.CreatedBy.DisplayName, qcat.Id AS qcAnnotationTypeId, qcat.Name, qcat.Color, qca.container.Path AS ContainerPath " +
                                 "FROM qcannotation qca " +
                                 "JOIN qcannotationtype qcat ON qcat.Id = qca.QCAnnotationTypeId " +
                                 "WHERE qcat.IsShareable = true AND (" + instrumentFilter + ")" + dateFilter;
@@ -1988,23 +1988,37 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                 .attr("d", this.annotationShape(4)).attr('transform', transformAcc)
                 .style("fill", colorAcc).style("stroke", colorAcc);
 
-        // add hover text for the annotation details
-        annotations.append("title")
-            .text(function(d) {
-                return "Created By: " + d['DisplayName'] + ", "
-                        + "\nType: " + d['Name'] + ", "
-                    + "\nDate: " + me.formatDate(new Date(d['Date']), true) + ", "
-                    + "\nDescription: " + d['Description'];
-            });
-
-        // add some mouseover effects for fun
-        var mouseOn = function(pt, strokeWidth) {
+        // add mouseover effects for fun
+        let mouseOn = function(pt, strokeWidth, d) {
             d3.select(pt).transition().duration(800).attr("stroke-width", strokeWidth).ease("elastic");
+
+            if (!pt._tippy) {
+                let content = "Created By: " + d['DisplayName'] + ", "
+                        + "<br/>Type: " + d['Name'] + ", "
+                        + "<br/>Date: " + me.formatDate(new Date(d['Date']), true) + ", "
+                        + "<br/>Description: " + d['Description'];
+
+                if (d['ContainerPath'] && d['ContainerPath'] !== LABKEY.ActionURL.getContainer()) {
+                    let containerPath = d['ContainerPath'];
+                    if (containerPath.startsWith('/')) {
+                        containerPath = containerPath.substring(1);
+                    }
+                    content += ",<br/>Shared From: " + containerPath;
+                }
+
+                tippy(pt, {
+                    content: content,
+                    allowHTML: true,
+                    arrow: true,
+                    theme: 'light-border',
+                    placement: 'top'
+                });
+            }
         };
         var mouseOff = function(pt) {
             d3.select(pt).transition().duration(800).attr("stroke-width", 1).ease("elastic");
         };
-        annotations.on("mouseover", function(){ return mouseOn(this, 3); });
+        annotations.on("mouseover", function(d){ return mouseOn(this, 3, d); });
         annotations.on("mouseout", function(){ return mouseOff(this); });
 
         if (this.canUserEdit()) {
@@ -2041,10 +2055,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                 .style("opacity", 0);
 
         // Add mouseover effects for add-annotations
-        nonAnnotationGroups.append("title")
-                .text("Add annotation");
-
-        nonAnnotationGroups.on("mouseover", function () {
+        nonAnnotationGroups.on("mouseover", function (d) {
             d3.select(this).select(".add-annotation-background")
                     .transition().duration(300)
                     .style("opacity", 0)
@@ -2053,6 +2064,15 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
                     .transition().duration(300)
                     .style("opacity", 1)
                     .style("cursor", "pointer");
+
+            if (!this._tippy) {
+                tippy(this, {
+                    content: "Add annotation",
+                    arrow: true,
+                    theme: 'light-border',
+                    placement: 'top'
+                });
+            }
         });
         nonAnnotationGroups.on("mouseout", function () {
             d3.select(this).select(".add-annotation-background")


### PR DESCRIPTION
#### Rationale
Panorama users want to record changes to the system (MP, SSTs, columns, PMs, etc) via the Annotations features and having them in separate folders requires them to add the Annotations to both even though it is the same system. 
This will simplify the need by adding the shared annotations for the same instrument across multiple QC folders.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Add new columns to QCAnnotation and QCAnnotationType tables
* Associate shared annotations with instrument of the QC folder
* Display shared annotations in qc folders with same instruments across server
