### PR TITLE
Ensure FKs and indices in targetedms schema

### DIFF
--- a/resources/schemas/dbscripts/postgresql/targetedms-26.003-26.004.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-26.003-26.004.sql
@@ -1,5 +1,12 @@
--- Adding missing foreign keys to core.Containers(EntityId)
 SELECT core.executeJavaUpgradeCode('reparentOrphanedTargetedMSData');
+
+-- Adding missing foreign keys to core.Containers(EntityId)1
+ALTER TABLE targetedms.Runs ADD CONSTRAINT FK_Runs_Container FOREIGN KEY (Container) REFERENCES core.Containers(EntityId);
+ALTER TABLE targetedms.QCAnnotation ADD CONSTRAINT FK_QCAnnotation_Container FOREIGN KEY (Container) REFERENCES core.Containers(EntityId);
+ALTER TABLE targetedms.GuideSet ADD CONSTRAINT FK_GuideSet_Container FOREIGN KEY (Container) REFERENCES core.Containers(EntityId);
+ALTER TABLE targetedms.AutoQCPing ADD CONSTRAINT FK_AutoQCPing_Container FOREIGN KEY (Container) REFERENCES core.Containers(EntityId);
+ALTER TABLE targetedms.PrecursorChromInfo ADD CONSTRAINT FK_PrecursorChromInfo_Container FOREIGN KEY (Container) REFERENCES core.Containers(EntityId);
+ALTER TABLE targetedms.SampleFileChromInfo ADD CONSTRAINT FK_SampleFileChromInfo_Container FOREIGN KEY (Container) REFERENCES core.Containers(EntityId);
 
 -- Adding missing indices on Container
 CREATE INDEX IX_QCAnnotationType_Container ON targetedms.QCAnnotationType(Container);

--- a/resources/schemas/dbscripts/postgresql/targetedms-26.003-26.004.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-26.003-26.004.sql
@@ -1,10 +1,5 @@
 -- Adding missing foreign keys to core.Containers(EntityId)
-ALTER TABLE targetedms.Runs ADD CONSTRAINT FK_Runs_Container FOREIGN KEY (Container) REFERENCES core.Containers(EntityId);
-ALTER TABLE targetedms.QCAnnotation ADD CONSTRAINT FK_QCAnnotation_Container FOREIGN KEY (Container) REFERENCES core.Containers(EntityId);
-ALTER TABLE targetedms.GuideSet ADD CONSTRAINT FK_GuideSet_Container FOREIGN KEY (Container) REFERENCES core.Containers(EntityId);
-ALTER TABLE targetedms.AutoQCPing ADD CONSTRAINT FK_AutoQCPing_Container FOREIGN KEY (Container) REFERENCES core.Containers(EntityId);
-ALTER TABLE targetedms.PrecursorChromInfo ADD CONSTRAINT FK_PrecursorChromInfo_Container FOREIGN KEY (Container) REFERENCES core.Containers(EntityId);
-ALTER TABLE targetedms.SampleFileChromInfo ADD CONSTRAINT FK_SampleFileChromInfo_Container FOREIGN KEY (Container) REFERENCES core.Containers(EntityId);
+SELECT core.executeJavaUpgradeCode('reparentOrphanedTargetedMSData');
 
 -- Adding missing indices on Container
 CREATE INDEX IX_QCAnnotationType_Container ON targetedms.QCAnnotationType(Container);

