### PR TITLE
Use centrally configured SchemaFactory

### DIFF
--- a/src/org/labkey/targetedms/parser/skyaudit/SkylineAuditLogParser.java
+++ b/src/org/labkey/targetedms/parser/skyaudit/SkylineAuditLogParser.java
@@ -31,7 +31,6 @@ import org.labkey.targetedms.TargetedMSModule;
 import org.labkey.targetedms.parser.XmlUtil;
 import org.xml.sax.SAXException;
 
-import javax.xml.XMLConstants;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.transform.stream.StreamSource;
@@ -114,10 +113,10 @@ public class SkylineAuditLogParser implements AutoCloseable
         try (InputStream schemaStream = new BufferedInputStream(openSchemaInputStream());
              InputStream auditLogStream = new BufferedInputStream(new FileInputStream(_file)))
             {
-                //prepare validator
-                SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+                //prepare validator, hardened against XXE (CWE-611) since the audit log is attacker-supplied
+                SchemaFactory schemaFactory = XmlBeansUtil.schemaFactory();
                 Schema schema = schemaFactory.newSchema(new StreamSource(schemaStream));
-                Validator validator = schema.newValidator();
+                Validator validator = XmlBeansUtil.hardenValidator(schema.newValidator());
                 validator.validate(new StreamSource(auditLogStream));
             }
     }


### PR DESCRIPTION
## Rationale
We should configure `SchemaFactory` centrally like other XML objects so that we get the right settings consistently.

## Related Pull Requests
- https://github.com/LabKey/platform/pull/7875

## Changes
- Use utility/factory method to get a configured `SchemaFactory` with external references disabled