### PR TITLE
Fix instrument schedule datetime-local fields showing midnight on Firefox browsers

### DIFF
--- a/resources/views/scheduleInstrument.html
+++ b/resources/views/scheduleInstrument.html
@@ -89,9 +89,6 @@
                         <div class="form-group row" >
                             <div class="col-sm-10 offset-sm-2 labkey-error" style="min-height: 2em;" id="schedule-save-error"></div>
                         </div>
-                        <div class="form-group row" >
-                            <div class="col-sm-12" style="min-height: 2em; color: #0a7d00; font-size: 11px; word-break: break-all;" id="tzDebug"></div>
-                        </div>
                     </form>
                 </div>
                 <div class="modal-footer">

--- a/resources/views/scheduleInstrument.html
+++ b/resources/views/scheduleInstrument.html
@@ -89,6 +89,9 @@
                         <div class="form-group row" >
                             <div class="col-sm-10 offset-sm-2 labkey-error" style="min-height: 2em;" id="schedule-save-error"></div>
                         </div>
+                        <div class="form-group row" >
+                            <div class="col-sm-12" style="min-height: 2em; color: #0a7d00; font-size: 11px; word-break: break-all;" id="tzDebug"></div>
+                        </div>
                     </form>
                 </div>
                 <div class="modal-footer">

--- a/webapp/TargetedMS/js/scheduler.js
+++ b/webapp/TargetedMS/js/scheduler.js
@@ -385,9 +385,9 @@ $(function() {
     });
 
 
