### PR TITLE
Add short descriptions for all Panorama Selenium tests

### DIFF
--- a/test/src/org/labkey/test/tests/panoramapremium/TargetedMSHidePeptidesAndMolecules.java
+++ b/test/src/org/labkey/test/tests/panoramapremium/TargetedMSHidePeptidesAndMolecules.java
@@ -13,6 +13,10 @@ import org.labkey.test.util.PortalHelper;
 
 import java.util.Arrays;
 
+/**
+ * Tests the ability to hide/show specific peptides and molecules in QC folders across multiple folder structure
+ * configurations.
+ */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 6)
 public class TargetedMSHidePeptidesAndMolecules extends TargetedMSTest

--- a/test/src/org/labkey/test/tests/panoramapremium/TargetedMSIsotopologueTest.java
+++ b/test/src/org/labkey/test/tests/panoramapremium/TargetedMSIsotopologueTest.java
@@ -13,6 +13,9 @@ import org.labkey.test.pages.targetedms.PanoramaDashboard;
 
 import static org.junit.Assert.assertTrue;
 
+/**
+ * Validates isotopologue metric display and calculation in the Panorama Dashboard QC metrics panel.
+ */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 3)
 public class TargetedMSIsotopologueTest extends TargetedMSPremiumTest

--- a/test/src/org/labkey/test/tests/panoramapremium/TargetedMSQCFolderImportExport.java
+++ b/test/src/org/labkey/test/tests/panoramapremium/TargetedMSQCFolderImportExport.java
@@ -17,6 +17,9 @@ import java.io.File;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+/**
+ * Tests import/export of QC folder configurations and data as a round-trip operation.
+ */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 6)
 public class TargetedMSQCFolderImportExport extends TargetedMSPremiumTest

--- a/test/src/org/labkey/test/tests/panoramapremium/TargetedMSQCPremiumTest.java
+++ b/test/src/org/labkey/test/tests/panoramapremium/TargetedMSQCPremiumTest.java
@@ -37,6 +37,10 @@ import static org.junit.Assert.fail;
 import static org.labkey.test.components.targetedms.QCPlotsWebPart.QCPlotType.CUSUMm;
 import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
+/**
+ * Tests premium-tier QC functionality: guide sets, advanced QC metrics, CUSUM plots, and premium-specific permission
+ * checks.
+ */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 6)
 public class TargetedMSQCPremiumTest extends TargetedMSPremiumTest

--- a/test/src/org/labkey/test/tests/panoramapremium/TargetedMSSampleManagerIntegrationTest.java
+++ b/test/src/org/labkey/test/tests/panoramapremium/TargetedMSSampleManagerIntegrationTest.java
@@ -20,6 +20,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Tests integration between TargetedMS and the Sample Manager module, including linked sample type data flowing into
+ * Skyline documents.
+ */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 3)
 public class TargetedMSSampleManagerIntegrationTest extends TargetedMSPremiumTest

--- a/test/src/org/labkey/test/tests/panoramapremium/TargetedMSiRTMetricsTest.java
+++ b/test/src/org/labkey/test/tests/panoramapremium/TargetedMSiRTMetricsTest.java
@@ -18,6 +18,9 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * Tests iRT metrics calculations and their visualization specifically within the QC dashboard context.
+ */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class TargetedMSiRTMetricsTest extends TargetedMSPremiumTest

--- a/test/src/org/labkey/test/tests/targetedms/ClustergrammerTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/ClustergrammerTest.java
@@ -27,6 +27,9 @@ import org.labkey.test.components.targetedms.TargetedMSRunsTable;
 
 import java.util.Arrays;
 
+/**
+ * Tests the Clustergrammer heatmap visualization integration for peptide data.
+ */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class ClustergrammerTest extends TargetedMSTest

--- a/test/src/org/labkey/test/tests/targetedms/GetDataAPITest.java
+++ b/test/src/org/labkey/test/tests/targetedms/GetDataAPITest.java
@@ -27,6 +27,9 @@ import org.labkey.test.util.WikiHelper;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertThat;
 
+/**
+ * Tests the GetData API with query transformations, filtering, and pivot operations on TargetedMS data.
+ */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class GetDataAPITest extends TargetedMSTest

