### PR TITLE
fix audit log container scoping test

### DIFF
--- a/resources/schemas/dbscripts/postgresql/targetedms-26.008-26.009.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-26.008-26.009.sql
@@ -1,0 +1,2 @@
+-- Drop the AuditLog view so targetedms-create.sql (runs after this script) rebuilds it with the fixed recursive CTE.
+SELECT core.fn_dropifexists('AuditLog', 'targetedms', 'VIEW', NULL);

--- a/resources/schemas/dbscripts/postgresql/targetedms-create.sql
+++ b/resources/schemas/dbscripts/postgresql/targetedms-create.sql
@@ -14,7 +14,7 @@ WITH RECURSIVE logTree as (
          , nxt.entryHash
          , nxt.parentEntryHash
     FROM targetedms.AuditLogEntry nxt
-             JOIN logTree prev ON prev.parentEntryHash = nxt.entryHash
+             JOIN logTree prev ON prev.entryHash = nxt.parentEntryHash
 )
 SELECT t.entryId
      , e.documentguid

--- a/src/org/labkey/targetedms/TargetedMSModule.java
+++ b/src/org/labkey/targetedms/TargetedMSModule.java
@@ -231,7 +231,7 @@ public class TargetedMSModule extends SpringModule implements ProteomicsModule
     @Override
     public Double getSchemaVersion()
     {
-        return 26.008;
+        return 26.009;
     }
 
     @Override


### PR DESCRIPTION
## Rationale
The Skyline audit log "Detailed Info" popup was broken, clicking it returned a 404 for most audit entries. This caused TargetedMSContainerScopingTest to fail.                                                              
                                                                                                                                                                                                                                    
  The cause is a bug in the targetedms.AuditLog database view. It uses a recursive query that's supposed to walk the whole chain of audit entries for a document, but the recursion runs in the wrong direction. As a result, the view only ever returns the first entry in each chain instead of all of them.                                                                                                                                                      
                                                                                                                                                                                                                                    
  The code that renders the detail popup looks up an entry by id, but the entry it needs is the last one in the chain, which the broken view never returns, so the lookup finds nothing and returns a 404.                        
                                                                                                                                                                                                                                    
The bug was introduced in 2022 by #502 (Issue 44507, "Allow audit log entries to belong to multiple runs"). That change flipped the query's starting point from the last entry to the first entry, but left the recursion walking in the old direction, so the two no longer matched. It has been latent ever since (the view definition is identical across 25.7, 25.11, and 26.3) and only surfaced now because the new audit-detail lookup relies on reaching entries the broken view drops.                                                                                                                                                                                 
                                                                                                                                                                                                                                    
 This fix corrects the recursion direction so the view returns every entry in the chain. It also adds a schema upgrade step to rebuild the view on existing databases.

## Related Pull Requests
- https://github.com/labkey/targetedms/pull/502

## Changes
- targetedms-create.sql — corrected the recursive CTE to walk root → children:                                                                                                                                                    
  JOIN logTree prev ON prev.entryHash = nxt.parentEntryHash. Verified fix returns the full tree (7516/7516 entries; both terminal entries reachable), so retrieve() resolves them.                                                  
 - targetedms-26.008-26.009.sql (new) — drops the AuditLog view via fn_dropifexists so the corrected create.sql rebuilds it on existing installations (the drop/create pair only re-runs on a schema-version bump).                
 - TargetedMSModule.getSchemaVersion() — bumped to 26.009 to trigger the view recreation on upgrade.

<!-- list of standard tasks (remove this comment to enable)
## Tasks 📍
- [ ] Claude Code Review
- [ ] Manual Testing
- [ ] Test Automation
- [ ] Verify Fix
-->