### PR TITLE
Move TargetedMS QC/chart UI off ExtJS to plain JS + HTML

### DIFF
--- a/resources/views/configureQCMetric.html
+++ b/resources/views/configureQCMetric.html
@@ -230,7 +230,7 @@
 
                         const windowConfig = {
                             parent: this,
-                            traces: tracesPresent ? traces : {} ,
+                            traces: tracesPresent ? traces : [] ,
                             tracesPresent: tracesPresent,
                             operation: op
                         }
@@ -239,7 +239,7 @@
                             windowConfig.metric = clickedMetric;
                         }
 
-                        Ext4.create('Panorama.Window.AddTraceMetricWindow', windowConfig).show();
+                        Panorama.Window.AddTraceMetricWindow.show(windowConfig);
                     }
                 });
             },

--- a/resources/web/PanoramaPremium/window/AddNewTraceMetricWindow.js
+++ b/resources/web/PanoramaPremium/window/AddNewTraceMetricWindow.js
@@ -4,518 +4,263 @@
  * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
  */
 
-Ext4.define('Panorama.Window.AddTraceMetricWindow', {
-    extend: 'Ext.window.Window',
+(function($) {
+    window.Panorama = window.Panorama || {};
+    window.Panorama.Window = window.Panorama.Window || {};
 
-    modal: true,
-    closeAction: 'destroy',
-    bodyStyle: 'padding: 10px;',
-    autoScroll: true,
-    border: false,
-    update: 'update',
-    insert: 'insert',
-    timeValueOptions:  Ext4.create('Ext.data.Store', {
-        fields: ['value'],
-        data : [
-            { "value":"First"},
-            { "value":"Last"},
-            { "value":"Max"},
-            { "value":"Min"}
-        ]
-    }),
+    const DIALOG_ID = 'lk-trace-metric-dialog';
+    const TIME_VALUE_OPTIONS = ['First', 'Last', 'Max', 'Min'];
+    let _config = null;
 
-    initComponent: function() {
-        var title = this.operation === this.insert ? 'Add New Trace Metric' : 'Edit Trace Metric';
-        this.setTitle(title);
-        this.height = Ext4.max([Ext4.getBody().getHeight() * 0.3, 250]);
-        this.width = Ext4.max([Ext4.getBody().getWidth() * 0.3, 600]);
-        this.items = this.getItems();
-        this.dockedItems= [{
-            xtype: 'toolbar',
-            dock: 'bottom',
-            ui: 'footer',
-            items: this.getButtons()
-        }]
+    function closeDialog() {
+        $('#' + DIALOG_ID).remove();
+    }
 
-        this.callParent();
+    function showError(msg) {
+        $('#lk-trace-metric-error').text(msg).show();
+    }
 
-        this.timeValue = true;
-        this.traceValue = false;
+    function clearErrors() {
+        $('#lk-trace-metric-error').hide().text('');
+        $('#lk-trace-metric-name, #lk-trace-use-trace, #lk-trace-ylabel, #lk-trace-time-option, #lk-trace-min-time, #lk-trace-max-time, #lk-trace-value')
+            .css('border-color', '');
+    }
 
-    },
+    function markInvalid($field) {
+        $field.css('border-color', 'red');
+    }
 
-    getItems: function() {
-        return [
-            this.getMetricNameField(),
-            this.getTracesCombo(),
-            this.getYAxisLabelField(),
-            this.getTraceValueRadioGroup(),
-            this.getQueryError()
-        ];
-    },
+    function getMode() {
+        return $('input[name="metricValue"]:checked').val(); // 'timeValue' or 'traceValue'
+    }
 
-    getButtons: function () {
-        var buttons = [];
+    // Enable only the fields belonging to the selected mode
+    function refreshMode() {
+        const isTime = getMode() === 'timeValue';
+        $('#lk-trace-time-option, #lk-trace-min-time, #lk-trace-max-time').prop('disabled', !isTime);
+        $('#lk-trace-value').prop('disabled', isTime);
+    }
 
-        buttons.push(this.getCancelButton());
-        buttons.push('->'); // to push remaining buttons to the right
-        if (this.operation === this.update) {
-            buttons.push(this.getDeleteButton());
+    function isNonNegativeNumber(val) {
+        return val !== '' && val !== null && !isNaN(val) && Number(val) >= 0;
+    }
+
+    function validate() {
+        clearErrors();
+        let isValid = true;
+
+        if (!$('#lk-trace-metric-name').val().trim()) {
+            markInvalid($('#lk-trace-metric-name'));
+            isValid = false;
         }
-        buttons.push(this.getSaveButton());
-        return buttons;
-    },
+        if (!$('#lk-trace-use-trace').val()) {
+            markInvalid($('#lk-trace-use-trace'));
+            isValid = false;
+        }
+        if (!$('#lk-trace-ylabel').val().trim()) {
+            markInvalid($('#lk-trace-ylabel'));
+            isValid = false;
+        }
 
-    getMetricNameField: function() {
-        if (!this.metricNameField) {
-            this.metricNameField = Ext4.create('Ext.form.field.Text', {
-                fieldLabel: 'Metric Name',
-                labelWidth: 150,
-                width: 570,
-                name: 'metricName'
-            });
-
-            if (this.operation === this.update) {
-                this.metricNameField.setValue(this.metric.name);
+        if (getMode() === 'timeValue') {
+            if (!$('#lk-trace-time-option').val()) {
+                markInvalid($('#lk-trace-time-option'));
+                isValid = false;
+            }
+            if (!isNonNegativeNumber($('#lk-trace-min-time').val())) {
+                markInvalid($('#lk-trace-min-time'));
+                isValid = false;
+            }
+            if (!isNonNegativeNumber($('#lk-trace-max-time').val())) {
+                markInvalid($('#lk-trace-max-time'));
+                isValid = false;
             }
         }
-
-        return this.metricNameField;
-    },
-
-    getTracesCombo: function () {
-      if (!this.tracesCombo) {
-          var config = {
-              fieldLabel: 'Use Trace',
-              name: 'useTrace',
-              labelWidth: 150,
-              width: 570
-          }
-          if (!this.tracesPresent) {
-              config.emptyText = 'No trace can be found';
-          }
-          else {
-              config.store = this.getTracesComboStore();
-              config.valueField = 'TextId';
-              config.displayField = 'TextId';
-          }
-          this.tracesCombo = Ext4.create('Ext.form.field.ComboBox', config);
-
-          if (this.operation === this.update) {
-              this.tracesCombo.setValue(this.metric.TraceName);
-              this.tracesCombo.bindStore(this.getTracesComboStore());
-          }
-      }
-      return this.tracesCombo;
-    },
-
-    getTracesComboStore: function () {
-        return Ext4.create('Ext.data.Store', {
-            fields: ['TextId'],
-            sorters: [{property: 'TextId'}],
-            data: this.traces
-        });
-    },
-
-    getTraceValueRadioGroup: function () {
-        if (!this.traceValueRadioGroup) {
-            this.traceValueRadioGroup =
-                    Ext4.create('Ext.form.Panel', {
-                        renderTo: Ext4.getBody(),
-                        width: 570,
-
-                        border:false,
-                        items: [{
-                            xtype: 'radiogroup',
-                            columns: 1, // Stack radio buttons vertically
-                            vertical: true,
-                            items: [
-                                {
-                                    xtype: 'container',
-                                    layout: 'hbox',
-                                    items: [
-                                        {
-                                            xtype: 'radio',
-                                            name: 'metricValue',
-                                            inputValue: 'timeValue',
-                                            boxLabel: 'Use the',
-                                            width: 65,
-                                            checked: this.operation === this.update ? this.metric.MinTimeValue >= 0 : true,
-                                            listeners: {
-                                                 change: {fn : function(cmp, newVal, oldVal){
-                                                     this.minTimeValueNumberField.setDisabled(oldVal);
-                                                     this.maxTimeValueNumberField.setDisabled(oldVal);
-                                                     this.timeValueOptionField.setDisabled(oldVal);
-                                                     this.traceValueNumberField.setDisabled(newVal);
-
-                                                     // restore the value onChange when it is present
-                                                     if (this.operation === this.update) {
-                                                         if (newVal) {
-                                                             this.minTimeValueNumberField.setValue(this.metric.MinTimeValue);
-                                                             this.maxTimeValueNumberField.setValue(this.metric.MaxTimeValue);
-                                                         }
-                                                         else {
-                                                             this.traceValueNumberField.setValue(this.metric.TraceValue);
-                                                         }
-                                                     }
-                                                     else {
-                                                         this.traceValueNumberField.setValue(undefined);
-                                                         this.minTimeValueNumberField.setValue(undefined);
-                                                         this.maxTimeValueNumberField.setValue(undefined);
-                                                         this.timeValueOptionField.setValue(undefined);
-                                                     }
-                                                 }},
-                                                 scope   : this
-                                            }
-                                        },
-                                        this.getTimeValueOptionField(),
-                                        {
-                                            xtype: 'displayfield',
-                                            value: 'trace value when time in minutes is between',
-                                            margin: '0 5'
-                                        },
-                                        this.getMinTimeValueNumberField(),
-                                        {
-                                            xtype: 'displayfield',
-                                            value: 'and',
-                                            margin: '0 5'
-                                        },
-                                        this.getMaxTimeValueNumberField()
-                                    ]
-                                },
-                                {
-                                    xtype: 'container',
-                                    layout: 'hbox',
-                                    items: [
-                                        {
-                                            xtype: 'radio',
-                                            name: 'metricValue',
-                                            inputValue: 'traceValue',
-                                            boxLabel: 'Use time in minutes when the trace first reaches a value greater than or equal to',
-                                            width: 450,
-                                            checked: this.operation === this.update ? this.metric.TraceValue > 0 : false
-                                        },
-                                        this.getTraceValueNumberField()
-                                    ]
-                                }
-                            ]
-                        }]
-                    });
-        }
-        return this.traceValueRadioGroup;
-    },
-
-    getTimeValueOptionField: function() {
-        if (!this.timeValueOptionField) {
-            this.timeValueOptionField = Ext4.create('Ext.form.field.ComboBox', {
-                name: 'timeValueOption',
-                store: this.timeValueOptions,
-                displayField: 'value',
-                valueField: 'value',
-                width: 50,
-                itemId: 'timeValueOption',
-            });
-
-            if(this.operation === this.update) {
-                this.timeValueOptionField.setValue(this.metric.TimeValueOption);
-            }
-        }
-
-        return this.timeValueOptionField
-    },
-
-    getMinTimeValueNumberField: function () {
-        if (!this.minTimeValueNumberField) {
-            this.minTimeValueNumberField = Ext4.create('Ext.form.field.Number', {
-                name: 'minTimeValue',
-                width: 65,
-                disabled: this.operation === this.update ? !(this.metric.MinTimeValue >= 0) : false
-            });
-
-            if (this.operation === this.update) {
-                this.minTimeValueNumberField.setValue(this.metric.MinTimeValue);
-            }
-
-        }
-        return this.minTimeValueNumberField;
-    },
-
-    getMaxTimeValueNumberField: function () {
-        if (!this.maxTimeValueNumberField) {
-            this.maxTimeValueNumberField = Ext4.create('Ext.form.field.Number', {
-                name: 'maxTimeValue',
-                width: 65,
-                disabled: this.operation === this.update ? !(this.metric.MaxTimeValue >= 0) : false
-            });
-
-            if (this.operation === this.update) {
-                this.maxTimeValueNumberField.setValue(this.metric.MaxTimeValue);
-            }
-
-        }
-        return this.maxTimeValueNumberField;
-    },
-
-
-    getTraceValueNumberField: function () {
-        if (!this.traceValueNumberField) {
-            this.traceValueNumberField = Ext4.create('Ext.form.field.Number', {
-                name: 'traceValue',
-                width: 65,
-                disabled: this.operation === this.update ? !(this.metric.TraceValue >= 0) : true
-            });
-
-            if (this.operation === this.update) {
-                this.traceValueNumberField.setValue(this.metric.TraceValue);
-            }
-        }
-        return this.traceValueNumberField;
-    },
-
-    getYAxisLabelField: function() {
-        if (!this.yAxisLabelField) {
-            this.yAxisLabelField = Ext4.create('Ext.form.field.Text', {
-                fieldLabel: 'Y Axis Label',
-                labelWidth: 150,
-                width: 570,
-                name: 'yAxisLabel'
-            });
-
-            if(this.operation === this.update) {
-                this.yAxisLabelField.setValue(this.metric.YAxisLabel);
-            }
-        }
-
-        return this.yAxisLabelField;
-    },
-
-    getQueryError: function() {
-        if (!this.queryError) {
-            this.queryError = Ext4.create('Ext.form.Label', {
-                name: 'errorMsg',
-                hidden: true,
-                cls: 'labkey-error',
-                text:''
-            });
-        }
-
-        return this.queryError;
-    },
-
-    getSaveButton: function() {
-        if (!this.saveButton) {
-            this.saveButton = Ext4.create('Ext.button.Button', {
-                text: 'Save',
-                scope: this,
-                handler: this.saveNewMetric,
-                disabled: !this.tracesPresent
-            });
-        }
-        return this.saveButton;
-    },
-
-    getDeleteButton: function() {
-        if (!this.deleteButton) {
-            this.deleteButton = Ext4.create('Ext.button.Button', {
-                text: 'Delete',
-                scope: this,
-                handler: this.deleteMetric
-            });
-        }
-        return this.deleteButton;
-    },
-
-    getCancelButton: function() {
-        if (!this.cancelButton) {
-            this.cancelButton = Ext4.create('Ext.button.Button', {
-                text: 'Cancel',
-                scope: this,
-                handler: function(btn){
-                    btn.up('window').close();
-                }
-            });
-        }
-        return this.cancelButton;
-    },
-
-    validateValues: function() {
-        var isValid = true;
-        var errorText = 'Required';
-
-        if (!(this.metricNameField.getValue().length > 0)) {
-            this.metricNameField.setActiveError(errorText);
+        else if (!isNonNegativeNumber($('#lk-trace-value').val())) {
+            markInvalid($('#lk-trace-value'));
             isValid = false;
         }
 
-        if (!this.tracesCombo.getValue()) {
-            this.tracesCombo.setActiveError(errorText);
-            isValid = false;
+        if (!isValid) {
+            showError('Please fill in all required fields.');
         }
-
-        if (!(this.yAxisLabelField.getValue().length > 0)) {
-            this.yAxisLabelField.setActiveError(errorText);
-            isValid = false;
-        }
-
-        if (this.timeValueOptionField.getValue() === null) {
-            this.timeValueOptionField.setActiveError(errorText);
-            isValid = false;
-        }
-
-        if (this.traceValueRadioGroup.down().getValue()['metricValue'] === 'timeValue' &&
-                (!(this.minTimeValueNumberField.getValue() >= 0))) {
-            this.minTimeValueNumberField.setActiveError(errorText);
-            isValid = false;
-        }
-
-        if (this.traceValueRadioGroup.down().getValue()['metricValue'] === 'timeValue' &&
-                (!(this.maxTimeValueNumberField.getValue() >= 0))) {
-            this.maxTimeValueNumberField.setActiveError(errorText);
-            isValid = false;
-        }
-
-        if (this.traceValueRadioGroup.down().getValue()['metricValue'] === 'traceValue' && !this.traceValueNumberField.getValue()) {
-            this.traceValueNumberField.setActiveError(errorText);
-            isValid = false;
-        }
-
         return isValid;
-    },
+    }
 
-    checkMetricNameExists: function (metricName, callback) {
-        let filterArray = [LABKEY.Filter.create('Name', metricName, LABKEY.Filter.Types.EQUAL)];
-
-        // If updating, exclude the current metric from the check
-        if (this.operation === this.update && this.metric) {
-            filterArray.push(LABKEY.Filter.create('id', this.metric.id, LABKEY.Filter.Types.NOT_EQUAL));
+    function checkMetricNameExists(metricName, callback) {
+        const filterArray = [LABKEY.Filter.create('Name', metricName, LABKEY.Filter.Types.EQUAL)];
+        if (_config.operation === 'update' && _config.metric) {
+            filterArray.push(LABKEY.Filter.create('id', _config.metric.id, LABKEY.Filter.Types.NOT_EQUAL));
         }
-
         LABKEY.Query.selectRows({
             containerPath: LABKEY.container.id,
             schemaName: 'targetedms',
             queryName: 'qcmetricconfiguration',
             filterArray: filterArray,
-            scope: this,
-            success: function (data) {
-                callback.call(this, data.rows.length > 0);
-            },
-            failure: function () {
-                callback.call(this, false);
+            success: function(data) { callback(data.rows.length > 0); },
+            failure: function() { callback(false); }
+        });
+    }
+
+    function save() {
+        if (!validate()) return;
+
+        const metricName = $('#lk-trace-metric-name').val().trim();
+        checkMetricNameExists(metricName, function(exists) {
+            if (exists) {
+                showError('A metric with the name "' + LABKEY.Utils.encodeHtml(metricName) + '" already exists. Please choose a different name.');
+                markInvalid($('#lk-trace-metric-name'));
+                return;
+            }
+
+            const newMetric = {
+                Name: metricName,
+                QueryName: 'QCTraceMetric', // dummy text to insert and not an actual query
+                PrecursorScoped: false,
+                TraceName: $('#lk-trace-use-trace').val(),
+                YAxisLabel: $('#lk-trace-ylabel').val().trim()
+            };
+
+            if (getMode() === 'traceValue') {
+                newMetric.TraceValue = Number($('#lk-trace-value').val());
+            }
+            else {
+                newMetric.TimeValueOption = $('#lk-trace-time-option').val();
+                newMetric.MinTimeValue = Number($('#lk-trace-min-time').val());
+                newMetric.MaxTimeValue = Number($('#lk-trace-max-time').val());
+            }
+
+            if (_config.operation === 'update') {
+                newMetric.id = _config.metric.id;
+            }
+
+            LABKEY.Query.saveRows({
+                containerPath: LABKEY.container.id,
+                commands: [{ schemaName: 'targetedms', queryName: 'qcmetricconfiguration', command: _config.operation, rows: [newMetric] }],
+                method: 'POST',
+                success: function() { window.location.reload(); },
+                failure: function(response) {
+                    showError((response && (response.exception || response.message)) || 'Error saving metric');
+                }
+            });
+        });
+    }
+
+    function deleteMetric() {
+        if (!confirm('This will delete the "' + _config.metric.name + '" metric. Are you sure?')) return;
+
+        LABKEY.Query.saveRows({
+            containerPath: LABKEY.container.id,
+            commands: [
+                { schemaName: 'targetedms', queryName: 'qcenabledmetrics', command: 'delete', rows: [{ metric: _config.metric.id }] },
+                { schemaName: 'targetedms', queryName: 'qcmetricconfiguration', command: 'delete', rows: [{ id: _config.metric.id }] }
+            ],
+            method: 'POST',
+            success: function() { window.location.reload(); },
+            failure: function(response) {
+                showError((response && (response.exception || response.message)) || 'Error deleting metric');
             }
         });
-    },
-    
-    
-
-    saveNewMetric: function () {
-        var isValid = this.validateValues();
-
-        if (isValid) {
-            var metricName = this.metricNameField.getValue();
-
-            this.checkMetricNameExists(metricName, function (exists) {
-                if (exists) {
-                    let errorMessage = 'A metric with the name "' + metricName + '" already exists. Please choose a different name.';
-                    this.queryError.setText(errorMessage);
-                    this.queryError.setVisible(true);
-                    this.metricNameField.setActiveError('Metric name already exists');
-                    return;
-                }
-
-                var records = [];
-                var newMetric = {};
-                newMetric.Name = metricName;
-                newMetric.QueryName = 'QCTraceMetric'; // dummy text to insert and not an actual query
-                newMetric.PrecursorScoped = false;
-                newMetric.TraceName = this.tracesCombo.getValue();
-                newMetric.YAxisLabel = this.yAxisLabelField.getValue();
-
-                if (this.traceValueNumberField.getValue()) {
-                    newMetric.TraceValue = this.traceValueNumberField.getValue();
-                } else {
-                    if (this.timeValueOptionField.getValue()) {
-                        newMetric.TimeValueOption = this.timeValueOptionField.getValue();
-                    }
-                    if (this.minTimeValueNumberField.getValue()) {
-                        newMetric.MinTimeValue = this.minTimeValueNumberField.getValue();
-                    }
-                    if (this.maxTimeValueNumberField.getValue()) {
-                        newMetric.MaxTimeValue = this.maxTimeValueNumberField.getValue();
-                    }
-                }
-
-                if (this.operation === this.update) {
-                    newMetric.id = this.metric.id;
-                }
-
-                records.push(newMetric);
-
-                LABKEY.Query.saveRows({
-                    containerPath: LABKEY.container.id,
-                    commands: [{
-                        schemaName: 'targetedms',
-                        queryName: 'qcmetricconfiguration',
-                        command: this.operation,
-                        rows: records
-                    }],
-                    scope: this,
-                    method: 'POST',
-                    success: function () {
-                        window.location.reload();
-                    },
-                    failure: function (response) {
-                        let errorMessage = 'Error saving metric';
-                        if (response && response.exception) {
-                            errorMessage = response.exception;
-                        } else if (response && response.message) {
-                            errorMessage = response.message;
-                        }
-                        this.queryError.setText(errorMessage);
-                        this.queryError.setVisible(true);
-                    }
-                });
-            });
-        }
-
-    },
-
-    deleteMetric: function() {
-        Ext4.Msg.confirm('Delete Trace Metric', 'This will delete ' + LABKEY.Utils.encodeHtml(this.metric.name) +  ' metric. Are you sure you want to do this?', function(val){
-            if (val === 'yes'){
-                const qcMetricToDelete = {metric: this.metric.id};
-                const metricToDelete = {id: this.metric.id};
-
-                LABKEY.Query.saveRows({
-                    containerPath: LABKEY.container.id,
-                    commands: [{
-                        schemaName: 'targetedms',
-                        queryName: 'qcenabledmetrics',
-                        command: 'delete',
-                        rows: [qcMetricToDelete]
-                    },{
-                        schemaName: 'targetedms',
-                        queryName: 'qcmetricconfiguration',
-                        command: 'delete',
-                        rows: [metricToDelete]
-                    }],
-                    scope: this,
-                    method: 'POST',
-                    success: function () {
-                        window.location.reload();
-                    },
-                    failure: function (response) {
-                        let errorMessage = 'Error saving metric';
-                        if (response && response.exception) {
-                            errorMessage = response.exception;
-                        } else if (response && response.message) {
-                            errorMessage = response.message;
-                        }
-                        this.queryError.setText(errorMessage);
-                        this.queryError.setVisible(true);
-                    }
-                });
-                win.close();
-            }
-        }, this);
     }
-});
+
+    function buildTraceOptions(selectedTrace) {
+        const traces = (_config.traces || []).slice().sort(function(a, b) {
+            return String(a.TextId).localeCompare(String(b.TextId));
+        });
+        let html = '<option value="">-- Select trace --</option>';
+        traces.forEach(function(row) {
+            const textId = row.TextId;
+            const sel = textId === selectedTrace ? ' selected' : '';
+            html += '<option value="' + LABKEY.Utils.encodeHtml(textId) + '"' + sel + '>' + LABKEY.Utils.encodeHtml(textId) + '</option>';
+        });
+        return html;
+    }
+
+    function buildTimeOptions(selectedOption) {
+        let html = '<option value=""></option>';
+        TIME_VALUE_OPTIONS.forEach(function(opt) {
+            const sel = opt === selectedOption ? ' selected' : '';
+            html += '<option value="' + opt + '"' + sel + '>' + opt + '</option>';
+        });
+        return html;
+    }
+
+    function buildDialogHtml() {
+        const op = _config.operation;
+        const metric = _config.metric || {};
+        const tracesPresent = !!_config.tracesPresent;
+        const title = op === 'insert' ? 'Add New Trace Metric' : 'Edit Trace Metric';
+
+        // In update mode, pick the mode based on the stored values; default to the time-value mode.
+        const isTraceValueMode = op === 'update' && metric.TraceValue > 0;
+
+        const num = function(v) {
+            return (v !== undefined && v !== null) ? LABKEY.Utils.encodeHtml(v) : '';
+        };
+
+        const traceSelect = tracesPresent
+            ? '<select id="lk-trace-use-trace" style="width:100%;box-sizing:border-box;">' + buildTraceOptions(metric.TraceName) + '</select>'
+            : '<select id="lk-trace-use-trace" style="width:100%;box-sizing:border-box;" disabled><option value="">No trace can be found</option></select>';
+
+        return '<div id="' + DIALOG_ID + '" style="position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.5);z-index:9999;display:flex;align-items:center;justify-content:center;">'
+            + '<div class="x4-window x4-window-default" style="min-width:640px;max-width:760px;">'
+            +   '<div class="x4-window-header x4-window-header-default x4-window-header-default-top" style="padding:4px 8px;border:none;">'
+            +     '<p class="x4-window-header-text-container-default" style="font-size:14px;margin:0;">' + LABKEY.Utils.encodeHtml(title) + '</p>'
+            +   '</div>'
+            +   '<div class="x4-window-body" style="background:white;padding:10px 12px;">'
+            +     '<table style="border-collapse:collapse;width:100%;">'
+            +       '<tr><td style="padding:5px 10px 5px 0;white-space:nowrap;"><label for="lk-trace-metric-name">Metric Name *</label></td>'
+            +           '<td style="padding:5px 0;"><input type="text" id="lk-trace-metric-name" style="width:100%;box-sizing:border-box;" value="' + num(metric.name) + '"/></td></tr>'
+            +       '<tr><td style="padding:5px 10px 5px 0;white-space:nowrap;"><label for="lk-trace-use-trace">Use Trace *</label></td>'
+            +           '<td style="padding:5px 0;">' + traceSelect + '</td></tr>'
+            +       '<tr><td style="padding:5px 10px 5px 0;white-space:nowrap;"><label for="lk-trace-ylabel">Y Axis Label *</label></td>'
+            +           '<td style="padding:5px 0;"><input type="text" id="lk-trace-ylabel" style="width:100%;box-sizing:border-box;" value="' + num(metric.YAxisLabel) + '"/></td></tr>'
+            +     '</table>'
+            +     '<div style="margin-top:10px;">'
+            +       '<div style="display:flex;align-items:center;flex-wrap:wrap;gap:5px;margin-bottom:8px;">'
+            +         '<label style="margin:0;"><input type="radio" name="metricValue" value="timeValue"' + (!isTraceValueMode ? ' checked' : '') + '> Use the</label>'
+            +         '<select id="lk-trace-time-option" style="width:70px;">' + buildTimeOptions(metric.TimeValueOption) + '</select>'
+            +         '<span>trace value when time in minutes is between</span>'
+            +         '<input type="number" id="lk-trace-min-time" style="width:70px;" value="' + num(metric.MinTimeValue) + '"/>'
+            +         '<span>and</span>'
+            +         '<input type="number" id="lk-trace-max-time" style="width:70px;" value="' + num(metric.MaxTimeValue) + '"/>'
+            +       '</div>'
+            +       '<div style="display:flex;align-items:center;flex-wrap:wrap;gap:5px;">'
+            +         '<label style="margin:0;"><input type="radio" name="metricValue" value="traceValue"' + (isTraceValueMode ? ' checked' : '') + '> Use time in minutes when the trace first reaches a value greater than or equal to</label>'
+            +         '<input type="number" id="lk-trace-value" style="width:70px;" value="' + num(metric.TraceValue) + '"/>'
+            +       '</div>'
+            +     '</div>'
+            +     '<div id="lk-trace-metric-error" class="labkey-error" style="display:none;margin-top:8px;"></div>'
+            +     '<div style="margin-top:12px;text-align:right;">'
+            +       '<button type="button" class="labkey-button" id="lk-trace-metric-cancel">Cancel</button>'
+            +       (op === 'update' ? ' <button type="button" class="labkey-button" id="lk-trace-metric-delete">Delete</button>' : '')
+            +       ' <button type="button" class="labkey-button primary" id="lk-trace-metric-save"' + (tracesPresent ? '' : ' disabled') + '>Save</button>'
+            +     '</div>'
+            +   '</div>'
+            + '</div>'
+            + '</div>';
+    }
+
+    window.Panorama.Window.AddTraceMetricWindow = {
+        show: function(config) {
+            _config = config;
+
+            $('#' + DIALOG_ID).remove();
+            $('body').append(buildDialogHtml());
+
+            $('#lk-trace-metric-cancel').on('click', closeDialog);
+            $('#lk-trace-metric-save').on('click', save);
+            if (config.operation === 'update') {
+                $('#lk-trace-metric-delete').on('click', deleteMetric);
+            }
+            $('input[name="metricValue"]').on('change', refreshMode);
+
+            // close on overlay click
+            $('#' + DIALOG_ID).on('click', function(e) {
+                if (e.target === this) closeDialog();
+            });
+
+            refreshMode();
+        }
+    };
+})(jQuery);

--- a/src/org/labkey/targetedms/view/calibrationCurve.jsp
+++ b/src/org/labkey/targetedms/view/calibrationCurve.jsp
@@ -30,7 +30,7 @@
     @Override
     public void addClientDependencies(ClientDependencies dependencies)
     {
-        dependencies.add("Ext4");
+        dependencies.add("Ext4"); // LABKEY.vis (vis/vis) still uses Ext.isArray for log-scale axes
         dependencies.add("vis/vis");
         dependencies.add("targetedms/js/CalibrationCurve.js");
         dependencies.add("targetedms/css/CalibrationCurve.css");
@@ -46,9 +46,9 @@
 
     var calibrationCurvePlot;
 
-    Ext4.onReady(function () {
+    LABKEY.Utils.onReady(function () {
 
-        calibrationCurvePlot = Ext4.create('LABKEY.targetedms.CalibrationCurve', {
+        calibrationCurvePlot = new LABKEY.targetedms.CalibrationCurve({
             renderTo: <%=q(elementId)%>,
             data: <%=bean%>
         });

--- a/src/org/labkey/targetedms/view/paretoPlot.jsp
+++ b/src/org/labkey/targetedms/view/paretoPlot.jsp
@@ -27,11 +27,10 @@
     @Override
     public void addClientDependencies(ClientDependencies dependencies)
     {
-        dependencies.add("Ext4");
+        dependencies.add("Ext4"); // still needed by QCMetricConfigLoader.js
         dependencies.add("vis/vis");
         dependencies.add("targetedms/css/SVGExportIcon.css");
         dependencies.add("targetedms/css/ParetoPlot.css");
-        dependencies.add("targetedms/js/BaseQCPlotPanel.js");
         dependencies.add("targetedms/js/ParetoPlotPanel.js");
         dependencies.add("targetedms/js/QCMetricConfigLoader.js");
     }
@@ -47,22 +46,11 @@
         function init() {
             var tiledPlotPanelId = <%=q(tiledPlotPanelId)%>;
 
-            if (Ext4.isIE8) {
-                Ext4.get(tiledPlotPanelId).update("<span class='labkey-error'>Unable to render report in Internet Explorer < 9.</span>");
-                return;
-            }
-
-            initializeParetoPlotPanel(tiledPlotPanelId);
-        }
-
-        function initializeParetoPlotPanel(tiledPlotPanelId) {
-
-            // initialize the panel that displays Pareto plot
-            Ext4.create('LABKEY.targetedms.ParetoPlotPanel', {
-                cls: 'themed-panel',
+            // initialize the panel that displays Pareto plots
+            new LABKEY.targetedms.ParetoPlotPanel({
                 plotDivId: tiledPlotPanelId
             });
         }
 
-        Ext4.onReady(init);
+        LABKEY.Utils.onReady(init);
 </script>

--- a/src/org/labkey/targetedms/view/summaryChartsView.jsp
+++ b/src/org/labkey/targetedms/view/summaryChartsView.jsp
@@ -30,7 +30,6 @@
     @Override
     public void addClientDependencies(ClientDependencies dependencies)
     {
-        dependencies.add("Ext4");
         dependencies.add("internal/jQuery");
         dependencies.add("TargetedMS/js/svgChart.js");
         dependencies.add("TargetedMS/css/svgChart.css");
@@ -62,7 +61,9 @@
     long moleculeId = bean.getMoleculeId();
     long moleculePrecursorId = bean.getMoleculePrecursorId();
 
-    if ((peptideList != null && !peptideList.isEmpty()) || peptideId != 0 || precursorId != 0)
+    boolean asProteomics = (peptideList != null && !peptideList.isEmpty()) || peptideId != 0 || precursorId != 0;
+
+    if (asProteomics)
     {
         peakAreaUrl.addParameter("asProteomics", true);
         retentionTimesUrl.addParameter("asProteomics", true);
@@ -98,6 +99,17 @@
     peakAreaUrl.addParameter("chartHeight", bean.getInitialHeight());
     retentionTimesUrl.addParameter("chartWidth", bean.getInitialWidth());
     retentionTimesUrl.addParameter("chartHeight", bean.getInitialHeight());
+
+    // The ExtJS stores prepended "All"/"None" entries, so the original visibility checks were
+    // count-based (e.g. store.count() > 2). Translate those to list-size checks here.
+    boolean hasPeptides = peptideList != null && !peptideList.isEmpty();
+    boolean hasMolecules = moleculeList != null && !moleculeList.isEmpty();
+    boolean showReplicate = replicateList.size() > 1;
+    boolean showAnnotName = !replicateAnnotationNameList.isEmpty();
+    boolean showAnnotValue = !replicateAnnotationValueList.isEmpty();
+    boolean showPeptide = hasPeptides && peptideList.size() > 1;
+    boolean showMolecule = hasMolecules && moleculeList.size() > 1;
+    boolean showCv = showReplicate || showAnnotName;
 %>
 <style>
     .summary_form_box {
@@ -126,397 +138,119 @@
         font-size: 10px;
         padding-left:105px;
     }
+    .summary-form-table {
+        border-collapse: collapse;
+    }
+    .summary-form-table td {
+        padding: 3px 4px;
+        vertical-align: middle;
+    }
+    .summary-form-table td.sc-label {
+        background-color: #E0E6EA;
+        width: 150px;
+    }
+    .summary-form-table select {
+        width: 400px;
+    }
+    .summary-form-table input[type=number] {
+        width: 100px;
+    }
 </style>
-<script type="text/javascript" nonce="<%=getScriptNonce()%>">
-    Ext4.onReady(function() {
-
-    // data stores
-    var replicateStore = Ext4.create('Ext.data.Store', {
-        fields: ['name', 'replicateId'],
-        data:   [
-            {"name":"All", "replicateId":"0"}
-            <%for(int i = 0; i < replicateList.size(); i++) {%>
-            ,{"name":<%=q(replicateList.get(i).getName())%>, "replicateId":"<%=replicateList.get(i).getId()%>" }
-            <%}%>
-        ]
-    });
-
-    var replicateAnnotNameStore = Ext4.create('Ext.data.Store', {
-        fields: ['name'],
-        data:   [
-            {"name":"None"}
-            <%for(int i = 0; i < replicateAnnotationNameList.size(); i++){%>
-            ,{"name":<%=q(replicateAnnotationNameList.get(i))%>}
-            <%}%>
-        ]
-    });
-
-    var replicateAnnotNameValueStore = Ext4.create('Ext.data.Store', {
-        fields: ['name-value'],
-        data:   [
-            {"name-value":"None"}
-            <%for(int i = 0; i < replicateAnnotationValueList.size(); i++){%>
-            ,{"name-value":<%=q(replicateAnnotationValueList.get(i).getDisplayName())%>}
-
-            <%}%>
-        ]
-    });
-
-    var valueStore = Ext4.create('Ext.data.Store', {
-        fields: ['value'],
-        data:   [
-            {"value":"All"},
-            {"value":"Retention Time"},
-            {"value":"FWHM"},
-            {"value":"FWB"}
-        ]
-    });
-
-    var peptideStore = Ext4.create('Ext.data.Store', {
-        fields: ['sequence', 'peptideId'],
-        data: [
-            {"sequence":"All", "peptideId":"0"}
-            <%for(int i = 0; i < peptideList.size(); i++) {%>
-            ,{"sequence":<%=q(peptideList.get(i).getPeptideModifiedSequence())%>, "peptideId": "<%=peptideList.get(i).getId()%>"}
-            <%}%>
-        ]
-    });
-
-    var moleculeStore = Ext4.create('Ext.data.Store', {
-        fields: ['customIonName', 'moleculeId'],
-        data: [
-            {"customIonName":"All", "moleculeId":"0"}
-            <%for(int i = 0; i < moleculeList.size(); i++) {%>
-            ,{"customIonName":<%=q(moleculeList.get(i).getCustomIonName())%>, "moleculeId": "<%=moleculeList.get(i).getId()%>"}
-            <%}%>
-        ]
-    });
-
-    // combo boxes
-    var replicateComboBox;
-    if(replicateStore.count() > 0)
-    {
-        replicateComboBox = Ext4.create('Ext.form.ComboBox', {
-            fieldLabel: 'Replicate',
-            store: replicateStore ,
-            queryMode: 'local',
-            displayField: 'name',
-            valueField: 'replicateId',
-            forceSelection: 'true',
-            allowBlank: 'false',
-            value: replicateStore.getAt(0),
-            width: 400,
-            listeners:{
-                select: function(combo, record, index){
-                    var selected = combo.getValue();
-                    if(selected != 0)
-                    {
-                        replicateAnnotNameComboBox.disable();
-                        replicateAnnotNameComboBox.setValue(replicateAnnotNameStore.getAt(0));
-                        peptideComboBox.disable();
-                        peptideComboBox.setValue(peptideStore.getAt(0));
-                        moleculeComboBox.disable();
-                        moleculeComboBox.setValue(moleculeStore.getAt(0));
-                        replicateAnnotNameValueComboBox.disable();
-                        replicateAnnotNameValueComboBox.setValue(replicateAnnotNameValueStore.getAt(0));
-                    }
-                    else
-                    {
-                        replicateAnnotNameComboBox.enable();
-                        peptideComboBox.enable();
-                        moleculeComboBox.enable();
-                        replicateAnnotNameValueComboBox.enable();
-                    }
-                    updateCvCheckbox();
-                }
-            }
-        });
-    }
-
-    var replicateAnnotNameComboBox;
-    if(replicateAnnotNameStore.count() > 0)
-    {
-        replicateAnnotNameComboBox = Ext4.create('Ext.form.ComboBox',{
-            fieldLabel: 'Group By',
-            store: replicateAnnotNameStore ,
-            queryMode: 'local',
-            displayField: 'name',
-            valueField: 'name',
-            forceSelection: 'true',
-            allowBlank: 'false',
-            value: replicateAnnotNameStore.getAt(0),
-            width: 400,
-            listeners:{
-                select: function(combo, record, index) {
-                    updateCvCheckbox();
-                }
-            }
-        });
-    }
-
-    var valueComboBox;
-    valueComboBox = Ext4.create('Ext.form.ComboBox',{
-        fieldLabel: 'Value',
-        store: valueStore ,
-        queryMode: 'local',
-        displayField: 'value',
-        valueField: 'value',
-        forceSelection: 'true',
-        allowBlank: 'false',
-        value: valueStore.getAt(0),
-        width: 400,
-        listeners:{
-            select: function(combo, record, index) {
-                updateCvCheckbox();
-            }
-        }
-    });
-
-    var valueLabel;
-    valueLabel = Ext4.create('Ext.form.Label',
-            {
-                fieldLabel: 'valueLabel',
-                forId: 'valueLabel',
-                text: 'Value only effects Retention Times chart.',
-                baseCls: "valuelabel"
-            });
-
-    var replicateAnnotNameValueComboBox;
-    if(replicateAnnotNameValueStore.count() > 0)
-    {
-        replicateAnnotNameValueComboBox = Ext4.create('Ext.form.ComboBox',{
-            fieldLabel: 'Filter',
-            lazyRender: true,
-            store: replicateAnnotNameValueStore ,
-            queryMode: 'local',
-            displayField: 'name-value',
-            valueField: 'name-value',
-            forceSelection: 'true',
-            allowBlank: 'false',
-            value: replicateAnnotNameValueStore.getAt(0),
-            width: 400,
-            listeners:{
-                select: function(combo, record, index){
-                    var selected = combo.getValue();
-                    if(selected != 0)
-                    {
-                        updateCvCheckbox();
-                    }
-                }
-            }
-        });
-    }
-
-    var peptideComboBox;
-    if(peptideStore.count() > 0)
-    {
-        peptideComboBox = Ext4.create('Ext.form.ComboBox', {
-            fieldLabel: 'Peptide',
-            store: peptideStore,
-            queryMods: 'local',
-            displayField: 'sequence',
-            valueField: 'peptideId',
-            forceSelection: 'true',
-            allowBlank: 'false',
-            value: peptideStore.getAt(0),
-            width: 400,
-            listeners:{
-                select: function(combo, record, index){
-                    var selected = combo.getValue();
-                    if(selected != 0)
-                    {
-                        replicateComboBox.setValue(replicateStore.getAt(0));
-                        replicateComboBox.disable();
-                    }
-                    else
-                    {
-                        replicateComboBox.enable();
-                    }
-                    updateCvCheckbox();
-                }
-            }
-        });
-    }
-
-    var moleculeComboBox;
-    if(moleculeStore.count() > 0)
-    {
-        moleculeComboBox = Ext4.create('Ext.form.ComboBox', {
-            fieldLabel: 'Small Molecule',
-            store: moleculeStore,
-            queryMods: 'local',
-            displayField: 'customIonName',
-            valueField: 'moleculeId',
-            forceSelection: 'true',
-            allowBlank: 'false',
-            value: moleculeStore.getAt(0),
-            width: 400,
-            listeners:{
-                select: function(combo, record, index){
-                    var selected = combo.getValue();
-                    if(selected != 0)
-                    {
-                        replicateComboBox.setValue(replicateStore.getAt(0));
-                        replicateComboBox.disable();
-                    }
-                    else
-                    {
-                        replicateComboBox.enable();
-                    }
-                    updateCvCheckbox();
-                }
-            }
-        });
-    }
-
-    // check boxes
-    var cvValuesCheckbox = Ext4.create('Ext.form.Checkbox', {
-        id: 'cvCheckbox',
-        fieldLabel: 'CV Values'
-    });
-
-    var logValuesCheckbox = Ext4.create('Ext.form.Checkbox', {
-        id: 'logCheckbox',
-        fieldLabel: 'Log Scale'
-    });
-
-    // peak areas graph
-    LABKEY.targetedms.SVGChart.requestAndRenderSVG(<%= q(peakAreaUrl) %>, document.getElementById('peakAreasGraph'), null, document.getElementById('peakAreasGraphLabel'));
-    LABKEY.targetedms.SVGChart.requestAndRenderSVG(<%= q(retentionTimesUrl) %>, document.getElementById('retentionTimesGraph'), null, document.getElementById('retentionTimesGraphLabel'));
-
-    // buttons
-    var updateBtn = Ext4.create('Ext.button.Button', {
-        text:'Update',
-        handler: function(){
-
-            var params = {
-                asProteomics: <%=(peptideList != null && !peptideList.isEmpty()) || peptideId != 0 || precursorId != 0%>,
-                peptideGroupId: <%=peptideGroupId%>,
-                replicateId: replicateComboBox.getValue(),
-                groupByReplicateAnnotName: replicateAnnotNameComboBox.getValue(),
-                filterByReplicateAnnotName: replicateAnnotNameValueComboBox.getValue(),
-                peptideId: peptideStore.count() > 1 ? peptideComboBox.getValue() : <%=peptideId%>,
-                moleculeId: moleculeStore.count() > 1 ? moleculeComboBox.getValue() : <%=moleculeId%>,
-                cvValues: cvValuesCheckbox.getValue(),
-                logValues: logValuesCheckbox.getValue(),
-                chartWidth: chartWidthTb.getValue(),
-                chartHeight: chartHeightTb.getValue()
-            };
-
-            var peakAreaUrl =  LABKEY.ActionURL.buildURL(
-                    'targetedms',  // controller
-                    'showPeakAreas', // action
-                    LABKEY.ActionURL.getContainer(),
-                    params
-            );
-
-            var retentionTimeParams = Ext4.apply(Ext4.clone(params), {
-                value: valueComboBox.getValue()
-            });
-
-            var retentionTimesUrl =  LABKEY.ActionURL.buildURL(
-                    'targetedms',  // controller
-                    'showRetentionTimesChart', // action
-                    LABKEY.ActionURL.getContainer(),
-                    retentionTimeParams
-            );
-
-            // change the src of the image
-            var areaElement = document.getElementById('peakAreasGraph');
-            LABKEY.targetedms.SVGChart.requestAndRenderSVG(peakAreaUrl, areaElement, null, document.getElementById('peakAreasGraphLabel'));
-            var timeElement = document.getElementById('retentionTimesGraph');
-            LABKEY.targetedms.SVGChart.requestAndRenderSVG(retentionTimesUrl, timeElement, null, document.getElementById('retentionTimesGraphLabel'));
-            areaElement.style.width = parseInt(chartWidthTb.getValue());
-            areaElement.style.height = parseInt(chartHeightTb.getValue());
-            timeElement.style.width = parseInt(chartWidthTb.getValue());
-            timeElement.style.height = parseInt(chartHeightTb.getValue());
-        }
-    });
-
-    // chart width and height
-    var chartWidthTb = Ext4.create('Ext.form.TextField',{
-                fieldLabel: "Width",
-                name: "chartWidth",
-                id: "chartWidth",
-                allowBlank: false,
-                maskRe: /[0-9]/,
-                value: "<%= bean.getInitialWidth() %>"}
-    );
-    var chartHeightTb = Ext4.create('Ext.form.TextField',{
-                fieldLabel: "Height",
-                name: "chartHeight",
-                id: "chartHeight",
-                allowBlank: false,
-                maskRe: /[0-9]/,
-                value: "<%= bean.getInitialHeight() %>"}
-    );
-
-    var items = [];
-    if(replicateStore.count() > 2) items.push(replicateComboBox);
-    if(replicateAnnotNameStore.count() > 1) items.push(replicateAnnotNameComboBox);
-    if(replicateAnnotNameValueStore.count() > 1) items.push(replicateAnnotNameValueComboBox);
-    if(peptideStore.count() > 2) items.push(peptideComboBox);
-    if(moleculeStore.count() > 2) items.push(moleculeComboBox);
-    if(replicateStore.count() > 2 || replicateAnnotNameStore.count() > 1)
-    {
-        items.push(cvValuesCheckbox);
-    }
-    items.push(logValuesCheckbox);
-    items.push(chartWidthTb);
-    items.push(chartHeightTb);
-    items.push(valueComboBox);
-    items.push(valueLabel);
-
-    if(items.length > 0)
-    {
-        Ext4.create('Ext.form.Panel', {
-            renderTo: Ext4.get('peakAreasFormDiv'),
-            border: false, frame: false,
-            buttonAlign: 'left',
-            items: items,
-            buttons: [updateBtn],
-            defaults: {
-                labelWidth: 150,
-                labelStyle: 'background-color: #E0E6EA; padding: 2px 4px; margin: 0px;'
-            }
-        });
-    }
-    updateCvCheckbox();
-
-
-    function updateCvCheckbox()
-    {
-        if(!cvValuesCheckbox.isVisible())
-            return;
-
-        var allReplicates = replicateComboBox.getValue() == replicateStore.getAt(0).get('replicateId'); // replicate = 'All'
-        var noAnnotations = replicateAnnotNameComboBox.getValue() == replicateAnnotNameStore.getAt(0).get('name'); // annotation = 'None'
-
-        var replicateEnabled = false;
-        if(replicateComboBox.isVisible())
-            replicateEnabled = replicateComboBox.disabled == false;
-        var annotEnabled = false;
-        if(replicateAnnotNameComboBox.isVisible())
-            annotEnabled = replicateAnnotNameComboBox.disabled == false;
-
-        //alert("allReplicates: "+allReplicates+", noAnnotations: "+noAnnotations+", replicateEnabled: "+replicateEnabled+", annotEnabled: "+annotEnabled);
-        if((replicateEnabled && allReplicates) ||
-                (annotEnabled && !noAnnotations)
-                )
-        {
-            cvValuesCheckbox.enable();
-        }
-        else
-        {
-            cvValuesCheckbox.setValue(false);
-            cvValuesCheckbox.disable();
-        }
-    }
-});
-
-</script>
 <div>
-    <div id="peakAreasFormDiv" class="summary_form_box" style="display: <%=h(bean.isShowControls() ? "block" : "none")%>;"></div>
+    <div id="peakAreasFormDiv" class="summary_form_box" style="display: <%=h(bean.isShowControls() ? "block" : "none")%>;">
+        <table class="summary-form-table">
+            <tr id="sc-row-replicate" style="display: <%=h(showReplicate ? "table-row" : "none")%>;">
+                <td class="sc-label"><label for="sc-replicate">Replicate</label></td>
+                <td>
+                    <select id="sc-replicate">
+                        <option value="0">All</option>
+                        <% for (Replicate r : replicateList) { %>
+                            <option value="<%=r.getId()%>"><%=h(r.getName())%></option>
+                        <% } %>
+                    </select>
+                </td>
+            </tr>
+            <tr id="sc-row-annotName" style="display: <%=h(showAnnotName ? "table-row" : "none")%>;">
+                <td class="sc-label"><label for="sc-annotName">Group By</label></td>
+                <td>
+                    <select id="sc-annotName">
+                        <option value="None">None</option>
+                        <% for (String annotName : replicateAnnotationNameList) { %>
+                            <option value="<%=h(annotName)%>"><%=h(annotName)%></option>
+                        <% } %>
+                    </select>
+                </td>
+            </tr>
+            <tr id="sc-row-annotValue" style="display: <%=h(showAnnotValue ? "table-row" : "none")%>;">
+                <td class="sc-label"><label for="sc-annotValue">Filter</label></td>
+                <td>
+                    <select id="sc-annotValue">
+                        <option value="None">None</option>
+                        <% for (ReplicateAnnotation annotValue : replicateAnnotationValueList) { %>
+                            <option value="<%=h(annotValue.getDisplayName())%>"><%=h(annotValue.getDisplayName())%></option>
+                        <% } %>
+                    </select>
+                </td>
+            </tr>
+            <tr id="sc-row-peptide" style="display: <%=h(showPeptide ? "table-row" : "none")%>;">
+                <td class="sc-label"><label for="sc-peptide">Peptide</label></td>
+                <td>
+                    <select id="sc-peptide">
+                        <option value="0">All</option>
+                        <% if (peptideList != null) { for (Peptide p : peptideList) { %>
+                            <option value="<%=p.getId()%>"><%=h(p.getPeptideModifiedSequence())%></option>
+                        <% } } %>
+                    </select>
+                </td>
+            </tr>
+            <tr id="sc-row-molecule" style="display: <%=h(showMolecule ? "table-row" : "none")%>;">
+                <td class="sc-label"><label for="sc-molecule">Small Molecule</label></td>
+                <td>
+                    <select id="sc-molecule">
+                        <option value="0">All</option>
+                        <% if (moleculeList != null) { for (Molecule mol : moleculeList) { %>
+                            <option value="<%=mol.getId()%>"><%=h(mol.getCustomIonName())%></option>
+                        <% } } %>
+                    </select>
+                </td>
+            </tr>
+            <tr id="sc-row-cv" style="display: <%=h(showCv ? "table-row" : "none")%>;">
+                <td class="sc-label"><label for="sc-cv">CV Values</label></td>
+                <td><input type="checkbox" id="sc-cv"></td>
+            </tr>
+            <tr>
+                <td class="sc-label"><label for="sc-log">Log Scale</label></td>
+                <td><input type="checkbox" id="sc-log"></td>
+            </tr>
+            <tr>
+                <td class="sc-label"><label for="sc-width">Width</label></td>
+                <td><input type="number" id="sc-width" value="<%= bean.getInitialWidth() %>"></td>
+            </tr>
+            <tr>
+                <td class="sc-label"><label for="sc-height">Height</label></td>
+                <td><input type="number" id="sc-height" value="<%= bean.getInitialHeight() %>"></td>
+            </tr>
+            <tr>
+                <td class="sc-label"><label for="sc-value">Value</label></td>
+                <td>
+                    <select id="sc-value">
+                        <option value="All">All</option>
+                        <option value="Retention Time">Retention Time</option>
+                        <option value="FWHM">FWHM</option>
+                        <option value="FWB">FWB</option>
+                    </select>
+                </td>
+            </tr>
+            <tr>
+                <td></td>
+                <td><span class="valuelabel">Value only effects Retention Times chart.</span></td>
+            </tr>
+            <tr>
+                <td></td>
+                <td><button type="button" id="sc-update" class="labkey-button">Update</button></td>
+            </tr>
+        </table>
+    </div>
     <div class="summary_title_box">
         <h3 class="title">Peak Areas</h3>
         <div id="peakAreasGraph"></div>
@@ -528,4 +262,138 @@
         <a href="<%= h(replicateListAction)%>"><div style="text-align: center" id="retentionTimesGraphLabel"></div></a>
     </div>
 </div>
+<script type="text/javascript" nonce="<%=getScriptNonce()%>">
+    LABKEY.Utils.onReady(function() {
 
+        const byId = function(id) { return document.getElementById(id); };
+
+        const replicateSel = byId('sc-replicate');
+        const annotNameSel = byId('sc-annotName');
+        const annotValueSel = byId('sc-annotValue');
+        const valueSel = byId('sc-value');
+        const peptideSel = byId('sc-peptide');
+        const moleculeSel = byId('sc-molecule');
+        const cvChk = byId('sc-cv');
+        const logChk = byId('sc-log');
+        const widthInput = byId('sc-width');
+        const heightInput = byId('sc-height');
+        const updateBtn = byId('sc-update');
+
+        const showReplicate = <%=showReplicate%>;
+        const showAnnotName = <%=showAnnotName%>;
+        const showCv = <%=showCv%>;
+        const hasPeptides = <%=hasPeptides%>;
+        const hasMolecules = <%=hasMolecules%>;
+
+        function updateCvCheckbox() {
+            if (!showCv) {
+                return;
+            }
+            const allReplicates = replicateSel.value === '0'; // replicate = 'All'
+            const noAnnotations = annotNameSel.value === 'None'; // annotation = 'None'
+
+            const replicateEnabled = showReplicate && !replicateSel.disabled;
+            const annotEnabled = showAnnotName && !annotNameSel.disabled;
+
+            if ((replicateEnabled && allReplicates) || (annotEnabled && !noAnnotations)) {
+                cvChk.disabled = false;
+            }
+            else {
+                cvChk.checked = false;
+                cvChk.disabled = true;
+            }
+        }
+
+        replicateSel.addEventListener('change', function() {
+            if (replicateSel.value !== '0') {
+                annotNameSel.disabled = true; annotNameSel.value = 'None';
+                peptideSel.disabled = true; peptideSel.value = '0';
+                moleculeSel.disabled = true; moleculeSel.value = '0';
+                annotValueSel.disabled = true; annotValueSel.value = 'None';
+            }
+            else {
+                annotNameSel.disabled = false;
+                peptideSel.disabled = false;
+                moleculeSel.disabled = false;
+                annotValueSel.disabled = false;
+            }
+            updateCvCheckbox();
+        });
+
+        annotNameSel.addEventListener('change', updateCvCheckbox);
+        valueSel.addEventListener('change', updateCvCheckbox);
+        annotValueSel.addEventListener('change', updateCvCheckbox);
+
+        peptideSel.addEventListener('change', function() {
+            if (peptideSel.value !== '0') {
+                replicateSel.value = '0';
+                replicateSel.disabled = true;
+            }
+            else {
+                replicateSel.disabled = false;
+            }
+            updateCvCheckbox();
+        });
+
+        moleculeSel.addEventListener('change', function() {
+            if (moleculeSel.value !== '0') {
+                replicateSel.value = '0';
+                replicateSel.disabled = true;
+            }
+            else {
+                replicateSel.disabled = false;
+            }
+            updateCvCheckbox();
+        });
+
+        updateBtn.addEventListener('click', function() {
+
+            const params = {
+                asProteomics: <%=asProteomics%>,
+                peptideGroupId: <%=peptideGroupId%>,
+                replicateId: replicateSel.value,
+                groupByReplicateAnnotName: annotNameSel.value,
+                filterByReplicateAnnotName: annotValueSel.value,
+                peptideId: hasPeptides ? peptideSel.value : <%=peptideId%>,
+                moleculeId: hasMolecules ? moleculeSel.value : <%=moleculeId%>,
+                cvValues: cvChk.checked,
+                logValues: logChk.checked,
+                chartWidth: widthInput.value,
+                chartHeight: heightInput.value
+            };
+
+            const peakAreaUrl = LABKEY.ActionURL.buildURL(
+                    'targetedms',  // controller
+                    'showPeakAreas', // action
+                    LABKEY.ActionURL.getContainer(),
+                    params
+            );
+
+            const retentionTimeParams = Object.assign({}, params, {value: valueSel.value});
+
+            const retentionTimesUrl = LABKEY.ActionURL.buildURL(
+                    'targetedms',  // controller
+                    'showRetentionTimesChart', // action
+                    LABKEY.ActionURL.getContainer(),
+                    retentionTimeParams
+            );
+
+            // change the src of the image
+            const areaElement = byId('peakAreasGraph');
+            LABKEY.targetedms.SVGChart.requestAndRenderSVG(peakAreaUrl, areaElement, null, byId('peakAreasGraphLabel'));
+            const timeElement = byId('retentionTimesGraph');
+            LABKEY.targetedms.SVGChart.requestAndRenderSVG(retentionTimesUrl, timeElement, null, byId('retentionTimesGraphLabel'));
+
+            areaElement.style.width = parseInt(widthInput.value) + 'px';
+            areaElement.style.height = parseInt(heightInput.value) + 'px';
+            timeElement.style.width = parseInt(widthInput.value) + 'px';
+            timeElement.style.height = parseInt(heightInput.value) + 'px';
+        });
+
+        // peak areas / retention times graphs
+        LABKEY.targetedms.SVGChart.requestAndRenderSVG(<%= q(peakAreaUrl) %>, byId('peakAreasGraph'), null, byId('peakAreasGraphLabel'));
+        LABKEY.targetedms.SVGChart.requestAndRenderSVG(<%= q(retentionTimesUrl) %>, byId('retentionTimesGraph'), null, byId('retentionTimesGraphLabel'));
+
+        updateCvCheckbox();
+    });
+</script>

--- a/webapp/TargetedMS/js/CalibrationCurve.js
+++ b/webapp/TargetedMS/js/CalibrationCurve.js
@@ -5,27 +5,29 @@
  */
 /**
  * Created by Marty on 3/16/2017.
+ *
+ * Plain JS/HTML implementation (no ExtJS). Renders the calibration curve plot (LABKEY.vis)
+ * into the element identified by config.renderTo.
  */
+if (!LABKEY.targetedms) {
+    LABKEY.targetedms = {};
+}
 
-Ext4.define('LABKEY.targetedms.CalibrationCurve', {
+(function() {
 
-    extend: 'Ext.panel.Panel',
-    layout: 'fit',
-    border: false,
+    function CalibrationCurve(config) {
+        this.renderTo = config.renderTo;
+        this.data = config.data;
 
-    selectedPointLayer: null,
-    plotHeight: 500,
-    minWidth: 800,
-
-    colors: {
-        unknown: 'black',
-        standard: 'gray',
-        qc: 'green'
-    },
-
-    initComponent: function () {
-        Ext4.tip.QuickTipManager.init();
-        this.callParent();
+        this.selectedPointLayer = null;
+        this.plotHeight = 500;
+        this.minWidth = 800;
+        this.plot = null;
+        this.colors = {
+            unknown: 'black',
+            standard: 'gray',
+            qc: 'green'
+        };
 
         this.width = this.getPanelSize();
 
@@ -35,281 +37,288 @@ Ext4.define('LABKEY.targetedms.CalibrationCurve', {
         this.maxX = this.data.calibrationCurve.maxX || 0;
 
         // Ensure plot goes to max x axis for selected point calculations
-        var calcMaxX = this.getQuadraticIntersect(this, this.maxY);
-        if (calcMaxX > this.maxX)
+        const calcMaxX = this.getQuadraticIntersect(this, this.maxY);
+        if (calcMaxX > this.maxX) {
             this.maxX = calcMaxX;
+        }
 
         this.addCurvePoints();
 
         this.refreshPlot();
 
-        var me = this;
-        window.addEventListener("resize", function () {
+        const me = this;
+        window.addEventListener("resize", function() {
             // Issue 43532 - may have been loaded even if we don't have a curve to plot
             if (me.plot) {
-                me.setWidth(me.getPanelSize());
-                me.plot.setWidth(me.getWidth());
+                me.width = me.getPanelSize();
+                me.plot.setWidth(me.width);
                 me.plot.render();
 
                 // Plot re-renders so need to shrink dots to get back to initial state
                 d3.selectAll('a.point path').transition().attr("stroke-width", 1);
             }
         }, false);
-    },
-
-    refreshPlot: function() {
-        // Clear out child <svg> elements
-        let children = document.getElementById(this.renderTo).childNodes;
-        for (let i = 0; i < children.length; ) {
-            if (children[i].localName === 'svg') {
-                children[i].parentNode.removeChild(children[i]);
-            }
-            else {
-                i++;
-            }
-        }
-        this.addPlot();
-    },
-
-    // Add points for quadratic calculated concentration curve
-    addCurvePoints: function () {
-        var curvePts = 50;
-        var x, y;
-        var increment = (this.maxX - this.minX) / curvePts;
-
-        this.data.curvePoints = [];
-        for (var pt = 0; pt <= curvePts; pt++) {
-            x = this.minX + (pt * increment);
-            y = this.data.calibrationCurve.quadraticCoefficient * (x * x) + this.data.calibrationCurve.slope * x
-                    + this.data.calibrationCurve.intercept;
-
-            this.data.curvePoints.push({x:x, y:y});
-        }
-    },
-
-    getPanelSize: function () {
-        return window.innerWidth - 100;
-    },
-
-    // Given y, solve for x
-    getQuadraticIntersect: function (scope, y) {
-        var a = scope.data.calibrationCurve.quadraticCoefficient;
-        var b = scope.data.calibrationCurve.slope;
-        var c = scope.data.calibrationCurve.intercept;
-
-        var intersect;
-        if (a !== 0) { //Quadratic
-            intersect = ((-1 * b) + Math.sqrt((b * b) - (4 * a * (c - y)))) / (2 * a);
-        }
-        else { //Linear
-            intersect = (y - c) / b;
-        }
-        return intersect;
-    },
-
-    getPointToLineLayer: function (scope, point) {
-        var data = [];
-        data.push(point);
-        data.push({
-            x: scope.getQuadraticIntersect(scope, point.y),
-            y: point.y,
-            type: point.type
-        });
-
-        data.push({
-            x: scope.getQuadraticIntersect(scope, point.y),
-            y: scope.minY,
-            type: point.type
-        });
-
-        return new LABKEY.vis.Layer({
-            geom: new LABKEY.vis.Geom.Path({size: 3, opacity: 0, color: 'red'}),
-            aes: {
-                y: function (row) {
-                    return row.y
-                },
-                x: function (row) {
-                    return row.x
-                }
-            },
-            data: data
-        })
-    },
-
-    addPlot: function () {
-        var me = this;
-
-        if (this.data.calibrationCurve.errorMessage) {
-            document.getElementById(this.renderTo).innerText = this.data.calibrationCurve.errorMessage;
-            return;
-        }
-
-        // This is a dummy layer to be overwritten by the line layer when selecting a point
-        this.selectedPointLayer = new LABKEY.vis.Layer({
-            geom: new LABKEY.vis.Geom.Path({size: 3, opacity: 0}),
-            data: [],
-            aes: {
-                y: function (row) {
-                    return row.y;
-                },
-                x: function (row) {
-                    return row.x;
-                }
-            }
-        });
-
-        var units = "";
-        if (this.data.calibrationCurve.units != null)
-            units = "(" + this.data.calibrationCurve.units + ")";
-
-        this.plot = new LABKEY.vis.Plot({
-            renderTo: this.renderTo,
-            rendererType: 'd3',
-            width: this.width,
-            height: this.plotHeight,
-            labels: {
-                main: {value: this.data.molecule.name},
-                y: {value: 'Normalized Peak Areas'},
-                x: {value: 'Analyte Concentration ' + units}
-            },
-            layers: [
-                this.selectedPointLayer,
-                new LABKEY.vis.Layer({
-                    data: this.data.curvePoints,
-                    geom: new LABKEY.vis.Geom.Path({size: 3, opacity: .4}),
-                    aes: {
-                        y: 'y',
-                        x: 'x'
-                    }
-                }),
-                new LABKEY.vis.Layer({
-                    data: this.data.dataPoints,
-                    geom: new LABKEY.vis.Geom.Point({size: 5, opacity: 0.75}),
-                    aes: {
-                        y: 'y',
-                        x: 'x',
-                        pointClickFn: function (event, data) {
-                            var legend = me.getLegendDataInfo(me)
-                                    .concat(me.getLegendDataSlopeCalculations(me))
-                                    .concat(me.getLegendDataPointCalculations(me, data));
-
-                            me.plot.setLegend(legend);
-
-                            var lineLayer = me.getPointToLineLayer(me, data);
-
-                            me.plot.replaceLayer(me.selectedPointLayer, lineLayer);
-                            me.selectedPointLayer = lineLayer;
-                            me.plot.render();
-
-                            // Shrink dots from previous clicks and grow clicked dot
-                            d3.selectAll('a.point path').transition().attr("stroke-width", 1);
-                            d3.select(event.srcElement).transition().attr("stroke-width", 8);
-
-                            // Transition in line layer visibility
-                            d3.selectAll('svg g.layer path[stroke-opacity="0"').transition().attr('stroke-opacity', .5)
-                        },
-                        hoverText: function (row) {
-                            return 'Name: ' + row.name + '\nPeak Area: ' + me.formatLegendValue(row.y, true) + '\nConcentration: ' + me.formatLegendValue(row.x) + (row.excluded ? '\nExcluded from calibration' : '');
-                        }
-                    }
-                })
-            ],
-            aes: {
-                color: function (row) {
-                    return row.type;
-                },
-                shape: function (row) {
-                    return row.excluded ? 'Excluded' : 'Included';
-                }
-            },
-            scales: {
-                color: {
-                    scaleType: 'discrete',
-                    scale: function (group) {
-                        if (Ext4.isDefined(me.colors[group]))
-                            return me.colors[group];
-
-                        return 'blue';
-                    },
-                },
-                y: {
-                    scaleType: 'continuous',
-                    trans: document.getElementById('calCurveYScale').value,
-                    domain: [me.minY, me.maxY],
-                    tickFormat: function (d) {
-                        if (d < 1000 && d > 0.001)
-                            return d;
-                        return d.toExponential();
-                    }
-                },
-                x: {
-                    trans: document.getElementById('calCurveXScale').value
-                }
-            },
-            legendData: this.getLegendDataInfo(me).concat(this.getLegendDataSlopeCalculations(me)),
-            legendNoWrap: true
-        });
-
-        this.plot.render();
-
-        LABKEY.targetedms.SVGChart.attachPlotExportIcons(this.renderTo, 'Calibration Curve: ' + this.data.molecule.name, 800, 0);
-    },
-
-    getLegendDataPointCalculations: function (scope, point) {
-
-        var result = [
-            {text: 'Selected Point', separator: true},
-            {text: 'Replicate: ' + point.name, color: 'white'},
-            {text: 'Peak Area: ' + scope.formatLegendValue(point.y, true), color: 'white'},
-            {text: 'Concentration: ' + scope.formatLegendValue(point.x), color: 'white'},
-            {
-                text: 'Calc. Concentration: ' + scope.formatLegendValue(scope.getQuadraticIntersect(scope, point.y)),
-                color: 'white'
-            }
-        ];
-        if (point.excluded) {
-            result.push({text: 'Excluded from calibration', color: 'white'});
-        }
-        return result
-    },
-
-    getLegendDataSlopeCalculations: function (scope) {
-        var result = [
-            {text: 'Calibration Curve', separator: true},
-            {text: 'Regression Fit: ' + Ext4.util.Format.htmlEncode(this.data.calibrationCurve.regressionFit), color: 'white'},
-            {text: 'Norm. Method: ' + Ext4.util.Format.htmlEncode(this.data.calibrationCurve.normalizationMethod), color: 'white'},
-            {text: 'Regression Weighting: ' + Ext4.util.Format.htmlEncode(this.data.calibrationCurve.regressionWeighting), color: 'white'},
-            {text: 'MS Level: ' + (this.data.msLevel > 0 ? this.data.msLevel : 'All'), color: 'white'},
-            {text: '', separator: true},
-            {text: 'Slope: ' + scope.formatLegendValue(this.data.calibrationCurve.slope, true), color: 'white'},
-            {text: 'Intercept: ' + scope.formatLegendValue(this.data.calibrationCurve.intercept, true), color: 'white'}
-        ];
-        if (this.data.calibrationCurve.quadraticCoefficient && this.data.calibrationCurve.quadraticCoefficient !== 0.0) {
-            result.push({text: 'Quadratic Coefficient: ' + scope.formatLegendValue(this.data.calibrationCurve.quadraticCoefficient), color: 'white'});
-        }
-        result.push({text: 'rSquared: ' + scope.formatLegendValue(this.data.calibrationCurve.rSquared), color: 'white'});
-        result.push({text: '', separator: true});
-        return result;
-    },
-
-    getLegendDataInfo: function (scope) {
-        return [
-            {text: 'Standard', color: scope.colors['standard'], shape:LABKEY.vis.Scale.Shape()[0]},
-            {text: 'QC', color: scope.colors['qc'], shape:LABKEY.vis.Scale.Shape()[0]},
-            {text: 'Unknown', color: scope.colors['unknown'], shape:LABKEY.vis.Scale.Shape()[0]},
-            {text: '', separator: true},
-            {text: 'Excluded', color: scope.colors['standard'], shape: LABKEY.vis.Scale.Shape()[1]},
-            {text: '', separator: true}
-        ];
-    },
-
-    formatLegendValue: function (value, exp) {
-        if (value == null)
-            return 'NaN';
-        var rounded = Math.round(value * 100000) / 100000;
-        // Use scientific notation if the number is large or very small
-        if (exp && (rounded > 10000 || rounded < -10000 || (rounded > -0.00001 && rounded < 0.00001)))
-            rounded.toExponential(4)
-        return rounded;
     }
-});
+
+    CalibrationCurve.prototype = {
+
+        refreshPlot: function() {
+            // Clear out child <svg> elements
+            const children = document.getElementById(this.renderTo).childNodes;
+            for (let i = 0; i < children.length; ) {
+                if (children[i].localName === 'svg') {
+                    children[i].parentNode.removeChild(children[i]);
+                }
+                else {
+                    i++;
+                }
+            }
+            this.addPlot();
+        },
+
+        // Add points for quadratic calculated concentration curve
+        addCurvePoints: function() {
+            const curvePts = 50;
+            let x, y;
+            const increment = (this.maxX - this.minX) / curvePts;
+
+            this.data.curvePoints = [];
+            for (let pt = 0; pt <= curvePts; pt++) {
+                x = this.minX + (pt * increment);
+                y = this.data.calibrationCurve.quadraticCoefficient * (x * x) + this.data.calibrationCurve.slope * x
+                        + this.data.calibrationCurve.intercept;
+
+                this.data.curvePoints.push({x: x, y: y});
+            }
+        },
+
+        getPanelSize: function() {
+            return window.innerWidth - 100;
+        },
+
+        // Given y, solve for x
+        getQuadraticIntersect: function(scope, y) {
+            const a = scope.data.calibrationCurve.quadraticCoefficient;
+            const b = scope.data.calibrationCurve.slope;
+            const c = scope.data.calibrationCurve.intercept;
+
+            let intersect;
+            if (a !== 0) { //Quadratic
+                intersect = ((-1 * b) + Math.sqrt((b * b) - (4 * a * (c - y)))) / (2 * a);
+            }
+            else { //Linear
+                intersect = (y - c) / b;
+            }
+            return intersect;
+        },
+
+        getPointToLineLayer: function(scope, point) {
+            const data = [];
+            data.push(point);
+            data.push({
+                x: scope.getQuadraticIntersect(scope, point.y),
+                y: point.y,
+                type: point.type
+            });
+
+            data.push({
+                x: scope.getQuadraticIntersect(scope, point.y),
+                y: scope.minY,
+                type: point.type
+            });
+
+            return new LABKEY.vis.Layer({
+                geom: new LABKEY.vis.Geom.Path({size: 3, opacity: 0, color: 'red'}),
+                aes: {
+                    y: function(row) {
+                        return row.y
+                    },
+                    x: function(row) {
+                        return row.x
+                    }
+                },
+                data: data
+            })
+        },
+
+        addPlot: function() {
+            const me = this;
+
+            if (this.data.calibrationCurve.errorMessage) {
+                document.getElementById(this.renderTo).innerText = this.data.calibrationCurve.errorMessage;
+                return;
+            }
+
+            // This is a dummy layer to be overwritten by the line layer when selecting a point
+            this.selectedPointLayer = new LABKEY.vis.Layer({
+                geom: new LABKEY.vis.Geom.Path({size: 3, opacity: 0}),
+                data: [],
+                aes: {
+                    y: function(row) {
+                        return row.y;
+                    },
+                    x: function(row) {
+                        return row.x;
+                    }
+                }
+            });
+
+            let units = "";
+            if (this.data.calibrationCurve.units != null) {
+                units = "(" + this.data.calibrationCurve.units + ")";
+            }
+
+            this.plot = new LABKEY.vis.Plot({
+                renderTo: this.renderTo,
+                rendererType: 'd3',
+                width: this.width,
+                height: this.plotHeight,
+                labels: {
+                    main: {value: this.data.molecule.name},
+                    y: {value: 'Normalized Peak Areas'},
+                    x: {value: 'Analyte Concentration ' + units}
+                },
+                layers: [
+                    this.selectedPointLayer,
+                    new LABKEY.vis.Layer({
+                        data: this.data.curvePoints,
+                        geom: new LABKEY.vis.Geom.Path({size: 3, opacity: .4}),
+                        aes: {
+                            y: 'y',
+                            x: 'x'
+                        }
+                    }),
+                    new LABKEY.vis.Layer({
+                        data: this.data.dataPoints,
+                        geom: new LABKEY.vis.Geom.Point({size: 5, opacity: 0.75}),
+                        aes: {
+                            y: 'y',
+                            x: 'x',
+                            pointClickFn: function(event, data) {
+                                const legend = me.getLegendDataInfo(me)
+                                        .concat(me.getLegendDataSlopeCalculations(me))
+                                        .concat(me.getLegendDataPointCalculations(me, data));
+
+                                me.plot.setLegend(legend);
+
+                                const lineLayer = me.getPointToLineLayer(me, data);
+
+                                me.plot.replaceLayer(me.selectedPointLayer, lineLayer);
+                                me.selectedPointLayer = lineLayer;
+                                me.plot.render();
+
+                                // Shrink dots from previous clicks and grow clicked dot
+                                d3.selectAll('a.point path').transition().attr("stroke-width", 1);
+                                d3.select(event.srcElement).transition().attr("stroke-width", 8);
+
+                                // Transition in line layer visibility
+                                d3.selectAll('svg g.layer path[stroke-opacity="0"').transition().attr('stroke-opacity', .5)
+                            },
+                            hoverText: function(row) {
+                                return 'Name: ' + row.name + '\nPeak Area: ' + me.formatLegendValue(row.y, true) + '\nConcentration: ' + me.formatLegendValue(row.x) + (row.excluded ? '\nExcluded from calibration' : '');
+                            }
+                        }
+                    })
+                ],
+                aes: {
+                    color: function(row) {
+                        return row.type;
+                    },
+                    shape: function(row) {
+                        return row.excluded ? 'Excluded' : 'Included';
+                    }
+                },
+                scales: {
+                    color: {
+                        scaleType: 'discrete',
+                        scale: function(group) {
+                            if (me.colors[group] !== undefined)
+                                return me.colors[group];
+
+                            return 'blue';
+                        },
+                    },
+                    y: {
+                        scaleType: 'continuous',
+                        trans: document.getElementById('calCurveYScale').value,
+                        domain: [me.minY, me.maxY],
+                        tickFormat: function(d) {
+                            if (d < 1000 && d > 0.001)
+                                return d;
+                            return d.toExponential();
+                        }
+                    },
+                    x: {
+                        trans: document.getElementById('calCurveXScale').value
+                    }
+                },
+                legendData: this.getLegendDataInfo(me).concat(this.getLegendDataSlopeCalculations(me)),
+                legendNoWrap: true
+            });
+
+            this.plot.render();
+
+            LABKEY.targetedms.SVGChart.attachPlotExportIcons(this.renderTo, 'Calibration Curve: ' + this.data.molecule.name, 800, 0);
+        },
+
+        getLegendDataPointCalculations: function(scope, point) {
+
+            const result = [
+                {text: 'Selected Point', separator: true},
+                {text: 'Replicate: ' + point.name, color: 'white'},
+                {text: 'Peak Area: ' + scope.formatLegendValue(point.y, true), color: 'white'},
+                {text: 'Concentration: ' + scope.formatLegendValue(point.x), color: 'white'},
+                {
+                    text: 'Calc. Concentration: ' + scope.formatLegendValue(scope.getQuadraticIntersect(scope, point.y)),
+                    color: 'white'
+                }
+            ];
+            if (point.excluded) {
+                result.push({text: 'Excluded from calibration', color: 'white'});
+            }
+            return result
+        },
+
+        getLegendDataSlopeCalculations: function(scope) {
+            const result = [
+                {text: 'Calibration Curve', separator: true},
+                {text: 'Regression Fit: ' + LABKEY.Utils.encodeHtml(this.data.calibrationCurve.regressionFit), color: 'white'},
+                {text: 'Norm. Method: ' + LABKEY.Utils.encodeHtml(this.data.calibrationCurve.normalizationMethod), color: 'white'},
+                {text: 'Regression Weighting: ' + LABKEY.Utils.encodeHtml(this.data.calibrationCurve.regressionWeighting), color: 'white'},
+                {text: 'MS Level: ' + (this.data.msLevel > 0 ? this.data.msLevel : 'All'), color: 'white'},
+                {text: '', separator: true},
+                {text: 'Slope: ' + scope.formatLegendValue(this.data.calibrationCurve.slope, true), color: 'white'},
+                {text: 'Intercept: ' + scope.formatLegendValue(this.data.calibrationCurve.intercept, true), color: 'white'}
+            ];
+            if (this.data.calibrationCurve.quadraticCoefficient && this.data.calibrationCurve.quadraticCoefficient !== 0.0) {
+                result.push({text: 'Quadratic Coefficient: ' + scope.formatLegendValue(this.data.calibrationCurve.quadraticCoefficient), color: 'white'});
+            }
+            result.push({text: 'rSquared: ' + scope.formatLegendValue(this.data.calibrationCurve.rSquared), color: 'white'});
+            result.push({text: '', separator: true});
+            return result;
+        },
+
+        getLegendDataInfo: function(scope) {
+            return [
+                {text: 'Standard', color: scope.colors['standard'], shape: LABKEY.vis.Scale.Shape()[0]},
+                {text: 'QC', color: scope.colors['qc'], shape: LABKEY.vis.Scale.Shape()[0]},
+                {text: 'Unknown', color: scope.colors['unknown'], shape: LABKEY.vis.Scale.Shape()[0]},
+                {text: '', separator: true},
+                {text: 'Excluded', color: scope.colors['standard'], shape: LABKEY.vis.Scale.Shape()[1]},
+                {text: '', separator: true}
+            ];
+        },
+
+        formatLegendValue: function(value, exp) {
+            if (value == null)
+                return 'NaN';
+            const rounded = Math.round(value * 100000) / 100000;
+            // Use scientific notation if the number is large or very small
+            if (exp && (rounded > 10000 || rounded < -10000 || (rounded > -0.00001 && rounded < 0.00001)))
+                rounded.toExponential(4)
+            return rounded;
+        }
+    };
+
+    LABKEY.targetedms.CalibrationCurve = CalibrationCurve;
+})();

--- a/webapp/TargetedMS/js/ParetoPlotPanel.js
+++ b/webapp/TargetedMS/js/ParetoPlotPanel.js
@@ -5,220 +5,427 @@
  * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
  *
  * Created by binalpatel on 7/9/15.
+ *
+ * Plain JS/HTML implementation (no ExtJS). Renders one set of Pareto plots per guide set
+ * into the element identified by config.plotDivId.
  */
+if (!LABKEY.targetedms) {
+    LABKEY.targetedms = {};
+}
 
-Ext4.define('LABKEY.targetedms.ParetoPlotPanel', {
+(function() {
 
-    extend: 'LABKEY.targetedms.BaseQCPlotPanel',
+    const MONTHS = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+    const DAYS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
-    initComponent : function()
-    {
-        this.callParent();
+    function ParetoPlotPanel(config) {
+        this.plotDivId = config.plotDivId;
+        this.metricPropArr = [];
+        this.plotWidth = null;
+        this._maskEl = null;
 
-        Ext4.get(this.plotDivId).mask("Loading...");
+        this.mask('Loading...');
 
+        const me = this;
         LABKEY.targetedms.QCMetricConfigLoader.getMetrics(this.initPlot, this, function() {
-            Ext4.get(this.plotDivId).unmask();
-            Ext4.get(this.plotDivId).update('Failed to load');
+            me.unmask();
+            const el = me.getPlotDiv();
+            if (el) {
+                el.innerHTML = 'Failed to load';
+            }
         });
-    },
+    }
 
-    initPlot : function(metrics) {
-        this.metricPropArr = metrics;
+    ParetoPlotPanel.prototype = {
 
-        LABKEY.Ajax.request({
-            url: LABKEY.ActionURL.buildURL('targetedms', 'GetQCMetricOutliers.api'),
-            success: this.processResponse,
-            failure: LABKEY.Utils.getCallbackWrapper(this.failureHandler),
-            scope: this
-        });
-    },
+        getPlotDiv: function() {
+            return document.getElementById(this.plotDivId);
+        },
 
-    processResponse: function(response) {
-        Ext4.get(this.plotDivId).unmask();
+        mask: function(text) {
+            const el = this.getPlotDiv();
+            if (!el) {
+                return;
+            }
+            this.unmask();
+            const m = document.createElement('div');
+            m.className = 'lk-pareto-loading';
+            m.style.padding = '10px';
+            m.textContent = text || 'Loading...';
+            el.appendChild(m);
+            this._maskEl = m;
+        },
 
-        var parsed = JSON.parse(response.responseText);
+        unmask: function() {
+            if (this._maskEl && this._maskEl.parentNode) {
+                this._maskEl.parentNode.removeChild(this._maskEl);
+            }
+            this._maskEl = null;
+        },
 
-        if (!parsed.sampleFiles || Object.keys(parsed.sampleFiles).length === 0) {
-            Ext4.get(this.plotDivId).update('<div class="tiledPlotPanel">No sample files loaded yet. Import some via Skyline, AutoQC, or the Data Pipeline tab here in Panorama.</div>');
-            return;
-        }
+        initPlot: function(metrics) {
+            this.metricPropArr = metrics;
 
-        var guideSets = parsed.guideSets;
+            LABKEY.Ajax.request({
+                url: LABKEY.ActionURL.buildURL('targetedms', 'GetQCMetricOutliers.api'),
+                success: this.processResponse,
+                failure: LABKEY.Utils.getCallbackWrapper(this.failureHandler, this),
+                scope: this
+            });
+        },
 
-        Ext4.each(guideSets, function(guideSet) {
-            guideSet.stats = {
-                CUSUMm: {count: 0, data: []},
-                CUSUMv: {count: 0, data: []},
-                mR: {count: 0, data: []},
-                Value: {count: 0, data: []}
-            };
+        processResponse: function(response) {
+            this.unmask();
 
-            Ext4.iterate(guideSet.MetricCounts, function(metricName, data) {
-                this.addOutlierToCounts(guideSet, data, metricName,'CUSUMm', 'CUSUMm', true);
-                this.addOutlierToCounts(guideSet, data, metricName, 'CUSUMv', 'CUSUMv', true);
-                this.addOutlierToCounts(guideSet, data, metricName, 'mR', 'Moving Range', true);
-                this.addOutlierToCounts(guideSet, data, metricName, 'Value', 'Metric Value', true);
-            }, this);
+            const parsed = JSON.parse(response.responseText);
+            const el = this.getPlotDiv();
 
-            Ext4.iterate(guideSet.stats, function(outlierType, data) {
-                var dataSet = data.data;
-
-                var totalCount = 0;
-                var maxOutliers = 0;
-
-                //find total count per guidesetID
-                for (var i = 0; i < dataSet.length; i++) {
-                    totalCount += dataSet[i]['count'];
-
-                    if(maxOutliers < dataSet[i]['count'])
-                    {
-                        maxOutliers = dataSet[i]['count'];
-                    }
+            if (!parsed.sampleFiles || Object.keys(parsed.sampleFiles).length === 0) {
+                if (el) {
+                    el.innerHTML = '<div class="tiledPlotPanel">No sample files loaded yet. Import some via Skyline, AutoQC, or the Data Pipeline tab here in Panorama.</div>';
                 }
+                return;
+            }
 
-                //sort by count in descending order
-                var sortedDataset = dataSet.sort(function(a, b) {
-                    var order = b.count - a.count;
-                    if (order !== 0)
-                        return order;
-                    return a.metricLabel.localeCompare(b.metricLabel);
+            const guideSets = parsed.guideSets;
+            const me = this;
+
+            guideSets.forEach(function(guideSet) {
+                guideSet.stats = {
+                    CUSUMm: {count: 0, data: []},
+                    CUSUMv: {count: 0, data: []},
+                    mR: {count: 0, data: []},
+                    Value: {count: 0, data: []}
+                };
+
+                Object.keys(guideSet.MetricCounts).forEach(function(metricName) {
+                    const data = guideSet.MetricCounts[metricName];
+                    me.addOutlierToCounts(guideSet, data, metricName, 'CUSUMm', 'CUSUMm', true);
+                    me.addOutlierToCounts(guideSet, data, metricName, 'CUSUMv', 'CUSUMv', true);
+                    me.addOutlierToCounts(guideSet, data, metricName, 'mR', 'Moving Range', true);
+                    me.addOutlierToCounts(guideSet, data, metricName, 'Value', 'Metric Value', true);
                 });
 
-                //calculate cumulative percentage on sorted data
-                for(var j = 0; j < sortedDataset.length; j++) {
-                    sortedDataset[j].percent = (j == 0 ? 0 : sortedDataset[j-1].percent) + ((sortedDataset[j].count / totalCount) * 100);
-                }
-                data.maxOutliers = maxOutliers;
-            }, this)
-        }, this);
+                Object.keys(guideSet.stats).forEach(function(outlierType) {
+                    const data = guideSet.stats[outlierType];
+                    const dataSet = data.data;
 
+                    let totalCount = 0;
+                    let maxOutliers = 0;
 
-        var guideSetCount = 1;
-        Ext4.each(guideSets, function(guideSetData) {
-            var id = "paretoPlot-GuideSet-"+guideSetCount;
-            const dateFormat = LABKEY.extDefaultDateTimeFormat || 'Y-m-d H:i';
-            var title = "Training Start: " + Ext4.util.Format.date(new Date(guideSetData.TrainingStart), dateFormat)
-                    + (guideSetData.ReferenceEnd ? " - Reference End: " + Ext4.util.Format.date(new Date(guideSetData.ReferenceEnd), dateFormat) : " - Training End: " + Ext4.util.Format.date(new Date(guideSetData.TrainingEnd), dateFormat));
+                    // find total count per guidesetID
+                    for (let i = 0; i < dataSet.length; i++) {
+                        totalCount += dataSet[i]['count'];
 
-            var plotIdSuffix = '', plotType = "Metric Value", plotWp = 'pareto-plot-wp', plotData = guideSetData.stats.Value.data, plotMaxY = guideSetData.stats.Value.maxOutliers;
-            var webpartTitleBase = "Guide Set " + guideSetCount + ' ';
-            this.addEachParetoPlot(id, webpartTitleBase, plotType, plotWp, title, "ParetoPlot-Guide Set "+guideSetCount + plotIdSuffix, plotData, plotMaxY);
+                        if (maxOutliers < dataSet[i]['count']) {
+                            maxOutliers = dataSet[i]['count'];
+                        }
+                    }
 
-            plotIdSuffix = '_mR'; plotType = "Moving Range"; plotData = guideSetData.stats.mR.data; plotMaxY = guideSetData.stats.mR.maxOutliers;
-            this.addEachParetoPlot(id + plotIdSuffix, webpartTitleBase, plotType, plotWp, title, "ParetoPlot-Guide Set "+guideSetCount + plotIdSuffix, plotData, plotMaxY);
+                    // sort by count in descending order
+                    const sortedDataset = dataSet.sort(function(a, b) {
+                        const order = b.count - a.count;
+                        if (order !== 0) {
+                            return order;
+                        }
+                        return a.metricLabel.localeCompare(b.metricLabel);
+                    });
 
-            plotIdSuffix = '_CUSUMm'; plotType = "Mean CUSUM"; plotData = guideSetData.stats.CUSUMm.data; plotMaxY = guideSetData.stats.CUSUMm.maxOutliers;
-            this.addEachParetoPlot(id + plotIdSuffix, webpartTitleBase, plotType, plotWp, title, "ParetoPlot-Guide Set "+guideSetCount + plotIdSuffix, plotData, plotMaxY);
+                    // calculate cumulative percentage on sorted data
+                    for (let j = 0; j < sortedDataset.length; j++) {
+                        sortedDataset[j].percent = (j === 0 ? 0 : sortedDataset[j - 1].percent) + ((sortedDataset[j].count / totalCount) * 100);
+                    }
+                    data.maxOutliers = maxOutliers;
+                });
+            });
 
-            plotIdSuffix = '_CUSUMv'; plotType = "Variability CUSUM"; plotData = guideSetData.stats.CUSUMv.data; plotMaxY = guideSetData.stats.CUSUMv.maxOutliers;
-            this.addEachParetoPlot(id + plotIdSuffix, webpartTitleBase, plotType, plotWp, title, "ParetoPlot-Guide Set "+guideSetCount + plotIdSuffix, plotData, plotMaxY);
+            let guideSetCount = 1;
+            guideSets.forEach(function(guideSetData) {
+                const id = "paretoPlot-GuideSet-" + guideSetCount;
+                const dateFormat = LABKEY.extDefaultDateTimeFormat || 'Y-m-d H:i';
+                const title = "Training Start: " + me.formatDate(new Date(guideSetData.TrainingStart), dateFormat)
+                        + (guideSetData.ReferenceEnd ? " - Reference End: " + me.formatDate(new Date(guideSetData.ReferenceEnd), dateFormat) : " - Training End: " + me.formatDate(new Date(guideSetData.TrainingEnd), dateFormat));
 
-            guideSetCount++;
-        }, this);
-    },
+                const webpartTitleBase = "Guide Set " + guideSetCount + ' ';
+                const wp = 'pareto-plot-wp';
+                const fileBase = "ParetoPlot-Guide Set " + guideSetCount;
 
-    addOutlierToCounts: function(guideSet, data, metricName, propertyName, plotTypeParamValue, isCusum) {
-        var count = data[propertyName];
-        guideSet.stats[propertyName].count += count;
-        var newData = {
-            metricLabel: metricName,
-            count: count,
-            metricId: data.MetricId,
-            TrainingStart: guideSet.TrainingStart,
-            ReferenceEnd: guideSet.ReferenceEnd,
-            plotType: plotTypeParamValue
-        };
-        if (isCusum) {
-            newData.CUSUMNegative = data[propertyName + 'N'];
-            newData.CUSUMPositive = data[propertyName + 'P'];
-        }
+                me.addEachParetoPlot(id, webpartTitleBase, "Metric Value", wp, title, fileBase, guideSetData.stats.Value.data, guideSetData.stats.Value.maxOutliers);
+                me.addEachParetoPlot(id + '_mR', webpartTitleBase, "Moving Range", wp, title, fileBase + '_mR', guideSetData.stats.mR.data, guideSetData.stats.mR.maxOutliers);
+                me.addEachParetoPlot(id + '_CUSUMm', webpartTitleBase, "Mean CUSUM", wp, title, fileBase + '_CUSUMm', guideSetData.stats.CUSUMm.data, guideSetData.stats.CUSUMm.maxOutliers);
+                me.addEachParetoPlot(id + '_CUSUMv', webpartTitleBase, "Variability CUSUM", wp, title, fileBase + '_CUSUMv', guideSetData.stats.CUSUMv.data, guideSetData.stats.CUSUMv.maxOutliers);
 
-        guideSet.stats[propertyName].data.push(newData);
+                guideSetCount++;
+            });
+        },
 
-    },
-
-    addEachParetoPlot: function (id, wpTitle, plotType, wp, plotTitle, fileName, plotData, yAxisMax)
-    {
-        this.addPlotWebPartToPlotDiv(id, wpTitle, this.plotDivId, wp);
-        this.setPlotWidth(this.plotDivId);
-        this.plotPareto(id, plotData, plotTitle, yAxisMax, plotType);
-        this.attachPlotExportIcons(id, id, 0, this.plotWidth - 30, 0);
-    },
-
-    plotPareto: function(id, data, title, yAxisMax, plotType)
-    {
-        var tickValues;
-        if (yAxisMax < 10) {
-            tickValues = [];
-            for (var i = 0; i <= yAxisMax; i++) {
-                tickValues.push(i);
+        addOutlierToCounts: function(guideSet, data, metricName, propertyName, plotTypeParamValue, isCusum) {
+            const count = data[propertyName];
+            guideSet.stats[propertyName].count += count;
+            const newData = {
+                metricLabel: metricName,
+                count: count,
+                metricId: data.MetricId,
+                TrainingStart: guideSet.TrainingStart,
+                ReferenceEnd: guideSet.ReferenceEnd,
+                plotType: plotTypeParamValue
+            };
+            if (isCusum) {
+                newData.CUSUMNegative = data[propertyName + 'N'];
+                newData.CUSUMPositive = data[propertyName + 'P'];
             }
-        }
-        var hoverFn = plotType.indexOf('CUSUM') > -1 ? this.plotBarHoverEvent : undefined;
-        var barChart = new LABKEY.vis.Plot({
-            renderTo: id,
-            rendererType: 'd3',
-            width: this.plotWidth - 30,
-            height: 500,
-            data: Ext4.Array.clone(data),
-            labels: {
-                main: {value: "Pareto Plot - " + plotType},
-                subtitle: {value: title, color: '#555555'},
-                yLeft: {value: '# Outliers'},
-                yRight: {value: 'Cumulative Percentage'}
-            },
-            layers : [
-                new LABKEY.vis.Layer({
-                    geom: new LABKEY.vis.Geom.BarPlot({clickFn: this.plotBarClickEvent, hoverFn: hoverFn})
-                }),
-                new LABKEY.vis.Layer({
-                    geom: new LABKEY.vis.Geom.Path({color: 'steelblue'}),
-                    aes: { x: 'metricLabel', yRight: 'percent' }
-                }),
-                new LABKEY.vis.Layer({
-                    geom: new LABKEY.vis.Geom.Point({color: 'steelblue'}),
-                    aes: { x: 'metricLabel', yRight: 'percent', hoverText: function(val){return val.percent.toPrecision(4) + "%"}}
-                })
-            ],
-            aes: {
-                x: 'metricLabel',
-                y: 'count'
-            },
-            scales : {
-                x : {
-                    scaleType: 'discrete',
-                    tickHoverText: function(val) {
-                        return val;
+
+            guideSet.stats[propertyName].data.push(newData);
+        },
+
+        addEachParetoPlot: function(id, wpTitle, plotType, wp, plotTitle, fileName, plotData, yAxisMax) {
+            this.addPlotWebPartToPlotDiv(id, wpTitle, wp);
+            this.setPlotWidth();
+            this.plotPareto(id, plotData, plotTitle, yAxisMax, plotType);
+            this.attachPlotExportIcons(id, id, 0, this.plotWidth - 30, 0);
+        },
+
+        plotPareto: function(id, data, title, yAxisMax, plotType) {
+            let tickValues;
+            if (yAxisMax < 10) {
+                tickValues = [];
+                for (let i = 0; i <= yAxisMax; i++) {
+                    tickValues.push(i);
+                }
+            }
+            const hoverFn = plotType.indexOf('CUSUM') > -1 ? this.plotBarHoverEvent : undefined;
+            const barChart = new LABKEY.vis.Plot({
+                renderTo: id,
+                rendererType: 'd3',
+                width: this.plotWidth - 30,
+                height: 500,
+                data: data.slice(),
+                labels: {
+                    main: {value: "Pareto Plot - " + plotType},
+                    subtitle: {value: title, color: '#555555'},
+                    yLeft: {value: '# Outliers'},
+                    yRight: {value: 'Cumulative Percentage'}
+                },
+                layers: [
+                    new LABKEY.vis.Layer({
+                        geom: new LABKEY.vis.Geom.BarPlot({clickFn: this.plotBarClickEvent, hoverFn: hoverFn})
+                    }),
+                    new LABKEY.vis.Layer({
+                        geom: new LABKEY.vis.Geom.Path({color: 'steelblue'}),
+                        aes: {x: 'metricLabel', yRight: 'percent'}
+                    }),
+                    new LABKEY.vis.Layer({
+                        geom: new LABKEY.vis.Geom.Point({color: 'steelblue'}),
+                        aes: {x: 'metricLabel', yRight: 'percent', hoverText: function(val) {return val.percent.toPrecision(4) + "%"}}
+                    })
+                ],
+                aes: {
+                    x: 'metricLabel',
+                    y: 'count'
+                },
+                scales: {
+                    x: {
+                        scaleType: 'discrete',
+                        tickHoverText: function(val) {
+                            return val;
+                        }
+                    },
+                    yLeft: {
+                        domain: [0, (yAxisMax === 0 ? 1 : yAxisMax)],
+                        tickValues: tickValues
+                    },
+                    yRight: {
+                        domain: [0, 100]
                     }
                 },
-                yLeft : {
-                    domain: [0, (yAxisMax==0 ? 1 : yAxisMax)],
-                    tickValues: tickValues
-                },
-                yRight : {
-                    domain: [0, 100]
+                margins: {
+                    bottom: 75
                 }
-            },
-            margins: {
-                bottom: 75
+            });
+            barChart.render();
+        },
+
+        plotBarClickEvent: function(event, row) {
+            const params = {startDate: row.TrainingStart, metric: row.metricId, plotTypes: row.plotType};
+            if (row.ReferenceEnd) {
+                params.endDate = row.ReferenceEnd;
             }
-        });
-        barChart.render();
-    },
+            window.location = LABKEY.ActionURL.buildURL('project', 'begin', null, params);
+        },
 
-    plotBarClickEvent : function(event, row) {
-        var params = {startDate: row.TrainingStart, metric: row.metricId, plotTypes: row.plotType};
-        if (row.ReferenceEnd)
-        {
-            params.endDate = row.ReferenceEnd;
+        plotBarHoverEvent: function(row) {
+            const CUSUMN = row.CUSUMNegative ? row.CUSUMNegative : 0, CUSUMP = row.CUSUMPositive ? row.CUSUMPositive : 0;
+            return 'CUSUM-:' + ' ' + CUSUMN + '\nCUSUM+:' + ' ' + CUSUMP + '\nTotal: ' + row.count;
+        },
+
+        // ---- helpers previously inherited from the ExtJS BaseQCPlotPanel ----
+
+        getPlotWebPartHeader: function(wp, title) {
+            return '<br/>' +
+                    '<table class="labkey-wp ' + LABKEY.Utils.encodeHtml(wp) + '">' +
+                    ' <tr class="labkey-wp-header">' +
+                    '     <th class="labkey-wp-title-left">' +
+                    '        <span class="labkey-wp-title-text ' + LABKEY.Utils.encodeHtml(wp) + '-title">' + LABKEY.Utils.encodeHtml(title) + '</span>' +
+                    '     </th>' +
+                    ' </tr>';
+        },
+
+        addPlotWebPartToPlotDiv: function(id, title, wp) {
+            let html = this.getPlotWebPartHeader(wp, title);
+            html += '<tr>' +
+                    '     <td class="labkey-wp-body">' +
+                    '        <div id="' + LABKEY.Utils.encodeHtml(id) + '" class="chart-render-div"></div>' +
+                    '     </td>' +
+                    ' </tr>' +
+                    '</table>';
+            const div = this.getPlotDiv();
+            if (div) {
+                div.insertAdjacentHTML('beforeend', html);
+            }
+        },
+
+        setPlotWidth: function() {
+            if (this.plotWidth == null) {
+                // set the width of the plot webparts based on the first labkey-wp-body element
+                this.plotWidth = 900;
+                const spacer = 33;
+                const wp = document.querySelector('.panel.panel-portal');
+                if (wp && (wp.clientWidth - spacer) > this.plotWidth) {
+                    this.plotWidth = wp.clientWidth - spacer;
+                }
+
+                const div = this.getPlotDiv();
+                if (div) {
+                    div.style.width = this.plotWidth + 'px';
+                }
+            }
+        },
+
+        attachPlotExportIcons: function(id, plotTitle, plotIndex, plotWidth, extraMargin) {
+            const me = this;
+            this.createExportIcon(id, 'fa-file-pdf-o', 'Export to PDF', 0, plotIndex, plotWidth, function() {
+                me.exportChartToImage(id, extraMargin, LABKEY.vis.SVGConverter.FORMAT_PDF, plotTitle);
+            });
+
+            this.createExportIcon(id, 'fa-file-image-o', 'Export to PNG', 1, plotIndex, plotWidth, function() {
+                me.exportChartToImage(id, extraMargin, LABKEY.vis.SVGConverter.FORMAT_PNG, plotTitle);
+            });
+        },
+
+        createExportIcon: function(divId, iconCls, tooltip, indexFromLeft, plotIndex, plotWidth, callbackFn) {
+            const leftPositionPx = (indexFromLeft * 30) + 60,
+                    exportIconDivId = divId + iconCls,
+                    html = '<div id="' + exportIconDivId + '" class="export-icon" title="' + LABKEY.Utils.encodeHtml(tooltip) + '" style="left: ' + leftPositionPx + 'px;">'
+                            + '<i class="fa ' + iconCls + '"></i></div>';
+
+            const container = document.getElementById(divId);
+            if (container) {
+                container.insertAdjacentHTML('afterbegin', html);
+                const iconEl = document.getElementById(exportIconDivId);
+                if (iconEl) {
+                    iconEl.addEventListener('click', callbackFn);
+                }
+            }
+        },
+
+        exportChartToImage: function(svgDivId, extraMargin, type, fileName) {
+            const svgStr = this.getExportSVGStr(svgDivId, extraMargin),
+                    exportType = type || LABKEY.vis.SVGConverter.FORMAT_PDF;
+            LABKEY.vis.SVGConverter.convert(svgStr, exportType, fileName);
+        },
+
+        getExportSVGStr: function(svgDivId, extraWidth) {
+            const container = document.getElementById(svgDivId);
+            const targetSvg = container.querySelector('svg');
+            const oldWidth = targetSvg.getBoundingClientRect().width;
+            // temporarily increase svg size to allow exporting of legends that's outside svg
+            if (extraWidth) {
+                targetSvg.setAttribute('width', oldWidth + extraWidth);
+            }
+            let svgStr = LABKEY.vis.SVGConverter.svgToStr(targetSvg);
+            if (extraWidth) {
+                targetSvg.setAttribute('width', oldWidth);
+            }
+            svgStr = svgStr.replace(/visibility="hidden"/g, 'visibility="visible"');
+            return svgStr;
+        },
+
+        failureHandler: function(response) {
+            const plotDiv = this.getPlotDiv();
+            if (plotDiv) {
+                this.unmask();
+                if (!response) {
+                    plotDiv.innerHTML = "<span>Failure loading data</span>";
+                }
+                else if (response.message) {
+                    plotDiv.innerHTML = "<span>" + LABKEY.Utils.encodeHtml(response.message) + "</span>";
+                }
+                else {
+                    plotDiv.innerHTML = "<span class='labkey-error'>Error: " + LABKEY.Utils.encodeHtml(response.exception) + "</span>";
+                }
+            }
+        },
+
+        /**
+         * Minimal replacement for Ext4.util.Format.date, supporting the PHP/Ext-style tokens used by
+         * LABKEY.extDefaultDateTimeFormat (default 'Y-m-d H:i').
+         */
+        formatDate: function(date, format) {
+            if (!date || isNaN(date.getTime())) {
+                return '';
+            }
+            const pad = function(n) { return (n < 10 ? '0' : '') + n; };
+            const year = date.getFullYear();
+            const month = date.getMonth();
+            const day = date.getDate();
+            const dow = date.getDay();
+            const hours = date.getHours();
+            const minutes = date.getMinutes();
+            const seconds = date.getSeconds();
+            let h12 = hours % 12;
+            if (h12 === 0) {
+                h12 = 12;
+            }
+
+            const tokens = {
+                Y: '' + year,
+                y: ('' + year).slice(-2),
+                m: pad(month + 1),
+                n: '' + (month + 1),
+                F: MONTHS[month],
+                M: MONTHS[month].slice(0, 3),
+                d: pad(day),
+                j: '' + day,
+                l: DAYS[dow],
+                D: DAYS[dow].slice(0, 3),
+                N: '' + (dow === 0 ? 7 : dow),
+                w: '' + dow,
+                H: pad(hours),
+                G: '' + hours,
+                h: pad(h12),
+                g: '' + h12,
+                i: pad(minutes),
+                s: pad(seconds),
+                A: hours < 12 ? 'AM' : 'PM',
+                a: hours < 12 ? 'am' : 'pm'
+            };
+
+            let out = '';
+            for (let i = 0; i < format.length; i++) {
+                const c = format[i];
+                if (c === '\\' && i + 1 < format.length) {
+                    out += format[++i];
+                }
+                else if (Object.prototype.hasOwnProperty.call(tokens, c)) {
+                    out += tokens[c];
+                }
+                else {
+                    out += c;
+                }
+            }
+            return out;
         }
-        window.location = LABKEY.ActionURL.buildURL('project', 'begin', null, params);
-    },
+    };
 
-    plotBarHoverEvent : function(row) {
-        var CUSUMN = row.CUSUMNegative ? row.CUSUMNegative : 0, CUSUMP = row.CUSUMPositive ? row.CUSUMPositive : 0;
-        return 'CUSUM-:' + ' ' + CUSUMN + '\nCUSUM+:' + ' ' + CUSUMP + '\nTotal: ' + row.count;
-
-    }
-});
+    LABKEY.targetedms.ParetoPlotPanel = ParetoPlotPanel;
+})();


### PR DESCRIPTION
## Rationale
We are gradually removing our dependency on ExtJS. ExtJS is old, heavy, and something we want to stop using. Each of these screens used ExtJS only as a wrapper around plain data or existing non-ExtJS chart code, so we can swap in simple HTML, plain JavaScript, and jQuery without changing what the user sees. This makes the code lighter, easier to read, and easier to maintain. 

## Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

## Changes
- Trace metric dialog (resources/web/PanoramaPremium/window/AddNewTraceMetricWindow.js)
- Pareto plot (webapp/TargetedMS/js/ParetoPlotPanel.js)
- Calibration curve (webapp/TargetedMS/js/CalibrationCurve.js)
- Summary charts (src/org/labkey/targetedms/view/summaryChartsView.jsp)

<!-- list of standard tasks (remove this comment to enable)
## Tasks 📍
- [ ] Claude Code Review
- [ ] Manual Testing
- [ ] Test Automation
- [ ] Verify Fix
-->