--- a/test/src/org/labkey/test/tests/targetedms/InstrumentSchedulingTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/InstrumentSchedulingTest.java
@@ -48,6 +48,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+/**
+ * Tests instrument scheduling workflows including date/time handling and permissions across QC folders.
+ */
 @Category({})
 @FixMethodOrder(MethodSorters.NAME_ASCENDING) // Don't insert additional projects until after testSchedule() has run
 public class InstrumentSchedulingTest extends TargetedMSTest implements PostgresOnlyTest

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSAuditLogTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSAuditLogTest.java
@@ -10,6 +10,9 @@ import org.labkey.test.util.DataRegionTable;
 
 import static org.junit.Assert.assertEquals;
 
+/**
+ * Verifies that audit log entries from Skyline documents are correctly imported and displayed as an audit trail.
+ */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class TargetedMSAuditLogTest extends TargetedMSTest

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSChromatogramOptimizationTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSChromatogramOptimizationTest.java
@@ -20,6 +20,9 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
+/**
+ * Tests chromatogram optimization workflows and library file generation from imported Skyline documents.
+ */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 3)
 public class TargetedMSChromatogramOptimizationTest extends TargetedMSTest

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSDocumentFormatsTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSDocumentFormatsTest.java
@@ -31,6 +31,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * Tests backward compatibility by importing Skyline documents across multiple historical format versions.
+ */
 @Category({})
 public class TargetedMSDocumentFormatsTest extends TargetedMSTest
 {

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSEarlyStagePTMReportTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSEarlyStagePTMReportTest.java
@@ -12,6 +12,10 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
+/**
+ * Tests the PTM (post-translational modification) peptide report feature, including data pre-pivoting for
+ * early-stage PTM analysis.
+ */
 @Category({})
 public class TargetedMSEarlyStagePTMReportTest extends TargetedMSTest
 {

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentIrtTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentIrtTest.java
@@ -21,6 +21,9 @@ import org.labkey.test.BaseWebDriverTest;
 
 import static org.junit.Assert.assertEquals;
 
+/**
+ * Tests iRT (indexed Retention Time) scale import in experiment folders, validating the standard peptide set.
+ */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class TargetedMSExperimentIrtTest extends TargetedMSIrtTest

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentTest.java
@@ -56,6 +56,9 @@ import static org.junit.Assert.assertTrue;
 import static org.labkey.test.util.DataRegionTable.DataRegion;
 import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
+/**
+ * Broad coverage of experiment folder behavior: file uploads, shared file access, and folder-level permissions.
+ */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 8)
 public class TargetedMSExperimentTest extends TargetedMSTest

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentalQCLinkTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSExperimentalQCLinkTest.java
@@ -17,6 +17,9 @@ import org.labkey.test.util.DataRegionTable;
 import java.util.Arrays;
 import java.util.List;
 
+/**
+ * Tests linking of experiment folders to QC folders, then validates guide sets and metrics flow across the link.
+ */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 4)
 public class TargetedMSExperimentalQCLinkTest extends TargetedMSTest

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSInstrumentNicknameTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSInstrumentNicknameTest.java
@@ -35,6 +35,9 @@ import static org.junit.Assert.assertEquals;
 import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
 import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
+/**
+ * Tests creation, inheritance, and permission-gating of instrument nicknames across folder hierarchies.
+ */
 @Category({})
 public class TargetedMSInstrumentNicknameTest extends TargetedMSTest
 {

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSLibraryIrtTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSLibraryIrtTest.java
@@ -23,6 +23,9 @@ import org.labkey.test.util.LogMethod;
 
 import static org.junit.Assert.assertEquals;
 
+/**
+ * Tests iRT scale updates in library folders, specifically the weighted-average recalculation logic.
+ */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 10)
 public class TargetedMSLibraryIrtTest extends TargetedMSIrtTest

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSLibraryTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSLibraryTest.java
@@ -36,6 +36,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
+/**
+ * Tests library folder behavior across multiple document imports and revision tracking.
+ */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class TargetedMSLibraryTest extends TargetedMSTest

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSLibraryTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSLibraryTest.java
@@ -37,7 +37,7 @@ import static org.junit.Assert.assertTrue;
 import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 /**
- * Tests library folder behavior across multiple document imports and revision tracking.
+ * Tests protein library folders, library revisions, and conflict resolution when uploaded documents contain the same targets as the existing library (parallel to the peptide and small molecule library tests).
  */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSLightHeavyRatioTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSLightHeavyRatioTest.java
@@ -15,6 +15,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.labkey.test.Locator.tag;
 
