### PR TITLE
Extract TargetedMSHelper and add upgrade test for 26.3 schema migration

### DIFF
--- a/test/src/org/labkey/test/tests/targetedms/TargetedMSTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/TargetedMSTest.java
@@ -19,6 +19,7 @@ import org.apache.commons.lang3.SystemUtils;
 import org.junit.BeforeClass;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.ModulePropertyValue;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestProperties;
@@ -37,9 +38,8 @@ import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
 import org.labkey.test.util.ReflectionUtils;
 import org.labkey.test.util.UIContainerHelper;
-import org.openqa.selenium.WebElement;
+import org.labkey.test.util.targetedms.TargetedMSHelper;
 
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 
@@ -62,6 +62,7 @@ public abstract class TargetedMSTest extends BaseWebDriverTest
     protected static final String SAMPLE_FILE_CHROM_INFO = "SampleFileChromInfo.sky.zip";
     protected static final String USER = "qcuser@targetedms.test";
     private static ConfiguresSite siteConfigurer;
+    protected final TargetedMSHelper _targetedMSHelper = new TargetedMSHelper(this);
 
     protected enum SvgShapes
     {
@@ -85,7 +86,7 @@ public abstract class TargetedMSTest extends BaseWebDriverTest
         Experiment
                 {
                     @Override
-                    public void chooseFolderType(TargetedMSTest test)
+                    public void chooseFolderType(WebDriverWrapper test)
                     {
                         test.click(Locator.radioButtonById("experimentalData")); // click the first radio button - Experimental Data
                     }
@@ -93,21 +94,21 @@ public abstract class TargetedMSTest extends BaseWebDriverTest
         ExperimentMAM
                 {
                     @Override
-                    public void chooseFolderType(TargetedMSTest test)
+                    public void chooseFolderType(WebDriverWrapper test)
                     {
                         test.click(Locator.radioButtonById("multiAttributeMethod")); // click the second radio button - Experimental Data
                     }
                 }, Library
                 {
                     @Override
-                    public void chooseFolderType(TargetedMSTest test)
+                    public void chooseFolderType(WebDriverWrapper test)
                     {
                         test.click(Locator.radioButtonById("chromatogramLibrary")); // click the 3rd radio button - Library
                     }
                 }, LibraryProtein
                 {
                     @Override
-                    public void chooseFolderType(TargetedMSTest test)
+                    public void chooseFolderType(WebDriverWrapper test)
                     {
                         test.click(Locator.radioButtonById("chromatogramLibrary")); // click the 3rd radio button - Library
                         test.click(Locator.checkboxByName("precursorNormalized")); // check the normalization checkbox.
@@ -115,13 +116,13 @@ public abstract class TargetedMSTest extends BaseWebDriverTest
                 }, QC
                 {
                     @Override
-                    public void chooseFolderType(TargetedMSTest test)
+                    public void chooseFolderType(WebDriverWrapper test)
                     {
                         test.click(Locator.radioButtonById("QC")); // click the 4th radio button - QC
                     }
                 };
 
-        public abstract void chooseFolderType(TargetedMSTest test);
+        public abstract void chooseFolderType(WebDriverWrapper test);
     }
 
     public TargetedMSTest()
@@ -181,10 +182,7 @@ public abstract class TargetedMSTest extends BaseWebDriverTest
 
     protected void setUpFolder(String folderName, FolderType folderType )
     {
-        _containerHelper.createProject(folderName, "Panorama");
-        waitForElement(Locator.linkContainingText("Save"));
-        clickAndWait(Locator.linkContainingText("Next"));
-        selectFolderType(folderType);
+        _targetedMSHelper.setupFolder(folderName, folderType);
         getSiteConfigurer().configureProject(getProjectName());
     }
 
@@ -227,20 +225,7 @@ public abstract class TargetedMSTest extends BaseWebDriverTest
     @LogMethod
     protected void importData(@LoggedParam String file, int jobCount, boolean expectError, boolean doDbMaintenance)
     {
-        Locator.XPathLocator importButtonLoc = Locator.lkButton("Process and Import Data");
-        WebElement importButton = importButtonLoc.findElementOrNull(getDriver());
-        if (null == importButton)
-        {
-            goToModule("Pipeline");
-            importButton = importButtonLoc.findElement(getDriver());
-        }
-        clickAndWait(importButton);
-        String fileName = Paths.get(file).getFileName().toString();
-        if (!_fileBrowserHelper.fileIsPresent(fileName))
-            _fileBrowserHelper.uploadFile(TestFileUtils.getSampleData("TargetedMS/" + file));
-        _fileBrowserHelper.importFile(fileName, "Import Skyline Results");
-        waitForText("Skyline document import");
-        waitForPipelineJobsToComplete(jobCount, file, expectError);
+        _targetedMSHelper.importData(file, jobCount, expectError);
 
         if (doDbMaintenance)
         {
@@ -327,9 +312,7 @@ public abstract class TargetedMSTest extends BaseWebDriverTest
 
     @LogMethod
     protected void selectFolderType(FolderType folderType) {
-        log("Select Folder Type: " + folderType);
-        folderType.chooseFolderType(this);
-        clickButton("Finish");
+        _targetedMSHelper.selectFolderType(folderType);
     }
 
     /** Verify that the comparison plots have been AJAX'd into place */

--- a/test/src/org/labkey/test/tests/targetedms/upgrade/TargetedMSUpgradeTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/upgrade/TargetedMSUpgradeTest.java
@@ -1,0 +1,71 @@
+package org.labkey.test.tests.targetedms.upgrade;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.labkey.remoteapi.query.SelectRowsCommand;
+import org.labkey.remoteapi.query.SelectRowsResponse;
+import org.labkey.test.tests.targetedms.TargetedMSTest.FolderType;
+import org.labkey.test.tests.upgrade.BaseUpgradeTest;
+import org.labkey.test.util.UIContainerHelper;
+import org.labkey.test.util.targetedms.TargetedMSHelper;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Verifies that the targetedms-26.006-26.007 upgrade script correctly populates PeptideGroupCount,
+ * MoleculeGroupCount, and ProteinCount on existing runs after the schema migration.
+ */
+@Category({})
+public class TargetedMSUpgradeTest extends BaseUpgradeTest
+{
+    private static final String SKY_FILE = "smallmol_plus_peptides.sky.zip";
+
+    public TargetedMSUpgradeTest()
+    {
+        setContainerHelper(new UIContainerHelper(this));
+    }
+
+    @Override
+    protected String getProjectName()
+    {
+        return "TargetedMS Upgrade Test";
+    }
+
+    @Override
+    protected void doSetup() throws Exception
+    {
+        TargetedMSHelper helper = new TargetedMSHelper(this);
+        helper.setupFolder(getProjectName(), FolderType.Experiment);
+        helper.importData(SKY_FILE);
+    }
+
+    @Test
+    public void testRunCounts() throws Exception
+    {
+        SelectRowsCommand cmd = new SelectRowsCommand("targetedms", "Runs");
+        cmd.setColumns(List.of("PeptideGroups", "MoleculeLists", "Proteins"));
+        SelectRowsResponse response = cmd.execute(createDefaultConnection(), getProjectName());
+
+        List<Map<String, Object>> rows = response.getRows();
+        assertEquals("Expected exactly one run", 1, rows.size());
+        Map<String, Object> run = rows.get(0);
+        assertEquals("PeptideGroupCount", 24, ((Number) run.get("PeptideGroups")).intValue());
+        assertEquals("MoleculeGroupCount", 3, ((Number) run.get("MoleculeLists")).intValue());
+        assertEquals("ProteinCount", 24, ((Number) run.get("Proteins")).intValue());
+    }
+
+    @Override
+    protected void doCleanup(boolean afterTest)
+    {
+        _containerHelper.deleteProject(getProjectName(), afterTest);
+    }
+
+    @Override
+    public List<String> getAssociatedModules()
+    {
+        return List.of("targetedms");
+    }
+}

--- a/test/src/org/labkey/test/tests/targetedms/upgrade/TargetedMSUpgradeTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/upgrade/TargetedMSUpgradeTest.java
@@ -47,15 +47,15 @@ public class TargetedMSUpgradeTest extends BaseUpgradeTest
     public void testPreUpgradeCounts() throws Exception
     {
         SelectRowsCommand cmd = new SelectRowsCommand("targetedms", "Runs");
-        cmd.setColumns(List.of("Peptides", "SmallMolecules", "Replicates"));
+        cmd.setColumns(List.of("PeptideCount", "SmallMoleculeCount", "ReplicateCount"));
         SelectRowsResponse response = cmd.execute(createDefaultConnection(), getProjectName());
 
         List<Map<String, Object>> rows = response.getRows();
         assertEquals("Expected exactly one run", 1, rows.size());
-        Map<String, Object> run = rows.get(0);
-        assertEquals("PeptideCount", 44, ((Number) run.get("Peptides")).intValue());
-        assertEquals("SmallMoleculeCount", 98, ((Number) run.get("SmallMolecules")).intValue());
-        assertEquals("ReplicateCount", 5, ((Number) run.get("Replicates")).intValue());
+        Map<String, Object> run = rows.getFirst();
+        assertEquals("PeptideCount", 44, ((Number) run.get("PeptideCount")).intValue());
+        assertEquals("SmallMoleculeCount", 98, ((Number) run.get("SmallMoleculeCount")).intValue());
+        assertEquals("ReplicateCount", 5, ((Number) run.get("ReplicateCount")).intValue());
     }
 
     @Test
@@ -70,10 +70,10 @@ public class TargetedMSUpgradeTest extends BaseUpgradeTest
 
         List<Map<String, Object>> rows = response.getRows();
         assertEquals("Expected exactly one run", 1, rows.size());
-        Map<String, Object> run = rows.get(0);
-        assertEquals("PeptideGroupCount", 24, ((Number) run.get("PeptideGroups")).intValue());
-        assertEquals("MoleculeGroupCount", 3, ((Number) run.get("MoleculeLists")).intValue());
-        assertEquals("ProteinCount", 24, ((Number) run.get("Proteins")).intValue());
+        Map<String, Object> run = rows.getFirst();
+        assertEquals("PeptideGroupCount", 24, ((Number) run.get("PeptideGroupCount")).intValue());
+        assertEquals("MoleculeGroupCount", 3, ((Number) run.get("MoleculeGroupCount")).intValue());
+        assertEquals("ProteinCount", 24, ((Number) run.get("ProteinCount")).intValue());
     }
 
     @Override

--- a/test/src/org/labkey/test/tests/targetedms/upgrade/TargetedMSUpgradeTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/upgrade/TargetedMSUpgradeTest.java
@@ -44,6 +44,7 @@ public class TargetedMSUpgradeTest extends BaseUpgradeTest
     }
 
     @Test
+    @EarliestVersion("25.11")
     public void testPreUpgradeCounts() throws Exception
     {
         SelectRowsCommand cmd = new SelectRowsCommand("targetedms", "Runs");
@@ -65,7 +66,7 @@ public class TargetedMSUpgradeTest extends BaseUpgradeTest
         Assume.assumeFalse("Skipping post-upgrade count checks during setup phase", isUpgradeSetupPhase);
 
         SelectRowsCommand cmd = new SelectRowsCommand("targetedms", "Runs");
-        cmd.setColumns(List.of("PeptideGroups", "MoleculeLists", "Proteins"));
+        cmd.setColumns(List.of("PeptideGroupCount", "MoleculeGroupCount", "ProteinCount"));
         SelectRowsResponse response = cmd.execute(createDefaultConnection(), getProjectName());
 
         List<Map<String, Object>> rows = response.getRows();

--- a/test/src/org/labkey/test/tests/targetedms/upgrade/TargetedMSUpgradeTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/upgrade/TargetedMSUpgradeTest.java
@@ -1,5 +1,6 @@
 package org.labkey.test.tests.targetedms.upgrade;
 
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.remoteapi.query.SelectRowsCommand;
@@ -43,8 +44,26 @@ public class TargetedMSUpgradeTest extends BaseUpgradeTest
     }
 
     @Test
-    public void testRunCounts() throws Exception
+    public void testPreUpgradeCounts() throws Exception
     {
+        SelectRowsCommand cmd = new SelectRowsCommand("targetedms", "Runs");
+        cmd.setColumns(List.of("Peptides", "SmallMolecules", "Replicates"));
+        SelectRowsResponse response = cmd.execute(createDefaultConnection(), getProjectName());
+
+        List<Map<String, Object>> rows = response.getRows();
+        assertEquals("Expected exactly one run", 1, rows.size());
+        Map<String, Object> run = rows.get(0);
+        assertEquals("PeptideCount", 44, ((Number) run.get("Peptides")).intValue());
+        assertEquals("SmallMoleculeCount", 98, ((Number) run.get("SmallMolecules")).intValue());
+        assertEquals("ReplicateCount", 5, ((Number) run.get("Replicates")).intValue());
+    }
+
+    @Test
+    @EarliestVersion("26.3")
+    public void testPostUpgradeCounts() throws Exception
+    {
+        Assume.assumeFalse("Skipping post-upgrade count checks during setup phase", isUpgradeSetupPhase);
+
         SelectRowsCommand cmd = new SelectRowsCommand("targetedms", "Runs");
         cmd.setColumns(List.of("PeptideGroups", "MoleculeLists", "Proteins"));
         SelectRowsResponse response = cmd.execute(createDefaultConnection(), getProjectName());

--- a/test/src/org/labkey/test/tests/targetedms/upgrade/TargetedMSUpgradeTest.java
+++ b/test/src/org/labkey/test/tests/targetedms/upgrade/TargetedMSUpgradeTest.java
@@ -52,7 +52,7 @@ public class TargetedMSUpgradeTest extends BaseUpgradeTest
 
         List<Map<String, Object>> rows = response.getRows();
         assertEquals("Expected exactly one run", 1, rows.size());
-        Map<String, Object> run = rows.getFirst();
+        Map<String, Object> run = rows.get(0);
         assertEquals("PeptideCount", 44, ((Number) run.get("PeptideCount")).intValue());
         assertEquals("SmallMoleculeCount", 98, ((Number) run.get("SmallMoleculeCount")).intValue());
         assertEquals("ReplicateCount", 5, ((Number) run.get("ReplicateCount")).intValue());
@@ -70,7 +70,7 @@ public class TargetedMSUpgradeTest extends BaseUpgradeTest
 
         List<Map<String, Object>> rows = response.getRows();
         assertEquals("Expected exactly one run", 1, rows.size());
-        Map<String, Object> run = rows.getFirst();
+        Map<String, Object> run = rows.get(0);
         assertEquals("PeptideGroupCount", 24, ((Number) run.get("PeptideGroupCount")).intValue());
         assertEquals("MoleculeGroupCount", 3, ((Number) run.get("MoleculeGroupCount")).intValue());
         assertEquals("ProteinCount", 24, ((Number) run.get("ProteinCount")).intValue());

--- a/test/src/org/labkey/test/util/targetedms/TargetedMSHelper.java
+++ b/test/src/org/labkey/test/util/targetedms/TargetedMSHelper.java
@@ -1,0 +1,68 @@
+package org.labkey.test.util.targetedms;
+
+import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.Locator;
+import org.labkey.test.TestFileUtils;
+import org.labkey.test.tests.targetedms.TargetedMSTest.FolderType;
+import org.labkey.test.util.LogMethod;
+import org.labkey.test.util.LoggedParam;
+import org.openqa.selenium.WebElement;
+
+import java.nio.file.Paths;
+
+/** Setup and import utilities to share between standard and upgrade tests for TargetedMS */
+public class TargetedMSHelper
+{
+    private final BaseWebDriverTest _test;
+
+    public TargetedMSHelper(BaseWebDriverTest test)
+    {
+        _test = test;
+    }
+
+    public void setupFolder(String projectName, FolderType folderType)
+    {
+        _test._containerHelper.createProject(projectName, "Panorama");
+        _test.waitForElement(Locator.linkContainingText("Save"));
+        _test.clickAndWait(Locator.linkContainingText("Next"));
+        selectFolderType(folderType);
+    }
+
+    @LogMethod
+    public void selectFolderType(@LoggedParam FolderType folderType)
+    {
+        _test.log("Select Folder Type: " + folderType);
+        folderType.chooseFolderType(_test);
+        _test.clickButton("Finish");
+    }
+
+    public void importData(String file)
+    {
+        importData(file, 1);
+    }
+
+    @LogMethod
+    public void importData(@LoggedParam String file, int jobCount)
+    {
+        importData(file, jobCount, false);
+    }
+
+    @LogMethod
+    public void importData(@LoggedParam String file, int jobCount, boolean expectError)
+    {
+        Locator.XPathLocator importButtonLoc = Locator.lkButton("Process and Import Data");
+        WebElement importButton = importButtonLoc.findElementOrNull(_test.getDriver());
+        if (null == importButton)
+        {
+            _test.goToModule("Pipeline");
+            importButton = importButtonLoc.findElement(_test.getDriver());
+        }
+        _test.clickAndWait(importButton);
+        String fileName = Paths.get(file).getFileName().toString();
+        if (!_test._fileBrowserHelper.fileIsPresent(fileName))
+            _test._fileBrowserHelper.uploadFile(TestFileUtils.getSampleData("TargetedMS/" + file));
+        _test._fileBrowserHelper.importFile(fileName, "Import Skyline Results");
+        _test.waitForText("Skyline document import");
+        _test.waitForPipelineJobsToComplete(jobCount, file, expectError);
+    }
+}


### PR DESCRIPTION
#### Rationale
Create the first upgrade test for the TargetedMS module.

#### Changes
* Set up a folder and import a Skyline document
* Extract a helper for use in upgrade and non-upgrade subclasses
* Check that the upgrade calculates the counts correctly (for use in 26.3)