--- a/resources/schemas/dbscripts/postgresql/targetedms-26.003-26.004.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-26.003-26.004.sql
@@ -1,0 +1,13 @@
+-- Adding missing foreign keys to core.Containers(EntityId)
+ALTER TABLE targetedms.Runs ADD CONSTRAINT FK_Runs_Container FOREIGN KEY (Container) REFERENCES core.Containers(EntityId);
+ALTER TABLE targetedms.QCAnnotation ADD CONSTRAINT FK_QCAnnotation_Container FOREIGN KEY (Container) REFERENCES core.Containers(EntityId);
+ALTER TABLE targetedms.GuideSet ADD CONSTRAINT FK_GuideSet_Container FOREIGN KEY (Container) REFERENCES core.Containers(EntityId);
+ALTER TABLE targetedms.AutoQCPing ADD CONSTRAINT FK_AutoQCPing_Container FOREIGN KEY (Container) REFERENCES core.Containers(EntityId);
+ALTER TABLE targetedms.PrecursorChromInfo ADD CONSTRAINT FK_PrecursorChromInfo_Container FOREIGN KEY (Container) REFERENCES core.Containers(EntityId);
+ALTER TABLE targetedms.SampleFileChromInfo ADD CONSTRAINT FK_SampleFileChromInfo_Container FOREIGN KEY (Container) REFERENCES core.Containers(EntityId);
+
+-- Adding missing indices on Container
+CREATE INDEX IX_QCAnnotationType_Container ON targetedms.QCAnnotationType(Container);
+CREATE INDEX IX_QCAnnotation_Container ON targetedms.QCAnnotation(Container);
+CREATE INDEX IX_GuideSet_Container ON targetedms.GuideSet(Container);
+CREATE INDEX IX_QCMetricConfiguration_Container ON targetedms.QCMetricConfiguration(Container);

--- a/resources/schemas/dbscripts/postgresql/targetedms-26.003-26.004.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-26.003-26.004.sql
@@ -1,6 +1,6 @@
 SELECT core.executeJavaUpgradeCode('reparentOrphanedTargetedMSData');
 
--- Adding missing foreign keys to core.Containers(EntityId)1
+-- Adding missing foreign keys to core.Containers(EntityId)
 ALTER TABLE targetedms.Runs ADD CONSTRAINT FK_Runs_Container FOREIGN KEY (Container) REFERENCES core.Containers(EntityId);
 ALTER TABLE targetedms.QCAnnotation ADD CONSTRAINT FK_QCAnnotation_Container FOREIGN KEY (Container) REFERENCES core.Containers(EntityId);
 ALTER TABLE targetedms.GuideSet ADD CONSTRAINT FK_GuideSet_Container FOREIGN KEY (Container) REFERENCES core.Containers(EntityId);

--- a/src/org/labkey/targetedms/TargetedMSListener.java
+++ b/src/org/labkey/targetedms/TargetedMSListener.java
@@ -71,6 +71,5 @@ public class TargetedMSListener implements ContainerManager.ContainerListener
         new SqlExecutor(TargetedMSManager.getSchema()).execute("DELETE FROM " + TargetedMSManager.getTableInfoMSInstrument() + " WHERE Container = ?", c);
         new SqlExecutor(TargetedMSManager.getSchema()).execute("DELETE FROM " + TargetedMSManager.getTableInfoPaymentMethod() + " WHERE Container = ?", c);
         new SqlExecutor(TargetedMSManager.getSchema()).execute("DELETE FROM " + TargetedMSManager.getTableInfoRateType() + " WHERE Container = ?", c);
-        new SqlExecutor(TargetedMSManager.getSchema()).execute("DELETE FROM " + TargetedMSManager.getTableInfoSampleFileChromInfo() + " WHERE Container = ?", c);
     }
 }

--- a/src/org/labkey/targetedms/TargetedMSListener.java
+++ b/src/org/labkey/targetedms/TargetedMSListener.java
@@ -71,5 +71,6 @@ public class TargetedMSListener implements ContainerManager.ContainerListener
         new SqlExecutor(TargetedMSManager.getSchema()).execute("DELETE FROM " + TargetedMSManager.getTableInfoMSInstrument() + " WHERE Container = ?", c);
         new SqlExecutor(TargetedMSManager.getSchema()).execute("DELETE FROM " + TargetedMSManager.getTableInfoPaymentMethod() + " WHERE Container = ?", c);
         new SqlExecutor(TargetedMSManager.getSchema()).execute("DELETE FROM " + TargetedMSManager.getTableInfoRateType() + " WHERE Container = ?", c);
+        new SqlExecutor(TargetedMSManager.getSchema()).execute("DELETE FROM " + TargetedMSManager.getTableInfoSampleFileChromInfo() + " WHERE Container = ?", c);
     }
 }

--- a/src/org/labkey/targetedms/TargetedMSManager.java
+++ b/src/org/labkey/targetedms/TargetedMSManager.java
@@ -2524,6 +2524,17 @@ public class TargetedMSManager
 
         new SqlExecutor(getSchema()).execute(updatePrecChromInfoSql);
 