-    // datetime-local inputs require a 'T' separator; the container format uses a space, which Firefox (unlike Chrome) rejects.
+    // datetime-local values use the fixed HTML format 'yyyy-MM-ddTHH:mm', independent of the container's display format; Firefox (unlike Chrome) rejects anything else.
     function toDateTimeLocalValue(date) {
-        return DateFormat.format.date(date, LABKEY.container.formats.dateTimeFormat).replace(' ', 'T');
+        return DateFormat.format.date(date, 'yyyy-MM-dd') + 'T' + DateFormat.format.date(date, 'HH:mm');
     }
 
     function editEvent(event) {

--- a/webapp/TargetedMS/js/scheduler.js
+++ b/webapp/TargetedMS/js/scheduler.js
@@ -153,12 +153,9 @@ $(function() {
                         editEvent({
                             startDate: arg.start,
                             endDate: arg.end,
-                            allDay: arg.allDay,
                             id: null,
                             name: '',
-                            notes: '',
-                            _debug: 'via=select allDay=' + arg.allDay + ' startStr=' + arg.startStr + ' endStr=' + arg.endStr
-                                + ' start=' + String(arg.start) + ' end=' + String(arg.end) + ' tz=' + Intl.DateTimeFormat().resolvedOptions().timeZone
+                            notes: ''
                         });
                         calendar.unselect()
                     },
@@ -168,8 +165,7 @@ $(function() {
                             endDate: arg.event.end,
                             id: arg.event.id,
                             name: arg.event.extendedProps.name,
-                            notes: arg.event.extendedProps.notes,
-                            _debug: 'via=eventClick id=' + arg.event.id + ' start=' + String(arg.event.start) + ' end=' + String(arg.event.end)
+                            notes: arg.event.extendedProps.notes
                         });
                     },
                     editable: true,
@@ -389,17 +385,18 @@ $(function() {
     });
 
 
-    // datetime-local values use the fixed HTML format 'yyyy-MM-ddTHH:mm', independent of the container's display format; Firefox (unlike Chrome) rejects anything else.
+    // Format to datetime-local's fixed 'yyyy-MM-ddTHH:mm' from local fields; DateFormat.format.date zeroes the time in timezones whose label contains a colon (e.g. Honolulu).
     function toDateTimeLocalValue(date) {
-        return DateFormat.format.date(date, 'yyyy-MM-dd') + 'T' + DateFormat.format.date(date, 'HH:mm');
+        let pad = function(n) { return (n < 10 ? '0' : '') + n; };
+        return date.getFullYear() + '-' + pad(date.getMonth() + 1) + '-' + pad(date.getDate())
+            + 'T' + pad(date.getHours()) + ':' + pad(date.getMinutes());
     }
 
     function editEvent(event) {
         let startDate = event.startDate;
         let endDate = event.endDate;
 
-        // Rely on FullCalendar's allDay flag rather than checking for midnight, which shifts with the browser's timezone
-        if (!event.id && event.allDay) {
+        if (!event.id && startDate.getHours() === 0 && startDate.getMinutes() === 0 && endDate.getHours() === 0 && endDate.getMinutes() === 0) {
             // Default to starting at 8AM and ending at 5PM
             startDate.setHours(8);
             endDate.setHours(17);
@@ -421,10 +418,6 @@ $(function() {
         $('#add-event').text('Save');
         $('#schedule-save-error').text('');
         $('#schedule-cost-error').text('');
-
-        // TZDEBUG: surface values in the DOM so they appear in the failure screenshot (console isn't captured under geckodriver)
-        $('#tzDebug').text('TZDEBUG ' + (event._debug || '') + ' | out start=' + startDateFormatted + ' end=' + endDateFormatted);
-
         $('#event-modal').modal();
     }
 

--- a/webapp/TargetedMS/js/scheduler.js
+++ b/webapp/TargetedMS/js/scheduler.js
@@ -156,7 +156,9 @@ $(function() {
                             allDay: arg.allDay,
                             id: null,
                             name: '',
-                            notes: ''
+                            notes: '',
+                            _debug: 'via=select allDay=' + arg.allDay + ' startStr=' + arg.startStr + ' endStr=' + arg.endStr
+                                + ' start=' + String(arg.start) + ' end=' + String(arg.end) + ' tz=' + Intl.DateTimeFormat().resolvedOptions().timeZone
                         });
                         calendar.unselect()
                     },
@@ -166,7 +168,8 @@ $(function() {
                             endDate: arg.event.end,
                             id: arg.event.id,
                             name: arg.event.extendedProps.name,
-                            notes: arg.event.extendedProps.notes
+                            notes: arg.event.extendedProps.notes,
+                            _debug: 'via=eventClick id=' + arg.event.id + ' start=' + String(arg.event.start) + ' end=' + String(arg.event.end)
                         });
                     },
                     editable: true,
@@ -418,6 +421,10 @@ $(function() {
         $('#add-event').text('Save');
         $('#schedule-save-error').text('');
         $('#schedule-cost-error').text('');
+
+        // TZDEBUG: surface values in the DOM so they appear in the failure screenshot (console isn't captured under geckodriver)
+        $('#tzDebug').text('TZDEBUG ' + (event._debug || '') + ' | out start=' + startDateFormatted + ' end=' + endDateFormatted);
+
         $('#event-modal').modal();
     }
 

--- a/webapp/TargetedMS/js/scheduler.js
+++ b/webapp/TargetedMS/js/scheduler.js
@@ -150,18 +150,6 @@ $(function() {
                         }, 200); // Add a delay to allow for hover on the popover
                     },
                     select: function(arg) {
-                        console.warn('TZDEBUG select ' + JSON.stringify({
-                            tz: Intl.DateTimeFormat().resolvedOptions().timeZone,
-                            offsetMin: arg.start ? arg.start.getTimezoneOffset() : null,
-                            allDay: arg.allDay,
-                            startStr: arg.startStr,
-                            endStr: arg.endStr,
-                            start: String(arg.start),
-                            end: String(arg.end),
-                            startMs: arg.start ? arg.start.getTime() : null,
-                            endMs: arg.end ? arg.end.getTime() : null,
-                            sameRef: arg.start === arg.end
-                        }));
                         editEvent({
                             startDate: arg.start,
                             endDate: arg.end,
@@ -173,14 +161,6 @@ $(function() {
                         calendar.unselect()
                     },
                     eventClick: function(arg) {
-                        console.warn('TZDEBUG eventClick ' + JSON.stringify({
-                            id: arg.event.id,
-                            allDay: arg.event.allDay,
-                            startStr: arg.event.startStr,
-                            endStr: arg.event.endStr,
-                            start: String(arg.event.start),
-                            end: String(arg.event.end)
-                        }));
                         editEvent({
                             startDate: arg.event.start,
                             endDate: arg.event.end,
@@ -425,17 +405,6 @@ $(function() {
 
         let startDateFormatted = toDateTimeLocalValue(startDate);
         let endDateFormatted = toDateTimeLocalValue(endDate);
-
-        console.warn('TZDEBUG editEvent ' + JSON.stringify({
-            id: event.id,
-            allDay: event.allDay,
-            blockRan: !event.id && !!event.allDay,
-            startAfter: String(startDate),
-            endAfter: String(endDate),
-            startFormatted: startDateFormatted,
-            endFormatted: endDateFormatted,
-            dateTimeFormat: (window.LABKEY && LABKEY.container && LABKEY.container.formats) ? LABKEY.container.formats.dateTimeFormat : null
-        }));
 
         // remove the old event log rows
         removeEventLog();

--- a/webapp/TargetedMS/js/scheduler.js
+++ b/webapp/TargetedMS/js/scheduler.js
@@ -153,6 +153,7 @@ $(function() {
                         editEvent({
                             startDate: arg.start,
                             endDate: arg.end,
+                            allDay: arg.allDay,
                             id: null,
                             name: '',
                             notes: ''
@@ -394,7 +395,8 @@ $(function() {
         let startDate = event.startDate;
         let endDate = event.endDate;
 
-        if (!event.id && startDate.getHours() === 0 && startDate.getMinutes() === 0 && endDate.getHours() === 0 && endDate.getMinutes() === 0) {
+        // Rely on FullCalendar's allDay flag rather than checking for midnight, which shifts with the browser's timezone
+        if (!event.id && event.allDay) {
             // Default to starting at 8AM and ending at 5PM
             startDate.setHours(8);
             endDate.setHours(17);

--- a/webapp/TargetedMS/js/scheduler.js
+++ b/webapp/TargetedMS/js/scheduler.js
@@ -385,6 +385,11 @@ $(function() {
     });
 
 
+    // datetime-local inputs require a 'T' separator; the container format uses a space, which Firefox (unlike Chrome) rejects.
+    function toDateTimeLocalValue(date) {
+        return DateFormat.format.date(date, LABKEY.container.formats.dateTimeFormat).replace(' ', 'T');
+    }
+
     function editEvent(event) {
         let startDate = event.startDate;
         let endDate = event.endDate;
@@ -396,8 +401,8 @@ $(function() {
             endDate.setDate(endDate.getDate() - 1);
         }
 
-        let startDateFormatted = DateFormat.format.date(startDate, LABKEY.container.formats.dateTimeFormat);
-        let endDateFormatted = DateFormat.format.date(endDate, LABKEY.container.formats.dateTimeFormat);
+        let startDateFormatted = toDateTimeLocalValue(startDate);
+        let endDateFormatted = toDateTimeLocalValue(endDate);
 
         // remove the old event log rows
         removeEventLog();

--- a/webapp/TargetedMS/js/scheduler.js
+++ b/webapp/TargetedMS/js/scheduler.js
@@ -150,6 +150,18 @@ $(function() {
                         }, 200); // Add a delay to allow for hover on the popover
                     },
                     select: function(arg) {
+                        console.warn('TZDEBUG select ' + JSON.stringify({
+                            tz: Intl.DateTimeFormat().resolvedOptions().timeZone,
+                            offsetMin: arg.start ? arg.start.getTimezoneOffset() : null,
+                            allDay: arg.allDay,
+                            startStr: arg.startStr,
+                            endStr: arg.endStr,
+                            start: String(arg.start),
+                            end: String(arg.end),
+                            startMs: arg.start ? arg.start.getTime() : null,
+                            endMs: arg.end ? arg.end.getTime() : null,
+                            sameRef: arg.start === arg.end
+                        }));
                         editEvent({
                             startDate: arg.start,
                             endDate: arg.end,
@@ -161,6 +173,14 @@ $(function() {
                         calendar.unselect()
                     },
                     eventClick: function(arg) {
+                        console.warn('TZDEBUG eventClick ' + JSON.stringify({
+                            id: arg.event.id,
+                            allDay: arg.event.allDay,
+                            startStr: arg.event.startStr,
+                            endStr: arg.event.endStr,
+                            start: String(arg.event.start),
+                            end: String(arg.event.end)
+                        }));
                         editEvent({
                             startDate: arg.event.start,
                             endDate: arg.event.end,
@@ -405,6 +425,17 @@ $(function() {
 
         let startDateFormatted = toDateTimeLocalValue(startDate);
         let endDateFormatted = toDateTimeLocalValue(endDate);
+
+        console.warn('TZDEBUG editEvent ' + JSON.stringify({
+            id: event.id,
+            allDay: event.allDay,
+            blockRan: !event.id && !!event.allDay,
+            startAfter: String(startDate),
+            endAfter: String(endDate),
+            startFormatted: startDateFormatted,
+            endFormatted: endDateFormatted,
+            dateTimeFormat: (window.LABKEY && LABKEY.container && LABKEY.container.formats) ? LABKEY.container.formats.dateTimeFormat : null
+        }));
 
         // remove the old event log rows
         removeEventLog();


### PR DESCRIPTION
## Rationale
The instrument scheduler populated its two datetime-local inputs via DateFormat.format.date(...). In timezones whose Date.toTimeString() label contains a colon (e.g. Honolulu → (GMT-10:00)), jquery-dateFormat's parseTime() splits the   
  whole string on , gets more than 3 parts, bails, and pads the time to 00:00. Both start and end then collapsed to midnight, so start == end and the server rejected the save with "StartTime must be before EndTime" — failing the test on 
  the Honolulu TeamCity agent while passing elsewhere.

Fix: format the start/end fields directly to datetime-local's fixed yyyy-MM-ddTHH:mm wire format from the Date's own local fields, bypassing the buggy library path. 

I think we need to fix the library path. Attached report.
[DateTZBug.pdf](https://github.com/user-attachments/files/30390486/DateTZBug.pdf)


## Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

## Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->

<!-- list of standard tasks (remove this comment to enable)
## Tasks 📍
- [ ] Claude Code Review
- [ ] Manual Testing
- [ ] Test Automation
- [ ] Verify Fix
-->