### PR TITLE
Skip checking for enabled metrics in non-QC folders

### DIFF
--- a/src/org/labkey/targetedms/TargetedMSController.java
+++ b/src/org/labkey/targetedms/TargetedMSController.java
@@ -505,6 +505,9 @@ public class TargetedMSController extends SpringActionController
             addDataPipelineTab(c);
             addRawFilesPipelineTab(c);
 
+            // We may have toggled into or out of QC folder type, so clear out the cache
+            TargetedMSManager.get().clearQCMetricCache(c, true);
+
             // Inform listeners so that any additional folder configuration can be done.
             TargetedMSService.get().getTargetedMSFolderTypeListeners().forEach(listener -> listener.folderCreated(c, getUser()));
 

--- a/src/org/labkey/targetedms/TargetedMSManager.java
+++ b/src/org/labkey/targetedms/TargetedMSManager.java
@@ -167,9 +167,18 @@ public class TargetedMSManager
     private static final Cache<Container, List<QCMetricConfiguration>> _metricCache = CacheManager.getBlockingCache(1000, TimeUnit.HOURS.toMillis(1), "Enabled QC metric configs",
             (c, argument) ->
             {
+                if (!(argument instanceof TargetedMSSchema schema))
+                {
+                    throw new IllegalArgumentException("Argument must be a TargetedMSSchema but was " + argument);
+                }
+
+                if (getFolderType(schema.getContainer()) != TargetedMSService.FolderType.QC)
+                {
+                    return Collections.emptyList();
+                }
+
                 try
                 {
-                    TargetedMSSchema schema = (TargetedMSSchema) argument;
                     TableInfo metricsTable = schema.getTableOrThrow("qcMetricsConfig", null);
                     List<QCMetricConfiguration> metrics = new TableSelector(metricsTable, null, new Sort(FieldKey.fromParts("Name"))).getArrayList(QCMetricConfiguration.class);
 


### PR DESCRIPTION
#### Rationale
The call to SkylineDocImporter.insertTraceCalculations() is very slow in some servers. It's caching QC metric configurations, including writing metrics values to the table that caches them. This is useless for non-QC folders.

#### Changes
* Only bother figuring out QC metrics in QC folders
