### PR TITLE
fix verifyGuideSetRelatedElementsForPlots

### DIFF
--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCGuideSetTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCGuideSetTest.java
@@ -220,7 +220,7 @@ public class TargetedMSQCGuideSetTest extends TargetedMSTest
         List<Pair<String, Integer>> shapeCounts = new ArrayList<>();
         shapeCounts.add(Pair.of(SvgShapes.CIRCLE.getPathPrefix(), 289));
         shapeCounts.add(Pair.of(SvgShapes.TRIANGLE.getPathPrefix(), 40));
-        verifyGuideSetRelatedElementsForPlots(qcPlotsWebPart, 4, shapeCounts, 47);
+        verifyGuideSetRelatedElementsForPlots(qcPlotsWebPart, 4, shapeCounts, 48);
 
         // check box for group x-axis values by date and verify
         qcPlotsWebPart.setGroupXAxisValuesByDate(true);

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCGuideSetTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCGuideSetTest.java
@@ -220,7 +220,7 @@ public class TargetedMSQCGuideSetTest extends TargetedMSTest
         List<Pair<String, Integer>> shapeCounts = new ArrayList<>();
         shapeCounts.add(Pair.of(SvgShapes.CIRCLE.getPathPrefix(), 289));
         shapeCounts.add(Pair.of(SvgShapes.TRIANGLE.getPathPrefix(), 40));
-        verifyGuideSetRelatedElementsForPlots(qcPlotsWebPart, 4, shapeCounts, 48);
+        verifyGuideSetRelatedElementsForPlots(qcPlotsWebPart, 4, shapeCounts, 47);
 
         // check box for group x-axis values by date and verify
         qcPlotsWebPart.setGroupXAxisValuesByDate(true);

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -203,7 +203,7 @@ public class TargetedMSQCTest extends TargetedMSTest
     protected void doCleanup(boolean afterTest) throws TestTimeoutException
     {
         // Use the API-based approach for deletion so that we don't trigger AJAX requests navigating to the delete page
-        // that may run in the background and cause SQL Server deadlock exceptions
+        // that may run in the background and cause deadlock exceptions
         new APIContainerHelper(this).deleteProject(getProjectName(), afterTest);
     }
 

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -25,6 +25,7 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.SortDirection;
 import org.labkey.test.TestFileUtils;
+import org.labkey.test.TestTimeoutException;
 import org.labkey.test.components.ext4.RadioButton;
 import org.labkey.test.components.ext4.Window;
 import org.labkey.test.components.html.SiteNavBar;
@@ -36,6 +37,7 @@ import org.labkey.test.components.targetedms.QCPlotsWebPart;
 import org.labkey.test.components.targetedms.QCSummaryWebPart;
 import org.labkey.test.pages.targetedms.PanoramaAnnotations;
 import org.labkey.test.pages.targetedms.PanoramaDashboard;
+import org.labkey.test.util.APIContainerHelper;
 import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;
@@ -195,6 +197,14 @@ public class TargetedMSQCTest extends TargetedMSTest
         QCPlotsWebPart qcPlotsWebPart = qcDashboard.getQcPlotsWebPart();
         scrollIntoView(qcPlotsWebPart.getComponentElement());
         qcPlotsWebPart.revertToDefaultView();
+    }
+
+    @Override
+    protected void doCleanup(boolean afterTest) throws TestTimeoutException
+    {
+        // Use the API-based approach for deletion so that we don't trigger AJAX requests navigating to the delete page
+        // that may run in the background and cause SQL Server deadlock exceptions
+        new APIContainerHelper(this).deleteProject(getProjectName(), afterTest);
     }
 
     @Test


### PR DESCRIPTION
#### Rationale
Add cleanup in TargetedMSQCTest as shared annotations were getting displayed in other test containers causing failures. The failures are intermittent because of the ordering of tests execution in TC.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
