### PR TITLE
Reduce log noise when a spectrum library file is missing or unreadable

### DIFF
--- a/src/org/labkey/targetedms/view/spectrum/LibrarySpectrumMatchGetter.java
+++ b/src/org/labkey/targetedms/view/spectrum/LibrarySpectrumMatchGetter.java
@@ -114,9 +114,10 @@ public class LibrarySpectrumMatchGetter
         }
         catch (IOException e)
         {
-            // If we cannot stat the file it is missing or unreadable, in which case the
-            // downstream library read will fail too.
-            LOG.warn("Could not determine size of spectrum library file " + libPath, e);
+            // The file is missing or unreadable; the downstream library read would fail too.
+            // Log a single WARN line and keep the stack trace at DEBUG so frequent hits do not flood the primary log.
+            LOG.warn("Could not determine size of spectrum library file " + libPath + " (" + e.getClass().getSimpleName() + ")");
+            LOG.debug("Could not determine size of spectrum library file " + libPath, e);
             return false;
         }
     }


### PR DESCRIPTION
#### Rationale
After deploying #1226 on PWEB-DR, the code that hides spectrum libraries from guests based on library file size logged a `NoSuchFileException` stack trace at WARN on every missing .elib/.blib file (PWEB-DR storage is not in sync with PWEB), filling up `labkey.log` very quickly. 

#### Related Pull Requests
- https://github.com/LabKey/targetedms/pull/1226

#### Changes
- Log a single WARN line (with the exception type) instead of the full trace.
- Keep the full stack trace at DEBUG (off by default at INFO) for when it is needed.
