### PR TITLE
Series highlight doesn't work when plot doesn't show replicate data points

### DIFF
--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -2070,6 +2070,7 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
             let label = checkbox.closest('label');
             if (label) {
                 label.addEventListener('mouseenter', function() {
+                    clearTimeout(precursorLeaveTimer); // cancel a pending precursor reset when moving sub-item -> header
                     let hidden = me.hiddenPrecursorSeries || {};
                     let hiddenFragments = group.fragments.filter(function(f) { return !!hidden[f]; });
                     if (hiddenFragments.length > 0) {

--- a/webapp/TargetedMS/js/QCTrendPlotPanel.js
+++ b/webapp/TargetedMS/js/QCTrendPlotPanel.js
@@ -1509,7 +1509,8 @@ Ext4.define('LABKEY.targetedms.QCTrendPlotPanel', {
 
     pathMouseOver : function(event, pathData, layerSel, path, valueName, config) {
         if (pathData.group) {
-            this.highlightFragmentSeries(pathData.group);
+            // pass base fragment, like the other highlight triggers
+            this.highlightFragmentSeries(pathData.group.split(LABKEY.targetedms.QCPlotHelperBase.SERIES_NAME_SEP)[0]);
         }
     },
 


### PR DESCRIPTION
#### Rationale
When a QC plot has too many replicates to render individual points, hovering a series highlighted the legend but not its trend line. 

#### Related Pull Requests
* https://github.com/LabKey/targetedms/pull/1197

#### Changes
*  pathMouseOver was passing the full series group to highlightFragmentSeries, while the legend/point handlers    
  pass the base fragment it expects; normalizing the path handler to the base fragment makes series highlighting work consistently in both summary and detail views.