+        SQLFragment updateSampleFileChromInfoSql = new SQLFragment("UPDATE ");
+        updateSampleFileChromInfoSql.append(getTableInfoSampleFileChromInfo(), "");
+        updateSampleFileChromInfoSql.append(" SET container = ?").add(newContainer);
+        updateSampleFileChromInfoSql.append(" WHERE sampleFileId IN (");
+        updateSampleFileChromInfoSql.append(" SELECT sf.Id FROM ").append(getTableInfoSampleFile(), "sf");
+        updateSampleFileChromInfoSql.append(" INNER JOIN ").append(getTableInfoReplicate(), "rep").append(" ON rep.Id = sf.ReplicateId");
+        updateSampleFileChromInfoSql.append(" WHERE rep.runId = ?").add(run.getId());
+        updateSampleFileChromInfoSql.append(" )");
+
+        new SqlExecutor(getSchema()).execute(updateSampleFileChromInfoSql);
+
         run.setExperimentRunLSID(newRunLSID);
         run.setDataId(newDataRowId);
         run.setContainer(newContainer);

--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -231,7 +231,7 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
     @Override
     public Double getSchemaVersion()
     {
-        return 26.002;
+        return 26.004;
     }
 
     @Override

--- a/src/org/labkey/targetedms/TargetedMSUpgradeCode.java
+++ b/src/org/labkey/targetedms/TargetedMSUpgradeCode.java
@@ -108,4 +108,42 @@ public class TargetedMSUpgradeCode implements UpgradeCode
 
         LOG.info("Finished populating PTMPercentsGroupedPrepivotCache for existing ExperimentMAM folders");
     }
+
+    @SuppressWarnings("UnusedDeclaration")
+    public void reparentOrphanedTargetedMSData(final ModuleContext moduleContext)
+    {
+        if (moduleContext.isNewInstall())
+        {
+            return;
+        }
+
+        Container sharedContainer = ContainerManager.getSharedContainer();
+
+        SqlExecutor executor = new SqlExecutor(TargetedMSManager.getSchema());
+
+        String[] tablesToDeleteOrphans = {"QCAnnotation", "GuideSet", "AutoQCPing"};
+        for (String tableName : tablesToDeleteOrphans)
+        {
+            SQLFragment deleteSql = new SQLFragment("DELETE FROM targetedms.").append(tableName)
+                    .append(" WHERE Container NOT IN (SELECT EntityId FROM core.Containers)");
+            int deletedCount = executor.execute(deleteSql);
+            if (deletedCount > 0)
+            {
+                LOG.info("Deleted " + deletedCount + " orphaned rows from targetedms." + tableName);
+            }
+        }
+
+        String[] tablesToReparentOrphans = {"Runs", "PrecursorChromInfo", "SampleFileChromInfo"};
+        for (String tableName : tablesToReparentOrphans)
+        {
+            SQLFragment updateSql = new SQLFragment("UPDATE targetedms.").append(tableName)
+                    .append(" SET Container = ? WHERE Container NOT IN (SELECT EntityId FROM core.Containers)")
+                    .add(sharedContainer.getEntityId());
+            int updatedCount = executor.execute(updateSql);
+            if (updatedCount > 0)
+            {
+                LOG.info("Reparented " + updatedCount + " orphaned rows from targetedms." + tableName + " to /Shared");
+            }
+        }
+    }
 }


### PR DESCRIPTION
#### Rationale
Add missing foreign key to core.Containers and add missing dedicated index on containers on columns.
26.002-26.003 upgrade script is here https://github.com/LabKey/targetedms/pull/1185

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
These tables have the Container column but lack a formal FOREIGN KEY constraint to the core.Containers table.
* targetedms.Runs 
* targetedms.QCAnnotation
* targetedms.GuideSet
* targetedms.AutoQCPing
* targetedms.PrecursorChromInfo
* targetedms.SampleFileChromInfo

missing index:

* targetedms.QCAnnotationType 
* targetedms.QCAnnotation 
* targetedms.GuideSet 
* targetedms.QCMetricConfiguration