+/**
+ * Validates light/heavy peptide ratio calculations and reproducibility report output.
+ */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 3)
 public class TargetedMSLightHeavyRatioTest extends TargetedMSTest

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSLinkVersionsTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSLinkVersionsTest.java
@@ -28,6 +28,9 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
+/**
+ * Tests the version-linking feature for multiple QC documents within experiment folders.
+ */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 25)
 public class TargetedMSLinkVersionsTest extends TargetedMSTest

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSLinkVersionsTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSLinkVersionsTest.java
@@ -29,7 +29,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 
 /**
- * Tests the version-linking feature for multiple QC documents within experiment folders.
+ * Tests the version-linking feature for multiple documents within experiment folders.
  */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 25)

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSListTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSListTest.java
@@ -35,6 +35,9 @@ import java.util.stream.Collectors;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+/**
+ * Tests list query functionality with document imports and property handling specific to TargetedMS.
+ */
 @Category({})
 public class TargetedMSListTest extends TargetedMSTest
 {

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSMAMTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSMAMTest.java
@@ -24,6 +24,9 @@ import org.labkey.test.util.DataRegionTable;
 
 import static org.junit.Assert.assertTrue;
 
+/**
+ * Tests MAM (Multi-Attribute Monitoring) experiment folders, including cross-linked peptides and iRT data.
+ */
 @Category({})
 public class TargetedMSMAMTest extends TargetedMSTest
 {

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSMovingSKYDocAcrossFoldersTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSMovingSKYDocAcrossFoldersTest.java
@@ -11,6 +11,9 @@ import org.labkey.test.TestTimeoutException;
 import org.labkey.test.util.APIContainerHelper;
 import org.labkey.test.util.DataRegionTable;
 
+/**
+ * Verifies that Skyline documents can be moved between different folder types (experiment and MAM).
+ */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 4)
 public class TargetedMSMovingSKYDocAcrossFoldersTest extends TargetedMSTest

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSMultiplePeptidePlotTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSMultiplePeptidePlotTest.java
@@ -14,6 +14,9 @@ import org.openqa.selenium.support.ui.ExpectedConditions;
 import java.io.File;
 import java.util.List;
 
+/**
+ * Tests rendering of multiple peptides on the same chromatogram visualization panel.
+ */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 2)
 public class TargetedMSMultiplePeptidePlotTest extends TargetedMSTest

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSMxNReproducibilityReportTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSMxNReproducibilityReportTest.java
@@ -23,6 +23,9 @@ import java.sql.SQLException;
 
 import static org.labkey.test.Locator.tag;
 
+/**
+ * Tests M×N reproducibility reports with both single and multiple replicate configurations.
+ */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 6)
 public class TargetedMSMxNReproducibilityReportTest extends TargetedMSTest

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSPeptideLibraryTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSPeptideLibraryTest.java
@@ -35,6 +35,9 @@ import java.util.Set;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+/**
+ * Tests peptide library folder revisions and conflict resolution when multiple documents define the same library entries.
+ */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class TargetedMSPeptideLibraryTest extends TargetedMSTest

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSPeptideSummaryHeatmapTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSPeptideSummaryHeatmapTest.java
@@ -17,6 +17,9 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
+/**
+ * Tests the peptide/molecule summary heatmap visualization in QC dashboards.
+ */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class TargetedMSPeptideSummaryHeatmapTest extends TargetedMSTest

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSPrecursorLevelDataTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSPrecursorLevelDataTest.java
@@ -18,6 +18,9 @@ import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+/**
+ * Validates precursor-level quantification data and figures-of-merit calculations.
+ */
 @Category({})
 public class TargetedMSPrecursorLevelDataTest extends AbstractQuantificationTest
 {

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSProteinGroupingTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSProteinGroupingTest.java
@@ -8,6 +8,9 @@ import org.labkey.test.Locator;
 import org.labkey.test.components.CustomizeView;
 import org.labkey.test.util.DataRegionTable;
 
+/**
+ * Tests protein grouping logic and the protein match visualization UI.
+ */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 2)
 public class TargetedMSProteinGroupingTest extends TargetedMSTest

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSProteinSequenceViewTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSProteinSequenceViewTest.java
@@ -10,6 +10,9 @@ import org.labkey.test.components.targetedms.SequenceCoverageWebPart;
 
 import java.util.Arrays;
 
