### PR TITLE
Drop redundant indices

### DIFF
--- a/resources/schemas/dbscripts/postgresql/targetedms-26.004-26.005.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-26.004-26.005.sql
@@ -1,0 +1,10 @@
+-- Dropping idx_instrumentusagepayment_instrumentscheduleid [instrumentScheduleId] because it overlaps with pk_instrumentusagepayment [instrumentScheduleId, paymentMethod]
+DROP INDEX targetedms.idx_instrumentusagepayment_instrumentscheduleid;
+-- Dropping ix_qcannotationtype_container [Container] because it overlaps with uq_qcannotationtype_containername [Container, Name]
+DROP INDEX targetedms.ix_qcannotationtype_container;
+-- Dropping ix_precursor_id [Id] because it overlaps with pk_precursor_id [Id]
+DROP INDEX targetedms.ix_precursor_id;
+-- Dropping ix_qcmetricexclusion_replicateid [ReplicateId] because it overlaps with uq_qcmetricexclusion_replicate_metric [ReplicateId, MetricId]
+DROP INDEX targetedms.ix_qcmetricexclusion_replicateid;
+-- Dropping ix_irtpeptide_irtscaleid [iRTScaleId] because it overlaps with uq_irtpeptide_sequenceandscale [iRTScaleId, ModifiedSequence]
+DROP INDEX targetedms.ix_irtpeptide_irtscaleid;

--- a/resources/schemas/dbscripts/postgresql/targetedms-26.005-26.006.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-26.005-26.006.sql
@@ -1,0 +1,4 @@
+-- When reparenting the QCEmailNotifications table from PanoramaPremium schema to targetedms, an attempt was made to
+-- drop this index, but the attempt failed because it targeted the old schema. This index is redundant with
+-- IX_qcEmailNotifications_Container.
+DROP INDEX IF EXISTS targetedms.IX_PanoramaPremium_qcEmailNotifications_Container;

--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -231,7 +231,7 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
     @Override
     public Double getSchemaVersion()
     {
-        return 26.005;
+        return 26.006;
     }
 
     @Override

--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -231,7 +231,7 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
     @Override
     public Double getSchemaVersion()
     {
-        return 26.004;
+        return 26.005;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Redundant indices waste disk space and degrade insert/update/delete performance

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/7630

Note: Once merged to develop, I'll immediately backport this change to 26.3.