+/**
+ * Tests protein sequence views including confidence score display and rendering of modified peptides.
+ */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 12)
 public class TargetedMSProteinSequenceViewTest extends TargetedMSTest

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCConfigureMetricTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCConfigureMetricTest.java
@@ -19,6 +19,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+/**
+ * Tests the QC metric configuration UI and verifies settings propagate consistently across folder hierarchies.
+ */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class TargetedMSQCConfigureMetricTest extends TargetedMSPremiumTest

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCGuideSetTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCGuideSetTest.java
@@ -51,6 +51,9 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
+/**
+ * Tests guide set management, statistics computation, and Pareto plot generation in QC folders.
+ */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 25)
 public class TargetedMSQCGuideSetTest extends TargetedMSTest

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCSummaryTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCSummaryTest.java
@@ -56,6 +56,9 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
+/**
+ * Tests the QC summary dashboard including guide sets, annotations, permissions, and trailing statistic calculations.
+ */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 12)
 public class TargetedMSQCSummaryTest extends TargetedMSTest

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSQCTest.java
@@ -69,6 +69,9 @@ import static org.labkey.test.components.targetedms.QCPlotsWebPart.QCPlotType.Mo
 import static org.labkey.test.components.targetedms.QCPlotsWebPart.QCPlotType.TrailingCV;
 import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
+/**
+ * Broad QC folder test covering plots, metric types, annotations, guide sets, and permissions together in one suite.
+ */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 35)
 public class TargetedMSQCTest extends TargetedMSTest

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSSampleFileChromInfoTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSSampleFileChromInfoTest.java
@@ -27,6 +27,9 @@ import org.labkey.test.util.DataRegionTable;
 
 import java.util.Arrays;
 
+/**
+ * Tests sample file-scoped chromatograms (e.g., pressure traces) parsed from Skyline documents.
+ */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 6)
 public class TargetedMSSampleFileChromInfoTest extends TargetedMSTest

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSSkydTextIdTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSSkydTextIdTest.java
@@ -27,6 +27,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/**
+ * Tests upload and parsing of small molecule SKYD text-format files.
+ */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 6)
 public class TargetedMSSkydTextIdTest extends TargetedMSTest

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSSmallMoleculeLibraryTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSSmallMoleculeLibraryTest.java
@@ -32,6 +32,10 @@ import java.util.Set;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+/**
+ * Tests small molecule library folders, document revisions, and conflict resolution (parallel to the peptide library
+ * test but for small molecules).
+ */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class TargetedMSSmallMoleculeLibraryTest extends TargetedMSTest

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSSmallMoleculeLightHeavyRatioTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSSmallMoleculeLightHeavyRatioTest.java
@@ -15,6 +15,9 @@ import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
 
+/**
+ * Validates light/heavy ratio metrics specifically for small molecule data in QC dashboards.
+ */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 3)
 public class TargetedMSSmallMoleculeLightHeavyRatioTest extends TargetedMSTest

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSTrailingMeanAndCVTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSTrailingMeanAndCVTest.java
@@ -13,6 +13,9 @@ import org.labkey.test.pages.targetedms.PanoramaDashboard;
 import org.labkey.test.util.PortalHelper;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
+/**
+ * Tests trailing mean and coefficient-of-variation metric calculations in the QC system.
+ */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class TargetedMSTrailingMeanAndCVTest extends TargetedMSTest

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSTransitionChromInfoLimitTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSTransitionChromInfoLimitTest.java
@@ -10,6 +10,10 @@ import org.labkey.remoteapi.query.Filter;
 
 import java.util.List;
 
+/**
+ * Validates behavior at chromatogram data storage limits for transitions and precursors, with custom configuration
+ * overrides.
+ */
 @Category({})
 public class TargetedMSTransitionChromInfoLimitTest extends TargetedMSTest
 {

--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSUtilizationCalendarTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSUtilizationCalendarTest.java
@@ -16,6 +16,9 @@ import java.util.Arrays;
 
 import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
+/**
+ * Tests the instrument utilization calendar: display options, date ranges, and permission-gating.
+ */
 @Category({})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class TargetedMSUtilizationCalendarTest extends TargetedMSTest

--- a/test/src/org/labkey/test/tests/targetedms/passport/PassportTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/passport/PassportTest.java
@@ -24,6 +24,10 @@ import org.labkey.test.util.LogMethod;
 
 import java.util.List;
 
+/**
+ * Tests Panorama Passport integration end-to-end, covering user management, permission setup, and project
+ * configuration for both normal and admin users.
+ */
 @Category({})
 public class PassportTest extends PassportTestPart
 {


### PR DESCRIPTION
#### Rationale
Having a quick summary of the coverage is useful for humans and LLM tools.

#### Changes
* One-sentence summary of the test's coverage
